### PR TITLE
Document the completed blinded Reviewer value audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ is, in this order:
 | Why does this test exist? | Its docstring names the specific failure it caught |
 | Why was this change made? | `git log` — bodies run to ~25 lines and explain the alternative that was rejected |
 | Was this hypothesis tested? | `docs/prereg-*.md` — predictions and falsification criteria registered *before* paid runs |
-| Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,053 lines, 56 write-ups. Ask the user for access if you need it |
+| Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,095 lines, 57 write-ups. Ask the user for access if you need it |
 
 Before writing or modifying CrewAI code specifically — the crew, the agents,
 the task definitions — read `docs/crewai-reference.md`. That is the vendor's
@@ -171,6 +171,17 @@ A run URL is a capability — the id is the credential.
   compared and rejected: it falsely dropped 6 relevant patents and sent 36/81
   cases to review. Production filtering remains unchanged. The next method must
   be semantic/claim-scope with abstention and must face an unseen challenge.
+- **The first report-level Reviewer audit is complete, but is not a general
+  utility result.** Both evaluator forms completed 9/9 pairs and passed the
+  frozen retention criterion. Exact agreement was 9/9 on overall preference,
+  8/9 on citation support, 3/9 on decision usefulness, and 7/9 on harm. Neither
+  evaluator opened external sources, so this measures report-internal support,
+  not source truth. One evaluator's method declaration was corrected by the
+  study owner after return; the result retains that form with explicit
+  disclosure rather than presenting the provenance as cleaner than it is. See
+  `docs/results-2026-08-23-reviewer-value-audit.md`. A stronger claim needs a
+  larger independently recruited sample and preferably correction-level plans
+  persisted by a future experiment.
 - **The first user-utility result is complete, and it did not prove the
   six-stage advantage.** Five reviewers returned 20/20 eligible blinded
   judgments over two rounds. Both rounds preferred the full workflow 6:4 for

--- a/README.md
+++ b/README.md
@@ -87,11 +87,18 @@ contract constant across **1-node, 4-node and 6-node workflows** for 10 topics
 with 3 repetitions each (90 paid cells). The 4-node workflow used **54.89% fewer
 median tokens and 47.03% lower median cost** than the production 6-node workflow,
 while substantially reducing contract violations and unsupported numeric lines
-relative to the monolith. This supports domain decomposition, but does not yet
-justify removing the production Scorer: Reviewer value still awaits a blinded
-9-pair human audit. Protocol, limitations and full results are recorded in the
-[topology ablation](docs/prereg-2026-08-21-agent-topology-ablation.md) and
-[Reviewer audit](docs/prereg-2026-08-22-reviewer-value-audit.md) documents.
+relative to the monolith. This supports domain decomposition, but does not by
+itself justify every production stage. The follow-up blinded Reviewer audit is
+now complete: both evaluator forms passed the frozen criterion across all nine
+report pairs. Each preferred the reviewed report in 7/9 pairs; exact agreement
+was 9/9 for overall preference, 8/9 for citation support, 3/9 for decision
+usefulness, and 7/9 for the harmful-version label. This provisionally supports
+retaining Reviewer, while the low decision-usefulness agreement and method
+limitations rule out a broader user-value claim. Protocols, results, and full
+caveats are in the
+[topology ablation](docs/prereg-2026-08-21-agent-topology-ablation.md),
+[Reviewer pre-registration](docs/prereg-2026-08-22-reviewer-value-audit.md), and
+[Reviewer result](docs/results-2026-08-23-reviewer-value-audit.md) documents.
 
 A separate pre-registered user-utility audit is now complete: five reviewers
 made **20 eligible blinded judgments** over ten matched full/monolith pairs and
@@ -906,10 +913,14 @@ TRL 校准将评分卡与基于公开里程碑建立、可独立核查的区间�
 **单节点、四节点和六节点工作流**，覆盖 10 个主题、每个重复 3 次，共 90 个
 付费单元。四节点相对生产六节点的 token 中位数降低 **54.89%**、成本中位数
 降低 **47.03%**，同时相对单节点显著减少合同违规和无证据数字。这支持领域
