### PR TITLE
Add a preregistered agent-topology ablation harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1181 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1203 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -143,7 +143,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  49 Python files, organised by subject under test
+tests/                  50 Python files, organised by subject under test
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 ops_report.py           what real runs actually did, vs what the benchmark covers
 ```

--- a/ablation.py
+++ b/ablation.py
@@ -1,0 +1,713 @@
+"""Run a fixture-only one/four/six-node agent-topology ablation.
+
+The command is plan-only unless ``--execute`` is present. That asymmetry is
+intentional: listing a ninety-cell study should be cheap and safe, while a
+typo must not turn into ninety paid model runs.
+"""
+
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+import traceback
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+from collections.abc import Callable, Sequence
+
+
+import benchmark_fixtures
+from ablation_check import analyse_report, reviewer_correction_count, write_summaries
+from benchmark import TOPICS, _slug
+
+# CrewAI 1.14.7 inspects a guardrail's raw runtime signature without resolving
+# postponed annotations. Enabling ``from __future__ import annotations`` makes
+# ``tuple[bool, Any]`` a string and Task construction rejects an otherwise
+# correct callable. Keep annotations eager in this module until that pinned
+# vendor version changes; the production guardrails rely on the same behaviour.
+
+
+ABLATION_ROOT = Path(__file__).parent / "outputs" / "ablation"
+VARIANTS = ("monolith", "specialists_writer", "full")
+TOPOLOGY_NODES = {"monolith": 1, "specialists_writer": 4, "full": 6}
+DEFAULT_PAUSE_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class ScheduleCell:
+    schedule_index: int
+    block_id: str
+    position: int
+    num: str
+    topic: str
+    expected_trl_range: tuple[int, int]
+    industry: str
+    rep: int
+    variant: str
+
+
+@dataclass
+class GuardrailAttempt:
+    task_name: str
+    passed: bool
+    before_chars: int
+    after_chars: int
+    before_sha256_16: str
+    after_sha256_16: str
+    failure: str
+    # Raw text stays in memory only long enough to calculate first-attempt
+    # report metrics. Persisting every failed completion would duplicate large,
+    # paid artifacts and encourage post-hoc qualitative cherry-picking.
+    raw_before: str
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "task_name": self.task_name,
+            "passed": self.passed,
+            "before_chars": self.before_chars,
+            "after_chars": self.after_chars,
+            "before_sha256_16": self.before_sha256_16,
+            "after_sha256_16": self.after_sha256_16,
+            "failure": self.failure,
+        }
+
+
+class GuardrailRecorder:
+    """Observe the guardrail seam without changing its return value."""
+
+    def __init__(self) -> None:
+        self.attempts: dict[str, list[GuardrailAttempt]] = {}
+
+    def wrap(
+        self,
+        task_name: str,
+        guardrail: Callable[[Any], tuple[bool, Any]],
+    ) -> Callable[[Any], tuple[bool, Any]]:
+        def recorded(output: Any) -> tuple[bool, Any]:
+            before = str(getattr(output, "raw", "") or "")
+            passed, payload = guardrail(output)
+            after = str(getattr(output, "raw", "") or "")
+            attempt = GuardrailAttempt(
+                task_name=task_name,
+                passed=bool(passed),
+                before_chars=len(before),
+                after_chars=len(after),
+                before_sha256_16=_digest(before),
+                after_sha256_16=_digest(after),
+                failure="" if passed else str(payload)[:2_000],
+                raw_before=before,
+            )
+            self.attempts.setdefault(task_name, []).append(attempt)
+            return passed, payload
+
+        return recorded
+
+    def instrument(self, tasks: Sequence[Any]) -> None:
+        for index, task in enumerate(tasks, start=1):
+            guardrail = getattr(task, "guardrail", None)
+            if not callable(guardrail):
+                continue
+            task_name = str(getattr(task, "name", "") or f"task_{index}")
+            task.guardrail = self.wrap(task_name, guardrail)
+
+    def task_summary(self, task_name: str) -> dict[str, Any]:
+        attempts = self.attempts.get(task_name, [])
+        failures = sum(not attempt.passed for attempt in attempts)
+        return {
+            "calls": len(attempts),
+            "failures": failures,
+            # One initial call is not a retry. A failed call that aborts without
+            # another attempt remains a failure but contributes zero retries.
+            "retries": max(0, len(attempts) - 1),
+            "attempts": [attempt.summary() for attempt in attempts],
+        }
+
+    def summaries(self) -> dict[str, dict[str, Any]]:
+        return {name: self.task_summary(name) for name in self.attempts}
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _commit_sha() -> str:
+    """Best-effort provenance; experiment execution must not depend on Git."""
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed executable and arguments
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).parent,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    return completed.stdout.strip() if completed.returncode == 0 else "unknown"
+
+
+def build_schedule(
+    cases: Sequence[tuple[str, str, tuple[int, int], str]],
+    *,
+    repeat: int,
+    variants: Sequence[str] = VARIANTS,
+) -> list[ScheduleCell]:
+    """Deterministic Latin-square order, balanced over 10 x 3 full blocks."""
+
+    if repeat < 1:
+        raise ValueError("repeat must be at least 1")
+    unknown = set(variants) - set(VARIANTS)
+    if unknown:
+        raise ValueError(f"unknown variants: {', '.join(sorted(unknown))}")
+    if len(set(variants)) != len(variants):
+        raise ValueError("variants must not contain duplicates")
+
+    cells: list[ScheduleCell] = []
+    schedule_index = 0
+    for case_index, (num, topic, trl_range, industry) in enumerate(cases):
+        for rep in range(1, repeat + 1):
+            offset = (case_index + rep - 1) % len(variants)
+            ordered = list(variants[offset:]) + list(variants[:offset])
+            block_id = f"{num}-r{rep}"
+            for position, variant in enumerate(ordered, start=1):
+                schedule_index += 1
+                cells.append(ScheduleCell(
+                    schedule_index=schedule_index,
+                    block_id=block_id,
+                    position=position,
+                    num=num,
+                    topic=topic,
+                    expected_trl_range=trl_range,
+                    industry=industry,
+                    rep=rep,
+                    variant=variant,
+                ))
+    return cells
+
+
+def _all_sources(collection: Any) -> list[Any]:
+    return (
+        list(collection.academic_sources)
+        + list(collection.patent_sources)
+        + list(collection.market_sources)
+    )
+
+
+def _localized_headings(collection: Any) -> tuple[str, ...] | None:
+    return tuple(collection.localized_headings) if collection.localized_headings else None
+
+
+def make_monolith_report_guardrail(
+    collection: Any,
+) -> Callable[[Any], tuple[bool, Any]]:
+    """Apply the production report policy directly to the frozen registry.
+
+    Production obtains these sources from Tasks 1-3's validated Pydantic
+    outputs. The monolith has no intermediate tasks, so requiring that route
+    would either add three hidden nodes or silently weaken its guardrail. This
+    adapter changes only how the immutable registry arrives; normalisation and
+    blocking checks delegate to the exact production implementation.
+    """
+
+    from academic_agent.evidence import _normalize_and_find_blocking_errors
+    from crewai.tasks.task_output import TaskOutput
+
+    allowed_sources = {source.source_id: source for source in _all_sources(collection)}
+    headings = _localized_headings(collection)
+
+    def validate(output: TaskOutput) -> tuple[bool, Any]:
+        if not allowed_sources:
+            return False, "No validated evidence sources are available."
+        if len(str(getattr(output, "raw", "") or "").strip()) < 500:
+            return False, "Final report is too short to be usable."
+        normalized, errors = _normalize_and_find_blocking_errors(
+            output.raw,
+            allowed_sources,
+            {},
+            required_headings=headings,
+            output_language=collection.output_language,
+        )
+        output.raw = normalized
+        if errors:
+            return (
+                False,
+                "Final report has blocking validation errors:\n- " + "\n- ".join(errors),
+            )
+        return True, output
+
+    return validate
+
+
+_MONOLITH_DESCRIPTION = """
+Produce a comprehensive commercialization assessment for {display_topic} by
+working directly from all three immutable, code-validated source registries.
+You are the only analysis node: no specialist summaries, reviewer, or scorer
+will run before or after you.
+
+Academic sources: {academic_sources_json}
+Patent sources: {patent_sources_json}
+Patent assignees exposed by retrieval: {patent_assignees_json}
+Market sources: {market_sources_json}
+Queries executed by code:
+- academic: {academic_search_queries_json}
+- patent: {patent_search_queries_json}
+- market: {market_search_queries_json}
+
+LANGUAGE REQUIREMENT: Write the entire report in {output_language}. Use these
+headings exactly and in this order:
+{localized_headings}
+
+Evidence coverage for this run:
+{retrieval_notice}
+
+Evidence and citation rules:
+- Use only facts and figures stated in the registries above.
+- Cite every factual, numerical, patent, company, market, and maturity claim on
+  the same line with source IDs such as [A1], [P2], and [M3].
+- Never invent or alter a title, URL, DOI, applicant, publisher, date, market
+  size, funding amount, customer, patent record, or legal status.
+- Preserve the distinction between observed facts, estimates, and analyst
+  inferences. State evidence gaps instead of filling them with prior knowledge.
+- Treat search snippets as fragments and company disclosures as attributed
+  first-party claims, not independent confirmation.
+- Patent observations are preliminary landscape research, not legal advice or
+  a freedom-to-operate opinion.
+- End with a References section containing each cited validated source exactly
+  once, including its validated URL or DOI. Add no uncited sources.
+"""
+
+_MONOLITH_EXPECTED = """
+A complete Markdown commercialization assessment in {output_language}, using
+the supplied headings in order. Every material claim has an inline validated
+[source_id] citation and every citation resolves exactly once in References.
+Do not include a scorecard or JSON wrapper.
+"""
+
+
+def _max_rpm() -> int:
+    raw = os.getenv("MAX_RPM", "6")
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"MAX_RPM environment variable must be an integer, got {raw!r}") from None
+
+
+def build_variant_crew(
+    variant: str,
+    collection: Any,
+) -> tuple[Any, str]:
+    """Build one treatment while leaving the production control untouched."""
+
+    from academic_agent.crew import AcademicAgent
+    from academic_agent.llm_config import create_llm
+    from crewai import Agent, Crew, Process, Task
+
+    if variant == "monolith":
+        agent = Agent(
+            role="Academic Commercialization Generalist",
+            goal=(
+                "Produce an evidence-bounded investment-facing commercialization "
+                "assessment directly from validated academic, patent, and market sources."
+            ),
+            backstory=(
+                "You combine technology-transfer, patent-landscape, and market-analysis "
+                "skills, but you have no external tools and may use only the supplied registry."
+            ),
+            # Match the production report writer's free-text LLM construction
+            # exactly. Forcing temperature zero here would confound topology
+            # with a model-setting change even though it looks more deterministic.
+            llm=create_llm(),
+            verbose=True,
+            allow_delegation=False,
+        )
+        task = Task(
+            name="monolith_report_task",
+            description=_MONOLITH_DESCRIPTION,
+            expected_output=_MONOLITH_EXPECTED,
+            agent=agent,
+            guardrail=make_monolith_report_guardrail(collection),
+            guardrail_max_retries=1,
+            markdown=True,
+        )
+        return (
+            Crew(
+                agents=[agent],
+                tasks=[task],
+                process=Process.sequential,
+                verbose=True,
+                max_rpm=_max_rpm(),
+            ),
+            "monolith_report_task",
+        )
+
+    production = AcademicAgent(collection).crew()
+    if variant == "full":
+        return production, "commercialization_report_task"
+    if variant == "specialists_writer":
+        # Rebuild only the Crew container. Task and Agent instances are the
+        # production first four, so prompts, context wiring, async specialist
+        # execution, guardrails, and LLM settings are not experiment copies.
+        return (
+            Crew(
+                agents=list(production.agents[:4]),
+                tasks=list(production.tasks[:4]),
+                process=Process.sequential,
+                verbose=True,
+                max_rpm=_max_rpm(),
+            ),
+            "commercialization_report_task",
+        )
+    raise ValueError(f"unknown variant: {variant}")
+
+
+def select_report_outputs(
+    variant: str,
+    task_outputs: Sequence[Any],
+) -> tuple[str | None, str | None]:
+    """Select draft and delivered text at the topology boundary."""
+
+    raw = [str(getattr(output, "raw", "") or "") for output in task_outputs]
+    if variant == "full":
+        draft = raw[3] if len(raw) > 3 else None
+        delivered = raw[4] if len(raw) > 4 else draft
+        return draft, delivered
+    if variant == "specialists_writer":
+        delivered = raw[3] if len(raw) > 3 else None
+        return delivered, delivered
+    if variant == "monolith":
+        delivered = raw[0] if raw else None
+        return delivered, delivered
+    raise ValueError(f"unknown variant: {variant}")
+
+
+def _without_reviewer_notes(report: str) -> str:
+    return report.split("## Reviewer Notes", maxsplit=1)[0].rstrip()
+
+
+def draft_retention_ratio(draft: str | None, delivered: str | None) -> float | None:
+    if not draft or not delivered:
+        return None
+    final_body = _without_reviewer_notes(delivered)
+    return round(SequenceMatcher(None, draft, final_body, autojunk=False).ratio(), 6)
+
+
+def _task_filename(index: int, output: Any) -> str:
+    name = str(getattr(output, "name", "") or f"task-{index}").lower()
+    safe = re.sub(r"[^a-z0-9]+", "-", name).strip("-") or f"task-{index}"
+    return f"task-{index:02d}-{safe}.txt"
+
+
+def _cell_directory(root: Path, cell: ScheduleCell) -> Path:
+    return root / (
+        f"{cell.schedule_index:03d}-{cell.num}-{cell.variant}-r{cell.rep}"
+    )
+
+
+def _fixture(collection_num: str, topic: str) -> tuple[Any, dict[str, Any]]:
+    collection = benchmark_fixtures.load(collection_num, _slug(topic))
+    if collection is None:
+        # This is deliberately the end of the path. Calling live retrieval here
+        # would relabel retrieval variance as topology variance.
+        raise FileNotFoundError(
+            f"no frozen fixture for case {collection_num}; live fallback is forbidden"
+        )
+    entry = benchmark_fixtures.load_manifest().get("fixtures", {}).get(collection_num)
+    if not entry:
+        raise ValueError(f"fixture {collection_num} has no manifest provenance")
+    return collection, entry
+
+def preflight_fixtures(
+    cases: Sequence[tuple[str, str, tuple[int, int], str]],
+) -> dict[str, dict[str, Any]]:
+    """Validate every frozen input before the first paid request."""
+
+    entries: dict[str, dict[str, Any]] = {}
+    for num, topic, _trl_range, _industry in cases:
+        _collection_value, entry = _fixture(num, topic)
+        entries[num] = entry
+    return entries
+
+
+def _reusable_cell_meta(
+    experiment_root: Path,
+    cell: ScheduleCell,
+    *,
+    commit_sha: str,
+    fixture_digest: str,
+) -> dict[str, Any] | None:
+    """Reuse only the same code, frozen input, block, and topology."""
+
+    path = _cell_directory(experiment_root, cell) / "meta.json"
+    try:
+        meta = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    expected = {
+        "status": "success",
+        "evidence_mode": "fixture",
+        "block_id": cell.block_id,
+        "variant": cell.variant,
+        "commit_sha": commit_sha,
+        "fixture_digest": fixture_digest,
+    }
+    if all(meta.get(key) == value for key, value in expected.items()):
+        return meta
+    return None
+
+
+def run_cell(
+    cell: ScheduleCell,
+    *,
+    experiment_id: str,
+    experiment_root: Path,
+    commit_sha: str,
+) -> dict[str, Any]:
+    """Run and persist one paid cell; failures retain usage and diagnostics."""
+
+    collection, fixture_entry = _fixture(cell.num, cell.topic)
+    cell_dir = _cell_directory(experiment_root, cell)
+    from academic_agent.token_usage import collect_usage
+
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    fixture_age = benchmark_fixtures.age_days(cell.num)
+    meta: dict[str, Any] = {
+        "schema_version": 1,
+        "experiment_id": experiment_id,
+        "block_id": cell.block_id,
+        "schedule_index": cell.schedule_index,
+        "position": cell.position,
+        "num": cell.num,
+        "rep": cell.rep,
+        "topic": cell.topic,
+        "industry": cell.industry,
+        "expected_trl_range": list(cell.expected_trl_range),
+        "variant": cell.variant,
+        "nodes": TOPOLOGY_NODES[cell.variant],
+        "status": "running",
+        "evidence_mode": "fixture",
+        "fixture_digest": fixture_entry.get("sha256_16", ""),
+        "fixture_age_days": None if fixture_age is None else round(fixture_age, 3),
+        "commit_sha": commit_sha,
+        "started_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+    (cell_dir / "validated_sources.json").write_text(
+        collection.model_dump_json(indent=2), encoding="utf-8"
+    )
+
+    crew_obj: Any | None = None
+    recorder = GuardrailRecorder()
+    report_task_name = ""
+    start = time.perf_counter()
+    try:
+        crew_obj, report_task_name = build_variant_crew(cell.variant, collection)
+        recorder.instrument(crew_obj.tasks)
+        result = crew_obj.kickoff(inputs=collection.crew_inputs())
+        task_outputs = list(getattr(result, "tasks_output", None) or [])
+        draft, delivered = select_report_outputs(cell.variant, task_outputs)
+        if not delivered:
+            raise RuntimeError("topology completed without a delivered report")
+
+        for index, output in enumerate(task_outputs, start=1):
+            (cell_dir / _task_filename(index, output)).write_text(
+                str(getattr(output, "raw", "") or ""), encoding="utf-8"
+            )
+        if draft is not None:
+            (cell_dir / "draft_report.md").write_text(draft, encoding="utf-8")
+        (cell_dir / "commercialization_report.md").write_text(delivered, encoding="utf-8")
+
+        headings = _localized_headings(collection)
+        metrics = analyse_report(
+            delivered,
+            _all_sources(collection),
+            required_headings=headings,
+            output_language=collection.output_language,
+        )
+        meta["report_metrics"] = metrics.as_dict()
+        meta["reviewer_corrections"] = (
+            reviewer_correction_count(delivered) if cell.variant == "full" else None
+        )
+        meta["draft_retention_ratio"] = (
+            draft_retention_ratio(draft, delivered) if cell.variant == "full" else None
+        )
+        meta["status"] = "success"
+    except Exception as exc:  # noqa: BLE001 - one failed cell must not erase the batch
+        meta["status"] = "error_crew"
+        meta["error"] = f"{type(exc).__name__}: {exc}"[:2_000]
+        (cell_dir / "error.log").write_text(traceback.format_exc(), encoding="utf-8")
+    finally:
+        meta["elapsed_seconds"] = round(time.perf_counter() - start, 3)
+        if crew_obj is not None:
+            meta["usage"] = collect_usage(crew_obj).as_dict()
+        meta["guardrails"] = recorder.summaries()
+        meta["report_guardrail"] = recorder.task_summary(report_task_name)
+
+        attempts = recorder.attempts.get(report_task_name, [])
+        if attempts:
+            first_metrics = analyse_report(
+                attempts[0].raw_before,
+                _all_sources(collection),
+                required_headings=_localized_headings(collection),
+                output_language=collection.output_language,
+            )
+            meta["first_attempt_report_metrics"] = first_metrics.as_dict()
+
+        meta["finished_at"] = datetime.now(UTC).isoformat(timespec="seconds")
+        (cell_dir / "meta.json").write_text(
+            json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    return meta
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument("--pilot", action="store_true", help="case 03, one repetition")
+    scope.add_argument("--full", action="store_true", help="all ten cases")
+    parser.add_argument("--only", action="append", default=[], metavar="CASE")
+    parser.add_argument("--repeat", type=int, default=None)
+    parser.add_argument("--variants", nargs="+", choices=VARIANTS, default=list(VARIANTS))
+    parser.add_argument("--execute", action="store_true", help="make paid model calls")
+    parser.add_argument("--confirm-full-study", action="store_true")
+    parser.add_argument("--experiment-id")
+    parser.add_argument("--pause-seconds", type=float, default=DEFAULT_PAUSE_SECONDS)
+    parser.add_argument(
+        "--stop-after-usd",
+        type=float,
+        help=(
+            "stop after observed complete cost reaches this value; one cell may "
+            "cross it, so this is a stop rule rather than a hard provider cap"
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.repeat is not None and args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+    if args.pause_seconds < 0:
+        parser.error("--pause-seconds must not be negative")
+    if args.stop_after_usd is not None and args.stop_after_usd <= 0:
+        parser.error("--stop-after-usd must be positive")
+    if (args.pilot or args.full) and args.only:
+        parser.error("--only cannot be combined with --pilot or --full")
+    if args.execute and not (args.pilot or args.full or args.only):
+        parser.error("paid execution requires an explicit --pilot, --full, or --only scope")
+    if args.execute and args.pilot:
+        if args.repeat not in (None, 1) or tuple(args.variants) != VARIANTS:
+            parser.error("the registered pilot requires one repetition of all three variants")
+    if args.execute and args.full:
+        if not args.confirm_full_study:
+            parser.error("paid --full requires --confirm-full-study")
+        if args.repeat not in (None, 3) or tuple(args.variants) != VARIANTS:
+            parser.error("the registered full study requires three repetitions of all variants")
+    return args
+
+
+def _selected_cases(args: argparse.Namespace) -> list[tuple[str, str, tuple[int, int], str]]:
+    if args.pilot:
+        requested = {"03"}
+    elif args.only:
+        requested = {str(num).zfill(2) for num in args.only}
+    else:
+        requested = {num for num, *_ in TOPICS}
+    selected = [case for case in TOPICS if case[0] in requested]
+    missing = requested - {case[0] for case in selected}
+    if missing:
+        raise ValueError(f"unknown benchmark cases: {', '.join(sorted(missing))}")
+    return selected
+
+
+def _experiment_id(args: argparse.Namespace, commit_sha: str) -> str:
+    if args.experiment_id:
+        return args.experiment_id
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{commit_sha[:8]}"
+
+
+def _print_plan(cells: Sequence[ScheduleCell], *, execute: bool) -> None:
+    mode = "PAID EXECUTION" if execute else "PLAN ONLY — no model calls"
+    print(f"Agent-topology ablation: {mode}")
+    print(f"cells: {len(cells)}")
+    for cell in cells:
+        print(
+            f"  {cell.schedule_index:03d}  {cell.block_id:<7}  "
+            f"position={cell.position}  {cell.variant:<20}  {cell.topic}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    cases = _selected_cases(args)
+    repeat = args.repeat if args.repeat is not None else (3 if args.full else 1)
+    cells = build_schedule(cases, repeat=repeat, variants=args.variants)
+    _print_plan(cells, execute=args.execute)
+    if not args.execute:
+        print("Add --execute for the paid pilot. No files or API calls were made.")
+        return 0
+
+    fixture_entries = preflight_fixtures(cases)
+    commit_sha = _commit_sha()
+    experiment_id = _experiment_id(args, commit_sha)
+    experiment_root = ABLATION_ROOT / experiment_id
+    experiment_root.mkdir(parents=True, exist_ok=True)
+    cumulative_cost = 0.0
+
+    for index, cell in enumerate(cells):
+        fixture_digest = str(fixture_entries[cell.num].get("sha256_16", ""))
+        meta = _reusable_cell_meta(
+            experiment_root,
+            cell,
+            commit_sha=commit_sha,
+            fixture_digest=fixture_digest,
+        )
+        reused = meta is not None
+        if reused:
+            print(
+                f"[{cell.schedule_index}/{len(cells)}] {cell.block_id} "
+                f"{cell.variant} already succeeded — reusing",
+                flush=True,
+            )
+        else:
+            print(
+                f"[{cell.schedule_index}/{len(cells)}] {cell.block_id} "
+                f"{cell.variant} starting",
+                flush=True,
+            )
+            meta = run_cell(
+                cell,
+                experiment_id=experiment_id,
+                experiment_root=experiment_root,
+                commit_sha=commit_sha,
+            )
+        usage = meta.get("usage") or {}
+        cost = usage.get("cost_usd")
+        complete = usage.get("cost_complete")
+        if isinstance(cost, (int, float)):
+            cumulative_cost += float(cost)
+        print(
+            f"[{cell.schedule_index}/{len(cells)}] {meta['status']}  "
+            f"{meta['elapsed_seconds']}s  observed cost=${cumulative_cost:.4f}",
+            flush=True,
+        )
+
+        if args.stop_after_usd is not None:
+            if complete is not True:
+                print("Stopping: cost is incomplete, so the USD stop rule cannot be trusted.")
+                break
+            if cumulative_cost >= args.stop_after_usd:
+                print(f"Stopping: observed cost reached ${args.stop_after_usd:.4f}.")
+                break
+        if not reused and index < len(cells) - 1 and args.pause_seconds:
+            time.sleep(args.pause_seconds)
+
+    summary_path, pairwise_path, _ = write_summaries(experiment_root)
+    print(f"summary: {summary_path}")
+    print(f"paired deltas: {pairwise_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ablation_check.py
+++ b/ablation_check.py
@@ -1,0 +1,434 @@
+"""Analyse agent-topology ablation outputs without making network calls.
+
+The paid runner writes one self-contained ``meta.json`` per cell. This module
+keeps report checks and aggregation separate from execution so a completed
+batch can be re-analysed after an accounting or presentation bug without
+spending another token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from itertools import combinations
+from pathlib import Path
+from statistics import mean, median
+from typing import Any
+from collections.abc import Iterable
+
+
+ABLATION_ROOT = Path(__file__).parent / "outputs" / "ablation"
+VARIANT_ORDER = ("monolith", "specialists_writer", "full")
+
+
+def _without_reviewer_notes(markdown: str) -> str:
+    """Remove deterministic audit notes from the report contract surface.
+
+    Reviewer reasons are appended after References and can themselves mention a
+    source ID. Feeding them back through reference validation would treat an
+    audit note as a malformed bibliography entry and create a full-arm-only
+    false positive.
+    """
+
+    return markdown.split("## Reviewer Notes", maxsplit=1)[0].rstrip()
+
+
+@dataclass(frozen=True)
+class FinalReportGrounding:
+    """High-precision numeric support screen for delivered Markdown.
+
+    The production grounding screen consumes structured EvidenceReports. An
+    ablation needs one common screen after every topology has produced the same
+    artifact type: Markdown. Reusing its deliberately conservative number and
+    source-support primitives keeps the two screens' meaning aligned. The
+    leading-underscore imports are intentional here: duplicating those rules in
+    an experiment would let the treatment and production definitions drift.
+    """
+
+    status: str
+    checked_claim_lines: int
+    unsupported_claim_lines: int
+    unverifiable_claim_lines: int
+    checked_figures: int
+    unsupported_figures: tuple[str, ...]
+    duplicates_collapsed: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReportMetrics:
+    contract_status: str
+    validation_errors: tuple[str, ...]
+    validation_error_classes: tuple[str, ...]
+    required_sections_complete: bool
+    word_count: int
+    unique_citations: int
+    citation_domains: tuple[str, ...]
+    grounding: FinalReportGrounding
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["grounding"] = self.grounding.as_dict()
+        return data
+
+
+def _validation_error_class(error: str) -> str:
+    """Stable categories for prose errors whose exact wording may improve."""
+
+    lowered = error.lower()
+    if "missing required heading" in lowered:
+        return "missing_heading"
+    if "unknown source" in lowered:
+        return "unknown_citation"
+    if "missing from references" in lowered:
+        return "missing_reference"
+    if "uncited source" in lowered:
+        return "uncited_reference"
+    if "exactly once" in lowered:
+        return "duplicate_reference"
+    if "validated url or doi" in lowered:
+        return "reference_locator"
+    if "citation" in lowered or "source id" in lowered:
+        return "citation_policy"
+    if "patent" in lowered or "freedom to operate" in lowered:
+        return "patent_framing"
+    return "other"
+
+
+def analyse_numeric_grounding(
+    markdown: str,
+    allowed_sources: dict[str, Any],
+) -> FinalReportGrounding:
+    """Check distinctive figures in report lines against their cited sources.
+
+    A source snippet is a fragment, so absence from it is ``unverifiable`` and
+    never ``unsupported``. Likewise, no checkable claim is ``not_checked``
+    rather than a vacuous pass. These distinctions are experiment outcomes,
+    not presentation details.
+    """
+
+    from academic_agent.claim_grounding import (
+        _render,
+        _source_is_checkable,
+        _source_text,
+        _supported,
+        checkable_figures,
+    )
+    from academic_agent.evidence import parse_citation_ids
+
+    body = markdown.split("## References", maxsplit=1)[0]
+    checked_lines = unsupported_lines = unverifiable_lines = 0
+    checked_figures = duplicates_collapsed = 0
+    unsupported_figures: list[str] = []
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or re.fullmatch(r"[-|:\s]+", line):
+            continue
+
+        figures = checkable_figures(line)
+        if not figures:
+            continue
+
+        source_ids, citation_errors = parse_citation_ids(line)
+        citation_key = tuple(sorted(set(source_ids)))
+        duplicate_key = (line, citation_key)
+        if duplicate_key in seen:
+            duplicates_collapsed += 1
+            continue
+        seen.add(duplicate_key)
+
+        cited = [allowed_sources[source_id] for source_id in citation_key
+                 if source_id in allowed_sources]
+        if citation_errors or not cited:
+            unverifiable_lines += 1
+            continue
+
+        checkable = [source for source in cited if _source_is_checkable(source)]
+        if not checkable:
+            unverifiable_lines += 1
+            continue
+
+        haystack = " ".join(_source_text(source) for source in checkable)
+        present = checkable_figures(haystack)
+        missing = [
+            _render(number, unit)
+            for number, unit in figures
+            if not _supported(number, unit, present, haystack)
+        ]
+        checked_lines += 1
+        checked_figures += len(figures)
+        if missing:
+            unsupported_lines += 1
+            unsupported_figures.extend(missing)
+
+    if checked_lines == 0:
+        status = "not_checked"
+    elif unsupported_lines:
+        status = "fail"
+    else:
+        status = "pass"
+
+    return FinalReportGrounding(
+        status=status,
+        checked_claim_lines=checked_lines,
+        unsupported_claim_lines=unsupported_lines,
+        unverifiable_claim_lines=unverifiable_lines,
+        checked_figures=checked_figures,
+        unsupported_figures=tuple(unsupported_figures),
+        duplicates_collapsed=duplicates_collapsed,
+    )
+
+
+def analyse_report(
+    markdown: str,
+    sources: Iterable[Any],
+    *,
+    required_headings: tuple[str, ...] | None = None,
+    output_language: str = "English",
+) -> ReportMetrics:
+    """Return metrics shared by all three topology arms."""
+
+    allowed = {source.source_id: source for source in sources}
+    from academic_agent.evidence import parse_citation_ids, validate_final_report
+
+    contract_markdown = _without_reviewer_notes(markdown)
+    errors = validate_final_report(
+        contract_markdown,
+        allowed,
+        required_headings=required_headings,
+        output_language=output_language,
+    )
+    body = contract_markdown.split("## References", maxsplit=1)[0]
+    citation_ids, _ = parse_citation_ids(body)
+    unique_ids = set(citation_ids)
+    error_classes = tuple(dict.fromkeys(_validation_error_class(error) for error in errors))
+
+    return ReportMetrics(
+        contract_status="pass" if not errors else "fail",
+        validation_errors=tuple(errors),
+        validation_error_classes=error_classes,
+        required_sections_complete=not any(
+            error.startswith("Missing required heading:") for error in errors
+        ),
+        # Markdown punctuation is not a word. This deliberately measures report
+        # scale, not provider tokens, which come from usage accounting below.
+        word_count=len(re.findall(r"\b\w+\b", markdown, flags=re.UNICODE)),
+        unique_citations=len(unique_ids),
+        citation_domains=tuple(sorted({source_id[0] for source_id in unique_ids})),
+        grounding=analyse_numeric_grounding(contract_markdown, allowed),
+    )
+
+
+def reviewer_correction_count(report: str) -> int | None:
+    """Accepted exact replacements, or None when no reviewer existed."""
+
+    marker = "## Reviewer Notes"
+    if marker not in report:
+        return None
+    notes = report.split(marker, maxsplit=1)[1]
+    if "No corrections required." in notes:
+        return 0
+    return sum(1 for line in notes.splitlines() if line.strip().startswith("- "))
+
+
+SUMMARY_COLUMNS = (
+    "experiment_id",
+    "block_id",
+    "schedule_index",
+    "position",
+    "num",
+    "rep",
+    "topic",
+    "variant",
+    "nodes",
+    "status",
+    "fixture_digest",
+    "fixture_age_days",
+    "elapsed_seconds",
+    "total_tokens",
+    "total_requests",
+    "cost_usd",
+    "cost_complete",
+    "contract_status",
+    "validation_error_count",
+    "grounding_status",
+    "checked_claim_lines",
+    "unsupported_claim_lines",
+    "unverifiable_claim_lines",
+    "report_guardrail_calls",
+    "report_guardrail_failures",
+    "report_guardrail_retries",
+    "word_count",
+    "unique_citations",
+    "citation_domains",
+    "reviewer_corrections",
+    "draft_retention_ratio",
+)
+
+
+def flatten_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one persisted result; this is the CSV/client boundary."""
+
+    metrics = meta.get("report_metrics") or {}
+    grounding = metrics.get("grounding") or {}
+    usage = meta.get("usage") or {}
+    report_guardrail = meta.get("report_guardrail") or {}
+    row = {
+        key: meta.get(key, "")
+        for key in (
+            "experiment_id", "block_id", "schedule_index", "position", "num",
+            "rep", "topic", "variant", "nodes", "status", "fixture_digest",
+            "fixture_age_days", "elapsed_seconds",
+        )
+    }
+    row.update({
+        "total_tokens": usage.get("total_tokens", ""),
+        "total_requests": usage.get("total_requests", ""),
+        "cost_usd": usage.get("cost_usd", ""),
+        "cost_complete": usage.get("cost_complete", ""),
+        "contract_status": metrics.get("contract_status", ""),
+        "validation_error_count": len(metrics.get("validation_errors") or []),
+        "grounding_status": grounding.get("status", ""),
+        "checked_claim_lines": grounding.get("checked_claim_lines", ""),
+        "unsupported_claim_lines": grounding.get("unsupported_claim_lines", ""),
+        "unverifiable_claim_lines": grounding.get("unverifiable_claim_lines", ""),
+        "report_guardrail_calls": report_guardrail.get("calls", ""),
+        "report_guardrail_failures": report_guardrail.get("failures", ""),
+        "report_guardrail_retries": report_guardrail.get("retries", ""),
+        "word_count": metrics.get("word_count", ""),
+        "unique_citations": metrics.get("unique_citations", ""),
+        "citation_domains": ",".join(metrics.get("citation_domains") or []),
+        "reviewer_corrections": meta.get("reviewer_corrections", ""),
+        "draft_retention_ratio": meta.get("draft_retention_ratio", ""),
+    })
+    return row
+
+
+def _numeric(value: Any) -> float | None:
+    if isinstance(value, bool) or value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def pairwise_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Paired deltas within one topic/repetition block.
+
+    Pairing is the reason the schedule carries a block ID. Comparing global
+    means would let an easy topic in one arm masquerade as an architecture
+    effect when a run is missing from another arm.
+    """
+
+    grouped: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in rows:
+        grouped[str(row.get("block_id", ""))][str(row.get("variant", ""))] = row
+
+    metrics = (
+        "elapsed_seconds", "total_tokens", "total_requests", "cost_usd",
+        "validation_error_count", "unsupported_claim_lines",
+        "report_guardrail_failures", "word_count", "unique_citations",
+    )
+    result: list[dict[str, Any]] = []
+    for block_id, variants in sorted(grouped.items()):
+        for left, right in combinations(VARIANT_ORDER, 2):
+            if left not in variants or right not in variants:
+                continue
+            row: dict[str, Any] = {
+                "block_id": block_id,
+                "left": left,
+                "right": right,
+            }
+            for metric in metrics:
+                left_value = _numeric(variants[left].get(metric))
+                right_value = _numeric(variants[right].get(metric))
+                row[f"{metric}_delta"] = (
+                    "" if left_value is None or right_value is None
+                    else round(right_value - left_value, 6)
+                )
+            result.append(row)
+    return result
+
+
+def write_summaries(experiment_root: Path) -> tuple[Path, Path, list[dict[str, Any]]]:
+    """Rebuild run and paired CSV files entirely from persisted cell metadata."""
+
+    metas = []
+    for path in experiment_root.rglob("meta.json"):
+        try:
+            metas.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, ValueError) as exc:
+            # Omitting a damaged paid cell would make an incomplete experiment
+            # look successful. Stop with the exact artifact instead; callers can
+            # repair or rerun it without guessing which result disappeared.
+            raise ValueError(
+                f"could not inspect ablation metadata: {path}"
+            ) from exc
+    rows = [flatten_meta(meta) for meta in metas]
+    rows.sort(key=lambda row: int(row.get("schedule_index") or 0))
+
+    summary_path = experiment_root / "ablation_summary.csv"
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=SUMMARY_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    paired = pairwise_rows(rows)
+    pairwise_path = experiment_root / "ablation_pairwise.csv"
+    pair_fields = list(paired[0]) if paired else ["block_id", "left", "right"]
+    with pairwise_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=pair_fields)
+        writer.writeheader()
+        writer.writerows(paired)
+    return summary_path, pairwise_path, rows
+
+
+def aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Small descriptive summary; never substitutes missing cells with zero."""
+
+    result: dict[str, dict[str, Any]] = {}
+    for variant in VARIANT_ORDER:
+        arm = [row for row in rows if row.get("variant") == variant]
+        successful = [row for row in arm if row.get("status") == "success"]
+        summary: dict[str, Any] = {
+            "runs": len(arm),
+            "successful": len(successful),
+        }
+        for metric in ("elapsed_seconds", "total_tokens", "cost_usd"):
+            values = [_numeric(row.get(metric)) for row in successful]
+            observed = [value for value in values if value is not None]
+            summary[f"median_{metric}"] = median(observed) if observed else None
+            summary[f"mean_{metric}"] = round(mean(observed), 6) if observed else None
+        result[variant] = summary
+    return result
+
+
+def _latest_experiment(root: Path) -> Path:
+    candidates = sorted(path for path in root.iterdir() if path.is_dir()) if root.exists() else []
+    if not candidates:
+        raise FileNotFoundError(f"no ablation experiments under {root}")
+    return candidates[-1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path)
+    args = parser.parse_args()
+    experiment_root = args.path or _latest_experiment(ABLATION_ROOT)
+    summary, paired, rows = write_summaries(experiment_root)
+    print(json.dumps(aggregate_rows(rows), indent=2, ensure_ascii=False))
+    print(f"run summary: {summary}")
+    print(f"paired deltas: {paired}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/prereg-2026-08-21-agent-topology-ablation.md
+++ b/docs/prereg-2026-08-21-agent-topology-ablation.md
@@ -1,0 +1,186 @@
+# Pre-registration — agent-topology ablation
+
+Written before the experiment harness and before any paid treatment run. The
+purpose is to test whether this product's six named agents buy measurable
+quality or reliability, rather than to defend the architecture already in the
+repository.
+
+## Question
+
+Holding the retrieved evidence, model settings, report contract, and blocking
+report validation fixed, what is gained by decomposing report generation into
+one, four, or six LLM nodes?
+
+This experiment tests **workflow topology**, not whether CrewAI is necessary.
+All three arms use CrewAI so provider integration, retry behaviour, and usage
+accounting stay comparable. A separate CrewAI-versus-raw-asyncio experiment
+would be needed to measure framework overhead.
+
+It also does not test whether a technology-transfer officer would act on the
+report. That requires independent users and remains an open product-validity
+question whatever this experiment finds.
+
+## Arms
+
+| arm | nodes | work performed |
+|---|---:|---|
+| `monolith` | 1 | One generalist reads the three immutable source registries and writes the report |
+| `specialists_writer` | 4 | The existing academic, patent, and market tasks feed the existing report writer |
+| `full` | 6 | The production workflow: three specialists, writer, reviewer, and scorer |
+
+The four- and six-node arms reuse production task objects without edited
+prompts. The monolith has a purpose-built prompt because telling it that three
+specialist outputs exist when they do not would contaminate the treatment. Its
+delivered report nevertheless passes the same normalisation and blocking
+validation implementation as Tasks 4 and 5.
+
+The scorer is intentionally absent from the one- and four-node arms. Therefore
+TRL and overall score are not common outcomes and will not be used to rank the
+topologies. Adding a scorer to every arm would turn this into a two/five/six
+node experiment and answer a different question.
+
+## Fixed inputs and controls
+
+- The ten committed `benchmark_fixtures` are the only evidence inputs. A
+  missing or digest-mismatched fixture aborts; there is no fallback to live
+  retrieval.
+- Model/provider and each production role's LLM construction, output language,
+  required headings, source registry, `MAX_RPM`, and final-report validation
+  are held fixed. The monolith matches the production writer's free-text setup.
+- Runs are serial. Within each topic/repetition block, arm order rotates by a
+  deterministic Latin-square schedule. Across ten topics and three
+  repetitions, every arm occupies every position ten times.
+- Every result records the fixture digest and age, commit SHA, arm position,
+  provider/model usage, request count, token count, cost basis/completeness,
+  elapsed time, and guardrail calls/failures.
+- The harness is plan-only by default. Paid calls require `--execute`; a pilot
+  and the full study are separate decisions.
+
+## Outcomes
+
+### Primary quality and reliability outcomes, common to all arms
+
+1. Completed-run rate.
+2. Final-report contract errors, including missing headings, unknown or
+   mismatched citations, and blocking citation-policy failures.
+3. High-precision numeric grounding against the cited source summaries:
+   checked claim lines, unsupported claim lines, and unverifiable claim lines.
+4. First-attempt report-guardrail failures and total guardrail retries.
+
+`0 unsupported / 0 checked` is recorded as `not_checked`, never as a pass.
+Qualitative claim correctness is outside the deterministic screen's reach and
+will not be described as verified.
+
+### Secondary operational outcomes
+
+- Prompt, completion, and total tokens.
+- Provider requests.
+- Estimated USD cost, always accompanied by price basis and whether every
+  model was priced.
+- Wall-clock latency and report word count.
+- Unique citations and represented evidence domains.
+
+### Six-node diagnostics, not common outcomes
+
+- Accepted reviewer correction count and stated reasons.
+- Draft-to-delivered-report text retention after removing deterministic
+  reviewer notes.
+
+A reviewer edit is activity, not proof of improvement. Correction counts are
+descriptive until the edits are manually judged.
+
+## Predictions
+
+| # | Prediction |
+|---|---|
+| P1 | The four-node arm has fewer first-attempt report-guardrail failures than the monolith |
+| P2 | The six-node arm has no more unsupported checked numeric claims than the four-node arm |
+| P3 | Removing two nodes reduces median cost and total tokens by at least 20% from six to four nodes |
+| P4 | The monolith is cheapest, but loses at least one common quality or reliability outcome to the four-node arm |
+
+## Decision and falsification rules
+
+The default decision is the simpler topology. Extra nodes are justified only
+by a measured benefit on a common outcome.
+
+- Any increase in high-confidence unsupported numeric claims is a material
+  regression even when averages elsewhere improve.
+- A cost or latency change below 20% is not treated as practically meaningful
+  for this small study.
+- If monolith matches both staged arms on all common quality/reliability
+  outcomes while using at least 20% fewer tokens or dollars, the claim that
+  specialist decomposition is necessary is falsified.
+- If four nodes improve first-attempt validation or grounding over monolith
+  without a material cost regression, domain decomposition is supported.
+- If six nodes match four nodes on common outcomes while costing at least 20%
+  more, the reviewer/scorer remain product features but do not establish that
+  six nodes are necessary for report generation.
+- Six nodes are not declared better merely because the reviewer produced
+  corrections.
+
+With only ten topics and three repetitions, the report will emphasize paired
+effect sizes and uncertainty rather than binary statistical significance. No
+metric or threshold will be changed after seeing the paid results.
+
+## Execution stages and stop rules
+
+### Stage 0 — offline harness verification
+
+Run unit tests, deliberately re-inject a known defect to prove the new test
+fails, run the full zero-network suite, and run Ruff. This stage costs nothing.
+
+### Stage 1 — paid pilot
+
+Run fixture case 03 once through all three arms. The pilot validates output
+wiring, accounting completeness, and actual per-arm cost. Pilot results do not
+decide the architecture.
+
+Inspect the exact three-cell plan first. This is the safe default and makes no
+files or API calls:
+
+```bash
+uv run python ablation.py --pilot
+```
+
+After separately approving the spend, run the pilot with a soft emergency
+ceiling. The ceiling is checked after each serial cell, so one in-flight cell
+can take the total above it:
+
+```bash
+uv run python ablation.py --pilot --execute --stop-after-usd 0.20
+```
+
+Then rebuild and inspect the summaries from persisted metadata rather than
+trusting terminal output:
+
+```bash
+uv run python ablation_check.py outputs/ablation/<experiment-id>
+```
+
+Stop before the full study if any arm:
+
+- uses live retrieval;
+- loses its final report at the persistence boundary;
+- reports cost as complete when an agent is unpriced;
+- records `0 checked` as a grounding pass; or
+- cannot identify its fixture digest, model usage, or guardrail attempts.
+
+### Stage 2 — full paid study
+
+Only after reviewing the pilot: ten topics, three repetitions, three arms,
+ninety serial cells. Existing successful cells are resumable; arm identity and
+fixture digest must match before reuse.
+
+The full-study confirmation flag is intentionally separate from `--execute`:
+
+```bash
+uv run python ablation.py --full --execute --confirm-full-study \
+  --stop-after-usd <approved-budget>
+```
+
+## Relationship to prior rejected work
+
+This experiment does not change the scoring formula, evidence-confidence
+floor, TRL rubric, maturity-language screen, uncited-claim blocking policy,
+prompt caching, source-summary retrieval, or CrewAI version. The production
+six-node arm is the unmodified control.

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -1,0 +1,543 @@
+"""Offline tests for the paid agent-topology ablation harness."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, date, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+import ablation
+from ablation import GuardrailRecorder, ScheduleCell
+from ablation_check import (
+    SUMMARY_COLUMNS,
+    analyse_numeric_grounding,
+    analyse_report,
+    flatten_meta,
+    pairwise_rows,
+    reviewer_correction_count,
+    write_summaries,
+)
+if TYPE_CHECKING:
+    from academic_agent.evidence import EvidenceSource
+    from academic_agent.source_pipeline import SourceCollection
+
+
+def _source(
+    source_id: str,
+    *,
+    summary: str | None = None,
+    summary_source: str | None = "abstract",
+) -> EvidenceSource:
+    from academic_agent.evidence import EvidenceSource
+
+    return EvidenceSource(
+        source_id=source_id,
+        title=f"Validated evidence for {source_id}",
+        url=f"https://evidence.example.org/{source_id.lower()}",
+        publisher="Evidence Publisher",
+        published_date=date(2025, 1, 1),
+        accessed_date=date(2026, 8, 21),
+        source_type=(
+            "academic_paper" if source_id.startswith("A")
+            else "patent" if source_id.startswith("P")
+            else "company_disclosure"
+        ),
+        evidence_summary=summary or (
+            f"Source {source_id} reports a measured efficiency of 26.1% in a "
+            "controlled validation study and explains the experimental conditions, "
+            "measurement protocol, comparison baseline, uncertainty, and limitations "
+            "in enough detail to support deterministic figure verification. The "
+            "record describes sample preparation, instrumentation, repeated "
+            "measurements, and the comparison control. It separates measured "
+            "performance from analyst interpretation and states where replication "
+            "is still needed, making this a substantive evidence record rather "
+            "than a truncated search-result fragment."
+        ),
+        summary_source=summary_source,
+    )
+
+
+def _collection() -> SourceCollection:
+    from academic_agent.source_pipeline import SourceCollection
+
+    return SourceCollection(
+        topic="Test commercialization technology",
+        display_topic="Test commercialization technology",
+        output_language="English",
+        collected_at=datetime.now(UTC),
+        academic_sources=[_source("A1")],
+        patent_sources=[_source("P1")],
+        market_sources=[_source("M1")],
+        academic_queries=["academic query"],
+        patent_queries=["patent query"],
+        market_queries=["market query"],
+    )
+
+
+def _cell(variant: str, schedule_index: int = 1) -> ScheduleCell:
+    return ScheduleCell(
+        schedule_index=schedule_index,
+        block_id="03-r1",
+        position=schedule_index,
+        num="03",
+        topic="solid-state batteries for electric vehicles",
+        expected_trl_range=(5, 7),
+        industry="Energy",
+        rep=1,
+        variant=variant,
+    )
+
+
+def test_full_schedule_balances_every_variant_across_positions() -> None:
+    """A time-of-day drift must not be confounded with one fixed arm order."""
+
+    cells = ablation.build_schedule(ablation.TOPICS, repeat=3)
+
+    assert len(cells) == 90
+    counts = {
+        (variant, position): sum(
+            cell.variant == variant and cell.position == position for cell in cells
+        )
+        for variant in ablation.VARIANTS
+        for position in (1, 2, 3)
+    }
+    assert set(counts.values()) == {10}
+    assert len({cell.block_id for cell in cells}) == 30
+
+
+def test_plan_only_is_the_default_and_never_dispatches_a_paid_cell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Printing a plan must remain a zero-cost operation at the CLI seam."""
+
+    def paid_call_would_be_a_defect(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("plan-only mode dispatched a paid cell")
+
+    monkeypatch.setattr(ablation, "run_cell", paid_call_would_be_a_defect)
+
+    assert ablation.main(["--pilot", "--pause-seconds", "0"]) == 0
+
+
+def test_full_paid_study_needs_a_second_explicit_confirmation() -> None:
+    """One generic execute flag must not accidentally launch ninety cells."""
+
+    with pytest.raises(SystemExit):
+        ablation._parse_args(["--full", "--execute"])
+
+
+def test_missing_fixture_aborts_without_live_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing frozen input must never silently become a live measurement."""
+
+    monkeypatch.setattr(ablation.benchmark_fixtures, "load", lambda *args: None)
+
+    with pytest.raises(FileNotFoundError, match="live fallback is forbidden"):
+        ablation._fixture("03", "solid-state batteries for electric vehicles")
+
+
+def test_variant_builders_have_the_registered_node_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The labels in persisted metadata must match the Crew that gets kicked off."""
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    collection = _collection()
+
+    monolith, monolith_task = ablation.build_variant_crew("monolith", collection)
+    four, four_task = ablation.build_variant_crew("specialists_writer", collection)
+    full, full_task = ablation.build_variant_crew("full", collection)
+
+    assert (len(monolith.agents), len(monolith.tasks), monolith_task) == (
+        1, 1, "monolith_report_task"
+    )
+    assert (len(four.agents), len(four.tasks), four_task) == (
+        4, 4, "commercialization_report_task"
+    )
+    assert (len(full.agents), len(full.tasks), full_task) == (
+        6, 6, "commercialization_report_task"
+    )
+    # Four nodes are an actual production prefix, not copied prompts that can
+    # drift while preserving the same marketing label.
+    assert [task.name for task in four.tasks] == [task.name for task in full.tasks[:4]]
+    assert four.tasks[3].name == four_task
+    assert full.tasks[3].name == full_task
+    # The generalist replaces the production writer as the report-producing
+    # node, so provider settings must not become a hidden second treatment.
+    assert monolith.agents[0].llm.model == four.agents[3].llm.model
+    assert monolith.agents[0].llm.temperature == four.agents[3].llm.temperature
+
+
+
+
+def test_monolith_guardrail_delegates_to_the_production_report_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one-node treatment may change evidence flow, not validation strength."""
+
+    from academic_agent import evidence
+
+    observed: dict[str, object] = {}
+
+    def fake_policy(raw, allowed_sources, finding_sources, **kwargs):  # noqa: ANN001
+        observed.update({
+            "raw": raw,
+            "allowed": set(allowed_sources),
+            "finding_sources": finding_sources,
+            "kwargs": kwargs,
+        })
+        return "normalized report", []
+
+    monkeypatch.setattr(evidence, "_normalize_and_find_blocking_errors", fake_policy)
+    output = SimpleNamespace(raw="x" * 501)
+
+    passed, returned = ablation.make_monolith_report_guardrail(_collection())(output)
+
+    assert passed is True
+    assert returned is output
+    assert output.raw == "normalized report"
+    assert observed["allowed"] == {"A1", "P1", "M1"}
+    assert observed["finding_sources"] == {}
+
+
+def test_guardrail_recorder_preserves_return_values_and_counts_retries() -> None:
+    """Instrumentation at the Task seam must not alter CrewAI retry semantics."""
+
+    calls = 0
+
+    def guardrail(output):  # noqa: ANN001
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return False, "first attempt failed"
+        output.raw = "normalized"
+        return True, output
+
+    recorder = GuardrailRecorder()
+    wrapped = recorder.wrap("report", guardrail)
+    first = SimpleNamespace(raw="draft one")
+    second = SimpleNamespace(raw="draft two")
+
+    assert wrapped(first) == (False, "first attempt failed")
+    assert wrapped(second) == (True, second)
+    summary = recorder.task_summary("report")
+
+    assert summary["calls"] == 2
+    assert summary["failures"] == 1
+    assert summary["retries"] == 1
+    assert summary["attempts"][0]["before_sha256_16"] != ""
+
+
+def test_report_selection_asserts_the_delivered_artifact_boundary() -> None:
+    """A correctly computed report that never reaches persistence is still a bug."""
+
+    outputs = [SimpleNamespace(raw=f"task-{index}") for index in range(6)]
+
+    assert ablation.select_report_outputs("monolith", outputs[:1]) == (
+        "task-0", "task-0"
+    )
+    assert ablation.select_report_outputs("specialists_writer", outputs[:4]) == (
+        "task-3", "task-3"
+    )
+    assert ablation.select_report_outputs("full", outputs) == ("task-3", "task-4")
+
+
+def test_numeric_grounding_distinguishes_pass_fail_and_not_checked() -> None:
+    """Zero checked claims cannot be flattened into the same status as support."""
+
+    source = _source("A1")
+    allowed = {"A1": source}
+
+    supported = analyse_numeric_grounding("Efficiency reached 26.1% [A1].", allowed)
+    unsupported = analyse_numeric_grounding("Efficiency reached 31.7% [A1].", allowed)
+    silent = analyse_numeric_grounding("Performance improved materially [A1].", allowed)
+
+    assert (supported.status, supported.checked_claim_lines) == ("pass", 1)
+    assert (unsupported.status, unsupported.unsupported_claim_lines) == ("fail", 1)
+    assert unsupported.unsupported_figures == ("31.7%",)
+    assert (silent.status, silent.checked_claim_lines) == ("not_checked", 0)
+
+
+def test_snippet_absence_is_unverifiable_not_unsupported() -> None:
+    """A search fragment cannot disprove a figure that may exist off-screen."""
+
+    snippet = _source(
+        "M1",
+        summary=(
+            "A search result fragment describes the commercial programme but "
+            "does not expose the complete underlying company disclosure text."
+        ),
+        summary_source="search_snippet",
+    )
+    result = analyse_numeric_grounding("Revenue reached $37.4 million [M1].", {"M1": snippet})
+
+    assert result.status == "not_checked"
+    assert result.checked_claim_lines == 0
+    assert result.unsupported_claim_lines == 0
+    assert result.unverifiable_claim_lines == 1
+
+
+def test_summary_boundary_carries_every_declared_column() -> None:
+    """Metrics stored correctly but dropped from CSV would make the study unauditable."""
+
+    meta = {
+        "experiment_id": "exp",
+        "block_id": "03-r1",
+        "schedule_index": 1,
+        "position": 1,
+        "num": "03",
+        "rep": 1,
+        "topic": "topic",
+        "variant": "monolith",
+        "nodes": 1,
+        "status": "success",
+        "fixture_digest": "abc",
+        "fixture_age_days": 2.5,
+        "elapsed_seconds": 12.0,
+        "usage": {
+            "total_tokens": 123,
+            "total_requests": 1,
+            "cost_usd": 0.01,
+            "cost_complete": True,
+        },
+        "report_metrics": {
+            "contract_status": "pass",
+            "validation_errors": [],
+            "grounding": {
+                "status": "not_checked",
+                "checked_claim_lines": 0,
+                "unsupported_claim_lines": 0,
+                "unverifiable_claim_lines": 2,
+            },
+            "word_count": 900,
+            "unique_citations": 8,
+            "citation_domains": ["A", "P", "M"],
+        },
+        "report_guardrail": {"calls": 2, "failures": 1, "retries": 1},
+        "reviewer_corrections": None,
+        "draft_retention_ratio": None,
+    }
+
+    row = flatten_meta(meta)
+
+    assert tuple(row) == SUMMARY_COLUMNS
+    assert row["grounding_status"] == "not_checked"
+    assert row["unverifiable_claim_lines"] == 2
+    assert row["report_guardrail_failures"] == 1
+    assert row["citation_domains"] == "A,P,M"
+
+
+def test_pairwise_rows_compare_only_within_the_same_block() -> None:
+    rows = [
+        {"block_id": "03-r1", "variant": "monolith", "total_tokens": 100},
+        {"block_id": "03-r1", "variant": "specialists_writer", "total_tokens": 150},
+        {"block_id": "04-r1", "variant": "full", "total_tokens": 999},
+    ]
+
+    paired = pairwise_rows(rows)
+
+    assert len(paired) == 1
+    assert paired[0]["block_id"] == "03-r1"
+    assert paired[0]["total_tokens_delta"] == 50
+
+
+def test_summary_files_are_rebuilt_from_persisted_meta() -> None:
+    """The analyser must not depend on in-memory state from the paid process."""
+
+    output_root = Path(__file__).parents[1] / "outputs"
+    with tempfile.TemporaryDirectory(prefix="test-ablation-", dir=output_root) as raw:
+        experiment_root = Path(raw)
+        for index, variant in enumerate(("monolith", "specialists_writer"), start=1):
+            directory = experiment_root / f"cell-{index}"
+            directory.mkdir()
+            (directory / "meta.json").write_text(
+                json.dumps({
+                    "experiment_id": "exp",
+                    "block_id": "03-r1",
+                    "schedule_index": index,
+                    "variant": variant,
+                    "status": "success",
+                    "usage": {"total_tokens": 100 * index},
+                }),
+                encoding="utf-8",
+            )
+
+        summary, paired, rows = write_summaries(experiment_root)
+
+        assert summary.exists()
+        assert paired.exists()
+        assert [row["variant"] for row in rows] == ["monolith", "specialists_writer"]
+
+
+def test_summary_rejects_unreadable_cell_metadata() -> None:
+    """A damaged paid result must not silently disappear from aggregation."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        cell = root / "001-03-monolith-r1"
+        cell.mkdir()
+        (cell / "meta.json").write_text("{not-json", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="could not inspect ablation metadata"):
+            write_summaries(root)
+
+        assert not (root / "ablation_summary.csv").exists()
+
+
+
+def test_reviewer_metrics_are_na_without_notes_and_zero_for_no_edits() -> None:
+    assert reviewer_correction_count("report") is None
+    assert reviewer_correction_count(
+        "report\n\n## Reviewer Notes\n\nNo corrections required."
+    ) == 0
+    assert reviewer_correction_count(
+        "report\n\n## Reviewer Notes\n\n- Fix one\n- Fix two"
+    ) == 2
+
+
+def test_draft_retention_ignores_deterministic_reviewer_notes() -> None:
+    draft = "A validated draft."
+    delivered = draft + "\n\n## Reviewer Notes\n\nNo corrections required."
+
+    assert ablation.draft_retention_ratio(draft, delivered) == 1.0
+
+
+def test_paid_execution_requires_an_explicit_scope() -> None:
+    """--execute alone must not imply a thirty-cell paid batch."""
+
+    with pytest.raises(SystemExit):
+        ablation._parse_args(["--execute"])
+
+
+def test_registered_pilot_cannot_silently_drop_an_arm() -> None:
+    """A cheaper partial run must not be filed under the preregistered pilot."""
+
+    with pytest.raises(SystemExit):
+        ablation._parse_args(["--pilot", "--execute", "--variants", "monolith"])
+
+
+def test_preflight_validates_every_fixture_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late missing fixture must be found before an earlier arm spends money."""
+
+    calls: list[str] = []
+
+    def fake_fixture(num: str, topic: str):
+        calls.append(f"{num}:{topic}")
+        return _collection(), {"sha256_16": num}
+
+    monkeypatch.setattr(ablation, "_fixture", fake_fixture)
+    cases = ablation.TOPICS[:2]
+
+    entries = ablation.preflight_fixtures(cases)
+
+    assert list(entries) == ["01", "02"]
+    assert calls == [f"{num}:{topic}" for num, topic, _trl, _industry in cases]
+
+
+def test_resume_requires_same_commit_fixture_and_topology() -> None:
+    """A result from different code or evidence must never be reused."""
+
+    output_root = Path(__file__).parents[1] / "outputs"
+    with tempfile.TemporaryDirectory(prefix="test-ablation-", dir=output_root) as raw:
+        root = Path(raw)
+        cell = _cell("monolith")
+        directory = ablation._cell_directory(root, cell)
+        directory.mkdir(parents=True)
+        (directory / "meta.json").write_text(
+            json.dumps({
+                "status": "success",
+                "evidence_mode": "fixture",
+                "block_id": cell.block_id,
+                "variant": cell.variant,
+                "commit_sha": "same-code",
+                "fixture_digest": "same-evidence",
+            }),
+            encoding="utf-8",
+        )
+
+        reused = ablation._reusable_cell_meta(
+            root,
+            cell,
+            commit_sha="same-code",
+            fixture_digest="same-evidence",
+        )
+        changed = ablation._reusable_cell_meta(
+            root,
+            cell,
+            commit_sha="different-code",
+            fixture_digest="same-evidence",
+        )
+
+        assert reused is not None
+        assert changed is None
+
+
+def test_reviewer_notes_are_outside_the_report_contract() -> None:
+    """Reviewer reasons mentioning IDs must not become bibliography failures."""
+
+    report = (
+        "A short report [A1].\n\n## References\n\n"
+        "[A1] Validated evidence. https://evidence.example.org/a1\n\n"
+        "## Reviewer Notes\n\n- Reframed an unsupported claim that cited [M99]."
+    )
+
+    metrics = analyse_report(report, [_source("A1")])
+
+    assert all("M99" not in error for error in metrics.validation_errors)
+
+
+def test_run_cell_persists_the_selected_report_at_the_disk_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selected in-memory report must reach the artifact the analyser reads."""
+
+    collection = _collection()
+    outputs = [
+        SimpleNamespace(raw="academic evidence", name="academic"),
+        SimpleNamespace(raw="patent evidence", name="patent"),
+        SimpleNamespace(raw="market evidence", name="market"),
+        SimpleNamespace(raw="delivered report", name="report"),
+    ]
+
+    class FakeCrew:
+        tasks: list[object] = []
+        agents: list[object] = []
+
+        def kickoff(self, *, inputs):  # noqa: ANN001
+            assert inputs["research_topic"] == collection.topic
+            return SimpleNamespace(tasks_output=outputs)
+
+    monkeypatch.setattr(
+        ablation,
+        "_fixture",
+        lambda *args: (collection, {"sha256_16": "fixture-digest"}),
+    )
+    monkeypatch.setattr(ablation.benchmark_fixtures, "age_days", lambda num: 1.0)
+    monkeypatch.setattr(
+        ablation,
+        "build_variant_crew",
+        lambda *args: (FakeCrew(), "commercialization_report_task"),
+    )
+
+    output_root = Path(__file__).parents[1] / "outputs"
+    with tempfile.TemporaryDirectory(prefix="test-ablation-", dir=output_root) as raw:
+        root = Path(raw)
+        cell = _cell("specialists_writer")
+        meta = ablation.run_cell(
+            cell,
+            experiment_id="experiment",
+            experiment_root=root,
+            commit_sha="commit",
+        )
+        delivered_path = ablation._cell_directory(root, cell) / "commercialization_report.md"
+
+        assert meta["status"] == "success"
+        assert delivered_path.read_text(encoding="utf-8") == "delivered report"
+        assert meta["report_metrics"]["contract_status"] == "fail"


### PR DESCRIPTION
## Why

The project can describe six CrewAI roles, but it did not have evidence that
six nodes improve report quality enough to justify their cost and latency.
This PR makes that architecture claim falsifiable before any paid comparison
is run.

## What this adds

- a pre-registered one/four/six-node experiment over the ten frozen benchmark
  fixtures;
- the exact first four production agents/tasks and the unmodified production
  crew as treatment and control, plus a one-node generalist using the same
  free-text model configuration as the production writer;
- a balanced serial schedule, fixture preflight, provenance-safe resume rules,
  plan-only defaults, explicit paid/full-study confirmations, and a soft USD
  stop rule;
- per-cell artifacts and an offline analyser for report validation, conservative
  numeric grounding, guardrails, citations, usage, cost completeness, latency,
  reviewer activity, and paired within-block deltas;
- 22 offline tests at the artifact and configuration seams.

## Validation

- 1203 tests and 545 subtests passed locally;
- Ruff passed with the same latest-version command used by CI;
- the CI-specific Pylint exception-order and undefined-variable checks passed;
- plan-only pilot output was inspected and made no API calls or result files;
- grounding, hidden-temperature, and damaged-metadata defects were deliberately
  re-injected and each relevant test failed before the fix was restored.

## Scope

This PR does not change production retrieval, prompts, scoring, confidence
rules, report blocking policy, CrewAI version, API behavior, or deployment.
No paid pilot has been run; that remains a separate budget decision after this
harness is reviewed.
