### PR TITLE
Add a pre-registered patent relevance human audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1218 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1230 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -143,7 +143,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  50 Python files, organised by subject under test
+tests/                  51 Python files, organised by subject under test
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 ops_report.py           what real runs actually did, vs what the benchmark covers
 ```
@@ -161,6 +161,10 @@ A run URL is a capability — the id is the credential.
   the assertions differ completely.
 - Code-package analysis (the other half of "upload a paper or a code package")
   is unbuilt.
+- Patent topical relevance now has a pre-registered, frozen 81-case human audit
+  and a strict summarizer, but **0/81 cases have human labels**. Until the packet
+  is completed, the project has no measured accepted-patent relevance rate and
+  must not present the prepared protocol as a result.
 - **No evidence exists that the output is *useful*.** Everything the project
   can currently demonstrate is that it does not lie — citations check out,
   formulas are right, hallucination rate is 0. Whether a TTO officer would act

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ justify removing the production Scorer: Reviewer value still awaits a blinded
 [topology ablation](docs/prereg-2026-08-21-agent-topology-ablation.md) and
 [Reviewer audit](docs/prereg-2026-08-22-reviewer-value-audit.md) documents.
 
+A separate human-label audit is now prepared for a retrieval question that the
+structural benchmark cannot answer: whether patents accepted by the pipeline
+are actually topically relevant. The frozen packet contains all **75** patent
+records from the 10 public benchmark fixtures plus all **6** records from one
+post-hoc sodium-ion grid-storage challenge run. The two corpora will be reported
+separately; the challenge set is not held out. No human labels or relevance-rate
+claims exist yet. The pre-registered protocol is in
+[`docs/prereg-2026-08-22-patent-relevance-audit.md`](docs/prereg-2026-08-22-patent-relevance-audit.md).
+
+```bash
+uv run python patent_relevance_eval.py prepare benchmark_fixtures \
+  outputs/patent-relevance-audit/packet \
+  --challenge evals/patent_relevance/sodium-ion-grid-storage-challenge.json
+
+uv run python patent_relevance_eval.py summarize \
+  outputs/patent-relevance-audit/packet/labels.csv \
+  outputs/patent-relevance-audit/packet/manifest.json \
+  outputs/patent-relevance-audit/summary.json
+```
+
+The summarizer refuses partial or drifting label sets and returns an explicit
+`incomplete` state with no metrics until all 81 rows are judged. It measures
+accepted-source relevance, not global retrieval recall.
+
 ---
 
 ### What's different from the CrewAI starter template

--- a/docs/prereg-2026-08-22-patent-relevance-audit.md
+++ b/docs/prereg-2026-08-22-patent-relevance-audit.md
@@ -1,0 +1,117 @@
+# Pre-registration: accepted-patent relevance audit
+
+**Registered:** 2026-08-22, before any human relevance labels were collected.
+
+## Question
+
+When the production retrieval pipeline accepts a patent source, how often is
+that source topically useful for assessing the patent landscape or
+commercialization position of the submitted research topic?
+
+This audit measures accepted-source relevance. It cannot measure global recall:
+the sample contains no patents that retrieval failed to find.
+
+## Frozen sample
+
+The audit uses public evidence already on disk and performs no network or model
+calls.
+
+- **Benchmark core:** a complete census of all 75 patent records in the 10
+  tracked `benchmark_fixtures/*.json` topic fixtures.
+- **Sodium-ion challenge:** all 6 patent records from retained production-style
+  run `20260707T012519Z-6e9d3f0d66`, frozen in
+  `evals/patent_relevance/sodium-ion-grid-storage-challenge.json`.
+- **Total:** 81 accepted patent-topic pairs across 11 topics.
+
+The sodium-ion run was selected after a topical-relevance weakness was observed.
+It is therefore a post-hoc challenge set, not an independent held-out set. Its
+results must remain separate from the benchmark-core headline result. Duplicate
+topic/URL pairs are rejected rather than counted twice.
+
+## Blinding and evidence available to the reviewer
+
+Each case card shows the research topic, retrieved patent title, source ID, URL,
+and frozen evidence summary. The card intentionally omits the corpus name so the
+reviewer is not told whether a case came from the benchmark core or the observed
+challenge. Corpus membership remains in the machine-readable manifest for later
+grouping.
+
+The primary judgment uses the frozen title and evidence summary. Reviewers must
+record whether they opened none, some, or all external URLs. Opening a URL is
+allowed for clarification, but this audit does not ask the reviewer to validate
+legal status, claim validity, ownership, freedom to operate, or commercial
+quality.
+
+## Labels
+
+Exactly one label is required for every case:
+
+- `RELEVANT`: the claimed invention directly concerns the topic's core
+  technology or the named commercialization application.
+- `WEAK`: adjacent or contextually useful, but not direct evidence of the core
+  patent landscape.
+- `IRRELEVANT`: keyword overlap without a material connection to the topic.
+- `UNCERTAIN`: the frozen title and summary are insufficient for a reliable
+  judgment; the reviewer must not guess.
+
+Every label also requires confidence from 1 to 5 and a concise rationale.
+`UNCERTAIN` remains in every denominator. Excluding difficult cases would let a
+weak corpus improve its own score by withholding judgment.
+
+The reviewer declaration records personal completion, substantive generative-AI
+use, external-link use, collaboration, elapsed time, expertise, and limitations.
+An AI-generated label set must not be represented as an independent human audit.
+
+## Locked analysis
+
+The summarizer calculates results only when all 81 expected case IDs have a
+complete label, confidence, and rationale. Missing, extra, duplicate, or partial
+rows are protocol errors. Before completion, the output must say `incomplete`
+and all metric fields must remain null.
+
+Metrics are reported overall and separately by corpus and topic:
+
+1. direct relevance rate: `RELEVANT / all cases`;
+2. usable relevance rate: `(RELEVANT + WEAK) / all cases`;
+3. weak rate;
+4. irrelevant rate;
+5. uncertain rate; and
+6. mean reviewer confidence.
+
+The benchmark-core result is the main descriptive baseline. The sodium-ion
+challenge result is diagnostic only. No pass/fail threshold is registered for
+this first audit because no prior human baseline exists; inventing one now would
+turn characterization into target-seeking.
+
+## Interpretation and next decision
+
+This audit can support claims about the topical precision of accepted patent
+evidence under these frozen topics. It cannot support claims about:
+
+- retrieval recall;
+- factual correctness of every evidence-summary sentence;
+- patent validity, ownership, enforceability, or freedom to operate;
+- usefulness of the final commercialization report; or
+- performance on future topic distributions.
+
+No production filter will be changed from these labels alone. A candidate
+relevance rule must first be frozen and compared against exactly the same human
+labels, with precision prioritized over recall because a false rejection removes
+evidence from a paid report.
+
+## Reproduction
+
+```bash
+uv run python patent_relevance_eval.py prepare benchmark_fixtures \
+  outputs/patent-relevance-audit/packet \
+  --challenge evals/patent_relevance/sodium-ion-grid-storage-challenge.json
+
+uv run python patent_relevance_eval.py summarize \
+  outputs/patent-relevance-audit/packet/labels.csv \
+  outputs/patent-relevance-audit/packet/manifest.json \
+  outputs/patent-relevance-audit/summary.json
+```
+
+`prepare` refuses to overwrite an existing packet so a started human audit
+cannot be silently reset. The manifest stores a SHA-256 hash for every case
+card, and `summarize` requires the exact manifest case-ID set.

--- a/evals/patent_relevance/README.md
+++ b/evals/patent_relevance/README.md
@@ -1,0 +1,15 @@
+# Patent-relevance evaluation fixtures
+
+This directory contains tracked challenge evidence for the human relevance
+audit described in
+[`docs/prereg-2026-08-22-patent-relevance-audit.md`](../../docs/prereg-2026-08-22-patent-relevance-audit.md).
+
+`sodium-ion-grid-storage-challenge.json` contains only the six patent records
+from retained run `20260707T012519Z-6e9d3f0d66`. It deliberately excludes the
+run's academic, market, report, score, credentials, and operational artifacts.
+The run was selected after a relevance weakness was observed, so this corpus is
+diagnostic and must not be described as held out.
+
+The 75 benchmark-core records are not duplicated here. They are read directly
+from the complete tracked `benchmark_fixtures/*.json` census so later fixture
+drift is detected by the packet manifest rather than hidden by another copy.

--- a/evals/patent_relevance/sodium-ion-grid-storage-challenge.json
+++ b/evals/patent_relevance/sodium-ion-grid-storage-challenge.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "corpus": "sodium_ion_grid_storage_challenge",
+  "source_run_id": "20260707T012519Z-6e9d3f0d66",
+  "topic": "sodium-ion batteries for grid energy storage",
+  "collected_at": "2026-07-07T01:27:03.527118Z",
+  "selection_note": "Post-hoc challenge containing every accepted patent from the latest locally retained sodium-ion grid-storage run; selected after weak relevance was observed and reported separately from benchmark_core.",
+  "patent_sources": [
+    {
+      "source_id": "P1",
+      "title": "WO2016027082A1 - Storage and/or transportation of sodium-ion cells",
+      "url": "https://patents.google.com/patent/WO2016027082A1/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "The present invention relates to a process for making sodium-ion cells, for example rechargeable sodium-ion cells, which are capable of being safely transported ..."
+    },
+    {
+      "source_id": "P2",
+      "title": "US8835041B2 - Electrode materials for sodium batteries",
+      "url": "https://patents.google.com/patent/US8835041B2/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "This invention relates to electrodes for sodium and sodium-ion cells and batteries comprising sodium/transition metal oxide electrode materials ..."
+    },
+    {
+      "source_id": "P3",
+      "title": "US20020192553A1 - Sodium ion batteries - Google Patents",
+      "url": "https://patents.google.com/patent/US20020192553A1/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "Sodium ion cells comprise an anode, cathode and an electrolyte. The cells were constructed using a NaVPO[0292] 4F active material cathode. The cathode material ..."
+    },
+    {
+      "source_id": "P4",
+      "title": "WO2017060718A1 - X/hard carbon composite material and method ...",
+      "url": "https://patents.google.com/patent/WO2017060718A1/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "The aim of the present invention is to provide novel hard carbon composite materials for use as anode-active materials in alkali metal-ion energy storage ..."
+    },
+    {
+      "source_id": "P5",
+      "title": "Molten inorganic electrolytes for low temperature sodium batteries",
+      "url": "https://patents.google.com/patent/US11258096B2/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "In particular, molten sodium batteries are promising candidates for high energy density, low cost grid-scale energy storage that could be enabled by effective ..."
+    },
+    {
+      "source_id": "P6",
+      "title": "US20170373310A1 - Kvopo4 cathode for sodium ion batteries",
+      "url": "https://patents.google.com/patent/US20170373310A1/en",
+      "doi": null,
+      "publisher": "Google",
+      "published_date": null,
+      "accessed_date": "2026-07-07",
+      "source_type": "patent",
+      "credibility_tier": "high",
+      "credibility_reason": "Official patent registry record; legal scope still requires claim review.",
+      "evidence_summary": "The present technology makes it possible for the cathode material to store more than one sodium ion in each single charge/discharge process, ..."
+    }
+  ]
+}

--- a/patent_relevance_eval.py
+++ b/patent_relevance_eval.py
@@ -1,0 +1,518 @@
+"""Build and summarize a human-labelled patent-relevance audit.
+
+The retrieval pipeline treats every validated patent as relevant enough to
+reach the report, but URL validation says nothing about topical relevance.
+This tool measures that separate question over evidence already on disk.  It
+never searches the web, never asks a model to label a case, and never reports
+recall from a positive-only sample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections.abc import Iterable
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+LABELS = {"RELEVANT", "WEAK", "IRRELEVANT", "UNCERTAIN"}
+LABEL_FIELDS = ("case_id", "label", "confidence", "rationale")
+INDEX_FIELDS = ("case_id", "topic", "source_id", "title", "url", "case_file")
+
+
+class PatentAuditError(ValueError):
+    """Raised when an audit artifact would misstate its evidence or denominator."""
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class PatentCase:
+    """One accepted patent judged against the topic that retrieved it."""
+
+    case_id: str
+    corpus: str
+    topic: str
+    source_id: str
+    title: str
+    url: str
+    evidence_summary: str
+    provenance: str
+
+    @property
+    def case_file(self) -> str:
+        return f"cases/{self.case_id}.md"
+
+    @property
+    def content_sha256(self) -> str:
+        return _sha256(_case_markdown(self))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise PatentAuditError(f"could not read JSON from {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PatentAuditError(f"{path} must contain a JSON object")
+    return value
+
+
+def _case_id(topic: str, url: str) -> str:
+    """Keep IDs stable when another fixture or corpus is added later."""
+
+    digest = hashlib.sha256(f"{topic}\0{url}".encode()).hexdigest()[:12]
+    return f"PR-{digest.upper()}"
+
+
+def _cases_from_payload(
+    payload: dict[str, Any],
+    *,
+    corpus: str,
+    provenance: str,
+) -> list[PatentCase]:
+    topic = str(payload.get("topic", "")).strip()
+    if not topic:
+        raise PatentAuditError(f"{provenance} has no topic")
+    patents = payload.get("patent_sources")
+    if not isinstance(patents, list) or not patents:
+        raise PatentAuditError(f"{provenance} has no patent_sources")
+
+    cases: list[PatentCase] = []
+    for index, patent in enumerate(patents, start=1):
+        if not isinstance(patent, dict):
+            raise PatentAuditError(f"{provenance} patent {index} is not an object")
+        source_id = str(patent.get("source_id", "")).strip()
+        title = str(patent.get("title", "")).strip()
+        url = str(patent.get("url", "")).strip()
+        summary = str(patent.get("evidence_summary", "")).strip()
+        missing = [
+            name
+            for name, value in (
+                ("source_id", source_id),
+                ("title", title),
+                ("url", url),
+                ("evidence_summary", summary),
+            )
+            if not value
+        ]
+        if missing:
+            raise PatentAuditError(
+                f"{provenance} patent {index} is missing {', '.join(missing)}"
+            )
+        cases.append(
+            PatentCase(
+                case_id=_case_id(topic, url),
+                corpus=corpus,
+                topic=topic,
+                source_id=source_id,
+                title=title,
+                url=url,
+                evidence_summary=summary,
+                provenance=provenance,
+            )
+        )
+    return cases
+
+
+def discover_cases(
+    fixture_dir: Path,
+    challenge_paths: Iterable[Path] = (),
+) -> list[PatentCase]:
+    """Read the complete frozen benchmark plus explicitly declared challenges."""
+
+    fixtures = sorted(path for path in fixture_dir.glob("*.json") if path.name != "manifest.json")
+    if not fixtures:
+        raise PatentAuditError(f"no benchmark fixtures found in {fixture_dir}")
+
+    cases: list[PatentCase] = []
+    for path in fixtures:
+        cases.extend(
+            _cases_from_payload(
+                _read_json(path),
+                corpus="benchmark_core",
+                provenance=path.as_posix(),
+            )
+        )
+    for path in sorted(challenge_paths):
+        payload = _read_json(path)
+        corpus = str(payload.get("corpus", "")).strip()
+        if not corpus or corpus == "benchmark_core":
+            raise PatentAuditError(f"{path} must declare a non-core corpus")
+        cases.extend(
+            _cases_from_payload(payload, corpus=corpus, provenance=path.as_posix())
+        )
+
+    # A repeated URL for the same topic is one judgment, even if two historical
+    # runs happened to retrieve it. Counting both would inflate the denominator
+    # and make a stable upstream result look like independent evidence.
+    seen: dict[tuple[str, str], PatentCase] = {}
+    for case in cases:
+        key = (case.topic.casefold(), case.url.casefold())
+        previous = seen.get(key)
+        if previous is not None:
+            raise PatentAuditError(
+                f"duplicate topic/URL across {previous.provenance} and {case.provenance}: "
+                f"{case.topic} | {case.url}"
+            )
+        seen[key] = case
+    return sorted(cases, key=lambda case: (case.corpus, case.topic.casefold(), case.source_id))
+
+
+def freeze_challenge(
+    source_path: Path,
+    output_path: Path,
+    *,
+    corpus: str,
+    selection_note: str,
+) -> dict[str, Any]:
+    """Copy only public patent evidence from one real run into a tracked fixture."""
+
+    if output_path.exists():
+        raise PatentAuditError(f"refusing to overwrite existing challenge fixture: {output_path}")
+    source = _read_json(source_path)
+    # Validate before writing. A malformed challenge file should fail at freeze
+    # time, not months later when somebody tries to reproduce the measurement.
+    _cases_from_payload(source, corpus=corpus, provenance=source_path.as_posix())
+    frozen = {
+        "schema_version": 1,
+        "corpus": corpus,
+        "source_run_id": source_path.parent.name,
+        "topic": source["topic"],
+        "collected_at": source.get("collected_at"),
+        "selection_note": selection_note,
+        "patent_sources": source["patent_sources"],
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(frozen, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return frozen
+
+
+def _case_markdown(case: PatentCase) -> str:
+    return f"""# Patent relevance case {case.case_id}
+
+- **Research topic:** {case.topic}
+- **Retrieved source ID:** `{case.source_id}`
+- **Patent title:** {case.title}
+- **Patent URL:** {case.url}
+
+## Retrieved evidence summary
+
+{case.evidence_summary}
+
+## Labeling question
+
+Does this patent directly help assess the patent landscape or commercialization
+position of the research topic above? Record the answer in `labels.csv`; judge
+topical relevance, not whether the patent is legally valid or commercially good.
+"""
+
+
+def _packet_readme(case_count: int, corpus_counts: Counter[str]) -> str:
+    counts = ", ".join(f"{name}={count}" for name, count in sorted(corpus_counts.items()))
+    return f"""# Patent-relevance audit packet
+
+This packet contains {case_count} patent records ({counts}) retrieved and accepted
+by the existing pipeline. It uses frozen evidence only and makes no API calls.
+
+Open each file under `cases/` and complete the matching row in `labels.csv`:
+
+- `RELEVANT`: the claimed invention directly concerns the topic's core technology
+  or the named commercialization application.
+- `WEAK`: adjacent or contextually useful, but not direct evidence of the core
+  patent landscape.
+- `IRRELEVANT`: keyword overlap without a material connection to the topic.
+- `UNCERTAIN`: the title and retrieved summary are insufficient for a reliable
+  judgment; do not guess.
+- `confidence`: integer 1-5.
+- `rationale`: concise evidence for the label; name the mismatch for weak,
+  irrelevant, or uncertain cases.
+
+After all labels are complete, also fill in `reviewer_declaration.md`; metrics
+without a documented review method are not an independent human audit.
+
+Every row must be completed before headline rates are calculated. Empty is
+"not evaluated", never relevant. This accepted-source sample can measure
+precision-like relevance rates, but it cannot measure global retrieval recall.
+Do not change production filtering rules until this baseline is complete and a
+candidate rule has been compared against the same labels.
+"""
+
+
+def _reviewer_declaration() -> str:
+    return """# Reviewer declaration
+
+Complete this after labeling all cases. This declaration distinguishes a human
+audit from an AI-generated opinion and records how the evidence was inspected.
+
+1. Did you personally review every case card? **[YES / NO]**
+2. Did generative AI create any substantive label or rationale?
+   **[NONE / LANGUAGE-ONLY / SOME-SUBSTANTIVE / MOST-OR-ALL]**
+3. Did you open any external patent URLs? **[NONE / SOME / ALL]**
+4. Were any labels discussed with another person before submission?
+   **[YES / NO]**
+5. Actual elapsed review time: **[minutes]**
+6. Relevant expertise or role (optional): **[text]**
+7. Additional limitations or conflicts (optional): **[text]**
+
+Reviewer name or pseudonym: **[text]**
+Date completed: **[YYYY-MM-DD]**
+"""
+
+
+def prepare_packet(
+    fixture_dir: Path,
+    packet_dir: Path,
+    *,
+    challenge_paths: Iterable[Path] = (),
+) -> dict[str, Any]:
+    """Create a deterministic human-label packet from existing evidence."""
+
+    if packet_dir.exists():
+        raise PatentAuditError(f"refusing to overwrite existing packet: {packet_dir}")
+    cases = discover_cases(fixture_dir, challenge_paths)
+    packet_dir.mkdir(parents=True)
+    case_dir = packet_dir / "cases"
+    case_dir.mkdir()
+
+    manifest_cases: list[dict[str, Any]] = []
+    with (packet_dir / "case_index.csv").open("w", encoding="utf-8", newline="") as handle:
+        index_writer = csv.DictWriter(handle, fieldnames=INDEX_FIELDS)
+        index_writer.writeheader()
+        for case in cases:
+            body = _case_markdown(case)
+            (packet_dir / case.case_file).write_text(body, encoding="utf-8")
+            index_writer.writerow(
+                {
+                    "case_id": case.case_id,
+                    "topic": case.topic,
+                    "source_id": case.source_id,
+                    "title": case.title,
+                    "url": case.url,
+                    "case_file": case.case_file,
+                }
+            )
+            manifest_cases.append(
+                {
+                    "case_id": case.case_id,
+                    "corpus": case.corpus,
+                    "topic": case.topic,
+                    "source_id": case.source_id,
+                    "url": case.url,
+                    "content_sha256": case.content_sha256,
+                    "provenance": case.provenance,
+                }
+            )
+
+    with (packet_dir / "labels.csv").open("w", encoding="utf-8", newline="") as handle:
+        label_writer = csv.DictWriter(handle, fieldnames=LABEL_FIELDS)
+        label_writer.writeheader()
+        for case in cases:
+            label_writer.writerow({"case_id": case.case_id})
+
+    corpus_counts = Counter(case.corpus for case in cases)
+    topic_counts = Counter(case.topic for case in cases)
+    manifest = {
+        "schema_version": 1,
+        "audit_unit": "accepted_patent_topic_pair",
+        "source_mode": "frozen evidence; zero network",
+        "prepared_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "case_count": len(cases),
+        "corpus_counts": dict(sorted(corpus_counts.items())),
+        "topic_counts": dict(sorted(topic_counts.items())),
+        "cases": manifest_cases,
+        "measurement_limit": (
+            "Accepted sources support relevance-rate measurement, not global retrieval recall."
+        ),
+    }
+    (packet_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    (packet_dir / "README.md").write_text(
+        _packet_readme(len(cases), corpus_counts),
+        encoding="utf-8",
+    )
+    (packet_dir / "reviewer_declaration.md").write_text(
+        _reviewer_declaration(),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _read_label_rows(path: Path) -> list[dict[str, str]]:
+    try:
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if tuple(reader.fieldnames or ()) != LABEL_FIELDS:
+                raise PatentAuditError(
+                    f"{path} columns must be exactly: {', '.join(LABEL_FIELDS)}"
+                )
+            return list(reader)
+    except OSError as exc:
+        raise PatentAuditError(f"could not read labels from {path}: {exc}") from exc
+
+
+def _validated_label(row: dict[str, str]) -> dict[str, Any] | None:
+    values = [row.get(field, "").strip() for field in LABEL_FIELDS[1:]]
+    if not any(values):
+        return None
+    if not all(values):
+        raise PatentAuditError(f"{row['case_id']} is partially completed")
+    label = values[0].upper()
+    if label not in LABELS:
+        raise PatentAuditError(f"{row['case_id']} has invalid label: {values[0]}")
+    try:
+        confidence = int(values[1])
+    except ValueError as exc:
+        raise PatentAuditError(f"{row['case_id']} confidence must be an integer") from exc
+    if confidence not in range(1, 6):
+        raise PatentAuditError(f"{row['case_id']} confidence must be between 1 and 5")
+    return {
+        "case_id": row["case_id"],
+        "label": label,
+        "confidence": confidence,
+        "rationale": values[2],
+    }
+
+
+def _metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    counts = Counter(row["label"] for row in rows)
+    # Uncertain stays in every denominator. Dropping it would let a difficult
+    # corpus improve its own headline rate merely by declining to judge cases.
+    return {
+        "case_count": total,
+        "label_counts": {label: counts[label] for label in sorted(LABELS)},
+        "direct_relevance_rate": counts["RELEVANT"] / total,
+        "usable_relevance_rate": (counts["RELEVANT"] + counts["WEAK"]) / total,
+        "weak_rate": counts["WEAK"] / total,
+        "irrelevant_rate": counts["IRRELEVANT"] / total,
+        "uncertain_rate": counts["UNCERTAIN"] / total,
+        "mean_confidence": sum(row["confidence"] for row in rows) / total,
+    }
+
+
+def summarize_labels(
+    labels_path: Path,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    """Validate a complete label contract before calculating headline rates."""
+
+    manifest = _read_json(manifest_path)
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise PatentAuditError(f"{manifest_path} has no cases")
+    expected = [str(case.get("case_id", "")) for case in cases]
+    if any(not case_id for case_id in expected) or len(expected) != len(set(expected)):
+        raise PatentAuditError("manifest case IDs must be non-empty and unique")
+
+    rows = _read_label_rows(labels_path)
+    observed = [row.get("case_id", "").strip() for row in rows]
+    if len(observed) != len(set(observed)):
+        raise PatentAuditError("labels contain duplicate case IDs")
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        extra = sorted(set(observed) - set(expected))
+        raise PatentAuditError(f"label case IDs do not match manifest; missing={missing}, extra={extra}")
+
+    validated_by_id: dict[str, dict[str, Any]] = {}
+    incomplete: list[str] = []
+    for row in rows:
+        validated = _validated_label(row)
+        if validated is None:
+            incomplete.append(row["case_id"])
+        else:
+            validated_by_id[row["case_id"]] = validated
+
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "protocol_status": "incomplete" if incomplete else "complete",
+        "case_count": len(expected),
+        "completed_case_count": len(validated_by_id),
+        "incomplete_case_ids": incomplete,
+        "metrics": None,
+        "by_corpus": None,
+        "by_topic": None,
+        "measurement_limit": manifest.get("measurement_limit"),
+    }
+    if incomplete:
+        return summary
+
+    ordered = [validated_by_id[case_id] for case_id in expected]
+    case_by_id = {str(case["case_id"]): case for case in cases}
+    summary["metrics"] = _metrics(ordered)
+    for dimension, output_key in (("corpus", "by_corpus"), ("topic", "by_topic")):
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for row in ordered:
+            group = str(case_by_id[row["case_id"]][dimension])
+            grouped.setdefault(group, []).append(row)
+        summary[output_key] = {
+            name: _metrics(group_rows) for name, group_rows in sorted(grouped.items())
+        }
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    freeze = commands.add_parser(
+        "freeze-challenge",
+        help="copy only patent evidence from one existing run into a public challenge fixture",
+    )
+    freeze.add_argument("source", type=Path)
+    freeze.add_argument("output", type=Path)
+    freeze.add_argument("--corpus", required=True)
+    freeze.add_argument("--selection-note", required=True)
+
+    prepare = commands.add_parser("prepare", help="create a blank human-label packet")
+    prepare.add_argument("fixtures", type=Path)
+    prepare.add_argument("packet", type=Path)
+    prepare.add_argument("--challenge", action="append", default=[], type=Path)
+
+    summarize = commands.add_parser("summarize", help="validate labels and write metrics")
+    summarize.add_argument("labels", type=Path)
+    summarize.add_argument("manifest", type=Path)
+    summarize.add_argument("output", type=Path)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    if args.command == "freeze-challenge":
+        result = freeze_challenge(
+            args.source,
+            args.output,
+            corpus=args.corpus,
+            selection_note=args.selection_note,
+        )
+    elif args.command == "prepare":
+        result = prepare_packet(
+            args.fixtures,
+            args.packet,
+            challenge_paths=args.challenge,
+        )
+    else:
+        result = summarize_labels(args.labels, args.manifest)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_patent_relevance_eval.py
+++ b/tests/test_patent_relevance_eval.py
@@ -1,0 +1,255 @@
+"""Contract tests for the frozen-evidence patent relevance audit."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import patent_relevance_eval as patent_eval
+
+
+def _patent(source_id: str, *, url: str | None = None) -> dict[str, str]:
+    return {
+        "source_id": source_id,
+        "title": f"Patent {source_id}",
+        "url": url or f"https://patents.example/{source_id}",
+        "evidence_summary": f"Evidence summary for {source_id}.",
+    }
+
+
+def _write_payload(
+    path: Path,
+    *,
+    topic: str,
+    patents: list[dict[str, str]],
+    corpus: str | None = None,
+) -> None:
+    payload: dict[str, object] = {"topic": topic, "patent_sources": patents}
+    if corpus is not None:
+        payload["corpus"] = corpus
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_labels(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=patent_eval.LABEL_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_preregistered_public_census_remains_75_core_plus_6_challenge() -> None:
+    """Fixture drift must not silently change the pre-registered denominator."""
+
+    root = Path(__file__).resolve().parents[1]
+    cases = patent_eval.discover_cases(
+        root / "benchmark_fixtures",
+        [
+            root
+            / "evals"
+            / "patent_relevance"
+            / "sodium-ion-grid-storage-challenge.json"
+        ],
+    )
+
+    assert len(cases) == 81
+    assert sum(case.corpus == "benchmark_core" for case in cases) == 75
+    assert (
+        sum(case.corpus == "sodium_ion_grid_storage_challenge" for case in cases)
+        == 6
+    )
+    assert len({case.topic for case in cases}) == 11
+
+
+def _packet(tmp_path: Path) -> Path:
+    fixtures = tmp_path / "fixtures"
+    _write_payload(
+        fixtures / "01-alpha.json",
+        topic="Alpha storage",
+        patents=[_patent("P1"), _patent("P2")],
+    )
+    challenge = tmp_path / "challenge.json"
+    _write_payload(
+        challenge,
+        topic="Beta sensing",
+        patents=[_patent("P1", url="https://patents.example/beta")],
+        corpus="post_hoc_challenge",
+    )
+    packet = tmp_path / "packet"
+    patent_eval.prepare_packet(fixtures, packet, challenge_paths=[challenge])
+    return packet
+
+
+def test_prepare_packet_preserves_every_patent_at_the_human_label_seam(
+    tmp_path: Path,
+) -> None:
+    """A source stored in fixtures is useless if it never reaches the label form."""
+
+    packet = _packet(tmp_path)
+    manifest = json.loads((packet / "manifest.json").read_text(encoding="utf-8"))
+    index = _read_csv(packet / "case_index.csv")
+    labels = _read_csv(packet / "labels.csv")
+
+    assert manifest["case_count"] == 3
+    assert manifest["corpus_counts"] == {"benchmark_core": 2, "post_hoc_challenge": 1}
+    manifest_ids = {case["case_id"] for case in manifest["cases"]}
+    assert {row["case_id"] for row in index} == manifest_ids
+    assert {row["case_id"] for row in labels} == manifest_ids
+    assert all(row["label"] == "" for row in labels)
+    assert (packet / "reviewer_declaration.md").is_file()
+    assert "corpus" not in index[0]
+    for case in manifest["cases"]:
+        case_path = packet / "cases" / f"{case['case_id']}.md"
+        assert case_path.is_file()
+        card = case_path.read_text(encoding="utf-8")
+        assert "**Corpus:**" not in card
+        assert patent_eval._sha256(card) == case[
+            "content_sha256"
+        ]
+
+
+def test_discovery_rejects_duplicate_topic_url_that_would_inflate_precision(
+    tmp_path: Path,
+) -> None:
+    fixtures = tmp_path / "fixtures"
+    repeated_url = "https://patents.example/repeated"
+    _write_payload(
+        fixtures / "01-alpha.json",
+        topic="Alpha storage",
+        patents=[_patent("P1", url=repeated_url)],
+    )
+    _write_payload(
+        fixtures / "02-alpha-again.json",
+        topic="Alpha storage",
+        patents=[_patent("P2", url=repeated_url)],
+    )
+
+    with pytest.raises(patent_eval.PatentAuditError, match="duplicate topic/URL"):
+        patent_eval.discover_cases(fixtures)
+
+
+def test_prepare_refuses_to_overwrite_a_started_human_audit(tmp_path: Path) -> None:
+    packet = _packet(tmp_path)
+    fixtures = tmp_path / "other-fixtures"
+    _write_payload(fixtures / "01.json", topic="Other", patents=[_patent("P1")])
+
+    with pytest.raises(patent_eval.PatentAuditError, match="overwrite"):
+        patent_eval.prepare_packet(fixtures, packet)
+
+
+def test_blank_rows_are_incomplete_and_never_become_zero_error_precision(
+    tmp_path: Path,
+) -> None:
+    packet = _packet(tmp_path)
+
+    summary = patent_eval.summarize_labels(
+        packet / "labels.csv", packet / "manifest.json"
+    )
+
+    assert summary["protocol_status"] == "incomplete"
+    assert summary["completed_case_count"] == 0
+    assert len(summary["incomplete_case_ids"]) == 3
+    assert summary["metrics"] is None
+    assert summary["by_corpus"] is None
+
+
+def test_summary_keeps_uncertain_in_every_headline_denominator(tmp_path: Path) -> None:
+    packet = _packet(tmp_path)
+    rows = _read_csv(packet / "labels.csv")
+    labels = ["RELEVANT", "WEAK", "UNCERTAIN"]
+    for row, label in zip(rows, labels, strict=True):
+        row.update({"label": label, "confidence": "4", "rationale": f"Reason for {label}"})
+    _write_labels(packet / "labels.csv", rows)
+
+    summary = patent_eval.summarize_labels(
+        packet / "labels.csv", packet / "manifest.json"
+    )
+
+    assert summary["protocol_status"] == "complete"
+    assert summary["metrics"]["case_count"] == 3
+    assert summary["metrics"]["direct_relevance_rate"] == pytest.approx(1 / 3)
+    assert summary["metrics"]["usable_relevance_rate"] == pytest.approx(2 / 3)
+    assert summary["metrics"]["uncertain_rate"] == pytest.approx(1 / 3)
+    assert sum(group["case_count"] for group in summary["by_corpus"].values()) == 3
+    assert sum(group["case_count"] for group in summary["by_topic"].values()) == 3
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra", "duplicate"])
+def test_summary_rejects_case_id_drift_instead_of_changing_the_denominator(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    packet = _packet(tmp_path)
+    rows = _read_csv(packet / "labels.csv")
+    if mutation == "missing":
+        rows.pop()
+    elif mutation == "extra":
+        rows.append({"case_id": "PR-EXTRA", "label": "", "confidence": "", "rationale": ""})
+    else:
+        rows[-1] = rows[0].copy()
+    _write_labels(packet / "labels.csv", rows)
+
+    with pytest.raises(patent_eval.PatentAuditError, match="case IDs|duplicate"):
+        patent_eval.summarize_labels(packet / "labels.csv", packet / "manifest.json")
+
+
+def test_summary_rejects_a_partially_completed_row(tmp_path: Path) -> None:
+    packet = _packet(tmp_path)
+    rows = _read_csv(packet / "labels.csv")
+    rows[0]["label"] = "RELEVANT"
+    _write_labels(packet / "labels.csv", rows)
+
+    with pytest.raises(patent_eval.PatentAuditError, match="partially completed"):
+        patent_eval.summarize_labels(packet / "labels.csv", packet / "manifest.json")
+
+
+def test_freeze_challenge_keeps_public_patents_and_drops_unrelated_run_data(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "run-123" / "validated_sources.json"
+    payload = {
+        "topic": "Sodium-ion storage",
+        "collected_at": "2026-08-22T00:00:00Z",
+        "patent_sources": [_patent("P1")],
+        "academic_sources": [{"secret": "not part of this audit"}],
+        "market_sources": [{"secret": "not part of this audit"}],
+    }
+    source.parent.mkdir()
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "challenge.json"
+
+    frozen = patent_eval.freeze_challenge(
+        source,
+        output,
+        corpus="sodium_ion_challenge",
+        selection_note="All accepted patents from the observed failure run.",
+    )
+
+    assert frozen["source_run_id"] == "run-123"
+    assert frozen["patent_sources"] == payload["patent_sources"]
+    assert "academic_sources" not in frozen
+    assert "market_sources" not in frozen
+    assert json.loads(output.read_text(encoding="utf-8")) == frozen
+
+
+def test_freeze_challenge_refuses_to_replace_a_frozen_measurement(tmp_path: Path) -> None:
+    source = tmp_path / "run" / "validated_sources.json"
+    _write_payload(source, topic="Topic", patents=[_patent("P1")])
+    output = tmp_path / "challenge.json"
+    output.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(patent_eval.PatentAuditError, match="overwrite"):
+        patent_eval.freeze_challenge(
+            source,
+            output,
+            corpus="challenge",
+            selection_note="Observed failure.",
+        )


### PR DESCRIPTION
## Why\n\nURL and metadata validation does not establish that an accepted patent is topically relevant. This change measures that missing property before changing production retrieval.\n\n## What\n\n- freeze a 75-record benchmark census and a separately reported six-record post-hoc sodium-ion challenge\n- generate blinded human case cards, a strict label contract, and a reviewer-method declaration\n- refuse partial, duplicate, missing, or extra label sets and keep UNCERTAIN in every denominator\n- pre-register interpretation limits: accepted-source relevance only, not recall, FTO, or final-report usefulness\n- add seam tests for packet delivery and lock the public 75+6 denominator\n\n## Verification\n\n- defect re-injection: disabling topic/URL deduplication made the dedicated test fail\n- restored targeted suite: 12 passed\n- full suite: 1230 passed, 545 subtests passed\n- uv run --with ruff ruff check .