-分解，但尚不足以删除生产 Scorer：Reviewer 的价值还在等待 9 组报告级人工
-盲评。预注册规则、限制和完整结果见
-[拓扑消融文档](docs/prereg-2026-08-21-agent-topology-ablation.md)与
-[Reviewer 盲评文档](docs/prereg-2026-08-22-reviewer-value-audit.md)。
+分解，但这本身不足以证明每一个生产阶段都必要。后续 Reviewer 盲评现已完成：
+两份评审表均完成全部 9 组并通过冻结判据；两位评审者都在 7/9 组中偏好
+Reviewer 版本。整体偏好的精确一致率为 9/9，引用支持为 8/9，决策价值仅为
+3/9，有害版本判断为 7/9。因此结果仅初步支持保留 Reviewer；较低的决策价值
+一致率和方法学限制不支持把它扩大解释为普遍用户价值。完整协议、结果与限制见
+[拓扑消融文档](docs/prereg-2026-08-21-agent-topology-ablation.md)、
+[Reviewer 盲评预注册](docs/prereg-2026-08-22-reviewer-value-audit.md)和
+[Reviewer 盲评结果](docs/results-2026-08-23-reviewer-value-audit.md)。
 
 另有一组预注册用户效用盲评已经完成：5 名评审者对同一冻结证据下的 10 组
 完整工作流 / 单节点报告完成两轮交叉分配，共得到 **20 条合格匿名判断**，且

--- a/docs/prereg-2026-08-22-reviewer-value-audit.md
+++ b/docs/prereg-2026-08-22-reviewer-value-audit.md
@@ -3,6 +3,11 @@
 **Registered:** 2026-08-22, before any human preference labels were collected
 **Cost:** zero API calls; existing topology-ablation artifacts only
 
+> **Status (2026-08-23): complete.** Two evaluator forms completed all nine
+> report pairs and independently passed the frozen criterion. See the
+> [result report](results-2026-08-23-reviewer-value-audit.md). The thresholds
+> below remain unchanged from registration.
+
 ## Question
 
 The full topology's Reviewer accepted 34 corrections across 9 of 29 successful

