### PR TITLE
Document the completed user-utility audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ is, in this order:
 | Why does this test exist? | Its docstring names the specific failure it caught |
 | Why was this change made? | `git log` — bodies run to ~25 lines and explain the alternative that was rejected |
 | Was this hypothesis tested? | `docs/prereg-*.md` — predictions and falsification criteria registered *before* paid runs |
-| Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,014 lines, 55 write-ups. Ask the user for access if you need it |
+| Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,053 lines, 56 write-ups. Ask the user for access if you need it |
 
 Before writing or modifying CrewAI code specifically — the crew, the agents,
 the task definitions — read `docs/crewai-reference.md`. That is the vendor's
@@ -171,9 +171,14 @@ A run URL is a capability — the id is the credential.
   compared and rejected: it falsely dropped 6 relevant patents and sent 36/81
   cases to review. Production filtering remains unchanged. The next method must
   be semantic/claim-scope with abstention and must face an unseen challenge.
-- **No evidence exists yet that the output is *useful*.** A pre-registered
-  3–5-reviewer protocol, ten matched report pairs, distributable packets, and a
-  strict summarizer now exist, but 0 eligible human judgments have been
-  collected. Everything the project can currently demonstrate is that it does
-  not lie — citations check out, formulas are right, hallucination rate is 0.
-  Whether a TTO officer would act on a report remains the gap that matters most.
+- **The first user-utility result is complete, and it did not prove the
+  six-stage advantage.** Five reviewers returned 20/20 eligible blinded
+  judgments over two rounds. Both rounds preferred the full workflow 6:4 for
+  decision usefulness, but both failed the pre-registered rule because the
+  monolith was allowed at most two wins. Across both rounds the monolith won
+  information gain 11:5, and topic-level agreement was only 2/10. The panel had
+  one target user, one technical proxy, and three other reviewers; several
+  returned enums required disclosed post-return coding. This is small proxy-user
+  evidence, not adoption, ROI, accuracy, or proof that six agents are necessary.
+  See docs/results-2026-08-23-user-utility-audit.md. The largest remaining gap
+  is independent utility evidence from more actual target users.

--- a/README.md
+++ b/README.md
@@ -93,13 +93,18 @@ justify removing the production Scorer: Reviewer value still awaits a blinded
 [topology ablation](docs/prereg-2026-08-21-agent-topology-ablation.md) and
 [Reviewer audit](docs/prereg-2026-08-22-reviewer-value-audit.md) documents.
 
-A separate small-panel user-utility audit is now **pre-registered and
-prepared, not completed**. It reuses ten matched full/monolith pairs over
-identical frozen evidence, distributes the primary round across 3–5 reviewers,
-and requires no new model calls. As of 2026-08-22 it has **0 eligible human
-judgments**, so the repository still makes no claim that target users find the
-reports useful. Recruitment, distribution, and claim boundaries are documented
-in the [small-panel audit guide](docs/user-utility-audit-guide.md).
+A separate pre-registered user-utility audit is now complete: five reviewers
+made **20 eligible blinded judgments** over ten matched full/monolith pairs and
+two independently assigned rounds, with no new model calls. Both rounds
+reproduced a 6/10 versus 4/10 full-workflow advantage in overall preference and
+decision usefulness, but both **failed the pre-registered criterion** because
+the monolith was allowed at most 2/10 wins. Across both rounds the monolith led
+information gain 11/20 to 5/20, and only 2/10 topics selected the same topology
+across reviewers. The result is a small proxy-user study with one target user,
+not adoption or proof that six agents are necessary. See the
+[protocol](docs/prereg-2026-08-22-user-utility-audit.md),
+[audit guide](docs/user-utility-audit-guide.md), and
+[full result](docs/results-2026-08-23-user-utility-audit.md).
 
 A separate human-label audit now answers a retrieval question that the
 structural benchmark cannot: whether patents accepted by the pipeline are
@@ -906,11 +911,14 @@ TRL 校准将评分卡与基于公开里程碑建立、可独立核查的区间�
 [拓扑消融文档](docs/prereg-2026-08-21-agent-topology-ablation.md)与
 [Reviewer 盲评文档](docs/prereg-2026-08-22-reviewer-value-audit.md)。
 
