### PR TITLE
Add a blinded audit path for reviewer value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1208 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1218 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/ablation.py
+++ b/ablation.py
@@ -407,6 +407,61 @@ def draft_retention_ratio(draft: str | None, delivered: str | None) -> float | N
     return round(SequenceMatcher(None, draft, final_body, autojunk=False).ratio(), 6)
 
 
+def persist_successful_reviewer_plan(
+    cell_dir: Path,
+    recorder: GuardrailRecorder,
+    expected_corrections: int,
+) -> Path | None:
+    """Persist only the accepted structured plan used to build the final report.
+
+    Hashes and final prose cannot reconstruct exact patch boundaries. Failed
+    plans remain hash-only to preserve the pre-registered anti-cherry-picking
+    boundary; the final successful plan is different because it is the causal
+    record of what the Reviewer changed.
+    """
+
+    attempts = recorder.attempts.get("report_review_task", [])
+    successful = [
+        attempt
+        for attempt in attempts
+        if attempt.passed and attempt.raw_before.lstrip().startswith("{")
+    ]
+    if not successful:
+        if expected_corrections:
+            raise RuntimeError(
+                "Reviewer corrections were delivered without a persisted JSON plan"
+            )
+        return None
+
+    raw_plan = json.loads(successful[-1].raw_before)
+    raw_corrections = raw_plan.get("corrections")
+    if not isinstance(raw_corrections, list):
+        raise RuntimeError("successful Reviewer plan has no corrections list")
+    corrections = [
+        correction
+        for correction in raw_corrections
+        if isinstance(correction, dict)
+        and correction.get("find") != correction.get("replace")
+    ]
+    if len(corrections) != expected_corrections:
+        raise RuntimeError(
+            "Reviewer plan/report correction count mismatch: "
+            f"{len(corrections)} plan items vs {expected_corrections} notes"
+        )
+
+    path = cell_dir / "reviewer_correction_plan.json"
+    path.write_text(
+        json.dumps(
+            {"schema_version": 1, "corrections": corrections},
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _task_filename(index: int, output: Any) -> str:
     name = str(getattr(output, "name", "") or f"task-{index}").lower()
     safe = re.sub(r"[^a-z0-9]+", "-", name).strip("-") or f"task-{index}"
@@ -542,6 +597,12 @@ def run_cell(
         meta["reviewer_corrections"] = (
             reviewer_correction_count(delivered) if cell.variant == "full" else None
         )
+        if cell.variant == "full":
+            persist_successful_reviewer_plan(
+                cell_dir,
+                recorder,
+                meta["reviewer_corrections"],
+            )
         meta["draft_retention_ratio"] = (
             draft_retention_ratio(draft, delivered) if cell.variant == "full" else None
         )

--- a/docs/prereg-2026-08-22-reviewer-value-audit.md
+++ b/docs/prereg-2026-08-22-reviewer-value-audit.md
@@ -1,0 +1,79 @@
+# Pre-registration: blinded audit of Reviewer value
+
+**Registered:** 2026-08-22, before any human preference labels were collected
+**Cost:** zero API calls; existing topology-ablation artifacts only
+
+## Question
+
+The full topology's Reviewer accepted 34 corrections across 9 of 29 successful
+reports. "Accepted by the structural guardrail" does not mean "helpful to a
+reader." This audit asks whether the delivered, reviewed report is actually
+better than its validated Writer draft.
+
+## Historical-data boundary
+
+The 90-cell experiment persisted each Writer draft, delivered report, Reviewer
+notes, and the number of accepted correction-plan items. It did **not** persist
+the original structured `find` / `replace` / `reason` objects. Character or
+token diffs cannot reconstruct those objects one-to-one: the 34 plan items
+produce 51 token-level edit opcodes. Therefore:
+
+- the audit unit is one complete report pair, giving 9 cases;
+- the 34 count describes how many plan items produced those pairs;
+- no result from this audit may be described as "34 corrections independently
+  judged" or as a correction-level accuracy rate.
+
+This limitation is preferable to manufacturing a more precise-looking sample
+from an irreversible diff.
+
+## Blinding and packet construction
+
+`reviewer_audit.py prepare` strips deterministic Reviewer Notes, shuffles the
+9 cases with a fixed seed, and randomly assigns the reviewed report to A or B.
+The packet contains only the A/B reports, rubric, manifest, and blank form. The
+answer key is required to live outside the packet directory.
+
+For each pair, an evaluator records:
+
+1. overall preferred version;
+2. version with better citation support;
+3. version with greater commercialization-decision usefulness;
+4. whether either version contains a harmful change;
+5. confidence from 1 to 5 and a short rationale.
+
+Allowed A/B judgments are `A`, `B`, `TIE`, and `UNCERTAIN`. Harm uses `A`, `B`,
+`NONE`, or `UNCERTAIN`. Empty means **not evaluated**, never tie or pass.
+
+## Pre-registered decision rule
+
+The Reviewer is provisionally supported only if all 9 cases are completed and:
+
+- the reviewed version is preferred in at least 6 of 9 reports;
+- the reviewed version is identified as harmful in at most 1 of 9 reports;
+- the draft has better citation support in at most 1 of 9 reports.
+
+This is a small, one-experiment audit. Passing supports retaining the Reviewer
+for a larger independent evaluation; it does not prove general user value.
+Failing means the six-node topology has not justified the Reviewer's extra cost
+and latency. A tie-heavy result is inconclusive, not positive.
+
+## Execution
+
+```bash
+uv run python reviewer_audit.py prepare \
+  outputs/ablation/20260821T234300Z-7dd894ef \
+  outputs/reviewer-audit/20260822-packet \
+  outputs/reviewer-audit/20260822-answer-key.json \
+  --seed 20260822
+
+# Fill outputs/reviewer-audit/20260822-packet/review_form.csv without opening
+# the answer key, then unblind once every row is complete:
+uv run python reviewer_audit.py summarize \
+  outputs/reviewer-audit/20260822-packet/review_form.csv \
+  outputs/reviewer-audit/20260822-answer-key.json \
+  outputs/reviewer-audit/20260822-summary.json
+```
+
+For a resume-grade claim, two independent evaluators should complete separate
+copies of the packet before either sees the key. Agreement and disagreements
+should be reported alongside the aggregate outcome.

--- a/reviewer_audit.py
+++ b/reviewer_audit.py
@@ -1,0 +1,356 @@
+"""Prepare and score a blinded human audit of Reviewer-edited reports.
+
+The first topology ablation retained the Writer draft, the delivered report,
+and a count of accepted Reviewer corrections.  It did not retain each
+structured ``find``/``replace`` operation, so those historical runs support a
+report-level A/B audit, not an exact correction-level audit.  This tool keeps
+that distinction explicit and never treats an unfilled form as a tie or pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+PAIR_LABELS = {"A", "B", "TIE", "UNCERTAIN"}
+HARM_LABELS = {"A", "B", "NONE", "UNCERTAIN"}
+REQUIRED_JUDGMENTS = (
+    "preferred_version",
+    "citation_support",
+    "decision_usefulness",
+    "harmful_version",
+    "confidence",
+)
+FORM_FIELDS = ("sample_id", *REQUIRED_JUDGMENTS, "notes")
+
+
+class AuditDataError(ValueError):
+    """Raised when an audit would silently misrepresent missing evidence."""
+
+
+@dataclass(frozen=True)
+class ReviewCase:
+    """One successful full-arm run with at least one accepted correction."""
+
+    source_cell: str
+    topic: str
+    declared_corrections: int
+    draft: str
+    reviewed: str
+    reviewer_cost_usd: float | None
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _without_reviewer_notes(report: str) -> str:
+    """Remove deterministic notes that would reveal which side is reviewed."""
+
+    return report.split("## Reviewer Notes", maxsplit=1)[0].rstrip()
+
+
+def _reviewer_cost(meta: dict[str, Any]) -> float | None:
+    agents = meta.get("usage", {}).get("agents", [])
+    for agent in agents:
+        if "quality reviewer" in str(agent.get("role", "")).lower():
+            value = agent.get("cost_usd")
+            return float(value) if value is not None else None
+    return None
+
+
+def discover_review_cases(experiment_dir: Path) -> list[ReviewCase]:
+    """Read auditable historical pairs and fail loudly on missing artifacts."""
+
+    cases: list[ReviewCase] = []
+    for meta_path in sorted(experiment_dir.glob("*/meta.json")):
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        corrections = meta.get("reviewer_corrections")
+        if (
+            meta.get("variant") != "full"
+            or meta.get("status") != "success"
+            or not isinstance(corrections, int)
+            or corrections <= 0
+        ):
+            continue
+
+        draft_path = meta_path.parent / "draft_report.md"
+        reviewed_path = meta_path.parent / "commercialization_report.md"
+        missing = [path.name for path in (draft_path, reviewed_path) if not path.is_file()]
+        if missing:
+            raise AuditDataError(
+                f"{meta_path.parent.name} declares {corrections} corrections but is missing "
+                + ", ".join(missing)
+            )
+
+        draft = draft_path.read_text(encoding="utf-8").rstrip()
+        reviewed = _without_reviewer_notes(reviewed_path.read_text(encoding="utf-8"))
+        if draft == reviewed:
+            raise AuditDataError(
+                f"{meta_path.parent.name} declares corrections but the report bodies are equal"
+            )
+        cases.append(
+            ReviewCase(
+                source_cell=meta_path.parent.name,
+                topic=str(meta.get("topic", "")),
+                declared_corrections=corrections,
+                draft=draft,
+                reviewed=reviewed,
+                reviewer_cost_usd=_reviewer_cost(meta),
+            )
+        )
+
+    if not cases:
+        raise AuditDataError("no successful full-arm runs with accepted corrections were found")
+    return cases
+
+
+def _assert_separate_key(packet_dir: Path, answer_key_path: Path) -> None:
+    packet = packet_dir.resolve()
+    key = answer_key_path.resolve()
+    if key == packet or packet in key.parents:
+        raise AuditDataError("the answer key must be outside the blinded packet directory")
+
+
+def _write_form(path: Path, sample_ids: list[str]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FORM_FIELDS)
+        writer.writeheader()
+        for sample_id in sample_ids:
+            writer.writerow({"sample_id": sample_id})
+
+
+def _packet_readme(case_count: int) -> str:
+    return f"""# Blinded Reviewer value audit
+
+This packet contains {case_count} report pairs. A and B are randomly assigned;
+neither filename indicates which report passed through the Reviewer.
+
+Read both reports in each sample directory and complete `review_form.csv`:
+
+- `preferred_version`, `citation_support`, `decision_usefulness`:
+  `A`, `B`, `TIE`, or `UNCERTAIN`.
+- `harmful_version`: `A`, `B`, `NONE`, or `UNCERTAIN`.
+- `confidence`: integer 1-5.
+- `notes`: concise evidence for the judgment.
+
+Do not open the separately stored answer key until every row is complete. An
+empty row means *not evaluated*, never a tie. The historical artifacts did not
+retain the 34 exact patch-plan items, so the unit here is a complete report
+pair. Do not report this as a correction-level audit.
+"""
+
+
+def prepare_packet(
+    experiment_dir: Path,
+    packet_dir: Path,
+    answer_key_path: Path,
+    *,
+    seed: int,
+) -> dict[str, Any]:
+    """Create a deterministic, anonymized packet and a physically separate key."""
+
+    _assert_separate_key(packet_dir, answer_key_path)
+    if packet_dir.exists() or answer_key_path.exists():
+        raise AuditDataError("packet and answer-key paths must not already exist")
+
+    cases = discover_review_cases(experiment_dir)
+    rng = random.Random(seed)
+    rng.shuffle(cases)
+    packet_dir.mkdir(parents=True)
+    answer_key_path.parent.mkdir(parents=True, exist_ok=True)
+
+    key_cases: list[dict[str, Any]] = []
+    sample_ids: list[str] = []
+    for index, case in enumerate(cases, start=1):
+        sample_id = f"R{index:02d}"
+        sample_ids.append(sample_id)
+        reviewed_side = rng.choice(("A", "B"))
+        reports = (
+            {"A": case.reviewed, "B": case.draft}
+            if reviewed_side == "A"
+            else {"A": case.draft, "B": case.reviewed}
+        )
+        sample_dir = packet_dir / sample_id
+        sample_dir.mkdir()
+        for side, report in reports.items():
+            (sample_dir / f"{side}.md").write_text(report + "\n", encoding="utf-8")
+
+        key_cases.append(
+            {
+                "sample_id": sample_id,
+                "source_cell": case.source_cell,
+                "topic": case.topic,
+                "reviewed_side": reviewed_side,
+                "declared_corrections": case.declared_corrections,
+                "reviewer_cost_usd": case.reviewer_cost_usd,
+                "report_sha256": {side: _sha256(report) for side, report in reports.items()},
+            }
+        )
+
+    declared_total = sum(case.declared_corrections for case in cases)
+    manifest = {
+        "schema_version": 1,
+        "audit_unit": "report_pair",
+        "case_count": len(cases),
+        "declared_correction_count": declared_total,
+        "review_status": "not_started",
+        "blinding": "randomized A/B; answer key stored separately",
+        "historical_limit": (
+            "Exact find/replace plans were not persisted; correction-level claims are invalid."
+        ),
+    }
+    (packet_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    (packet_dir / "README.md").write_text(_packet_readme(len(cases)), encoding="utf-8")
+    _write_form(packet_dir / "review_form.csv", sample_ids)
+
+    answer_key = {
+        "schema_version": 1,
+        "seed": seed,
+        "experiment_dir": experiment_dir.name,
+        "cases": key_cases,
+    }
+    answer_key_path.write_text(
+        json.dumps(answer_key, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def _normalize_label(value: str) -> str:
+    return value.strip().upper()
+
+
+def _validate_complete_row(row: dict[str, str]) -> bool:
+    if any(not row.get(field, "").strip() for field in REQUIRED_JUDGMENTS):
+        return False
+    for field in ("preferred_version", "citation_support", "decision_usefulness"):
+        if _normalize_label(row[field]) not in PAIR_LABELS:
+            raise AuditDataError(f"{row['sample_id']} has invalid {field}: {row[field]}")
+    if _normalize_label(row["harmful_version"]) not in HARM_LABELS:
+        raise AuditDataError(
+            f"{row['sample_id']} has invalid harmful_version: {row['harmful_version']}"
+        )
+    try:
+        confidence = int(row["confidence"])
+    except ValueError as exc:
+        raise AuditDataError(f"{row['sample_id']} confidence must be an integer") from exc
+    if confidence not in range(1, 6):
+        raise AuditDataError(f"{row['sample_id']} confidence must be between 1 and 5")
+    return True
+
+
+def _relative_outcome(label: str, reviewed_side: str) -> str:
+    normalized = _normalize_label(label)
+    if normalized in {"TIE", "NONE", "UNCERTAIN"}:
+        return normalized.lower()
+    return "reviewed" if normalized == reviewed_side else "draft"
+
+
+def summarize_form(form_path: Path, answer_key_path: Path) -> dict[str, Any]:
+    """Unblind completed rows while preserving not-evaluated as a distinct state."""
+
+    key = json.loads(answer_key_path.read_text(encoding="utf-8"))
+    key_by_id = {case["sample_id"]: case for case in key["cases"]}
+    with form_path.open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    row_ids = [row.get("sample_id", "") for row in rows]
+    if len(row_ids) != len(set(row_ids)) or set(row_ids) != set(key_by_id):
+        raise AuditDataError("review form sample IDs do not match the answer key")
+
+    counts = {
+        metric: {label: 0 for label in ("reviewed", "draft", "tie", "uncertain")}
+        for metric in ("preferred_version", "citation_support", "decision_usefulness")
+    }
+    harm = {label: 0 for label in ("reviewed", "draft", "none", "uncertain")}
+    incomplete: list[str] = []
+    completed: list[dict[str, Any]] = []
+    for row in rows:
+        sample_id = row["sample_id"]
+        if not _validate_complete_row(row):
+            incomplete.append(sample_id)
+            continue
+        reviewed_side = key_by_id[sample_id]["reviewed_side"]
+        outcomes: dict[str, str] = {}
+        for metric in counts:
+            outcome = _relative_outcome(row[metric], reviewed_side)
+            counts[metric][outcome] += 1
+            outcomes[metric] = outcome
+        harmful_outcome = _relative_outcome(row["harmful_version"], reviewed_side)
+        harm[harmful_outcome] += 1
+        completed.append(
+            {
+                "sample_id": sample_id,
+                **outcomes,
+                "harmful_version": harmful_outcome,
+                "confidence": int(row["confidence"]),
+            }
+        )
+
+    evaluable = not incomplete
+    preferred = counts["preferred_version"]
+    citation = counts["citation_support"]
+    criterion_passed = (
+        evaluable
+        and preferred["reviewed"] >= 6
+        and harm["reviewed"] <= 1
+        and citation["draft"] <= 1
+    )
+    return {
+        "schema_version": 1,
+        "protocol_status": "complete" if evaluable else "incomplete",
+        "case_count": len(rows),
+        "completed_case_count": len(completed),
+        "incomplete_sample_ids": incomplete,
+        "outcomes": {**counts, "harmful_version": harm},
+        "pre_registered_criterion_passed": criterion_passed if evaluable else None,
+        "cases": completed,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare = commands.add_parser("prepare", help="create a blinded review packet")
+    prepare.add_argument("experiment_dir", type=Path)
+    prepare.add_argument("packet_dir", type=Path)
+    prepare.add_argument("answer_key", type=Path)
+    prepare.add_argument("--seed", type=int, default=20260822)
+
+    summarize = commands.add_parser("summarize", help="unblind a completed form")
+    summarize.add_argument("review_form", type=Path)
+    summarize.add_argument("answer_key", type=Path)
+    summarize.add_argument("output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "prepare":
+        result = prepare_packet(
+            args.experiment_dir,
+            args.packet_dir,
+            args.answer_key,
+            seed=args.seed,
+        )
+    else:
+        result = summarize_form(args.review_form, args.answer_key)
+        args.output.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ablation_reviewer_plan.py
+++ b/tests/test_ablation_reviewer_plan.py
@@ -1,0 +1,87 @@
+"""Tests for the correction-level audit artifact in future ablations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ablation
+
+
+def _attempt(raw: str, *, passed: bool) -> ablation.GuardrailAttempt:
+    return ablation.GuardrailAttempt(
+        task_name="report_review_task",
+        passed=passed,
+        before_chars=len(raw),
+        after_chars=100,
+        before_sha256_16="before",
+        after_sha256_16="after",
+        failure="" if passed else "invalid plan",
+        raw_before=raw,
+    )
+
+
+def test_persist_successful_reviewer_plan_keeps_exact_applied_edits(
+    tmp_path: Path,
+) -> None:
+    """Regression: counts and final prose cannot recover patch boundaries."""
+
+    failed = '{"corrections": ['
+    successful = json.dumps(
+        {
+            "corrections": [
+                {
+                    "find": "unsupported claim",
+                    "replace": "qualified claim [A1]",
+                    "reason": "Qualify and support the statement.",
+                },
+                {
+                    "find": "already supported [A1]",
+                    "replace": "already supported [A1]",
+                    "reason": "No change required.",
+                },
+            ]
+        }
+    )
+    recorder = ablation.GuardrailRecorder()
+    recorder.attempts["report_review_task"] = [
+        _attempt(failed, passed=False),
+        _attempt(successful, passed=True),
+    ]
+
+    path = ablation.persist_successful_reviewer_plan(tmp_path, recorder, 1)
+
+    assert path == tmp_path / "reviewer_correction_plan.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["corrections"] == [json.loads(successful)["corrections"][0]]
+    assert failed not in path.read_text(encoding="utf-8")
+
+
+def test_persist_successful_reviewer_plan_rejects_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    plan = json.dumps(
+        {
+            "corrections": [
+                {"find": "old", "replace": "new", "reason": "Correct it."}
+            ]
+        }
+    )
+    recorder = ablation.GuardrailRecorder()
+    recorder.attempts["report_review_task"] = [_attempt(plan, passed=True)]
+
+    with pytest.raises(RuntimeError, match="count mismatch"):
+        ablation.persist_successful_reviewer_plan(tmp_path, recorder, 2)
+
+
+def test_persist_successful_reviewer_plan_distinguishes_no_plan_from_empty_plan(
+    tmp_path: Path,
+) -> None:
+    recorder = ablation.GuardrailRecorder()
+
+    assert ablation.persist_successful_reviewer_plan(tmp_path, recorder, 0) is None
+    with pytest.raises(RuntimeError, match="without a persisted JSON plan"):
+        ablation.persist_successful_reviewer_plan(tmp_path, recorder, 1)

--- a/tests/test_reviewer_audit.py
+++ b/tests/test_reviewer_audit.py
@@ -1,0 +1,189 @@
+"""Regression tests for the blinded Reviewer-value audit boundary."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import reviewer_audit
+
+
+def _write_cell(
+    root: Path,
+    name: str,
+    *,
+    corrections: int = 2,
+    status: str = "success",
+) -> Path:
+    cell = root / name
+    cell.mkdir(parents=True)
+    meta = {
+        "variant": "full",
+        "status": status,
+        "topic": f"Topic for {name}",
+        "reviewer_corrections": corrections,
+        "usage": {
+            "agents": [
+                {
+                    "role": "Scientific Report Quality Reviewer",
+                    "cost_usd": 0.0123,
+                }
+            ]
+        },
+    }
+    (cell / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (cell / "draft_report.md").write_text(
+        f"# Report {name}\n\nA claim without a citation.\n", encoding="utf-8"
+    )
+    (cell / "commercialization_report.md").write_text(
+        f"# Report {name}\n\nA claim with a citation [A1].\n\n"
+        "## Reviewer Notes\n\n- Added support.\n",
+        encoding="utf-8",
+    )
+    return cell
+
+
+def _read_form(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_form(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=reviewer_audit.FORM_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_prepare_packet_blinds_identity_at_every_reviewer_seam(tmp_path: Path) -> None:
+    """Regression: a hidden key is useless if identity leaks into the packet."""
+
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1", corrections=2)
+    _write_cell(experiment, "002-topic-full-r2", corrections=3)
+    packet = tmp_path / "packet"
+    key_path = tmp_path / "private" / "answer-key.json"
+
+    manifest = reviewer_audit.prepare_packet(
+        experiment, packet, key_path, seed=42
+    )
+
+    assert manifest["case_count"] == 2
+    assert manifest["declared_correction_count"] == 5
+    assert "reviewed_side" not in (packet / "manifest.json").read_text(encoding="utf-8")
+    assert "source_cell" not in (packet / "manifest.json").read_text(encoding="utf-8")
+    assert "Reviewer Notes" not in (packet / "R01" / "A.md").read_text(encoding="utf-8")
+    assert "Reviewer Notes" not in (packet / "R01" / "B.md").read_text(encoding="utf-8")
+
+    rows = _read_form(packet / "review_form.csv")
+    key = json.loads(key_path.read_text(encoding="utf-8"))
+    assert [row["sample_id"] for row in rows] == ["R01", "R02"]
+    assert {case["sample_id"] for case in key["cases"]} == {"R01", "R02"}
+    assert all(row["preferred_version"] == "" for row in rows)
+    for case in key["cases"]:
+        sample = packet / case["sample_id"]
+        for side in ("A", "B"):
+            body = (sample / f"{side}.md").read_text(encoding="utf-8").rstrip()
+            assert reviewer_audit._sha256(body) == case["report_sha256"][side]
+
+
+def test_prepare_packet_rejects_answer_key_inside_blinded_packet(tmp_path: Path) -> None:
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1")
+
+    with pytest.raises(reviewer_audit.AuditDataError, match="outside"):
+        reviewer_audit.prepare_packet(
+            experiment,
+            tmp_path / "packet",
+            tmp_path / "packet" / "answer-key.json",
+            seed=1,
+        )
+
+
+def test_discovery_distinguishes_missing_artifact_from_no_change(tmp_path: Path) -> None:
+    """A declared correction with no delivered file is not an empty audit."""
+
+    experiment = tmp_path / "experiment"
+    cell = _write_cell(experiment, "001-topic-full-r1")
+    (cell / "commercialization_report.md").unlink()
+
+    with pytest.raises(reviewer_audit.AuditDataError, match="missing"):
+        reviewer_audit.discover_review_cases(experiment)
+
+
+def test_summary_keeps_unfilled_rows_distinct_from_ties(tmp_path: Path) -> None:
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1")
+    packet = tmp_path / "packet"
+    key_path = tmp_path / "answer-key.json"
+    reviewer_audit.prepare_packet(experiment, packet, key_path, seed=7)
+
+    summary = reviewer_audit.summarize_form(packet / "review_form.csv", key_path)
+
+    assert summary["protocol_status"] == "incomplete"
+    assert summary["completed_case_count"] == 0
+    assert summary["incomplete_sample_ids"] == ["R01"]
+    assert summary["outcomes"]["preferred_version"]["tie"] == 0
+    assert summary["pre_registered_criterion_passed"] is None
+
+
+def test_summary_unblinds_relative_outcomes_without_changing_labels(
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1")
+    packet = tmp_path / "packet"
+    key_path = tmp_path / "answer-key.json"
+    reviewer_audit.prepare_packet(experiment, packet, key_path, seed=9)
+    key = json.loads(key_path.read_text(encoding="utf-8"))
+    reviewed = key["cases"][0]["reviewed_side"]
+    draft = "B" if reviewed == "A" else "A"
+    rows = _read_form(packet / "review_form.csv")
+    rows[0].update(
+        {
+            "preferred_version": reviewed,
+            "citation_support": reviewed,
+            "decision_usefulness": "TIE",
+            "harmful_version": draft,
+            "confidence": "4",
+            "notes": "The reviewed side adds support without changing the claim.",
+        }
+    )
+    _write_form(packet / "review_form.csv", rows)
+
+    summary = reviewer_audit.summarize_form(packet / "review_form.csv", key_path)
+
+    assert summary["protocol_status"] == "complete"
+    assert summary["outcomes"]["preferred_version"]["reviewed"] == 1
+    assert summary["outcomes"]["citation_support"]["reviewed"] == 1
+    assert summary["outcomes"]["decision_usefulness"]["tie"] == 1
+    assert summary["outcomes"]["harmful_version"]["draft"] == 1
+
+
+def test_summary_rejects_form_with_missing_or_extra_samples(tmp_path: Path) -> None:
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1")
+    packet = tmp_path / "packet"
+    key_path = tmp_path / "answer-key.json"
+    reviewer_audit.prepare_packet(experiment, packet, key_path, seed=11)
+    _write_form(packet / "review_form.csv", [])
+
+    with pytest.raises(reviewer_audit.AuditDataError, match="do not match"):
+        reviewer_audit.summarize_form(packet / "review_form.csv", key_path)
+
+def test_summary_rejects_duplicate_sample_that_would_inflate_outcome(
+    tmp_path: Path,
+) -> None:
+    experiment = tmp_path / "experiment"
+    _write_cell(experiment, "001-topic-full-r1")
+    packet = tmp_path / "packet"
+    key_path = tmp_path / "answer-key.json"
+    reviewer_audit.prepare_packet(experiment, packet, key_path, seed=13)
+    rows = _read_form(packet / "review_form.csv")
+    _write_form(packet / "review_form.csv", [rows[0], rows[0]])
+
+    with pytest.raises(reviewer_audit.AuditDataError, match="do not match"):
+        reviewer_audit.summarize_form(packet / "review_form.csv", key_path)


### PR DESCRIPTION
## Why\n\nThe 90-cell topology study records 34 accepted Reviewer plan items, but the historical artifacts do not preserve exact structured patch boundaries. Treating token diffs as 34 independent judgments would overstate the evidence.\n\n## What this adds\n\n- a zero-network tool that creates nine randomized A/B report pairs and a separate answer key\n- explicit incomplete-state semantics so blank reviews are never counted as ties or passes\n- a pre-registered report-level rubric and decision rule\n- persistence of the final successful structured Reviewer plan in future ablations\n- seam tests for blinding leaks, sample identity, duplicate rows, missing artifacts, and plan/count mismatches\n\n## Validation\n\n- 1218 tests and 545 subtests passed\n- latest Ruff check passed\n- the answer-leak defect was re-injected; the seam test failed, then passed after restoration\n- the real packet contains 9 report pairs representing 34 historical plan items, with no Reviewer Notes or answer identity in the reviewer-facing directory