### PR TITLE
Harden the paid pilot reviewer and precision screens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1203 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1208 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/docs/prereg-2026-08-21-agent-topology-ablation.md
+++ b/docs/prereg-2026-08-21-agent-topology-ablation.md
@@ -222,3 +222,51 @@ saved output but does not repair the missing runtime guardrail-attempt history.
 The one-run cost differences are descriptive pilot observations, not an
 architecture decision. The paid pilot must be rerun from the corrected commit
 before the ninety-cell study can be considered.
+
+## Corrected Stage 1 pilot outcome - 2026-08-21
+
+The three approved cells were rerun from merge commit `2d929429` against the
+same frozen case 03 and fixture digest `8643e7369b337b9b`. The persisted
+experiment is `outputs/ablation/20260821T130155Z-2d929429`.
+
+| Arm | Status | Requests | Tokens | Observed cost | Elapsed |
+|---|---:|---:|---:|---:|---:|
+| Monolith | success | 1 | 16,484 | $0.008272 | 56.758 s |
+| Specialists + writer | success | 4 | 37,558 | $0.017908 | 64.534 s |
+| Full | reviewer guardrail failure | 6 | 67,940 | $0.028757 | 89.574 s |
+
+Total observed spend was $0.054937, below the approved $0.20 soft ceiling.
+Every provider request was attributed to a priced model, and all three cells
+used fixture evidence rather than live retrieval.
+
+The corrected measurement seam worked. The monolith recorded one report
+guardrail call; the four-node arm recorded one call for each of its four tasks;
+and the full arm recorded one call for each evidence task and the writer plus
+two failed reviewer calls, including one retry. This resolves the instrumentation
+defect found in the first pilot without changing production guardrail behavior.
+
+The full arm did not reach the scorer or persist a final report. On both
+reviewer attempts, the model returned at least one correction whose `find` and
+`replace` strings were identical while explaining that no change was needed.
+The reviewer guardrail correctly rejected the no-op, but the second identical
+failure exhausted its single retry and failed the whole crew. This is a real
+workflow-reliability result, not a harness or persistence defect, and triggers
+the Stage 1 stop rule. No full ninety-cell study should run until the no-op
+review path is made failure-tolerant and another three-cell pilot succeeds.
+
+The two completed reports also failed the offline report contract: the
+monolith had 12 findings and the four-node arm had 3. The monolith introduced
+an uncited automotive cycle-life threshold, which the numeric grounding screen
+correctly identified as unsupported. The four-node screen's `2013 eur` finding
+is a false positive caused by reading the phrase "2013 European patent" as a
+currency amount. Its patent-framing finding is also a negated disclaimer that
+contains the prohibited phrase rather than an affirmative legal claim. These
+precision defects must be separated from genuine report defects before the
+quality metrics can support an architecture decision.
+
+This corrected pilot still does not decide P1-P4. P1 was not supported in this
+single case because both completed arms passed the report guardrail on their
+first attempt. P2 and the common full-arm quality outcomes are unavailable
+because the reviewer stopped the full arm. The four-node arm used 55.3% of the
+failed full arm's tokens and 62.3% of its observed cost, but the full arm never
+reached its scorer, so those differences are diagnostic only.

--- a/docs/prereg-2026-08-21-agent-topology-ablation.md
+++ b/docs/prereg-2026-08-21-agent-topology-ablation.md
@@ -270,3 +270,28 @@ first attempt. P2 and the common full-arm quality outcomes are unavailable
 because the reviewer stopped the full arm. The four-node arm used 55.3% of the
 failed full arm's tokens and 62.3% of its observed cost, but the full arm never
 reached its scorer, so those differences are diagnostic only.