-另有一组小样本用户效用盲评已经**预注册并完成材料准备，但尚未完成评审**。
-它复用同一冻结证据下的 10 组完整工作流 / 单节点配对报告，将第一轮分摊给
-3–5 名评审者，不产生新的模型费用。截至 2026-08-22，符合条件的人类判断仍为
-**0 条**，因此项目尚不声称目标用户认为报告有用。招募、发放和结论边界见
-[小样本盲评操作指南](docs/user-utility-audit-guide.md)。
+另有一组预注册用户效用盲评已经完成：5 名评审者对同一冻结证据下的 10 组
+完整工作流 / 单节点报告完成两轮交叉分配，共得到 **20 条合格匿名判断**，且
+没有新增模型调用。两轮的总体偏好和决策价值均复现为完整工作流 6/10、单节点
+4/10，但都因单节点超过预注册最多 2/10 的上限而**未通过成功标准**；两轮合计
+信息增量反而由单节点以 11/20 对 5/20 领先，同一主题跨评审仅 2/10 选择相同
+架构。评审构成只有 1 名目标用户，因此结果是小样本代理用户证据，不是采用率、
+ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-22-user-utility-audit.md)、
+[操作指南](docs/user-utility-audit-guide.md)和[完整结果](docs/results-2026-08-23-user-utility-audit.md)。
 
 另有一组专利来源相关性人工审计，覆盖 10 个公开基准主题的全部 75 条已接受
 专利，以及 6 条事后构造的钠离子储能 challenge。首组逐项人工标签显示，核心

--- a/docs/results-2026-08-23-user-utility-audit.md
+++ b/docs/results-2026-08-23-user-utility-audit.md
@@ -1,0 +1,127 @@
+# Result: two-round blinded user-utility audit
+
+- **Completed:** 2026-08-23
+- **Pre-registration:** [user-utility audit protocol](prereg-2026-08-22-user-utility-audit.md)
+- **Model cost:** zero; the audit reused frozen topology-ablation reports
+
+## Decision
+
+The protocol completed, but the pre-registered primary criterion **did not
+pass**. The production six-stage report won decision usefulness in 6/10 primary
+cases, satisfying the lower bound, but the monolith won 4/10, exceeding the
+pre-registered maximum of 2/10. The optional replication round produced the
+same 6/10 versus 4/10 split and also failed the criterion. Round 2 is
+replication evidence; it does not rescue the failed primary result.
+
+The supported conclusion is narrow: the six-stage report had a modest aggregate
+preference and recommendation-acceptance advantage, but this small panel did
+not establish that the additional workflow complexity creates a stable
+decision-utility advantage.
+
+## Sample and completion
+
+- Five reviewers completed both rounds: 20/20 eligible assignments and no
+  exclusions.
+- Each of the ten topics was judged once per round by a different reviewer.
+- Role mix: one target user, one technical proxy, and three other reviewers.
+- Four reviewers declared no generative-AI use. One declared translation or
+  clerical assistance only; no substantive AI-generated judgment was counted.
+- Both report variants used the same frozen evidence and DeepSeek model family.
+  This was not a comparison with ordinary ChatGPT or a human analyst.
+
+The role mix is a material limitation. One target-user reviewer cannot
+represent technology-transfer officers, investors, or industry analysts as
+populations.
+
+## Outcomes
+
+| Outcome | Round 1: full / monolith / tie | Round 2: full / monolith / tie | Both rounds |
+|---|---:|---:|---:|
+| Overall preference | 6 / 4 / 0 | 6 / 4 / 0 | **12 / 8 / 0** |
+| Decision usefulness | 6 / 4 / 0 | 6 / 4 / 0 | **12 / 8 / 0** |
+| Information gain | 2 / 5 / 3 | 3 / 6 / 1 | **5 / 11 / 4** |
+| Actionability | 4 / 5 / 1 | 4 / 4 / 2 | **8 / 9 / 3** |
+
+Recommendation-acceptance medians replicated exactly: 3.0/5 for the full
+workflow and 2.5/5 for the monolith in both rounds. Median reading time was
+16.5 versus 15.5 minutes in Round 1 and 17.5 versus 15.5 in Round 2. Estimated
+revision time was 27.5 versus 20 minutes in Round 1 and tied at 22.5 minutes in
+Round 2.
+
+Only four of twenty assignments opened any cited source, all by one reviewer;
+none checked every citation. The first round gave the full report two
+citation-trust preferences, while the replication produced two ties. Both
+variants had the same factual-error categories in every checked pair. These
+observations are too sparse to support a comparative accuracy or hallucination-
+rate claim.
+
+Each variant changed the topic-only decision in one case per round. The study
+therefore does not show that either topology more often changes a go/no-go/
+defer decision.
+
+## Replication and disagreement
+
+The aggregate 6:4 preference reproduced exactly, but the topic-level result did
+not. Only U09 and U10 selected the same topology in both rounds; the preferred
+topology reversed for the other eight topics. Per-topic agreement was therefore
+**2/10 (20%)**.
+
+| Reviewer | Full preferred | Monolith preferred |
+|---|---:|---:|
+| R01 | 4 | 0 |
+| R02 | 1 | 3 |
+| R03 | 1 | 3 |
+| R04 | 4 | 0 |
+| R05 | 2 | 2 |
+
+This pattern is descriptive, not a causal reviewer-effect estimate: reviewer,
+topic, and professional role are confounded in a five-person incomplete-block
+design. It does show that the stable 60/40 aggregate must not be presented as
+stable superiority for particular technologies.
+
+## Post-return normalization
+
+The raw returned CSV files were preserved locally. Several reviewers used
+free-text profile labels, numeric values where pairwise enums were requested,
+or NOT_CHECKED where the citation-check field required NONE. Formal copies were
+normalized conservatively and each mapping was recorded beside the form.
+
+Two primary-round reviewers required pairwise metrics to be coded from their
+written rationales. One replication response contained two A/B values that
+contradicted its explicit preference and rationale; those values were coded to
+match the prose. A checked-citation response used a numeric trust score and was
+coded as a tie because both variants had the same 2_PLUS error category and the
+rationale gave no comparative trust basis.
+
+This post-return coding weakens precision and is disclosed rather than hidden.
+It does not change the primary pass/fail decision: among primary rows whose
+decision-usefulness choices required no interpretation, the monolith already
+had three wins, exceeding the pre-registered maximum of two.
+
+## What this result supports
+
+The data support these statements:
+
+- the full workflow received 60% of overall and decision-usefulness preferences
+  in each round;
+- the monolith more often won information gain across both rounds;
+- actionability was close to even;
+- the six-stage workflow's pre-registered utility advantage was not
+  demonstrated; and
+- individual reviewer preference was large enough that more target-user
+  replication is needed before making a product-value claim.
+
+The result does **not** establish adoption, ROI, objectively correct investment
+decisions, comparative hallucination rates, superiority to ordinary ChatGPT,
+or that six agents are necessary. No production prompt, scoring formula, or
+workflow topology was changed in response to this audit.
+
+## Next hypothesis, not a shipped conclusion
+
+Reviewer rationales suggest a post-hoc product hypothesis: the full workflow's
+evidence boundaries and caution can improve overall trust, while its report
+structure may dilute information density and action priority. Before changing
+the production report, a separate experiment should pre-register a concise,
+decision-first brief derived from the same full evidence and recruit more
+actual target users. The present data are development evidence for that
+hypothesis, not validation of the proposed solution.

