### PR TITLE
Unify paid-operation admission across runs and PDF extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,40 +111,42 @@ SERPER_API_KEY=your-serper-key-here
 # actually used their code without checking each one individually.
 # ACCESS_CODE_ADMIN=choose-another-random-string
 
-# ── Optional: daily run cap ─────────────────────────────────────────────────────
-# Hard ceiling on total runs per UTC day, independent of concurrency — a
-# second line of defence if a code ever leaks. Applied separately to each
-# access code (including the admin one), not as one pool every code shares.
-# 0 (default) disables it.
+# ── Optional: daily paid-operation cap ─────────────────────────────────────────
+# Per-process ceiling on operator-funded provider admissions per UTC day. A
+# full assessment and an inline PDF contribution extraction each consume one
+# unit, so an upload-then-run journey consumes two. Applied separately to each
+# validated access code (including the admin one), not as one shared pool.
+# BYOK operations are exempt because the visitor pays. 0 (default) disables
+# the cap; a process restart also resets this in-memory safety ledger.
 #
-# Size this against your search quota, not your LLM bill. Measured over 30
-# runs: a run issues a median of 9 web searches (range 5-15), which is well
-# under the ~22 queries it constructs — collection stops early once a domain
-# has enough sources, and academic retrieval goes to OpenAlex/PubMed/arXiv
-# rather than the search API. Tavily's 1000/month free tier is therefore
-# roughly 110 runs in total across every code.
-# API_DAILY_RUN_CAP=3
+# Size this against the stricter of your LLM and search budgets. Measured over
+# 30 runs, a full assessment issues a median of 9 web searches (range 5-15).
+# PDF extraction adds one LLM call but no search call. Tavily's 1000/month free
+# tier is therefore roughly 110 full runs in total across every code, while
+# the per-code cap bounds how much any one leaked credential can spend.
+# API_DAILY_PAID_OPERATION_CAP=3
+# API_DAILY_RUN_CAP remains accepted as a backward-compatible fallback when
+# the accurately named variable above is unset.
 
 # ── Optional: request rate limit ────────────────────────────────────────────────
 # Requests per minute per client, refilled continuously. Distinct from the two
-# caps above, which count *runs*: this counts *requests*, and exists because
-# the endpoints reachable without a code (a run addressed by its id, and the
-# gate check itself) cost nothing to serve and are otherwise unbounded.
-# Charged per access code where one is present, per address otherwise, so
-# several people behind one campus NAT are not throttled as a single client.
+# caps above, which count *paid operations*: this counts *HTTP requests* and
+# protects cheap capability-URL polling and access checks from unbounded load.
+# Charged per validated access code, per server-resolved peer address otherwise.
+# Arbitrary X-Access-Code or X-Forwarded-For values cannot mint fresh buckets;
+# configure trusted proxy handling at the ASGI server boundary if needed.
 # Default 300; 0 disables it. The web client polls progress every 1.2-4s and
 # capacity once a second, so two open tabs already sit near 100/min.
 # API_RATE_LIMIT_PER_MINUTE=300
 
-# How many of the concurrent slots visitors bringing their own key may hold at
-# once. Defaults to one below API_MAX_CONCURRENT, i.e. one slot that only an
-# access-code holder can take.
+# How many shared paid-operation slots visitors bringing their own key may hold
+# at once, across full runs and PDF extraction. Defaults to one below
+# API_MAX_CONCURRENT, i.e. one slot that only an access-code holder can take.
 #
-# BYOK runs are exempt from the daily cap, because the visitor pays for their
-# own tokens — which is exactly what made them able to occupy every slot, and
-# a submission whose key is wrong still holds one while it fails. Without this
-# the people you handed a code to could be shut out by anonymous traffic that
-# costs you nothing.
+# BYOK operations are exempt from the daily wallet cap, because the visitor
+# pays for their own tokens. They still consume finite host/provider capacity;
+# without this separate share, anonymous traffic — including bad-key failures
+# — could occupy every slot and shut out access-code holders.
 # API_BYOK_MAX_CONCURRENT=2
 
 # ── Optional: run retention ────────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1172 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1181 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Running on Railway — nothing to install. The gate offers two ways in:
 - **Access code** — runs on the deployment's own keys. Codes are handed out
   privately; without one, use the BYOK option above.
 