+
+### Post-pilot reliability fixes - 2026-08-21
+
+The three pilot defects were reproduced at their delivery or metric seams before
+implementation: the new focused selection failed three tests while the explicit
+EUR amount and contrast-clause patent overclaim controls still passed.
+
+The reviewer now treats an identical `find`/`replace` pair as an empty
+correction rather than spending its only retry on a harmless representation of
+"no change." Real edits in the same plan still follow the exact-match rules,
+and the preserved draft still passes the complete delivered-report validation.
+Alphabetic numeric units now require a token boundary, so "2013 European" is a
+year and adjective while "2013 EUR" remains a checkable amount. Patent-framing
+detection recognises a locally negated disclaimer but ends that exemption at
+punctuation or a contrast such as "but," preserving positive-overclaim checks.
+
+A zero-network re-analysis with the project functions leaves the monolith's 12
+contract findings and one unsupported numeric claim unchanged. The four-node
+report moves from three to two contract findings because the negated patent
+disclaimer is no longer misclassified, and its grounding changes from one
+unsupported line out of seven checked to zero out of six: the removed line is
+the publication-year false positive. The genuine monolith `1,000+` automotive
+cycle-life threshold remains unsupported. The failed full cell cannot be
+reconstructed from persisted artifacts, so a successful three-cell paid rerun
+is still required before Stage 2 can be considered.

--- a/src/academic_agent/claim_grounding.py
+++ b/src/academic_agent/claim_grounding.py
@@ -44,10 +44,14 @@ _SUBSTANTIVE_SUMMARY_CHARS = 400
 #: figure must carry a decimal point, a percent sign, a unit, or be large.
 _LARGE_ENOUGH = 1000
 
+# Alphabetic units must end at the token boundary. Without this, ``eur`` at
+# the start of "European" turns an ordinary publication year into a currency
+# figure; the optional unit group then bypasses the bare-year exclusion below.
 _UNIT_PATTERN = (
     r"(?:%|percent|wh/kg|wh/l|mah|kwh|mwh|gwh|kw|mw|gw|mpa|gpa|kpa|"
-    r"°c|℃|k\b|nm|µm|um|mm|cm|km|kg|mg|µg|ug|ml|mol|hz|khz|mhz|ghz|"
-    r"usd|eur|billion|million|trillion|bn|yr|years?|months?|cycles?|x\b)"
+    r"°c|℃|k|nm|µm|um|mm|cm|km|kg|mg|µg|ug|ml|mol|hz|khz|mhz|ghz|"
+    r"usd|eur|billion|million|trillion|bn|yr|years?|months?|cycles?|x)"
+    r"(?![A-Za-z])"
 )
 
 #: Spellings of the same unit. A claim writing "%" against a source writing
@@ -69,7 +73,7 @@ def _normalize_unit(unit: str) -> str:
 
 
 _FIGURE_RE = re.compile(
-    r"(?<![\w.])(\d[\d,]*(?:\.\d+)?)\s*" + _UNIT_PATTERN + r"?",
+    r"(?<![\w.])(\d[\d,]*(?:\.\d+)?)\s*(?:" + _UNIT_PATTERN + r")?",
     re.IGNORECASE,
 )
 