--- a/docs/user-utility-audit-guide.md
+++ b/docs/user-utility-audit-guide.md
@@ -4,6 +4,13 @@ This guide operationalizes the protocol frozen in
 [`prereg-2026-08-22-user-utility-audit.md`](prereg-2026-08-22-user-utility-audit.md).
 It does not change the pre-registered estimand or thresholds.
 
+> **Status (2026-08-23):** both rounds are complete: five reviewers returned
+> 20/20 eligible judgments. The primary criterion and its replication both
+> failed. See the
+> [result report](results-2026-08-23-user-utility-audit.md). The instructions
+> below are retained as the frozen collection procedure, not as an open call to
+> add labels to the completed denominator.
+
 ## The sample is ten report pairs, not ten reviewers
 
 Use **three to five independent reviewers**. Round 1 assigns each of the ten


### PR DESCRIPTION
## Why

The pre-registered five-reviewer audit is complete, so the repository must stop reporting zero eligible judgments and must not convert a repeated 6:4 aggregate preference into proof that six agents are necessary.

## What

- publish the full two-round result and claim boundaries
- update English and Chinese README status
- mark the collection guide as completed while preserving its frozen procedure
- update AGENTS with the failed criterion and remaining target-user gap

## Result

Both rounds completed 10/10 assignments and preferred the full workflow 6:4, but both failed because the monolith exceeded the pre-registered maximum of two wins. Across rounds, the monolith led information gain 11:5 and topic-level agreement was 2/10.

## Verification

- uv run pytest -q --basetemp outputs/pytest-user-utility-doc-sync-20260823
- uv run --with ruff ruff check .
- 1255 passed, 545 subtests passed
- git diff --check