-A run takes roughly 3 minutes and costs a few cents of LLM plus about 9 search
-queries, so the deployment caps concurrency and daily runs per code. See
-[Deploying publicly](#deploying-publicly) for how the two entrances work.
+A full run takes roughly 3 minutes and costs a few cents of LLM plus about 9
+search queries. The deployment therefore caps shared paid-operation concurrency
+and daily operator-funded admissions per code, including PDF extraction. See
+[Deploying publicly](#deploying-publicly) for the exact boundary.
 
 ---
 
@@ -337,17 +338,19 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/health` | Liveness, active-run count, resolved LLM provider |
-| `POST` | `/api/runs` | Queue an assessment (`202`, or `429` at capacity) |
+| `GET` | `/health` | Liveness, active-run and shared paid-operation capacity, resolved LLM provider |
+| `POST` | `/api/papers` | Upload a PDF and extract its contribution (`429` at shared paid capacity) |
+| `POST` | `/api/runs` | Queue an assessment (`202`, or `429` at shared paid capacity) |
 | `GET` | `/api/runs` | List runs, newest first |
 | `GET` | `/api/runs/{id}` | Stage, state, elapsed time, available artifacts |
 | `DELETE` | `/api/runs/{id}` | Terminate a running assessment |
 | `GET` | `/api/runs/{id}/report` | Final report as Markdown |
 | `GET` | `/api/runs/{id}/{artifact}` | Run artifacts, including `scores`, `sources`, checks, and failed-run `retrieval` diagnostics |
 
-Concurrency is capped at 2 runs (`API_MAX_CONCURRENT` to change) — the binding
-constraint is upstream API rate limits, not local CPU. Runs exceeding 30 minutes
-are terminated automatically.
+Concurrency is capped at 2 paid operations (`API_MAX_CONCURRENT` to change),
+shared by worker runs and inline PDF extraction — the binding constraint is
+upstream provider capacity, not local CPU. Runs exceeding 30 minutes are
+terminated automatically; extraction releases its slot on every exit path.
 
 The web client and the JSON API share the same `outputs/` directory and launch the
 same worker, so a run started from one is visible to the other.
@@ -417,36 +420,38 @@ state. API keys come from `.env` at runtime and are never baked into a layer.
 
 ### Deploying publicly
 
-Anything reachable on the open internet at `/api/runs` triggers real, billed
-calls — the pipeline makes six LLM calls and dozens of search-API calls per
-run. For a link shared with a specific, small audience (e.g. reviewers
-looking at this project) rather than the general public, two settings in
-`.env` close that off without building a login system:
+Both `/api/runs` and `/api/papers` can trigger real, billed calls — a full
+pipeline makes six LLM calls plus search-API calls, while PDF contribution
+extraction makes an inline LLM call. For a link shared with a specific, small
+audience (e.g. reviewers) rather than the general public, two settings in
+`.env` close those paths without building a login system:
 
 ```bash
-ACCESS_CODE=choose-a-long-random-string   # gates every /api/ route
-API_DAILY_RUN_CAP=3                       # hard ceiling, in case the code leaks
+ACCESS_CODE=choose-a-long-random-string        # gates every /api/ route
+API_DAILY_PAID_OPERATION_CAP=3                 # per-code provider admissions
 ```
 
 `ACCESS_CODE` (or `ACCESS_CODES` — see below) is checked by a middleware in
-`api/main.py` against an `X-Access-Code` header; the web client prompts for
-it once and remembers it in `localStorage` from then on. `/health` stays
-open regardless — platform load balancers poll it without a header, and
-serving it costs nothing. Leaving both unset (the default) makes the gate
-inert: local development sees no difference from before it existed.
+`api/main.py` against an `X-Access-Code` header; the web client prompts once
+and remembers it in `localStorage`. `/health` stays open for platform probes.
+Leaving every access-code setting unset (the default) makes the gate inert, so
+local development sees no difference.
 
-`API_DAILY_RUN_CAP` is a second, independent line of defence: the
-concurrency cap only limits how many runs execute at once, so a leaked code
-could still trigger hundreds of runs one after another over a day. This caps
-the total regardless of pacing. 0 (default) disables it.
+`API_DAILY_PAID_OPERATION_CAP` is an independent, per-process wallet guard. A
+full assessment and a PDF extraction each consume one operator-funded unit, so
+an upload-then-run journey consumes two. It is applied separately to each
+validated code (including the admin code); BYOK operations are exempt because
+the visitor pays. 0 disables it. The old `API_DAILY_RUN_CAP` name remains a
+backward-compatible fallback when the new variable is unset. Because the ledger
+is in memory, UTC midnight and a process restart reset it; durable multi-replica
+accounting would require an external store.
 
-Size it against your **search** quota rather than your LLM bill. Measured
-over 30 runs, one run issues a median of 9 web searches (range 5-15) — fewer
-than the ~22 queries it builds, because collection stops early once a domain
-has enough sources and because academic retrieval goes to OpenAlex/PubMed/arXiv
-rather than the search API. Tavily's 1000-per-month free tier is therefore
-roughly 110 runs in total across every code. Note the cap is per code, so it bounds what any one leaked code
-can do, not what every code can do put together.
+Size the value against the stricter of your **LLM and search** budgets. Across
+30 measured runs, one full assessment issues a median of 9 web searches (range
+5-15); PDF extraction adds one LLM call but no search call. Tavily's
+1000-per-month free tier is therefore roughly 110 full runs in total across all
+codes. The per-code cap bounds one leaked credential, not the aggregate of every
+code.
 
 **Two more settings worth turning on before a link goes public**, both
 default-off so local use is unaffected:
@@ -456,13 +461,13 @@ API_RATE_LIMIT_PER_MINUTE=300   # requests per client per minute
 RUN_RETENTION_DAYS=30           # delete finished runs after N days
 ```
 
-The rate limit counts *requests*, which neither cap above does — those count
-runs. It matters because the endpoints reachable without a code are the cheap
-ones: a run id is a capability URL, so whoever holds one can poll it freely,
-and the gate check itself must stay open in order to reject wrong codes at
-all. Charged per access code where one is present and per address otherwise,
-so several people behind one campus NAT are not throttled as a single client.
-`/health` is exempt — a throttled health check reads as the service being down.
+The rate limit counts *HTTP requests*; the caps above count *paid operations*.
+A capability URL can be polled without a code, so cheap routes still need a
+bound. A validated access code receives its own bucket; all other callers use
+the peer address resolved by the ASGI server. The application deliberately does
+not trust raw `X-Forwarded-For` or arbitrary code text as identity — trusted
+proxy handling belongs in Uvicorn/deployment configuration. `/health` is exempt,
+because a throttled health check reads as the service being down.
 
 Retention matters *because* run links are shareable. Reading a run needs only
 its id, so a shared link lives exactly as long as the run does, and a visitor
@@ -504,12 +509,12 @@ id or raw topic, and exposes its `trace_id` and explicit
 disabled/active/degraded state through both run endpoints. See
 [Agent observability](docs/observability.md) for setup and the data contract.
 
-`API_BYOK_MAX_CONCURRENT` bounds how many of those slots visitors using their
-own keys may hold at once; it defaults to one below `API_MAX_CONCURRENT`.
-Bring-your-own-key runs skip the daily cap since the visitor pays for their
-own tokens, and that exemption is what let anonymous traffic — including
-submissions failing on a bad key — fill every slot and lock out the people
-holding a code.
+`API_BYOK_MAX_CONCURRENT` bounds the BYOK share of the shared slots across both
+full runs and PDF extraction; it defaults to one below `API_MAX_CONCURRENT`.
+BYOK operations skip the daily wallet cap because the visitor pays, but still
+consume finite host/provider capacity. This prevents anonymous traffic —
+including bad-key failures — from filling every slot and locking out code
+holders.
 
 **Handing out a separate code per person:** `ACCESS_CODES` accepts a
 comma-separated list instead of one shared value — `ACCESS_CODES=for-alice,
@@ -521,14 +526,11 @@ process, one `outputs/` directory, codes just partition what `GET /api/runs`
 returns. `ACCESS_CODE` (singular) still works for the original one-code-for-
 everyone setup; both may be set together.
 
-`ACCESS_CODE_ADMIN` is one further code that authorizes runs like any
-other (its own owner tag, its own daily-cap budget) but is exempt from that
-same filter, so its holder sees every code's history combined — a way to
-check who has actually used their code without checking each one
-individually. `API_DAILY_RUN_CAP` is likewise applied per code (including
-the admin one), not as one shared total — otherwise one enthusiastic
-tester could exhaust the day's budget for everyone else holding a
-different code.
+`ACCESS_CODE_ADMIN` is one further code that authorizes runs like any other
+(its own owner tag and paid-operation budget) but is exempt from that same
+history filter, so its holder sees every code's runs combined. The daily cap
+is likewise per code, including the admin one, rather than one shared total
+that an enthusiastic tester could exhaust for everyone else.
 
 **A second, open entrance:** `POST /api/runs` also accepts `llm_provider` /
 `llm_api_key` / `serper_api_key` in the body as an alternative to any access
@@ -543,7 +545,10 @@ A BYOK run gets no code tag at all, so it never appears in any code's
 history server-side; the web client instead keeps a session-only list of
 the visitor's own runs (in `sessionStorage`) so their sidebar still shows
 what they submitted — gone the moment the tab closes, complete for as long
-as it's open.
+as it's open. `POST /api/papers` accepts the same BYOK LLM provider/key pair
+(the extractor does not need a search key); both upload extraction and full
+runs enter the shared paid-operation admission boundary before calling a
+provider.
 
 `GET /api/runs` (the run-history list) always stays behind a code
 regardless of any of this — opening it up would show every visitor's topics
@@ -730,7 +735,7 @@ academic_agent/
 - **HTTP API**: FastAPI + Uvicorn, serving both the client and the JSON API (OpenAPI docs at `/docs`)
 - **PDF export**: reportlab Platypus (embedded TTFont for CJK; falls back to CID fonts)
 - **Container**: Docker multi-stage build (dependency layer cached separately from source), `tini` as PID 1 for subprocess reaping, non-root user, build-time CJK font verification
-- **Access control**: optional shared-secret middleware (`ACCESS_CODE`) plus a daily run cap, for exposing a demo link without an open API bill — with an open bring-your-own-key path alongside it, so a visitor without the code can still run it on their own keys
+- **Paid-operation boundary**: validated-code access control, shared concurrency across runs/PDF extraction, per-code daily wallet cap, launch-failure refunds, and a separately bounded BYOK path
 - **Python**: 3.11+
 
 Invalid or unreachable URLs/DOIs, mismatched citation IDs, References inconsistencies, malformed report sections, hallucinated source IDs in scoring, and scoring JSON format errors all block the task and trigger automatic retries.
@@ -1067,16 +1072,16 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
 
 | 方法 | 路径 | 用途 |
 |---|---|---|
-| `GET` | `/health` | 存活检查、当前运行数、已解析的 LLM provider |
-| `POST` | `/api/runs` | 提交评估任务（`202`，达到并发上限时 `429`） |
+| `GET` | `/health` | 存活检查、运行数、共享付费操作容量、已解析的 LLM provider |
+| `POST` | `/api/papers` | 上传 PDF 并提取贡献（共享付费容量满时返回 `429`） |
+| `POST` | `/api/runs` | 提交评估任务（共享付费容量满时返回 `429`） |
 | `GET` | `/api/runs` | 列出历史运行，最新在前 |
 | `GET` | `/api/runs/{id}` | 阶段、状态、已用时长、可用产物清单 |
 | `DELETE` | `/api/runs/{id}` | 终止运行中的任务 |
 | `GET` | `/api/runs/{id}/report` | Markdown 格式的最终报告 |
 | `GET` | `/api/runs/{id}/{artifact}` | 运行产物，包括 `scores`、`sources`、自动检查及失败运行的 `retrieval` 诊断 |
 
-并发上限默认为 2（通过 `API_MAX_CONCURRENT` 调整）——真正的瓶颈是上游 API 限速而非本机 CPU。
-超过 30 分钟的运行会被自动终止。
+共享付费操作并发上限默认为 2（通过 `API_MAX_CONCURRENT` 调整），完整运行与 PDF 在线提取共用这组槽位——真正的瓶颈是上游 Provider 容量而非本机 CPU。超过 30 分钟的运行会被自动终止；PDF 提取无论成功或失败都会释放槽位。
 
 网页客户端与 JSON API 共享同一个 `outputs/` 目录、启动同一个 worker，因此从任一入口发起的运行在另一侧都可见。
 
@@ -1141,18 +1146,18 @@ CI 每次提交都会构建镜像并断言 PID 1 是 tini、容器非 root 运�
 
 ### 公网部署
 
-只要 `/api/runs` 能被公网访问到，任何人都能触发真实计费的调用——一次运行会调六次 LLM，再加几十次检索 API。如果只是把链接发给特定的少数人看（比如给面试官看这个项目），而不是面向公众开放，`.env` 里两个开关就能把这个口子堵上，不用做一整套登录系统：
+`/api/runs` 与 `/api/papers` 都可能触发真实计费：完整流水线会调用六次 LLM 与检索 API，PDF 核心贡献提取则会在线调用一次 LLM。如果只把链接发给少数面试官或评审，而不是公开运营，`.env` 里的两个开关可以同时封住这两条路径：
 
 ```bash
-ACCESS_CODE=换成一串足够长的随机字符串     # 拦截所有 /api/ 路由
-API_DAILY_RUN_CAP=3                       # 硬上限，万一口令泄漏出去兜底
+ACCESS_CODE=换成一串足够长的随机字符串          # 拦截所有 /api/ 路由
+API_DAILY_PAID_OPERATION_CAP=3                  # 每个口令的付费操作额度
 ```
 
-`ACCESS_CODE`（或下面的 `ACCESS_CODES`）由 `api/main.py` 里的中间件校验请求头 `X-Access-Code`；网页客户端只在第一次访问时弹窗询问，之后记在 `localStorage` 里不用重复输入。`/health` 不受影响——云平台的健康检查不会带请求头，这个接口本身也不花钱。两个都不设置（默认）时门禁完全不生效，本地开发和之前没有任何区别。
+`ACCESS_CODE`（或下面的 `ACCESS_CODES`）由 `api/main.py` 中间件校验请求头 `X-Access-Code`；网页只在首次访问时询问并记入 `localStorage`。`/health` 仍对云平台探针开放。所有口令设置都留空（默认）时，门禁完全不生效，本地开发不受影响。
 
-`API_DAILY_RUN_CAP` 是第二道独立防线：并发上限只管同时跑几个，管不住口令泄漏后被人在一天内前后接力刷上百次；这个直接卡总数，与节奏无关。**按每个口令各自计数**，不是所有口令共用一个池子——不然一个人测得起劲，会把其他持有不同口令的人当天的额度全部用光。默认 0 表示不限制。
+`API_DAILY_PAID_OPERATION_CAP` 是独立的**单进程账单保险丝**：完整评估和 PDF 提取各消耗一个由部署方付费的单位，因此“上传论文再运行”会消耗两个。额度按每个已验证口令分别计算（包括管理员口令）；BYOK 因访客自行付费而豁免。0 表示关闭。旧变量 `API_DAILY_RUN_CAP` 在新变量未设置时仍作为兼容回退。这个账本保存在内存中，因此 UTC 零点或进程重启都会清零；要支持多副本持久计数，需要外部存储。
 
-**这个值要对着检索额度定，而不是对着 LLM 账单定。** 实测 30 次运行：单次运行消耗的网页检索**中位数是 9 次**（区间 5–15），远少于它构造出来的约 22 条 query——因为某个域凑够来源后会提前终止，而且学术检索走的是 OpenAlex/PubMed/arXiv，不消耗检索 API 额度。所以 Tavily 每月 1000 次的免费额度，换算下来是**所有口令加起来**约 110 次运行。另外注意这个上限是按口令算的，它兜住的是"单个口令泄漏能造成多大损失"，不是"所有口令加起来最多花多少"。
+这个值应按 **LLM 与检索预算中更严格的一项**确定。30 次实测中，完整评估的网页检索中位数为 9 次（区间 5–15）；PDF 提取增加一次 LLM 调用，但不使用搜索 API。Tavily 每月 1000 次免费额度约对应所有口令合计 110 次完整运行；每口令上限兜住的是单个泄漏凭证，而不是所有口令的总花费。
 
 **链接公开之前还值得打开的两个设置**，两个都默认关闭，本地使用不受影响：
 
@@ -1161,7 +1166,7 @@ API_RATE_LIMIT_PER_MINUTE=300   # 每个客户端每分钟请求数
 RUN_RETENTION_DAYS=30           # N 天后自动删除已完成的运行
 ```
 
-请求限流计的是**请求数**，上面两个上限计的都是**运行数**——这不是一回事。之所以需要，恰恰是因为不需要口令就能到达的接口最便宜：`run_id` 是能力 URL，持有者可以随意轮询；门禁校验接口本身也必须开放（拒绝错误口令正是它的用途）。有口令时按口令计额度、否则按地址计，这样同一个校园或公司出口 IP 后面的多个人不会被当成一个客户端限流。`/health` 豁免——被限流的健康检查会被平台读成服务已宕机。
+请求限流计的是 **HTTP 请求数**，上面的容量与每日上限计的是**付费操作**。能力 URL 无需口令即可轮询，所以便宜接口同样需要边界。只有校验成功的访问口令才拥有独立桶；其他请求按 ASGI 服务器解析出的对端地址计数。应用层刻意不直接信任原始 `X-Forwarded-For`，也不会让任意错误口令生成新桶；可信代理应在 Uvicorn/部署层配置。`/health` 豁免，否则限流会被平台误判为宕机。
 
 保留期之所以重要，**正是因为运行链接可以分享**：读取一个运行只需要 id，所以分享出去的链接活多久，取决于那次运行活多久；而一个上传了未发表论文的访客，会把论文内容、提取出的核心贡献、以及据此写成的评估长期留在你的服务器上。计龄用的是 run_id 自带的时间戳而不是目录 mtime，这样首次下载时渲染 PDF 不会给"正在被人打开的运行"偷偷续期；正在执行的运行永不删除。`/health` 会上报保留窗口、前端会显示——没被告知的删除读起来是数据丢失，不是策略。
 
@@ -1173,11 +1178,11 @@ token 是测出来的，成本不是：它需要一份本程序无法验证的�
 
 **可选的 Agent 链路追踪。** 项目现在可以显式启用 OpenTelemetry/OpenInference：一次运行会把来源采集、六个 CrewAI 任务、模型 Provider SDK 调用和运行后质量检查串成同一条脱敏 Trace，Phoenix 只是可替换的 OTLP 后端。`outputs/<run_id>/` 中的文件仍是事实来源；Collector 不可用只会把可观测性标成 `degraded`，不会让已经付费的报告失败。Trace 不增加 LLM/检索调用，也不上传作为能力令牌的完整 run id、原始话题、Prompt 或模型输出；两个运行接口都会返回同一个 `trace_id` 及 disabled/active/degraded 状态。配置与数据边界见 [Agent observability](docs/observability.md)。
 
-`API_BYOK_MAX_CONCURRENT` 限制自带 Key 的访客最多能同时占用几个并发槽位，默认比 `API_MAX_CONCURRENT` 少一个。自带 Key 的运行不计入每日额度（token 由访客自己付），而正是这个豁免让匿名流量——包括那些因为 Key 填错、几秒就失败的提交——可以占满全部槽位，把持有口令的人挡在外面。
+`API_BYOK_MAX_CONCURRENT` 限制 BYOK 流量在完整运行与 PDF 提取之间合计最多占用多少共享槽位，默认比 `API_MAX_CONCURRENT` 少一个。BYOK 不计每日账单额度，因为 token 由访客支付；但它仍消耗有限的主机与 Provider 容量，因此错误 Key 等匿名请求也不能占满所有槽位、挡住口令持有者。
 
 **给每个人发不同的口令：** `ACCESS_CODES` 接受逗号分隔的多个值，而不是一个共用口令——`ACCESS_CODES=给alice的口令,给bob的口令`。每个口令的运行历史都只属于它自己：持有"给alice的口令"的人，侧栏永远只看得到用这个口令跑过的记录，看不到"给bob的口令"跑过的。这只是运行时打的一个标记（口令的哈希值，写进每次运行的目录里），不是给每个人单独跑一套部署——还是一个进程、一个 `outputs/` 目录，口令只是决定 `GET /api/runs` 返回哪些。`ACCESS_CODE`（单数）还是照常可用，对应原来那种所有人共用一个口令的设置；两者可以同时设置。
 
-**第二个开放入口：** `POST /api/runs` 的请求体里也可以带 `llm_provider` / `llm_api_key` / `serper_api_key`，作为任意访问口令的替代——用访客自己的 Key，花费算在他们自己头上，不算在部署方头上。这条路不需要额外的服务端配置：只要配置了口令，网页客户端就会在门禁弹窗里自动多出这个选项；不设口令时它也不会出现，因为没有什么需要绕过。密钥直接进入这一次运行的子进程环境变量——不落盘、不并入服务端自身的环境——所以无论是不是 BYOK，并发的运行之间互相看不到对方的密钥。BYOK 提交的运行不会被打上任何口令标记，所以服务端不会把它记进任何一个口令的历史里；网页客户端转而在 `sessionStorage` 里维护一份访客自己这次会话提交过的运行列表，让侧栏依然能显示自己提交过什么——标签页一关就消失，标签页开着的时候完整可见。
+**第二个开放入口：** `POST /api/runs` 的请求体里也可以带 `llm_provider` / `llm_api_key` / `serper_api_key`，作为任意访问口令的替代——用访客自己的 Key，花费算在他们自己头上，不算在部署方头上。这条路不需要额外的服务端配置：只要配置了口令，网页客户端就会在门禁弹窗里自动多出这个选项；不设口令时它也不会出现，因为没有什么需要绕过。密钥直接进入这一次运行的子进程环境变量——不落盘、不并入服务端自身的环境——所以无论是不是 BYOK，并发的运行之间互相看不到对方的密钥。BYOK 提交的运行不会被打上任何口令标记，所以服务端不会把它记进任何一个口令的历史里；网页客户端转而在 `sessionStorage` 里维护一份访客自己这次会话提交过的运行列表，让侧栏依然能显示自己提交过什么——标签页一关就消失，标签页开着的时候完整可见。`POST /api/papers` 同样接受 BYOK 的 LLM provider/key（提取不需要搜索 Key）；PDF 提取与完整运行都会在调用 Provider 前进入同一付费操作准入边界。
 
 `GET /api/runs`（运行历史列表）无论如何都始终留在口令后面——开放的话会把每个访客的话题暴露给所有其他访客。按 `run_id` 读取或取消某一次具体的运行则不需要口令——`run_id` 本身带 128 位随机性，用的是和"分享一份已完成报告的链接"同一套能力令牌信任模型。
 
@@ -1317,7 +1322,7 @@ academic_agent/
 - **HTTP API**：FastAPI + Uvicorn（OpenAPI 文档位于 `/docs`）
 - **PDF 导出**：reportlab Platypus（嵌入式 TTFont，支持 CJK；回退至 CID 字体）
 - **容器化**：Docker 多阶段构建（依赖层与源码层分离缓存），`tini` 作 PID 1 回收子进程，非 root 运行，构建期 CJK 字体校验
-- **访问控制**：可选的共享口令中间件（`ACCESS_CODE`）+ 每日运行次数熔断，用于对外发布演示链接而不暴露一张空白账单；旁边还留了一条开放的"自带 Key"通道，没有口令的访客也能用自己的 Key 跑起来
+- **付费操作边界**：已验证口令门禁、运行/PDF 提取共享并发、按口令每日账单熔断、启动失败额度回滚，以及独立限额的 BYOK 通道
 - **Python**：3.11+
 
 URL/DOI 无效或不可达、引用编号错误、References 不一致、报告结构错误、幻觉来源 ID 和评分 JSON 格式错误都会阻止任务并触发重试。

--- a/api/main.py
+++ b/api/main.py
@@ -33,7 +33,10 @@ from fastapi.staticfiles import StaticFiles
 load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 from academic_agent.llm_config import _detect_provider  # noqa: E402
-from academic_agent.pdf_extractor import extract_paper_contribution  # noqa: E402
+from academic_agent.pdf_extractor import (  # noqa: E402
+    PaperContribution,
+    extract_paper_contribution,
+)
 from api import access, papers, runs  # noqa: E402  — must follow load_dotenv
 from api.models import (  # noqa: E402
     HealthStatus,
@@ -130,9 +133,9 @@ _SECURITY_HEADERS = {
 
 # Per-client request budget, refilled continuously (token bucket).
 #
-# Distinct from the concurrency cap and the daily run cap, which both count
-# *runs*: this counts *requests*, and exists because the endpoints that cost
-# nothing to serve are the ones an unauthenticated caller can reach. A run id
+# Distinct from the paid-operation concurrency and daily caps: this counts
+# *requests*, and exists because the endpoints that cost nothing to serve are
+# the ones an unauthenticated caller can reach. A run id
 # is a capability URL, so anyone holding one can poll a run as fast as they
 # like; the gate itself (/api/access/check) is likewise open by construction,
 # since rejecting a wrong code is what it is for. Neither is expensive per
@@ -152,20 +155,17 @@ _rate_lock = threading.Lock()
 def _client_key(request: Request) -> str:
     """Who to charge for this request.
 
-    Prefers the access code over the address: several people behind one
-    campus or corporate NAT share an IP, and throttling them as one client
-    would penalise the exact audience this deployment is for. A code holder
-    is charged individually; everyone else falls back to the peer address.
+    A *validated* access code gets its own bucket so people behind one campus
+    NAT do not throttle each other. Arbitrary header text must never become an
+    identity: changing an invalid code would otherwise mint a fresh bucket.
 
-    X-Forwarded-For is read because the app sits behind Railway's proxy, and
-    only its first entry — the rest are appendable by the caller.
+    The address comes from request.client, after any trusted-proxy handling by
+    the ASGI server. Reading X-Forwarded-For again here would bypass that trust
+    decision and let a direct caller choose a new address on every request.
     """
-    code = request.headers.get("x-access-code")
-    if code:
-        return f"code:{access.owner_id(code)}"
-    forwarded = request.headers.get("x-forwarded-for", "")
-    if forwarded:
-        return f"ip:{forwarded.split(',')[0].strip()}"
+    matched = access.matching_code(request.headers.get("x-access-code"))
+    if matched:
+        return f"code:{access.owner_id(matched)}"
     return f"ip:{request.client.host if request.client else 'unknown'}"
 
 
@@ -341,7 +341,7 @@ if _WEB_ROOT.is_dir():
 
 @app.get("/health", response_model=HealthStatus, tags=["meta"])
 def health() -> HealthStatus:
-    """Liveness check, current capacity, and the resolved LLM provider.
+    """Liveness, shared paid-operation capacity, and resolved LLM provider.
 
     `llm_provider` is null when no key is configured — a run submitted in that
     state will start but fail inside the worker, so check this first.
@@ -354,9 +354,18 @@ def health() -> HealthStatus:
     except RuntimeError:
         provider = None
 
+    # One locked snapshot prevents a worker finishing between two reads from
+    # producing the impossible-looking state
+    # active_paid_operations < active_runs.
+    active_runs, active_paid_operations = runs.capacity_counts()
     return HealthStatus(
         status="ok",
-        active_runs=runs.active_count(),
+        # Keep active_runs for clients and operators that specifically care
+        # about subprocesses. Capacity indicators must use the broader value:
+        # an inline PDF extraction holds the same slot even though it has no
+        # run id and never appears in the worker registry.
+        active_runs=active_runs,
+        active_paid_operations=active_paid_operations,
         max_concurrent=runs.MAX_CONCURRENT,
         retention_days=runs.RUN_RETENTION_DAYS,
         llm_provider=provider,
@@ -442,7 +451,7 @@ def health_ready(response: Response) -> ReadinessStatus:
     tags=["runs"],
     responses={
         401: {"description": "Neither the access code nor complete bring-your-own-key credentials were provided"},
-        429: {"description": "Concurrency limit or daily run cap reached"},
+        429: {"description": "Concurrency or daily paid-operation limit reached"},
     },
 )
 def submit_run(request: RunRequest, http_request: Request) -> RunAccepted:
@@ -493,12 +502,12 @@ def submit_run(request: RunRequest, http_request: Request) -> RunAccepted:
     except runs.ConcurrencyLimitReached as exc:
         raise HTTPException(
             status_code=429,
-            detail=f"{exc}. Retry once a run finishes.",
+            detail=f"{exc}. Retry once another paid operation finishes.",
         ) from exc
     except runs.DailyCapReached as exc:
         raise HTTPException(
             status_code=429,
-            detail=f"{exc}. The daily run budget resets at 00:00 UTC.",
+            detail=f"{exc}. The daily paid-operation budget resets at 00:00 UTC.",
         ) from exc
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Failed to start worker: {exc}") from exc
@@ -689,12 +698,36 @@ async def _read_capped(file: UploadFile, limit: int) -> bytes:
     return b"".join(chunks)
 
 
+def _extract_paper_with_paid_reservation(
+    pdf_path: str,
+    *,
+    owner: str | None,
+    byok: bool,
+    llm_provider: str | None,
+    llm_api_key: str | None,
+) -> PaperContribution:
+    """Extract while the actual worker thread owns the paid-operation slot.
+
+    asyncio cancellation stops awaiting ``to_thread`` but cannot stop its
+    underlying thread. Keeping the reservation in the request coroutine would
+    therefore publish a free slot while the provider call was still running.
+    The worker thread instead releases it only when extraction really exits.
+    """
+    with runs.reserve_inline_paid_operation(owner=owner, byok=byok):
+        return extract_paper_contribution(
+            pdf_path,
+            llm_provider=llm_provider if byok else None,
+            llm_api_key=llm_api_key if byok else None,
+        )
+
+
 @app.post(
     "/api/papers",
     response_model=PaperExtraction,
     tags=["papers"],
     responses={
         413: {"description": "File exceeds the size limit"},
+        429: {"description": "Concurrency or daily paid-operation limit reached"},
         422: {"description": "PDF could not be parsed into a contribution"},
     },
 )
@@ -727,6 +760,7 @@ async def upload_paper(
             status_code=401,
             detail="Provide the access code, or your own llm_provider/llm_api_key.",
         )
+    owner = access.owner_id(matched) if matched else None
 
     try:
         data = await _read_capped(file, papers.MAX_UPLOAD_BYTES)
@@ -741,10 +775,25 @@ async def upload_paper(
 
     try:
         contribution = await asyncio.to_thread(
-            extract_paper_contribution, str(pdf_path),
-            llm_provider=llm_provider if byok else None,
-            llm_api_key=llm_api_key if byok else None,
+            _extract_paper_with_paid_reservation,
+            str(pdf_path),
+            owner=owner,
+            byok=byok,
+            llm_provider=llm_provider,
+            llm_api_key=llm_api_key,
         )
+    except runs.ConcurrencyLimitReached as exc:
+        papers.discard(paper_id)
+        raise HTTPException(
+            status_code=429,
+            detail=f"{exc}. Retry once another paid operation finishes.",
+        ) from exc
+    except runs.DailyCapReached as exc:
+        papers.discard(paper_id)
+        raise HTTPException(
+            status_code=429,
+            detail=f"{exc}. The daily paid-operation budget resets at 00:00 UTC.",
+        ) from exc
     except Exception as exc:  # noqa: BLE001 - surface the reason to the client
         # The upload is unreachable from here on — no paper_id reaches the
         # client, so no run can name it — and it is somebody's unpublished

--- a/api/models.py
+++ b/api/models.py
@@ -277,7 +277,15 @@ class RunList(BaseModel):
 
 class HealthStatus(BaseModel):
     status: Literal["ok"]
-    active_runs: int
+    active_runs: int = Field(
+        description="Worker subprocesses currently running. Kept separately "
+                    "from active_paid_operations for API compatibility and "
+                    "run-specific operational diagnostics.",
+    )
+    active_paid_operations: int = Field(
+        description="All operations occupying the shared paid-provider/host "
+                    "capacity: worker runs plus inline PDF extraction.",
+    )
     max_concurrent: int
     retention_days: int = Field(
         default=0,

--- a/api/runs.py
+++ b/api/runs.py
@@ -14,6 +14,8 @@ the same run through files without sharing process memory.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import json
 import os
 import re
@@ -23,7 +25,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 from academic_agent.run_output import DEFAULT_OUTPUT_ROOT, create_run_id
@@ -32,17 +34,16 @@ from academic_agent.run_output import DEFAULT_OUTPUT_ROOT, create_run_id
 # not to whichever client submitted or polls the run.
 TIMEOUT_SECONDS = 1800
 
-# Concurrent workers. The real ceiling is upstream API rate limits, not local
-# CPU — each run issues dozens of requests to OpenAlex/Serper/the LLM.
+# Concurrent paid operations, not merely worker processes. A full assessment
+# occupies a subprocess; PDF contribution extraction calls the same upstream
+# LLM inline, so both paths draw from this one host/provider ceiling.
 MAX_CONCURRENT = int(os.getenv("API_MAX_CONCURRENT", "2"))
 
-# How many of those slots visitors bringing their own key may hold at once.
-# They are exempt from the daily cap because they pay for their own tokens,
-# which left them free to occupy every slot — and a submission whose key is
-# wrong still holds one while it fails. So the people the deployment exists
-# for, the ones handed an access code, could be shut out by anonymous traffic
-# that costs the operator nothing. Defaults to leaving one slot that only a
-# code holder can take.
+# How many paid-operation slots visitors bringing their own key may hold at
+# once, across worker runs and inline PDF extraction. They are exempt from the
+# daily wallet cap because they pay for their own tokens, but not from finite
+# host/provider capacity. Defaults to leaving one slot that only an
+# access-code holder can take.
 _BYOK_MAX_CONCURRENT_ENV = os.getenv("API_BYOK_MAX_CONCURRENT")
 BYOK_MAX_CONCURRENT: int | None = (
     int(_BYOK_MAX_CONCURRENT_ENV) if _BYOK_MAX_CONCURRENT_ENV else None
@@ -63,13 +64,18 @@ def byok_limit() -> int:
         return BYOK_MAX_CONCURRENT
     return max(1, MAX_CONCURRENT - 1)
 
-# Runs allowed per UTC day, independent of concurrency — applied separately
-# to each access code (see _daily_counts), not as one total every code
-# shares. The concurrency cap limits how many runs are billed at once; it
-# does nothing to stop one leaked code from triggering hundreds of runs
-# sequentially over a day. 0 disables the cap — the default for local
-# development.
-DAILY_CAP = int(os.getenv("API_DAILY_RUN_CAP", "0"))
+# Operator-funded paid operations admitted per UTC day, applied separately to
+# each access code. Both a full run and PDF contribution extraction reach a
+# paid provider, so counting only runs left an unmetered endpoint beside the
+# cap. BYOK operations remain exempt because the visitor pays.
+#
+# API_DAILY_RUN_CAP is retained as a deployment-compatible fallback. The new
+# name describes the boundary accurately; existing Railway environments do
+# not have to change atomically with this release. 0 disables the cap.
+_DAILY_CAP_ENV = os.getenv("API_DAILY_PAID_OPERATION_CAP")
+if _DAILY_CAP_ENV is None:
+    _DAILY_CAP_ENV = os.getenv("API_DAILY_RUN_CAP", "0")
+DAILY_CAP = int(_DAILY_CAP_ENV)
 
 # Days a finished run is kept before it is deleted automatically. 0 (the
 # default) keeps runs forever, which is right for local development where the
@@ -246,7 +252,7 @@ class ConcurrencyLimitReached(Exception):
 
 
 class DailyCapReached(Exception):
-    """Raised when the day's run budget is exhausted."""
+    """Raised when the day's operator-funded paid-operation budget is exhausted."""
 
 
 class RunNotFound(Exception):
@@ -259,24 +265,23 @@ class RunStillActive(Exception):
 
 _registry: dict[str, _Handle] = {}
 
-# Runs started so far today (UTC), per owner, and the date the counts apply
-# to — reset lazily on the next start_run call rather than with a scheduled
-# task. Keyed by owner (None = no code configured / BYOK is exempt before
-# this is ever consulted) so the cap is a per-person budget, not one pool
-# every code holder draws from: ten people sharing a single DAILY_CAP meant
-# one enthusiastic tester could exhaust everyone else's day, which defeats
-# the point of giving each person their own code in the first place.
-_daily_counts: dict[str | None, int] = {}
-_daily_date = None
+# Inline paid operations live in the API process rather than a subprocess, so
+# they cannot be represented by _Handle without making cancellation, polling
+# and run history lie. The opaque token exists only for the duration of the
+# context manager; the bool records whether it consumes the BYOK share.
+_inline_paid_operations: dict[object, bool] = {}
 
-# Guards _registry. FastAPI runs `def` endpoints in a thread pool, so two
-# submissions genuinely execute in parallel — the cap was checked and written
-# without any lock, and the gap between them spans a mkdir and a Popen. Six
-# concurrent submissions against a cap of 2 all started. Each run is a
-# six-agent LLM pipeline, so exceeding the cap costs real money and pushes
-# concurrent retrieval into upstream rate limits.
-#
-# Reentrant because start_run calls active_count while holding it.
+# Operator-funded paid operations admitted so far today (UTC), per owner, and
+# the date the counts apply. Reset lazily on the next admission rather than by
+# a scheduled task. Keyed by owner so ten separate access codes do not exhaust
+# one shared pool. BYOK is exempt before this counter is consulted.
+_daily_counts: dict[str | None, int] = {}
+_daily_date: date | None = None
+
+# Guards the worker registry, inline reservations, and daily accounting as one
+# admission decision. FastAPI executes sync endpoints in a thread pool and PDF
+# extraction in asyncio.to_thread, so check-and-reserve must be atomic across
+# both paths. Reentrant because admission reaps finished worker handles.
 _registry_lock = threading.RLock()
 
 
@@ -299,6 +304,109 @@ def active_byok_count() -> int:
     active_count()
     with _registry_lock:
         return sum(1 for h in _registry.values() if h.byok)
+
+
+def _active_paid_operation_count_locked() -> int:
+    """Live worker runs plus inline LLM calls; caller holds _registry_lock."""
+    return active_count() + len(_inline_paid_operations)
+
+
+def _active_byok_paid_operation_count_locked() -> int:
+    """The BYOK share across both execution paths; caller holds the lock."""
+    return active_byok_count() + sum(_inline_paid_operations.values())
+
+
+def capacity_counts() -> tuple[int, int]:
+    """Atomic (worker runs, all paid operations) capacity snapshot."""
+    with _registry_lock:
+        active_runs = active_count()
+        return active_runs, active_runs + len(_inline_paid_operations)
+
+
+def active_paid_operation_count() -> int:
+    """Current worker runs plus inline provider calls sharing the host cap."""
+    return capacity_counts()[1]
+
+
+def _daily_window_locked() -> date:
+    """Reset the per-owner ledger at UTC midnight; caller holds the lock."""
+    global _daily_date
+    today = datetime.now(UTC).date()
+    if _daily_date != today:
+        _daily_date = today
+        _daily_counts.clear()
+    return today
+
+
+def _admit_paid_operation_locked(*, owner: str | None, byok: bool) -> date | None:
+    """Check every limit and charge one operation atomically.
+
+    The returned date identifies an operator-funded charge that can be
+    refunded only if a worker process fails to launch. Once an inline
+    extraction begins, an exception cannot prove that the provider was never
+    reached, so that attempt remains charged even though its concurrency slot
+    is always released.
+    """
+    charged_on: date | None = None
+    if not byok:
+        charged_on = _daily_window_locked()
+        owner_count = _daily_counts.get(owner, 0)
+        if DAILY_CAP and owner_count >= DAILY_CAP:
+            raise DailyCapReached(
+                f"Daily limit reached: {DAILY_CAP} operator-funded paid "
+                "operations already admitted today"
+            )
+
+    active = _active_paid_operation_count_locked()
+    if active >= MAX_CONCURRENT:
+        raise ConcurrencyLimitReached(
+            f"{active} of {MAX_CONCURRENT} concurrent paid operations in use"
+        )
+
+    if byok:
+        active_byok = _active_byok_paid_operation_count_locked()
+        if active_byok >= byok_limit():
+            raise ConcurrencyLimitReached(
+                f"{active_byok} of {byok_limit()} concurrent bring-your-own-key "
+                "paid operations in use; the remaining capacity is reserved "
+                "for access-code holders"
+            )
+
+    if charged_on is not None:
+        _daily_counts[owner] = _daily_counts.get(owner, 0) + 1
+    return charged_on
+
+
+def _refund_daily_charge_locked(owner: str | None, charged_on: date | None) -> None:
+    """Refund a pre-provider launch failure without touching a new UTC day."""
+    if charged_on is None or _daily_date != charged_on:
+        return
+    remaining = _daily_counts.get(owner, 0)
+    if remaining <= 1:
+        _daily_counts.pop(owner, None)
+    else:
+        _daily_counts[owner] = remaining - 1
+
+
+@contextmanager
+def reserve_inline_paid_operation(
+    *, owner: str | None, byok: bool
+) -> Iterator[None]:
+    """Reserve one shared slot for an in-process provider call.
+
+    Concurrency is released in finally on success, cancellation, or failure.
+    Daily accounting deliberately is not: after the extractor starts, this
+    layer cannot know whether a failed provider request was billed.
+    """
+    token = object()
+    with _registry_lock:
+        _admit_paid_operation_locked(owner=owner, byok=byok)
+        _inline_paid_operations[token] = byok
+    try:
+        yield
+    finally:
+        with _registry_lock:
+            _inline_paid_operations.pop(token, None)
 
 
 def run_dir_for(run_id: str) -> Path:
@@ -344,45 +452,24 @@ def start_run(
     so list_runs() can show each code holder only the runs made under their
     own code.
     """
-    # Claim a slot and publish the run_id in one atomic step. Checking the cap
-    # and registering the handle separately let parallel submissions all pass
-    # the check before any of them registered.
-    #
-    # The slot is reserved with a placeholder handle so the subprocess launch —
-    # the slow part — happens outside the lock. A reservation counts towards
-    # the cap, so a burst cannot slip through while processes are starting.
+    # Claim the wallet budget and the shared provider/host slot in one atomic
+    # step. The placeholder remains visible while the slow filesystem and
+    # subprocess launch happen outside the lock, so a concurrent PDF
+    # extraction cannot slip through the same slot.
+    run_id = create_run_id()
+    charged_on: date | None = None
     with _registry_lock:
-        global _daily_date
-        if byok is None:
-            today = datetime.now(UTC).date()
-            if _daily_date != today:
-                _daily_date = today
-                _daily_counts.clear()
-            owner_count = _daily_counts.get(owner, 0)
-            if DAILY_CAP and owner_count >= DAILY_CAP:
-                raise DailyCapReached(f"{DAILY_CAP} runs already used today")
-
-        if active_count() >= MAX_CONCURRENT:
-            raise ConcurrencyLimitReached(
-                f"{active_count()} of {MAX_CONCURRENT} concurrent runs in use"
-            )
-        # Checked after the global cap, not instead of it: a code holder is
-        # still bounded by MAX_CONCURRENT, and only BYOK runs are bounded
-        # twice. The message names the BYOK limit specifically so a visitor
-        # is not told the service is busy when the deployment is idle.
-        if byok is not None and active_byok_count() >= byok_limit():
-            raise ConcurrencyLimitReached(
-                f"{active_byok_count()} of {byok_limit()} concurrent "
-                "bring-your-own-key runs in use; the remaining capacity is "
-                "reserved for access-code holders"
-            )
-        run_id = create_run_id()
-        if byok is None:
-            _daily_counts[owner] = _daily_counts.get(owner, 0) + 1
-        _registry[run_id] = _Handle(
-            run_id=run_id, topic=topic, proc=_PendingProcess(), log_file=None,
-            byok=byok is not None,
+        charged_on = _admit_paid_operation_locked(
+            owner=owner, byok=byok is not None
         )
+        try:
+            _registry[run_id] = _Handle(
+                run_id=run_id, topic=topic, proc=_PendingProcess(), log_file=None,
+                byok=byok is not None,
+            )
+        except BaseException:
+            _refund_daily_charge_locked(owner, charged_on)
+            raise
 
     run_dir = run_dir_for(run_id)
 
@@ -420,6 +507,10 @@ def start_run(
     except BaseException:
         with _registry_lock:
             _registry.pop(run_id, None)
+            # No worker exists, so no LLM/search provider could have been
+            # reached. Unlike a failed running worker, this attempt is safe
+            # to refund rather than silently consuming the user's day.
+            _refund_daily_charge_locked(owner, charged_on)
         raise
 
     with _registry_lock:

--- a/tests/test_access_gate.py
+++ b/tests/test_access_gate.py
@@ -1,29 +1,33 @@
-"""Tests for the public-deployment access gate and daily run cap.
+"""Tests for the public-deployment access gate and paid-operation caps.
 
 Both exist for the same reason: an interviewer-facing demo link is public
 enough that anyone who finds it could trigger LLM and Serper calls billed to
 the project owner. The gate (api/access.py + the middleware in api/main.py)
-keeps an anonymous visitor out entirely; the daily cap (api/runs.py) is the
-fallback if a shared code ever leaks. Neither exists, and neither test
-matters, once ACCESS_CODE is unset — which is the default, so local
-development and every prior test in this suite see no gate at all.
+keeps an anonymous visitor out entirely; the concurrency and daily caps
+(api/runs.py) bound both full runs and inline PDF extraction if a shared code
+ever leaks. Neither exists, and neither test matters, once ACCESS_CODE is
+unset — which is the default, so local development and every prior test in
+this suite see no gate at all.
 """
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import os
+import threading
 from datetime import date, timedelta
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from fastapi import Request, UploadFile
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
-from api import access, runs
+from api import access, papers, runs
 from api.main import app
 from api.models import RunRequest
 
@@ -255,7 +259,9 @@ class _RunLifecycleTestBase(unittest.TestCase):
     real subprocess or touching the real outputs/ directory."""
 
     def setUp(self):
+        # Both registries are one capacity boundary and must be isolated alike.
         runs._registry.clear()
+        runs._inline_paid_operations.clear()
         self._tmp = TemporaryDirectory()
         # Order matters: open process.log handles must close before the
         # directory holding them is removed — Windows refuses to unlink a
@@ -274,6 +280,7 @@ class _RunLifecycleTestBase(unittest.TestCase):
                 except OSError:
                     pass
         runs._registry.clear()
+        runs._inline_paid_operations.clear()
 
 
 class BYOKSubprocessEnvTests(_RunLifecycleTestBase):
@@ -413,6 +420,255 @@ class DailyCapTests(_RunLifecycleTestBase):
             runs.start_run("owner's run")              # spends the day's only slot
             with self.assertRaises(runs.DailyCapReached):
                 runs.start_run("owner's second run")
+
+    def test_launch_failure_refunds_an_unspent_daily_slot(self):
+        """A failure before Popen succeeds cannot have reached a paid API.
+
+        The concurrency reservation was already rolled back on this path, but
+        the daily charge was not. A transient filesystem or process-launch
+        failure could therefore exhaust a code's entire day without starting
+        a single worker.
+        """
+        with patch.object(runs, "DAILY_CAP", 1), \
+             patch.object(runs, "MAX_CONCURRENT", 100):
+            with patch("api.runs.subprocess.Popen", side_effect=OSError("cannot spawn")):
+                with self.assertRaises(OSError):
+                    runs.start_run("never launched", owner="alice")
+
+            with patch("api.runs.subprocess.Popen", _FakeProc):
+                runs.start_run("first billable attempt", owner="alice")
+
+
+class PaperPaidBoundaryTests(_RunLifecycleTestBase):
+    """PDF extraction and full runs draw from one paid-operation boundary.
+
+    Upload parsing itself is local work. The boundary begins immediately
+    before extraction reaches the LLM, and it must protect both the operator's
+    budget and the finite upstream/host concurrency shared with worker runs.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(setattr, runs, "_daily_counts", dict(runs._daily_counts))
+        self.addCleanup(setattr, runs, "_daily_date", runs._daily_date)
+        runs._daily_counts = {}
+        runs._daily_date = None
+
+        paper_root = Path(self._tmp.name) / "_papers"
+        paper_patcher = patch.object(papers, "PAPERS_ROOT", paper_root)
+        paper_patcher.start()
+        self.addCleanup(paper_patcher.stop)
+        self.client = TestClient(app)
+        self.addCleanup(self.client.close)
+
+    @staticmethod
+    def _contribution():
+        from academic_agent.pdf_extractor import PaperContribution
+
+        return PaperContribution(
+            title="A bounded extraction",
+            core_contribution="x" * 25,
+            application_domain="energy storage",
+            delta_from_prior="y" * 15,
+            commercialization_topic="z" * 15,
+            search_keywords=["a", "b", "c"],
+        )
+
+    def _upload(self, *, code: str | None = None, byok: bool = False):
+        headers = {"X-Access-Code": code} if code else {}
+        data = (
+            {"llm_provider": "deepseek", "llm_api_key": "visitor-key"}
+            if byok else {}
+        )
+        return self.client.post(
+            "/api/papers",
+            headers=headers,
+            data=data,
+            files={"file": ("paper.pdf", b"%PDF-1.4 body", "application/pdf")},
+        )
+
+    def test_operator_pdf_extraction_spends_the_same_daily_budget_as_a_run(self):
+        """The upload endpoint used to make an unmetered server-key LLM call."""
+        with patch.object(access, "ACCESS_CODE", "alice-code"), \
+             patch.object(runs, "DAILY_CAP", 1), \
+             patch.object(runs, "MAX_CONCURRENT", 10), \
+             patch("api.main.extract_paper_contribution", return_value=self._contribution()), \
+             patch("api.runs.subprocess.Popen", _FakeProc):
+            extracted = self._upload(code="alice-code")
+            submitted = self.client.post(
+                "/api/runs",
+                headers={"X-Access-Code": "alice-code"},
+                json={"topic": "a valid research topic"},
+            )
+
+        self.assertEqual(extracted.status_code, 200)
+        self.assertEqual(submitted.status_code, 429)
+        self.assertIn("daily", submitted.json()["detail"].lower())
+
+    def test_active_run_blocks_pdf_before_the_extractor_is_called(self):
+        """The two paid paths must share concurrency, not only a quota name."""
+        with patch.object(access, "ACCESS_CODE", "alice-code"), \
+             patch.object(runs, "DAILY_CAP", 0), \
+             patch.object(runs, "MAX_CONCURRENT", 1), \
+             patch("api.runs.subprocess.Popen", _FakeProc):
+            submitted = self.client.post(
+                "/api/runs",
+                headers={"X-Access-Code": "alice-code"},
+                json={"topic": "a valid research topic"},
+            )
+            with patch(
+                "api.main.extract_paper_contribution",
+                return_value=self._contribution(),
+            ) as extractor:
+                extracted = self._upload(code="alice-code")
+
+        self.assertEqual(submitted.status_code, 202)
+        self.assertEqual(extracted.status_code, 429)
+        extractor.assert_not_called()
+        self.assertFalse(papers.PAPERS_ROOT.exists() and any(papers.PAPERS_ROOT.iterdir()))
+
+    def test_inline_reservation_blocks_a_run_and_reaches_the_health_payload(self):
+        """The shared slot must work in both directions and reach the client.
+
+        The inverse seam is already covered above (a run blocks extraction).
+        This proves an inline call blocks run admission and that the health
+        response does not silently report a free slot merely because inline
+        calls do not have run ids.
+        """
+        with patch.object(access, "ACCESS_CODE", "alice-code"), \
+             patch.object(runs, "DAILY_CAP", 0), \
+             patch.object(runs, "MAX_CONCURRENT", 1), \
+             patch("api.runs.subprocess.Popen") as popen:
+            with runs.reserve_inline_paid_operation(owner="alice", byok=False):
+                capacity = self.client.get("/health").json()
+                submitted = self.client.post(
+                    "/api/runs",
+                    headers={"X-Access-Code": "alice-code"},
+                    json={"topic": "a valid research topic"},
+                )
+
+        self.assertEqual(capacity["active_runs"], 0)
+        self.assertEqual(capacity["active_paid_operations"], 1)
+        self.assertEqual(submitted.status_code, 429)
+        popen.assert_not_called()
+
+    def test_failed_extraction_releases_its_shared_concurrency_slot(self):
+        """A provider failure may spend budget but must never leak capacity.
+
+        DAILY_CAP is disabled here on purpose: once extraction begins the API
+        cannot prove that a failed provider request was unbilled, so the daily
+        admission remains spent. This test isolates the independently safe
+        guarantee that the in-process concurrency reservation is released.
+        """
+        with patch.object(access, "ACCESS_CODE", "alice-code"), \
+             patch.object(runs, "DAILY_CAP", 0), \
+             patch.object(runs, "MAX_CONCURRENT", 1), \
+             patch(
+                 "api.main.extract_paper_contribution",
+                 side_effect=RuntimeError("provider failed after admission"),
+             ), \
+             patch("api.runs.subprocess.Popen", _FakeProc):
+            failed = self._upload(code="alice-code")
+            submitted = self.client.post(
+                "/api/runs",
+                headers={"X-Access-Code": "alice-code"},
+                json={"topic": "a valid research topic"},
+            )
+
+        self.assertEqual(failed.status_code, 422)
+        self.assertEqual(submitted.status_code, 202)
+        self.assertEqual(runs._inline_paid_operations, {})
+
+    def test_cancelled_waiter_keeps_the_slot_until_its_thread_finishes(self):
+        """Cancelling asyncio.to_thread does not stop the provider call.
+
+        The reservation must therefore live inside that thread. Releasing it
+        with the cancelled request task would admit another paid operation
+        while the abandoned extraction was still running upstream.
+        """
+        from api import main
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def blocking_extractor(*_args, **_kwargs):
+            started.set()
+            try:
+                if not release.wait(timeout=2):
+                    raise TimeoutError("test did not release extractor")
+                return self._contribution()
+            finally:
+                finished.set()
+
+        async def exercise_cancellation():
+            request = Request({
+                "type": "http",
+                "method": "POST",
+                "path": "/api/papers",
+                "headers": [],
+                "query_string": b"",
+                "client": ("test", 123),
+                "server": ("test", 80),
+                "scheme": "http",
+                "http_version": "1.1",
+            })
+            upload = UploadFile(
+                file=io.BytesIO(b"%PDF-1.4 body"),
+                filename="paper.pdf",
+            )
+            task = asyncio.create_task(
+                main.upload_paper(
+                    request,
+                    file=upload,
+                    llm_provider="deepseek",
+                    llm_api_key="visitor-key",
+                )
+            )
+            try:
+                self.assertTrue(await asyncio.to_thread(started.wait, 1))
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                self.assertEqual(runs.active_paid_operation_count(), 1)
+            finally:
+                release.set()
+                await upload.close()
+
+            self.assertTrue(await asyncio.to_thread(finished.wait, 1))
+            for _ in range(100):
+                if runs.active_paid_operation_count() == 0:
+                    break
+                await asyncio.sleep(0.001)
+            self.assertEqual(runs.active_paid_operation_count(), 0)
+
+        with patch.object(runs, "DAILY_CAP", 0), \
+             patch.object(runs, "MAX_CONCURRENT", 1), \
+             patch.object(runs, "BYOK_MAX_CONCURRENT", 1), \
+             patch("api.main.extract_paper_contribution", side_effect=blocking_extractor):
+            asyncio.run(exercise_cancellation())
+
+    def test_byok_pdf_is_daily_cap_exempt_but_not_resource_cap_exempt(self):
+        """Who pays changes the wallet limit, never the host/upstream limit."""
+        with patch.object(access, "ACCESS_CODE", "alice-code"), \
+             patch.object(runs, "DAILY_CAP", 1), \
+             patch.object(runs, "MAX_CONCURRENT", 2), \
+             patch.object(runs, "BYOK_MAX_CONCURRENT", 1), \
+             patch("api.runs.subprocess.Popen", _FakeProc), \
+             patch("api.main.extract_paper_contribution", return_value=self._contribution()):
+            byok = runs.BYOKCredentials("deepseek", "visitor-key", "search-key")
+            runs.start_run("visitor run", byok=byok)
+            extracted = self._upload(byok=True)
+
+        self.assertEqual(extracted.status_code, 429)
+
+        # The refused BYOK extraction did not consume the operator's daily
+        # budget. End the synthetic visitor run so only that rule is tested.
+        runs._registry.clear()
+        with patch.object(runs, "DAILY_CAP", 1), \
+             patch.object(runs, "MAX_CONCURRENT", 2), \
+             patch("api.runs.subprocess.Popen", _FakeProc):
+            runs.start_run("operator run", owner="alice")
 
 
 class BYOKSubmissionTests(_RunLifecycleTestBase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,6 +100,7 @@ class HealthTests(_ApiTestCase):
     def test_reports_capacity(self):
         body = self.client.get("/health").json()
         self.assertEqual(body["active_runs"], 0)
+        self.assertEqual(body["active_paid_operations"], 0)
         self.assertEqual(body["max_concurrent"], runs.MAX_CONCURRENT)
 
     # Patched where api.main looks it up, not where it is defined. The
@@ -125,7 +126,9 @@ class HealthTests(_ApiTestCase):
     def test_active_run_counted(self, mock_popen):
         mock_popen.return_value = self._live_proc()
         self.client.post("/api/runs", json={"topic": "counted topic"})
-        self.assertEqual(self.client.get("/health").json()["active_runs"], 1)
+        capacity = self.client.get("/health").json()
+        self.assertEqual(capacity["active_runs"], 1)
+        self.assertEqual(capacity["active_paid_operations"], 1)
 
 
 # ---------------------------------------------------------------------------
@@ -514,8 +517,8 @@ class SecurityHeaderTests(_ApiTestCase):
 
 class RateLimitTests(_ApiTestCase):
     """Bounds request volume, which the concurrency and daily caps do not:
-    those count runs, and the endpoints reachable without a code cost nothing
-    to serve but are unbounded without this."""
+    those count paid operations, while cheap capability polling and access
+    checks remain unbounded without this."""
 
     def setUp(self):
         super().setUp()
@@ -558,6 +561,40 @@ class RateLimitTests(_ApiTestCase):
             fresh = self.client.get("/api/runs", headers={"X-Access-Code": "bob"})
         self.assertEqual(spent.status_code, 429)
         self.assertEqual(fresh.status_code, 200)
+
+    def test_invalid_codes_cannot_mint_fresh_budgets(self):
+        """A caller must not bypass the limiter by changing a wrong code.
+
+        A capability URL deliberately bypasses the access gate, so its request
+        still reaches the limiter with whatever code header the caller chose.
+        The limiter must validate that value before using it as an identity;
+        hashing arbitrary text gives an attacker unlimited fresh buckets.
+        """
+        self.main._RATE_LIMIT_REQUESTS = 1
+        with patch.object(access, "ACCESS_CODE", "the-real-code"):
+            first = self.client.get(
+                "/api/runs/not-a-real-run",
+                headers={"X-Access-Code": "wrong-one"},
+            )
+            second = self.client.get(
+                "/api/runs/not-a-real-run",
+                headers={"X-Access-Code": "wrong-two"},
+            )
+        self.assertEqual(first.status_code, 404)
+        self.assertEqual(second.status_code, 429)
+
+    def test_forwarded_for_is_not_a_client_chosen_bucket(self):
+        """Proxy trust belongs at the server boundary, not in an HTTP header.
+
+        Uvicorn can replace ``request.client`` after validating its trusted
+        proxy configuration. Reading X-Forwarded-For again in application
+        code trusts a value a direct caller can change for every request.
+        """
+        self.main._RATE_LIMIT_REQUESTS = 1
+        first = self.client.get("/api/runs", headers={"X-Forwarded-For": "198.51.100.1"})
+        second = self.client.get("/api/runs", headers={"X-Forwarded-For": "198.51.100.2"})
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 429)
 
     def test_zero_disables_the_limit(self):
         self.main._RATE_LIMIT_REQUESTS = 0

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -519,16 +519,22 @@ document.addEventListener("keydown", (e) => {
 
 async function refreshCapacity() {
   try {
-    const { active_runs, max_concurrent, retention_days } = await api.health();
+    const {
+      active_runs,
+      active_paid_operations = active_runs,
+      max_concurrent,
+      retention_days,
+    } = await api.health();
     const dots = $("#capacity-dots");
     dots.innerHTML = "";
     for (let i = 0; i < max_concurrent; i += 1) {
       const dot = document.createElement("span");
       dot.className = "capacity__dot";
-      dot.dataset.busy = String(i < active_runs);
+      dot.dataset.busy = String(i < active_paid_operations);
       dots.append(dot);
     }
-    $("#capacity-label").textContent = `${active_runs}/${max_concurrent} ${t("running_label")}`;
+    $("#capacity-label").textContent =
+      `${active_paid_operations}/${max_concurrent} ${t("running_label")}`;
     // Someone who uploads an unpublished paper is entitled to know how long it
     // stays here — and a deletion nobody was told about reads as data loss
     // rather than as policy. Shown on the capacity line rather than in a


### PR DESCRIPTION
## Why

PDF contribution extraction invokes a paid LLM and shares the same upstream/host resources as a full assessment, but it previously bypassed the run concurrency and daily-wallet controls. The request limiter also accepted arbitrary code and forwarded-address text as identities, allowing callers to mint fresh buckets.

## What changed

- unify full runs and inline PDF extraction behind one atomic paid-operation admission boundary
- apply per-owner daily accounting to operator-funded extraction while keeping BYOK wallet-exempt and resource-bounded
- refund daily admission only when worker launch proves no provider could have been reached
- keep the PDF reservation inside the actual worker thread so request cancellation cannot release a still-running provider call
- validate access codes before assigning code-specific request buckets and stop parsing raw X-Forwarded-For in application code
- expose atomic active-paid-operation capacity through the health API and web client
- introduce API_DAILY_PAID_OPERATION_CAP while retaining API_DAILY_RUN_CAP as a backward-compatible fallback
- update English/Chinese deployment documentation and configuration guidance

## Verification

- uv run pytest -q: 1181 passed, 545 subtests passed
- uv run --with ruff ruff check .: passed
- CI-specific narrow Pylint invocation: passed
- defect re-injection: replacing the worker-owned reservation with the old abandoned-waiter behavior makes the new cancellation seam test fail as expected
- no live LLM or search calls were made

