### PR TITLE
Fix ablation measurement seams exposed by the paid pilot

### DIFF
--- a/ablation.py
+++ b/ablation.py
@@ -114,7 +114,17 @@ class GuardrailRecorder:
             if not callable(guardrail):
                 continue
             task_name = str(getattr(task, "name", "") or f"task_{index}")
-            task.guardrail = self.wrap(task_name, guardrail)
+            recorded = self.wrap(task_name, guardrail)
+            task.guardrail = recorded
+            # CrewAI 1.14.7 copies the validated public field into this private
+            # execution slot during Task construction. Assignment validation
+            # does not refresh it later, so wrapping only ``task.guardrail``
+            # produces convincing metadata with zero attempts while the
+            # original private callable still runs. Keep both views aligned;
+            # patching CrewAI's invocation method would be broader and would
+            # make the experiment depend on framework internals elsewhere.
+            if hasattr(task, "_guardrail"):
+                task._guardrail = recorded
 
     def task_summary(self, task_name: str) -> dict[str, Any]:
         attempts = self.attempts.get(task_name, [])

--- a/ablation_check.py
+++ b/ablation_check.py
@@ -152,7 +152,14 @@ def analyse_numeric_grounding(
             continue
 
         checkable = [source for source in cited if _source_is_checkable(source)]
-        if not checkable:
+        if len(checkable) != len(cited):
+            # A report line may contain several clauses and citations. Pooling
+            # the line lets an abstract or patent make the line "checkable"
+            # while the actual number belongs to a search-snippet citation.
+            # Without clause-level attribution, marking that number unsupported
+            # is a false accusation. Treat the whole mixed-provenance line as
+            # unverifiable: this deliberately gives up recall to preserve the
+            # experiment's pre-registered precision-first interpretation.
             unverifiable_lines += 1
             continue
 

--- a/docs/prereg-2026-08-21-agent-topology-ablation.md
+++ b/docs/prereg-2026-08-21-agent-topology-ablation.md
@@ -184,3 +184,41 @@ This experiment does not change the scoring formula, evidence-confidence
 floor, TRL rubric, maturity-language screen, uncited-claim blocking policy,
 prompt caching, source-summary retrieval, or CrewAI version. The production
 six-node arm is the unmodified control.
+
+## Stage 1 pilot outcome - 2026-08-21
+
+The three approved paid cells ran from commit `e532eb80` against frozen case
+03 (`solid-state batteries for electric vehicles`). The persisted experiment
+is `outputs/ablation/20260821T114329Z-e532eb80`.
+
+| Arm | Status | Requests | Tokens | Observed cost | Elapsed |
+|---|---:|---:|---:|---:|---:|
+| Monolith | success | 1 | 15,535 | $0.009123 | 43.935 s |
+| Specialists + writer | success | 4 | 37,130 | $0.019728 | 61.739 s |
+| Full | success | 6 | 79,143 | $0.028989 | 74.257 s |
+
+All three final reports reached disk, used the same fixture digest, represented
+all three source domains, and had complete model pricing. Total observed spend
+was $0.057840.
+
+The pilot nevertheless hit the pre-registered stop rule. CrewAI 1.14.7 executes
+the private `Task._guardrail` callable captured during construction, while the
+recorder had replaced only the later public `Task.guardrail` field. Production
+guardrails still ran, but all attempt counts were therefore falsely recorded as
+zero and P1 could not be evaluated.
+
+A second measurement defect was exposed by the saved reports. A line containing
+both a checkable academic or patent citation and a non-checkable search-snippet
+market citation was treated as wholly checkable. Market figures that appeared
+verbatim in M4 and M5 were then compared only with the unrelated checkable
+sources and falsely marked unsupported. The precision-first correction treats
+mixed-provenance lines as unverifiable unless every cited source is checkable.
+
+With that correction, offline re-analysis reports zero unsupported numeric lines
+for all three arms; checked/unverifiable lines are 6/30, 5/12, and 4/14 for the
+monolith, four-node, and full arms respectively. This re-analysis diagnoses the
+saved output but does not repair the missing runtime guardrail-attempt history.
+
+The one-run cost differences are descriptive pilot observations, not an
+architecture decision. The paid pilot must be rerun from the corrected commit
+before the ninety-cell study can be considered.

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -206,7 +206,7 @@ def test_monolith_guardrail_delegates_to_the_production_report_policy(
 
 
 def test_guardrail_recorder_preserves_return_values_and_counts_retries() -> None:
-    """Instrumentation at the Task seam must not alter CrewAI retry semantics."""
+    """Instrumentation must wrap CrewAI's private seam without changing retries."""
 
     calls = 0
 
@@ -231,6 +231,18 @@ def test_guardrail_recorder_preserves_return_values_and_counts_retries() -> None
     assert summary["failures"] == 1
     assert summary["retries"] == 1
     assert summary["attempts"][0]["before_sha256_16"] != ""
+
+    task = SimpleNamespace(
+        name="runtime",
+        guardrail=guardrail,
+        _guardrail=guardrail,
+    )
+    runtime_recorder = GuardrailRecorder()
+    runtime_recorder.instrument([task])
+    third = SimpleNamespace(raw="delivered report")
+    assert task._guardrail(third) == (True, third)
+    assert task.guardrail is task._guardrail
+    assert runtime_recorder.task_summary("runtime")["calls"] == 1
 
 
 def test_report_selection_asserts_the_delivered_artifact_boundary() -> None:
@@ -264,7 +276,7 @@ def test_numeric_grounding_distinguishes_pass_fail_and_not_checked() -> None:
 
 
 def test_snippet_absence_is_unverifiable_not_unsupported() -> None:
-    """A search fragment cannot disprove a figure that may exist off-screen."""
+    """A snippet stays unverifiable even when a checkable source shares its line."""
 
     snippet = _source(
         "M1",
@@ -280,6 +292,16 @@ def test_snippet_absence_is_unverifiable_not_unsupported() -> None:
     assert result.checked_claim_lines == 0
     assert result.unsupported_claim_lines == 0
     assert result.unverifiable_claim_lines == 1
+
+    mixed = analyse_numeric_grounding(
+        "Laboratory efficiency improved [A1]. Market revenue reached "
+        "$37.4 million [M1].",
+        {"A1": _source("A1"), "M1": snippet},
+    )
+    assert mixed.status == "not_checked"
+    assert mixed.checked_claim_lines == 0
+    assert mixed.unsupported_claim_lines == 0
+    assert mixed.unverifiable_claim_lines == 1
 
 
 def test_summary_boundary_carries_every_declared_column() -> None:


### PR DESCRIPTION
The first paid one/four/six-node pilot completed, but it exposed two measurement defects that trigger the pre-registered stop rule. CrewAI executes the private Task._guardrail callable captured during construction, while the recorder had wrapped only the public field, so guardrails ran but every attempt count was falsely zero. The patch keeps both execution views aligned. It also treats report lines with mixed checkable and search-snippet citations as unverifiable, because pooling those sources produced false unsupported market figures. Regression assertions were proven by re-injecting both defects. The preregistration now records the 0.057840 USD pilot, the invalid measurements, and why the full study remains blocked pending a corrected pilot. Verification: uv run pytest -q (1203 passed, 545 subtests); uv run --with ruff ruff check . (passed).