### PR TITLE
Add durable checkpoint persistence contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1255 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1266 tests (545 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/src/academic_agent/checkpoints.py
+++ b/src/academic_agent/checkpoints.py
@@ -1,0 +1,362 @@
+"""Durable, content-addressed contracts for future node-level recovery.
+
+This module deliberately does not decide when a CrewAI task may be skipped.
+It supplies the smaller primitive that decision needs: a validated node output
+can be committed atomically, and a later process can distinguish a reusable
+checkpoint from a missing, stale, or corrupt one.
+
+The distinction matters for paid work.  Treating an unreadable checkpoint as a
+cache miss would silently repeat a model call; treating a merely stale one as
+reusable would mix outputs produced from different evidence or prompts.  The
+caller must therefore handle every inspection state explicitly.
+
+Only hashes and non-secret model identity are persisted.  Provider credentials
+are intentionally absent from these models, so a recovered BYOK run will still
+need the user to supply fresh credentials.  Atomic persistence also does not
+claim exactly-once provider execution: a process can die after a provider has
+accepted a request but before its validated response is committed.  Recovery
+is consequently at-least-once at that external boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Annotated, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+
+NodeId = Literal[
+    "retrieval",
+    "academic",
+    "patent",
+    "market",
+    "writer",
+    "reviewer",
+    "scorer",
+]
+OutputFormat = Literal["json", "markdown", "text"]
+InspectionState = Literal["reusable", "missing", "mismatch", "corrupt"]
+
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+Sha256 = Annotated[str, Field(pattern=_SHA256_PATTERN)]
+_OUTPUT_FILE_PATTERN = r"^output-[0-9a-f]{64}\.(?:json|md|txt)$"
+_OUTPUT_EXTENSIONS: dict[OutputFormat, str] = {
+    "json": "json",
+    "markdown": "md",
+    "text": "txt",
+}
+
+
+class _FrozenModel(BaseModel):
+    """Reject schema drift and accidental reassignment in persisted contracts."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ModelIdentity(_FrozenModel):
+    """Non-secret model settings that can change a node's output.
+
+    ``endpoint_sha256`` identifies a custom endpoint without persisting its URL.
+    It is not an authentication mechanism; it only prevents accidental reuse
+    across providers or gateways that may implement different model behaviour.
+    """
+
+    provider: str = Field(min_length=1, max_length=100)
+    model: str = Field(min_length=1, max_length=200)
+    endpoint_sha256: Sha256 | None = None
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    response_format: str | None = Field(default=None, min_length=1, max_length=100)
+
+    @field_validator("provider", "model", "response_format")
+    @classmethod
+    def _strip_non_empty_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("model identity text must not be blank")
+        return stripped
+
+
+class CheckpointUsage(_FrozenModel):
+    """Bounded accounting retained with a completed node.
+
+    Token counters are kept separate because provider SDKs disagree on whether
+    cached tokens are included in ``prompt_tokens``.  The store records the
+    observed counters without trying to reinterpret them.
+    """
+
+    prompt_tokens: int = Field(default=0, ge=0)
+    completion_tokens: int = Field(default=0, ge=0)
+    cached_prompt_tokens: int = Field(default=0, ge=0)
+    cache_creation_tokens: int = Field(default=0, ge=0)
+    total_tokens: int = Field(default=0, ge=0)
+    total_requests: int = Field(default=0, ge=0)
+    cost_usd: float | None = Field(default=None, ge=0.0)
+    cost_complete: bool = False
+
+
+class CheckpointIdentity(_FrozenModel):
+    """Everything that must match before a node result can be reused.
+
+    The hashes are deliberately supplied by the orchestration layer.  That
+    layer knows which topic, uploaded paper, evidence, prompt files, weight
+    profile, and runtime settings reach each node; this storage primitive must
+    not guess at those dependency seams.
+    """
+
+    node_id: NodeId
+    input_sha256: Sha256
+    evidence_sha256: Sha256
+    config_sha256: Sha256
+    upstream_sha256: dict[NodeId, Sha256] = Field(default_factory=dict)
+    pipeline_revision: str = Field(min_length=1, max_length=200)
+    as_of_date: date
+    model: ModelIdentity | None = None
+
+    @field_validator("pipeline_revision")
+    @classmethod
+    def _strip_revision(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("pipeline_revision must not be blank")
+        return stripped
+
+    @model_validator(mode="after")
+    def _reject_self_dependency(self) -> CheckpointIdentity:
+        if self.node_id in self.upstream_sha256:
+            raise ValueError("a checkpoint cannot depend on its own output")
+        return self
+
+
+class CheckpointManifest(_FrozenModel):
+    """The commit record written only after the output file is durable."""
+
+    schema_version: Literal[1] = 1
+    status: Literal["validated"] = "validated"
+    identity: CheckpointIdentity
+    identity_sha256: Sha256
+    output_sha256: Sha256
+    output_file: str = Field(pattern=_OUTPUT_FILE_PATTERN)
+    output_format: OutputFormat
+    output_bytes: int = Field(ge=0)
+    completed_at: datetime
+    usage: CheckpointUsage | None = None
+
+    @field_validator("completed_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("completed_at must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _require_content_addressed_filename(self) -> CheckpointManifest:
+        extension = _OUTPUT_EXTENSIONS[self.output_format]
+        expected = f"output-{self.output_sha256}.{extension}"
+        if self.output_file != expected:
+            raise ValueError("output_file must match output_sha256 and output_format")
+        return self
+
+
+@dataclass(frozen=True)
+class CheckpointInspection:
+    """One explicit inspection outcome; only ``reusable`` carries payload."""
+
+    state: InspectionState
+    reasons: tuple[str, ...] = ()
+    manifest: CheckpointManifest | None = None
+    payload: bytes | None = None
+
+    def text(self) -> str:
+        """Decode a reusable UTF-8 payload without hiding state mistakes."""
+
+        if self.state != "reusable" or self.payload is None:
+            raise RuntimeError(f"checkpoint is {self.state}, not reusable")
+        return self.payload.decode("utf-8")
+
+
+def hash_bytes(value: bytes) -> str:
+    """Return the full SHA-256 digest used by persisted checkpoint contracts."""
+
+    return hashlib.sha256(value).hexdigest()
+
+
+def hash_text(value: str) -> str:
+    """Hash UTF-8 text after normalising platform line endings.
+
+    Line-ending normalisation prevents the same checked-out prompt from being
+    treated as different on Linux and Windows.  No whitespace is stripped:
+    leading, trailing, and repeated spaces can change an LLM request and must
+    therefore change its identity.
+    """
+
+    normalised = value.replace("\r\n", "\n").replace("\r", "\n")
+    return hash_bytes(normalised.encode("utf-8"))
+
+
+def hash_json(value: object) -> str:
+    """Hash canonical JSON while preserving semantic string content.
+
+    Mapping keys are sorted and insignificant JSON whitespace is removed.  The
+    function intentionally rejects NaN and non-JSON values instead of falling
+    back to ``str(value)``; a lossy fallback could make two different runtime
+    inputs appear reusable.
+    """
+
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hash_bytes(encoded)
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    """Fsync a same-directory temporary file before atomically replacing path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        # A failed replace leaves only an unreferenced temporary file.  Cleanup
+        # is best-effort because masking the original disk error would make the
+        # recovery diagnosis less truthful.
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+class CheckpointStore:
+    """Persist and inspect node checkpoints below one run directory."""
+
+    def __init__(self, run_directory: Path | str):
+        self.run_directory = Path(run_directory)
+        self.root = self.run_directory / "checkpoints"
+
+    def _node_directory(self, node_id: NodeId) -> Path:
+        return self.root / node_id
+
+    def _manifest_path(self, node_id: NodeId) -> Path:
+        return self._node_directory(node_id) / "manifest.json"
+
+    def commit(
+        self,
+        identity: CheckpointIdentity,
+        output: str,
+        *,
+        output_format: OutputFormat,
+        usage: CheckpointUsage | None = None,
+        completed_at: datetime | None = None,
+    ) -> CheckpointManifest:
+        """Atomically publish one validated output.
+
+        The content-addressed output is written first and the manifest is the
+        commit point.  If the process fails between those writes, the old
+        manifest still points to its unchanged payload and the new file is only
+        an orphan.  Reusing a fixed output filename would corrupt the previous
+        checkpoint in exactly that failure window.
+        """
+
+        payload = output.encode("utf-8")
+        output_sha256 = hash_bytes(payload)
+        extension = _OUTPUT_EXTENSIONS[output_format]
+        output_file = f"output-{output_sha256}.{extension}"
+        node_directory = self._node_directory(identity.node_id)
+        manifest = CheckpointManifest(
+            identity=identity,
+            identity_sha256=hash_json(identity),
+            output_sha256=output_sha256,
+            output_file=output_file,
+            output_format=output_format,
+            output_bytes=len(payload),
+            completed_at=completed_at or datetime.now(UTC),
+            usage=usage,
+        )
+
+        # Do not delete superseded content-addressed outputs here.  A concurrent
+        # reader may already have loaded the old manifest; pruning its payload
+        # would turn a valid observation into a transient corruption report.
+        _atomic_write_bytes(node_directory / output_file, payload)
+        manifest_payload = (manifest.model_dump_json(indent=2) + "\n").encode("utf-8")
+        _atomic_write_bytes(self._manifest_path(identity.node_id), manifest_payload)
+        return manifest
+
+    def inspect(self, expected: CheckpointIdentity) -> CheckpointInspection:
+        """Classify the on-disk checkpoint without treating silence as a pass."""
+
+        manifest_path = self._manifest_path(expected.node_id)
+        try:
+            raw_manifest = manifest_path.read_bytes()
+        except FileNotFoundError:
+            return CheckpointInspection("missing", ("manifest",))
+        except OSError as exc:
+            return CheckpointInspection("corrupt", (f"manifest_read:{type(exc).__name__}",))
+
+        try:
+            manifest = CheckpointManifest.model_validate_json(raw_manifest)
+        except (ValidationError, ValueError) as exc:
+            return CheckpointInspection("corrupt", (f"manifest_parse:{type(exc).__name__}",))
+
+        actual_identity_sha256 = hash_json(manifest.identity)
+        if manifest.identity_sha256 != actual_identity_sha256:
+            return CheckpointInspection("corrupt", ("identity_sha256",), manifest)
+
+        node_directory = self._node_directory(expected.node_id)
+        output_path = node_directory / manifest.output_file
+        try:
+            resolved_node = node_directory.resolve()
+            resolved_output = output_path.resolve(strict=True)
+        except (FileNotFoundError, OSError) as exc:
+            return CheckpointInspection(
+                "corrupt",
+                (f"output_resolve:{type(exc).__name__}",),
+                manifest,
+            )
+        if resolved_output.parent != resolved_node or not resolved_output.is_file():
+            return CheckpointInspection("corrupt", ("output_path",), manifest)
+
+        try:
+            payload = resolved_output.read_bytes()
+        except OSError as exc:
+            return CheckpointInspection(
+                "corrupt",
+                (f"output_read:{type(exc).__name__}",),
+                manifest,
+            )
+        integrity_errors = []
+        if len(payload) != manifest.output_bytes:
+            integrity_errors.append("output_bytes")
+        if hash_bytes(payload) != manifest.output_sha256:
+            integrity_errors.append("output_sha256")
+        if integrity_errors:
+            return CheckpointInspection("corrupt", tuple(integrity_errors), manifest)
+
+        expected_values = expected.model_dump(mode="json")
+        actual_values = manifest.identity.model_dump(mode="json")
+        mismatches = tuple(
+            f"identity.{field_name}"
+            for field_name in CheckpointIdentity.model_fields
+            if actual_values[field_name] != expected_values[field_name]
+        )
+        if mismatches:
+            return CheckpointInspection("mismatch", mismatches, manifest)
+
+        return CheckpointInspection("reusable", (), manifest, payload)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,289 @@
+"""Checkpoint persistence tests at the disk seam used by a restarted worker."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import academic_agent.checkpoints as checkpoint_module
+from academic_agent.checkpoints import (
+    CheckpointIdentity,
+    CheckpointInspection,
+    CheckpointStore,
+    CheckpointUsage,
+    ModelIdentity,
+    hash_bytes,
+    hash_json,
+    hash_text,
+)
+
+
+_COMPLETED_AT = datetime(2026, 8, 23, 12, 30, tzinfo=UTC)
+
+
+def _identity(**changes: object) -> CheckpointIdentity:
+    values: dict[str, object] = {
+        "node_id": "writer",
+        "input_sha256": hash_text("topic\npaper"),
+        "evidence_sha256": hash_json({"academic": ["A1"], "patent": ["P1"]}),
+        "config_sha256": hash_json({"prompt": "writer-v1", "language": "en"}),
+        "upstream_sha256": {
+            "academic": hash_text("academic output"),
+            "patent": hash_text("patent output"),
+            "market": hash_text("market output"),
+        },
+        "pipeline_revision": "f66f2e2",
+        "as_of_date": date(2026, 8, 23),
+        "model": ModelIdentity(
+            provider="deepseek",
+            model="deepseek-chat",
+            endpoint_sha256=hash_text("https://api.deepseek.com"),
+            temperature=0,
+            response_format="text",
+        ),
+    }
+    values.update(changes)
+    return CheckpointIdentity.model_validate(values)
+
+
+def _manifest_path(run_directory: Path) -> Path:
+    return run_directory / "checkpoints" / "writer" / "manifest.json"
+
+
+def test_hashes_are_full_stable_and_conservative() -> None:
+    assert hash_bytes(b"abc") == (
+        "ba7816bf8f01cfea414140de5dae2223"
+        "b00361a396177a9cb410ff61f20015ad"
+    )
+    assert hash_text("line one\r\nline two\r") == hash_text("line one\nline two\n")
+    assert hash_text("topic") != hash_text("topic ")
+    assert hash_json({"b": 2, "a": 1}) == hash_json({"a": 1, "b": 2})
+    assert hash_json(_identity()) == hash_json(_identity())
+    with pytest.raises(ValueError):
+        hash_json({"not_json": float("nan")})
+
+
+def test_commit_is_reusable_after_a_fresh_process_reads_the_file_boundary(
+    tmp_path: Path,
+) -> None:
+    identity = _identity()
+    output = "# Commercialization report\n\nEvidence-backed conclusion.\n"
+    usage = CheckpointUsage(
+        prompt_tokens=120,
+        completion_tokens=80,
+        total_tokens=200,
+        total_requests=1,
+        cost_usd=0.0014,
+        cost_complete=True,
+    )
+
+    manifest = CheckpointStore(tmp_path).commit(
+        identity,
+        output,
+        output_format="markdown",
+        usage=usage,
+        completed_at=_COMPLETED_AT,
+    )
+
+    # Reconstructing the store is intentional: an in-memory cache could make
+    # this pass while a restarted Railway worker still had nothing to resume.
+    inspection = CheckpointStore(tmp_path).inspect(identity)
+    assert inspection.state == "reusable"
+    assert inspection.reasons == ()
+    assert inspection.text() == output
+    assert inspection.manifest == manifest
+    assert manifest.status == "validated"
+    assert manifest.output_file == f"output-{hash_bytes(output.encode())}.md"
+    assert manifest.output_bytes == len(output.encode("utf-8"))
+    assert manifest.usage == usage
+
+    raw_manifest = _manifest_path(tmp_path).read_text(encoding="utf-8")
+    assert "https://api.deepseek.com" not in raw_manifest
+    assert "api_key" not in raw_manifest.lower()
+
+
+def test_complete_but_stale_checkpoint_reports_each_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    original = _identity()
+    CheckpointStore(tmp_path).commit(original, "draft", output_format="text")
+
+    alternatives = {
+        "input_sha256": _identity(input_sha256=hash_text("different input")),
+        "evidence_sha256": _identity(evidence_sha256=hash_text("different evidence")),
+        "config_sha256": _identity(config_sha256=hash_text("different config")),
+        "upstream_sha256": _identity(
+            upstream_sha256={"academic": hash_text("different upstream")}
+        ),
+        "pipeline_revision": _identity(pipeline_revision="new-revision"),
+        "as_of_date": _identity(as_of_date=date(2026, 8, 24)),
+        "model": _identity(
+            model=ModelIdentity(provider="openai", model="gpt-5", temperature=0)
+        ),
+    }
+    for field_name, expected in alternatives.items():
+        inspection = CheckpointStore(tmp_path).inspect(expected)
+        assert inspection.state == "mismatch"
+        assert inspection.reasons == (f"identity.{field_name}",)
+        assert inspection.payload is None
+
+
+def test_upstream_mapping_order_does_not_invalidate_the_same_dependencies(
+    tmp_path: Path,
+) -> None:
+    first_order = {
+        "academic": hash_text("A"),
+        "patent": hash_text("P"),
+        "market": hash_text("M"),
+    }
+    reverse_order = dict(reversed(list(first_order.items())))
+    stored = _identity(upstream_sha256=first_order)
+    expected = _identity(upstream_sha256=reverse_order)
+
+    CheckpointStore(tmp_path).commit(stored, "report", output_format="text")
+
+    assert hash_json(stored) == hash_json(expected)
+    assert CheckpointStore(tmp_path).inspect(expected).state == "reusable"
+
+
+def test_tampered_output_is_corrupt_not_a_cache_miss(tmp_path: Path) -> None:
+    identity = _identity()
+    manifest = CheckpointStore(tmp_path).commit(
+        identity, "validated report", output_format="text"
+    )
+    output_path = _manifest_path(tmp_path).parent / manifest.output_file
+    output_path.write_text("tampered report", encoding="utf-8")
+
+    inspection = CheckpointStore(tmp_path).inspect(identity)
+
+    assert inspection.state == "corrupt"
+    assert inspection.reasons == ("output_bytes", "output_sha256")
+    assert inspection.payload is None
+
+
+def test_missing_output_is_corrupt_while_an_orphan_without_manifest_is_missing(
+    tmp_path: Path,
+) -> None:
+    identity = _identity()
+    manifest = CheckpointStore(tmp_path).commit(identity, "report", output_format="text")
+    (_manifest_path(tmp_path).parent / manifest.output_file).unlink()
+    assert CheckpointStore(tmp_path).inspect(identity).state == "corrupt"
+
+    orphan_run = tmp_path / "orphan-run"
+    orphan_directory = orphan_run / "checkpoints" / "writer"
+    orphan_directory.mkdir(parents=True)
+    orphan_directory.joinpath(f"output-{'0' * 64}.txt").write_text(
+        "uncommitted", encoding="utf-8"
+    )
+    inspection = CheckpointStore(orphan_run).inspect(identity)
+    assert inspection.state == "missing"
+    assert inspection.reasons == ("manifest",)
+
+
+def test_manifest_schema_and_identity_corruption_are_reported_explicitly(
+    tmp_path: Path,
+) -> None:
+    identity = _identity()
+    CheckpointStore(tmp_path).commit(identity, "report", output_format="text")
+    manifest_path = _manifest_path(tmp_path)
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    raw["output_file"] = "../commercialization_report.md"
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    bad_path = CheckpointStore(tmp_path).inspect(identity)
+    assert bad_path.state == "corrupt"
+    assert bad_path.reasons == ("manifest_parse:ValidationError",)
+
+    CheckpointStore(tmp_path).commit(identity, "report", output_format="text")
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw["output_file"] = f"output-{'0' * 64}.txt"
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    bad_content_address = CheckpointStore(tmp_path).inspect(identity)
+    assert bad_content_address.state == "corrupt"
+    assert bad_content_address.reasons == ("manifest_parse:ValidationError",)
+
+    CheckpointStore(tmp_path).commit(identity, "report", output_format="text")
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw["identity"]["pipeline_revision"] = "tampered-revision"
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    bad_identity = CheckpointStore(tmp_path).inspect(identity)
+    assert bad_identity.state == "corrupt"
+    assert bad_identity.reasons == ("identity_sha256",)
+
+
+def test_manifest_failure_preserves_the_previous_reusable_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The old manifest must never point at bytes overwritten by a failed commit."""
+
+    store = CheckpointStore(tmp_path)
+    old_identity = _identity()
+    store.commit(old_identity, "old validated output", output_format="text")
+    original_atomic_write = checkpoint_module._atomic_write_bytes
+
+    def fail_manifest(path: Path, payload: bytes) -> None:
+        if path.name == "manifest.json":
+            raise OSError("injected manifest write failure")
+        original_atomic_write(path, payload)
+
+    monkeypatch.setattr(checkpoint_module, "_atomic_write_bytes", fail_manifest)
+    with pytest.raises(OSError, match="injected manifest write failure"):
+        store.commit(
+            _identity(config_sha256=hash_text("new configuration")),
+            "new output that must remain uncommitted",
+            output_format="text",
+        )
+
+    # This is the recovery seam: a new process still sees the complete old
+    # pair, while the newly written content-addressed file is only an orphan.
+    inspection = CheckpointStore(tmp_path).inspect(old_identity)
+    assert inspection.state == "reusable"
+    assert inspection.text() == "old validated output"
+    assert len(list(_manifest_path(tmp_path).parent.glob("output-*.txt"))) == 2
+
+
+def test_failed_atomic_replace_cleans_its_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(checkpoint_module.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="injected replace failure"):
+        CheckpointStore(tmp_path).commit(_identity(), "report", output_format="text")
+
+    node_directory = _manifest_path(tmp_path).parent
+    assert not list(node_directory.glob(".*.tmp"))
+    assert not _manifest_path(tmp_path).exists()
+
+
+def test_contract_rejects_secrets_self_dependencies_and_naive_timestamps(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValidationError, match="api_key"):
+        ModelIdentity(
+            provider="deepseek",
+            model="deepseek-chat",
+            api_key="must-not-be-persisted",  # type: ignore[call-arg]
+        )
+    with pytest.raises(ValidationError, match="own output"):
+        _identity(upstream_sha256={"writer": hash_text("self")})
+    with pytest.raises(ValidationError, match="literal_error"):
+        _identity(node_id="unknown")
+    with pytest.raises(ValidationError, match="timezone"):
+        CheckpointStore(tmp_path).commit(
+            _identity(),
+            "report",
+            output_format="text",
+            completed_at=datetime(2026, 8, 23, 12, 30),
+        )
+    assert not _manifest_path(tmp_path).exists()
+
+
+def test_non_reusable_inspection_cannot_be_read_as_success() -> None:
+    with pytest.raises(RuntimeError, match="missing, not reusable"):
+        CheckpointInspection("missing", ("manifest",)).text()


### PR DESCRIPTION
## Why

Long paid runs need a trustworthy persistence primitive before any task-skipping or resume behavior is introduced. Reusing stale evidence would be worse than rerunning, while treating a corrupt artifact as a normal cache miss would hide a recovery failure and may repeat paid work.

## What this adds

- content-addressed UTF-8 node outputs with an fsynced, atomically replaced manifest as the commit point
- identity binding for input, evidence, config, upstream outputs, pipeline revision, date-sensitive prompts, and non-secret model settings
- explicit reusable, missing, mismatch, and corrupt inspection states
- bounded token and cost accounting without persisting BYOK credentials
- integrity validation for manifest schema, identity digest, content digest, byte count, filename, extension, and path confinement
- 11 zero-network seam tests, including interrupted replacement and tamper cases

This PR intentionally does not connect checkpoints to CrewAI execution or advertise resume support. The current Railway and CLI paths remain unchanged; orchestration integration and fault-recovery measurement belong in follow-up work.

## Verification

- uv run pytest -q: 1266 passed, 545 subtests passed
- uv run --with ruff ruff check .: passed
- CI-equivalent narrow pylint checks: passed
- defect reinjection: replacing content-addressed filenames with one fixed filename made the interrupted-commit seam test fail with corrupt instead of reusable; restoring the implementation returned the test to green