--- a/src/academic_agent/evidence.py
+++ b/src/academic_agent/evidence.py
@@ -1274,6 +1274,37 @@ def _validate_currency_unit_contradictions(
     return errors
 
 
+_REPORT_PATENT_OVERCLAIM_RE = re.compile(
+    r"\b(?:freedom-to-operate opportunit(?:y|ies)|without infringing|"
+    r"non[- ]infringing|clear freedom to operate)\b",
+    re.IGNORECASE,
+)
+_NEGATED_PATENT_OVERCLAIM_PREFIX_RE = re.compile(
+    r"\b(?:never|cannot|can't|does\s+not|do\s+not|did\s+not|"
+    r"is\s+not|are\s+not|must\s+not|should\s+not)\b"
+    r"(?P<scope>[^.!?;]{0,120})$",
+    re.IGNORECASE,
+)
+_NEGATION_SCOPE_BREAK_RE = re.compile(
+    r"\b(?:but|however|yet|although|except)\b", re.IGNORECASE
+)
+
+
+def _patent_overclaim_is_negated(line: str, match_start: int) -> bool:
+    """Recognise an explicit disclaimer without hiding a later positive claim.
+
+    The scope is intentionally local and stops at sentence punctuation. A
+    contrast conjunction after the negation also ends the exemption: "not legal
+    advice, but this is an FTO opportunity" remains an overclaim.
+    """
+
+    clause_prefix = re.split(r"[.!?;]", line[:match_start])[-1][-160:]
+    negation = _NEGATED_PATENT_OVERCLAIM_PREFIX_RE.search(clause_prefix)
+    if negation is None:
+        return False
+    return _NEGATION_SCOPE_BREAK_RE.search(negation.group("scope")) is None
+
+
 def _validate_high_risk_claims(
     body: str,
     allowed_sources: dict[str, EvidenceSource],
@@ -1300,9 +1331,9 @@ def _validate_high_risk_claims(
         ]
         for label in noncanonical_labels:
             errors.append(f"Noncanonical citation label on report line {line_number}: [{label}].")
-        if re.search(
-            r"\b(?:freedom-to-operate opportunit|without infringing|non[- ]infringing|clear freedom to operate)",
-            lowered,
+        if any(
+            not _patent_overclaim_is_negated(lowered, match.start())
+            for match in _REPORT_PATENT_OVERCLAIM_RE.finditer(lowered)
         ):
             errors.append(
                 f"Patent legal overclaim on report line {line_number}: "
@@ -1968,7 +1999,12 @@ def _apply_reviewer_corrections(
     reasons: list[str] = []
     for index, correction in enumerate(plan.corrections, start=1):
         if correction.find == correction.replace:
-            return None, [], f"Correction {index} is a no-op."
+            # A no-op cannot alter the validated draft. Rejecting it spends the
+            # reviewer's only retry on asking the model to express "no change"
+            # differently, and the paid pilot showed that it may repeat the same
+            # harmless plan and discard the whole run. Drop it exactly as an empty
+            # correction; real edits in the same plan still pass through below.
+            continue
         if re.search(r"(?m)^#{1,6}\s", correction.find + "\n" + correction.replace):
             return None, [], f"Correction {index} attempts to edit a section heading."
 

--- a/tests/test_claim_grounding.py
+++ b/tests/test_claim_grounding.py
@@ -85,6 +85,13 @@ class FigureExtractionTests(TestCase):
     def test_a_year_with_a_unit_is_a_quantity_not_a_date(self):
         self.assertIn(("2024", "gwh"), checkable_figures("shipped 2024 GWh of capacity"))
 
+    def test_year_before_european_is_not_misread_as_eur_currency(self):
+        """The paid pilot's "2013 European patent" is a date plus adjective."""
+        self.assertEqual(checkable_figures("The 2013 European patent describes casting"), [])
+
+    def test_explicit_eur_amount_after_year_shaped_number_remains_checkable(self):
+        self.assertEqual(checkable_figures("The contract value was 2013 EUR"), [("2013", "eur")])
+
     def test_round_numbers_behind_a_comparative_are_bounds_not_quotations(self):
         """The false positives that motivated this rule. Each is sound given
         sources stating a larger figure."""

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -361,6 +361,35 @@ Only public evidence was reviewed.
 
         self.assertTrue(any("Patent legal overclaim" in error for error in errors))
 
+    def test_negated_patent_overclaim_phrase_is_not_rejected(self) -> None:
+        """A disclaimer naming the forbidden claim is not making that claim."""
+        report = self.valid_report.replace(
+            "This preliminary patent scan is not legal advice or a freedom-to-operate opinion.",
+            (
+                "This preliminary patent scan is not legal advice or a freedom-to-operate opinion.\n"
+                "The discussion never describes inferred white space as a "
+                "freedom-to-operate opportunity or proof that infringement is absent."
+            ),
+        )
+
+        errors = validate_final_report(report, self.allowed)
+
+        self.assertFalse(any("Patent legal overclaim" in error for error in errors))
+
+    def test_contrast_after_disclaimer_does_not_hide_an_overclaim(self) -> None:
+        """Negation in an earlier clause must not excuse a later positive claim."""
+        report = self.valid_report.replace(
+            "This preliminary patent scan is not legal advice or a freedom-to-operate opinion.",
+            (
+                "This preliminary patent scan is not legal advice, but it identifies a "
+                "freedom-to-operate opportunity [A1]."
+            ),
+        )
+
+        errors = validate_final_report(report, self.allowed)
+
+        self.assertTrue(any("Patent legal overclaim" in error for error in errors))
+
     def test_broad_no_government_claim_contradicts_government_source(self) -> None:
         government_source = EvidenceSource(
             source_id="M1",

--- a/tests/test_reviewer_guardrail.py
+++ b/tests/test_reviewer_guardrail.py
@@ -198,6 +198,33 @@ class ReviewerCorrectionPlanTests(unittest.TestCase):
         self.assertIn("[P1] Source P1", result)
         self.assertIn("Qualified an unsupported absolute deployment claim.", result)
 
+    def test_noop_correction_is_treated_as_an_empty_plan(self):
+        """A model saying "no change needed" must not discard a paid report.
+
+        The corrected ablation pilot returned an exact find/replace pair whose
+        strings were identical, twice. Retrying cannot improve a semantically
+        harmless operation, so the safe boundary behavior is to preserve the
+        validated draft and record that no correction was required.
+        """
+        draft = _complete_report()
+        unchanged = "Findings are supported by [A1][P1][M1]."
+
+        ok, result = _run(
+            _plan(
+                {
+                    "find": unchanged,
+                    "replace": unchanged,
+                    "reason": "No change needed; citation is present and correct.",
+                }
+            ),
+            draft=draft,
+            context_tasks=_EVIDENCE_TASKS,
+        )
+
+        self.assertTrue(ok)
+        self.assertIn(unchanged, result)
+        self.assertIn("## Reviewer Notes\n\nNo corrections required.", result)
+
     def test_ambiguous_target_is_rejected_instead_of_patching_first_match(self):
         ok, message = _run(
             _plan(


### PR DESCRIPTION
## Why

The corrected paid topology pilot proved that guardrail-attempt measurement now observes CrewAI's real execution seam, but it also exposed three reliability and precision defects that must be fixed before another paid pilot:

- The full topology lost its report after five successful model calls because the reviewer returned identical find/replace strings twice.
- The numeric screen parsed the ur prefix of European as a currency unit.
- The patent screen treated a locally negated disclaimer as a positive legal claim.

## Changes

- Treat reviewer no-op replacements as an empty correction while preserving all exact-match rules for real edits and revalidating the delivered report.
- Require alphabetic numeric units to end at a token boundary; explicit 2013 EUR remains checkable.
- Exempt only locally negated patent-overclaim phrases, with punctuation and contrast clauses ending that exemption.
- Record the corrected pilot, its stop condition, and the zero-network re-analysis in the preregistration.
- Update the repository test count.

## Evidence

The new tests were run against the original implementation first: 3 failed and 2 controls passed. After the fix:

- Focused regression selection: 5 passed.
- Related modules: 121 passed + 14 subtests.
- Full suite: 1208 passed + 545 subtests.
- Ruff: passed.
- Saved paid report re-analysis: four-node numeric grounding changed from 1 unsupported / 7 checked to 0 / 6; its negated patent false positive disappeared. The monolith's genuine unsupported 1,000+ cycle-life threshold remains flagged.

No paid calls were made for this fix, and the ninety-cell study remains stopped pending another approved three-cell pilot.