--- a/docs/results-2026-08-23-reviewer-value-audit.md
+++ b/docs/results-2026-08-23-reviewer-value-audit.md
@@ -1,0 +1,115 @@
+# Result: blinded audit of Reviewer value
+
+**Completed:** 2026-08-23
+
+**Registered before labels:**
+[`prereg-2026-08-22-reviewer-value-audit.md`](prereg-2026-08-22-reviewer-value-audit.md)
+
+**Incremental model cost:** USD 0; the audit reused frozen ablation artifacts
+
+## Decision
+
+Both evaluator forms completed all nine report pairs and independently passed
+the frozen retention criterion. The result therefore **provisionally supports
+retaining the production Reviewer** for a larger independent evaluation.
+
+It does not prove that all six production nodes are necessary, that the reports
+are useful to target users, or that the cited claims are factually correct.
+Those questions require different comparisons and endpoints.
+
+## Unit of analysis
+
+The topology ablation recorded 34 accepted Reviewer plan items across nine
+successful full-topology runs. It did not persist a clean before/after pair for
+every individual correction. The pre-registered audit therefore used the nine
+complete Writer-draft versus reviewed-report pairs as its units. The result
+must not be restated as “34 corrections were verified.”
+
+## Frozen criterion
+
+The Reviewer was provisionally supported only if every report pair was judged
+and all three thresholds passed:
+
+| Frozen threshold | Evaluator A | Evaluator B | Result |
+|---|---:|---:|---|
+| Reviewed report preferred in at least 6/9 pairs | 7 | 7 | Both pass |
+| Reviewed report labelled harmful in at most 1/9 pairs | 0 | 0 | Both pass |
+| Draft has better citation support in at most 1/9 pairs | 1 | 1 | Both pass |
+
+The harmful-version counts above refer specifically to cases where the
+**reviewed** report was judged harmful. Evaluator B marked the draft harmful in
+two pairs; Evaluator A marked neither version harmful.
+
+## Descriptive outcomes
+
+| Dimension | Evaluator A | Evaluator B |
+|---|---|---|
+| Overall preference | reviewed 7, draft 1, tie 1 | reviewed 7, draft 1, tie 1 |
+| Citation support | reviewed 6, draft 1, tie 2 | reviewed 7, draft 1, tie 1 |
+| Decision usefulness | reviewed 2, draft 0, tie 7 | reviewed 7, draft 1, tie 1 |
+| Harmful version | reviewed 0, draft 0, neither 9 | reviewed 0, draft 2, neither 7 |
+
+Across the 18 evaluator-pair judgments, the reviewed report was preferred 14
+times, the draft twice, and two pairs were ties. These totals are descriptive;
+the sample is too small and its recruitment too informal for population-level
+inference.
+
+## Inter-rater agreement
+
+| Dimension | Exact agreement | Disagreements |
+|---|---:|---|
+| Overall preference | 9/9 (100%) | none |
+| Citation support | 8/9 (88.9%) | R09 |
+| Decision usefulness | 3/9 (33.3%) | R01 and R05–R09 |
+| Harmful version | 7/9 (77.8%) | R02 and R09 |
+| All recorded categorical judgments | 27/36 (75.0%) | — |
+
+The stable part of the result is overall preference, with relatively strong
+agreement on citation support. Decision usefulness is not stable: Evaluator A
+used `tie` in seven pairs while Evaluator B preferred the reviewed report in
+seven. The project therefore does not promote the stronger claim that Reviewer
+reliably improves business decisions.
+
+## Method records and limitations
+
+- Evaluator B confirmed reading all nine pairs, using no generative AI, seeing
+  no answer key, A/B identity, or other reviewer results, and spending about
+  2 hours 30 minutes.
+- Evaluator A's returned material included an AI-use statement. The study owner
+  later clarified that the substantive judgments were made and checked by a
+  person and that the AI-related statement was pasted in error. The form is
+  retained because its labels were owner-confirmed, but the correction happened
+  after return and the actual human review time is unavailable. This weakens
+  provenance and is disclosed rather than silently normalised.
+- Neither evaluator opened the underlying papers, patents, or market sources.
+  “Citation support” therefore means internal correspondence and apparent
+  support in the report, not independent verification of source truth.
+- This is one 9-pair experiment built from a single frozen evidence set and one
+  model configuration. Evaluators were not recruited as a representative panel
+  of technology-transfer or investment professionals.
+- The audit evaluates complete reports, not the accuracy of each of the 34
+  accepted Reviewer plan items.
+
+## What this changes
+
+The production topology remains unchanged. The audit supplies evidence for
+keeping Reviewer while the project gathers stronger evidence. It does not
+override the topology ablation's conclusion that four domain-specialised nodes
+captured the measured quality at lower cost than the six-node workflow.
+
+The Reviewer comparison and the separate user-utility audit answer different
+questions. This audit compares Writer draft with reviewed report; the utility
+audit compares the complete system with a monolithic baseline. A report-level
+Reviewer preference can coexist with no demonstrated end-user utility advantage
+for the full topology.
+
+## Next evidence required
+
+1. Persist structured correction-level plans in a future paid experiment so
+   individual Reviewer edits can be audited rather than inferred from full
+   reports.
+2. Repeat with a larger, independently recruited evaluator panel and record
+   expertise, time, AI use, and source-opening behaviour before unblinding.
+3. If decision usefulness remains an objective, tighten its rubric or use
+   target-user tasks with observable go/no-go decisions instead of relying only
+   on a broad ordinal judgment.


### PR DESCRIPTION
## Why

The topology ablation showed Reviewer activity but could not establish that its 34 accepted plan items improved the reports. Two completed nine-pair evaluator forms now allow the frozen retention criterion to be judged without another paid model run.

## What this records

- both evaluator forms completed 9/9 pairs and independently passed the frozen criterion
- each preferred the reviewed report in 7/9 pairs
- exact agreement was 9/9 for overall preference, 8/9 for citation support, 3/9 for decision usefulness, and 7/9 for harm
- neither evaluator opened external sources, so citation support is report-internal rather than source-truth verification
- one evaluator method declaration required a disclosed post-return clarification
- README, the pre-registration status, and AGENTS now point to a full result report

The conclusion is intentionally narrow: this provisionally supports retaining Reviewer for a larger evaluation. It does not prove six-node necessity, correction-level accuracy, general user utility, or factual truth.

## Verification

- uv run pytest -q --basetemp outputs/pytest-reviewer-audit-result-final-20260823
  - 1255 passed, 545 subtests passed
- uv run --with ruff ruff check .
  - all checks passed
- git diff --cached --check
  - clean

No production behavior or scoring baseline changed.