### PR TITLE
Add durable node-level recovery for interrupted runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1266 tests (545 subtests), CI green on Linux + Windows × Python
+Current state: 1280 tests (551 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -62,6 +62,7 @@ is, in this order:
 | Why does this test exist? | Its docstring names the specific failure it caught |
 | Why was this change made? | `git log` — bodies run to ~25 lines and explain the alternative that was rejected |
 | Was this hypothesis tested? | `docs/prereg-*.md` — predictions and falsification criteria registered *before* paid runs |
+| How does crash recovery work? | `docs/checkpoint-recovery.md` — identity, persistence, authorization, observable states, and the at-least-once boundary |
 | Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,095 lines, 57 write-ups. Ask the user for access if you need it |
 
 Before writing or modifying CrewAI code specifically — the crew, the agents,
@@ -140,10 +141,14 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
   source_pipeline.py    ~2,900 lines, retrieval for all three domains
   evidence.py           models, guardrails, scoring rubric
   pipeline_worker.py    the subprocess one run executes in
+  checkpoint_runtime.py
+                        CrewAI hydration, task identity, and post-guardrail commits
+  run_spec.py           immutable, non-secret input contract for child recovery
+  checkpoints.py        atomic content-addressed storage and inspection states
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  55 test modules plus conftest, organised by subject
+tests/                  60 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering
@@ -153,11 +158,20 @@ user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 
 Runs are subprocesses writing to `outputs/<run_id>/`; the API, the browser and
 the CLI all observe the same run through those files rather than shared memory.
-A run URL is a capability — the id is the credential.
+A run URL is a read capability. Mutating a code-owned run additionally requires
+its owner/admin code; an ownerless BYOK run has no second server-side identity.
+Failed, cancelled, or timed-out runs with a retrieval checkpoint can start an
+immutable child from the longest validated prefix. The child snapshots its
+parent before launch, requires fresh credentials, and reports persistence and
+reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
 
 ## Things that are known-open
 
 - Blocking on uncited claims (above) — needs the detector tighter first.
+- Node-level recovery mechanics are covered by zero-network fault/restart tests,
+  but there is no paid production fault-injection result yet. Do not claim a
+  recovery-rate, token reduction, cost reduction, or exactly-once provider
+  execution until those values have been measured.
 - The benchmark's input distribution misses the shapes real traffic has:
   Chinese topics, very short inputs, non-technical topics. Before adding them,
   decide whether each is a "should succeed" or a "should fail gracefully" case;

--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ Step 6     Agent 6 — Quantitative scoring  (independent of report; formula aut
 
 The pipeline runs in a **subprocess** (`pipeline_worker.py`) so a run can be cancelled immediately via `proc.terminate()` rather than waiting for the current agent to finish.
 
+Every post-guardrail node output is also published as a non-secret,
+content-addressed checkpoint. A failed, cancelled, or timed-out run can start
+an immutable child that validates and reuses the longest matching task prefix;
+the original run remains untouched for audit. Recovery uses fresh credentials,
+shares the normal paid-operation limits, and is at-least-once—not
+exactly-once—at the external Provider boundary. See
+[Node-level checkpoint recovery](docs/checkpoint-recovery.md) for the complete
+identity, authorization, failure, and observability contract.
+
 ---
 
 ### Report structure
@@ -383,6 +392,10 @@ the API — no build step and no framework, so what is in `web/` is what runs.
 - **Reliability**: a separate panel distinguishes a failed retrieval domain,
   incomplete clinical-authority coverage, a check that could not run, and a
   check that ran without finding a problem — silence is never rendered as pass
+- **Crash recovery**: terminal failures with a durable retrieval checkpoint can
+  start an immutable child run. The header reports reused stages or degraded
+  checkpointing; fresh BYOK credentials are sent again and never recovered
+  from disk
 - **Attach a paper**: drop a PDF on the composer and it becomes source A1; the
   pipeline then searches around that paper's specific contribution. Its DOI
   and URL were read out of the PDF by a model, so they are resolved before
@@ -407,6 +420,10 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5
 
 # Fetch the report once state is "completed"
 curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
+
+# Resume a failed/cancelled/timed-out run as an immutable child
+curl -X POST http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/resume \
+     -H 'Content-Type: application/json' -d '{}'
 ```
 
 | Method | Path | Purpose |
@@ -414,6 +431,7 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
 | `GET` | `/health` | Liveness, active-run and shared paid-operation capacity, resolved LLM provider |
 | `POST` | `/api/papers` | Upload a PDF and extract its contribution (`429` at shared paid capacity) |
 | `POST` | `/api/runs` | Queue an assessment (`202`, or `429` at shared paid capacity) |
+| `POST` | `/api/runs/{id}/resume` | Start a recovery child from validated checkpoints (`202`) |
 | `GET` | `/api/runs` | List runs, newest first |
 | `GET` | `/api/runs/{id}` | Stage, state, elapsed time, available artifacts |
 | `DELETE` | `/api/runs/{id}` | Terminate a running assessment |
@@ -623,12 +641,15 @@ as it's open. `POST /api/papers` accepts the same BYOK LLM provider/key pair
 runs enter the shared paid-operation admission boundary before calling a
 provider.
 
-`GET /api/runs` (the run-history list) always stays behind a code
-regardless of any of this — opening it up would show every visitor's topics
-to every other visitor. Reading or cancelling one specific run by its id
-needs no code either way — the id itself carries 128 bits of randomness, the
-same capability-URL trust model already used for sharing a finished
-report's link.
+`GET /api/runs` (the run-history list) always stays behind a code regardless
+of any of this — opening it up would show every visitor's topics to every
+other visitor. Reading one specific run still uses an id carrying 128 bits of randomness
+as a capability URL. Mutation is stricter: cancelling, deleting, or resuming a
+code-owned run requires the same owner code (or the admin code). Ownerless
+BYOK runs have no second server-side identity, so their id remains the
+mutation capability; recovery nevertheless requires a fresh complete BYOK
+credential set. A resume creates a new child and enters the same concurrency
+and paid-operation admission boundary as a new run.
 
 **Deploying to Railway specifically:** the Dockerfile builds cleanly with
 plain `docker build`/`docker-compose`, but Railway's builder is stricter
@@ -757,6 +778,9 @@ academic_agent/
 ├── src/academic_agent/
 │   ├── crew.py              # Crew definition (6 agents / tasks wired together)
 │   ├── pipeline_worker.py   # Subprocess worker: runs pipeline, writes status.json + steps.jsonl
+│   ├── checkpoint_runtime.py # CrewAI adapter: validates and restores a contiguous task prefix
+│   ├── checkpoints.py       # Atomic, content-addressed node checkpoint contracts
+│   ├── run_spec.py          # Frozen non-secret run inputs used by recovery
 │   ├── main.py              # CLI entry point (--topic "your topic" flag)
 │   ├── evidence.py          # Evidence models, guardrail validators, CommercializationScore
 │   ├── source_pipeline.py   # Structured pre-agent source collection & validation
@@ -807,6 +831,7 @@ academic_agent/
 - **Academic metadata**: Crossref API (DOI verification and abstract retrieval)
 - **Data validation**: Pydantic v2 + custom guardrails (source structure, citation integrity, report structure, scoring formula, hallucinated source ID detection)
 - **Agent observability**: OpenTelemetry + OpenInference instrumentors with redacted content and optional Arize Phoenix OTLP export
+- **Durable recovery**: content-addressed node checkpoints keyed by input, evidence, configuration, and pipeline hashes; immutable child runs reuse only a validated contiguous prefix and require fresh BYOK credentials
 - **Web client**: static HTML, CSS and ES modules served by FastAPI — no build step, no framework
 - **HTTP API**: FastAPI + Uvicorn, serving both the client and the JSON API (OpenAPI docs at `/docs`)
 - **PDF export**: reportlab Platypus (embedded TTFont for CJK; falls back to CID fonts)
@@ -1030,6 +1055,13 @@ Step 6     Agent 6 — 量化评分（独立于报告；公式自动修正）
 
 流水线在 **子进程**（`pipeline_worker.py`）中运行，可通过 `proc.terminate()` 即时取消，无需等待当前智能体结束。
 
+每个通过 guardrail 的节点输出还会发布为不含密钥、按内容寻址的检查点。失败、
+取消或超时的运行可创建一个不可变子运行，逐项验证并复用最长连续匹配前缀；
+原运行保持不变以便审计。恢复必须使用新凭据、共用正常付费操作限额，而且在
+外部 Provider 边界提供的是 at-least-once，而不是 exactly-once。完整的身份、
+授权、失败和可观测性契约见
+[节点级检查点恢复](docs/checkpoint-recovery.md)。
+
 ---
 
 ### 报告结构
@@ -1157,6 +1189,7 @@ uv run uvicorn api.main:app --port 8000
 - **实时进度**：Phase 1 并行三个 Agent 的独立状态行 + 已用时间
 - **评分卡**：综合分（0–100）+ 五维雷达图 + 条形图，每个维度展示支撑来源 ID 标签（如 `A2` `M1`）；Weight Profile 徽章显示当前使用的评分权重方案
 - **来源与权威覆盖**：检索域失败或适用临床主题缺少监管/试验注册来源时显示警告，但不把“没检索到”写成“不存在”
+- **崩溃恢复**：已持久化检索检查点的失败运行可创建不可变子运行；标题栏显示复用阶段数或检查点降级状态，BYOK 凭据必须重新提供且不会从磁盘恢复
 - **报告**：Markdown 全文渲染 + `.md` / `.pdf` 双格式下载（PDF 后台生成，报告立即显示）
 - **History 标签页**：浏览所有历史运行；点击任意行自动填入 Run ID；包含 Run ID 列便于复制
 
@@ -1178,6 +1211,10 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5
 
 # state 变为 completed 后获取报告
 curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
+
+# 将失败/取消/超时运行恢复为一个不可变子运行
+curl -X POST http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/resume \
+     -H 'Content-Type: application/json' -d '{}'
 ```
 
 | 方法 | 路径 | 用途 |
@@ -1185,6 +1222,7 @@ curl http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/report
 | `GET` | `/health` | 存活检查、运行数、共享付费操作容量、已解析的 LLM provider |
 | `POST` | `/api/papers` | 上传 PDF 并提取贡献（共享付费容量满时返回 `429`） |
 | `POST` | `/api/runs` | 提交评估任务（共享付费容量满时返回 `429`） |
+| `POST` | `/api/runs/{id}/resume` | 从已验证检查点创建恢复子运行（`202`） |
 | `GET` | `/api/runs` | 列出历史运行，最新在前 |
 | `GET` | `/api/runs/{id}` | 阶段、状态、已用时长、可用产物清单 |
 | `DELETE` | `/api/runs/{id}` | 终止运行中的任务 |
@@ -1294,7 +1332,7 @@ token 是测出来的，成本不是：它需要一份本程序无法验证的�
 
 **第二个开放入口：** `POST /api/runs` 的请求体里也可以带 `llm_provider` / `llm_api_key` / `serper_api_key`，作为任意访问口令的替代——用访客自己的 Key，花费算在他们自己头上，不算在部署方头上。这条路不需要额外的服务端配置：只要配置了口令，网页客户端就会在门禁弹窗里自动多出这个选项；不设口令时它也不会出现，因为没有什么需要绕过。密钥直接进入这一次运行的子进程环境变量——不落盘、不并入服务端自身的环境——所以无论是不是 BYOK，并发的运行之间互相看不到对方的密钥。BYOK 提交的运行不会被打上任何口令标记，所以服务端不会把它记进任何一个口令的历史里；网页客户端转而在 `sessionStorage` 里维护一份访客自己这次会话提交过的运行列表，让侧栏依然能显示自己提交过什么——标签页一关就消失，标签页开着的时候完整可见。`POST /api/papers` 同样接受 BYOK 的 LLM provider/key（提取不需要搜索 Key）；PDF 提取与完整运行都会在调用 Provider 前进入同一付费操作准入边界。
 
-`GET /api/runs`（运行历史列表）无论如何都始终留在口令后面——开放的话会把每个访客的话题暴露给所有其他访客。按 `run_id` 读取或取消某一次具体的运行则不需要口令——`run_id` 本身带 128 位随机性，用的是和"分享一份已完成报告的链接"同一套能力令牌信任模型。
+`GET /api/runs`（运行历史列表）无论如何都始终留在口令后面——开放的话会把每个访客的话题暴露给所有其他访客。按 `run_id` 读取单次运行仍依赖 128 位随机性，并采用能力 URL；写操作更严格：取消、删除或恢复带归属标记的运行必须提供同一归属口令（或管理员口令）。BYOK 运行没有第二份服务端身份，因此其 `run_id` 仍是写操作能力，但恢复时仍必须重新提供完整 BYOK 凭据。恢复会创建新子运行，并与新运行共用相同的并发和付费操作准入边界。
 
 **`ACCESS_CODE_ADMIN`** 是再多的一个口令，授权运行的方式和其他口令完全一样（有自己的归属标记、自己的每日额度），但它不受历史列表过滤的限制——持有这个口令的人能看到所有口令的历史合在一起，用来确认"到底哪几个口令真的被用过"而不用一个个去查。
 
@@ -1383,6 +1421,9 @@ academic_agent/
 ├── src/academic_agent/
 │   ├── crew.py              # Crew 定义（6 个 Agent / Task 接线）
 │   ├── pipeline_worker.py   # 子进程 Worker：运行流水线，写入 status.json + steps.jsonl
+│   ├── checkpoint_runtime.py # CrewAI 适配层：校验并恢复连续任务前缀
+│   ├── checkpoints.py       # 原子写入、内容寻址的节点 Checkpoint 契约
+│   ├── run_spec.py          # 恢复使用的冻结、非敏感运行输入
 │   ├── main.py              # 命令行入口（支持 --topic 参数）
 │   ├── evidence.py          # 证据模型、guardrail 校验、CommercializationScore 模型
 │   ├── source_pipeline.py   # 六智能体启动前的结构化来源收集与验证
@@ -1431,6 +1472,7 @@ academic_agent/
 - **学术元数据**：Crossref API（DOI 验证与摘要检索）+ 并发引用数补全
 - **数据校验**：Pydantic v2 + 自定义 guardrail（来源结构、引用完整性、报告结构、幻觉来源 ID 检测、评分算法验证）
 - **Agent 可观测性**：OpenTelemetry + OpenInference 自动埋点，内容脱敏，可选导出到 Arize Phoenix OTLP 后端
+- **持久化恢复**：按输入、证据、配置与流水线哈希寻址的节点级 Checkpoint；不可变子运行仅复用已验证的连续前缀，BYOK 恢复必须重新提供凭据
 - **网页客户端**：静态 HTML / CSS / ES 模块，由 FastAPI 托管——无构建步骤、无框架
 - **HTTP API**：FastAPI + Uvicorn（OpenAPI 文档位于 `/docs`）
 - **PDF 导出**：reportlab Platypus（嵌入式 TTFont，支持 CJK；回退至 CID 字体）

--- a/api/main.py
+++ b/api/main.py
@@ -42,6 +42,7 @@ from api.models import (  # noqa: E402
     HealthStatus,
     PaperExtraction,
     ReadinessStatus,
+    ResumeRunRequest,
     RunAccepted,
     RunList,
     RunProgress,
@@ -245,12 +246,12 @@ async def _access_gate(request: Request, call_next):
       decision needs the parsed body, which a middleware does not cheaply
       have — for /api/papers the body is a multipart upload, less cheaply
       still.
-    - GET/DELETE /api/runs/{id}/... — a specific run, addressed by its id, is
-      a capability URL: the id itself (128 bits of randomness, see
-      create_run_id) is the credential, the same trust model already used for
-      sharing a finished report's link. Reading or cancelling one run costs
-      nothing further, unlike GET /api/runs (no id), which lists every run on
-      the deployment and stays gated.
+    - /api/runs/{id}/... routes bypass this global list gate because reads
+      use the run id as a capability. Their mutating handlers independently
+      verify ownership before cancellation, deletion, or a paid child resume.
+      Keeping that decision in the handler also lets resume parse fresh BYOK
+      credentials without consuming and rebuilding the request body here.
+      GET /api/runs itself stays gated because it lists deployment history.
     """
     path = request.url.path
     if not path.startswith("/api/"):
@@ -277,13 +278,13 @@ async def _access_gate(request: Request, call_next):
     return await call_next(request)
 
 
-def _authorize_destructive(run_id: str, http_request: Request) -> None:
-    """Require the code that owns this run before cancelling or deleting it.
+def _authorize_run_mutation(run_id: str, http_request: Request) -> None:
+    """Require proof of ownership before mutating or restarting a run.
 
     The access-gate middleware exempts /api/runs/{id}/... so a report link
-    can be shared without handing over the access code. That exemption is
-    right for reads and wrong for destructive calls, which is why this check
-    lives in the handler rather than the middleware.
+    can be shared without an access code. That exemption is right for reads
+    and insufficient for cancellation, deletion, or a paid recovery child,
+    which is why each mutating handler calls this check explicitly.
 
     Raises 404 rather than 403 on a mismatch: a distinct "forbidden" would
     confirm to a caller probing ids that a given run exists. Capability URLs
@@ -514,6 +515,79 @@ def submit_run(request: RunRequest, http_request: Request) -> RunAccepted:
 
     return RunAccepted(run_id=run_id, state="running", topic=request.topic)
 
+@app.post(
+    "/api/runs/{run_id}/resume",
+    response_model=RunAccepted,
+    status_code=202,
+    tags=["runs"],
+    responses={
+        401: {"description": "Fresh access-code or BYOK credentials are required"},
+        404: {"description": "Unknown run_id or caller does not own the source run"},
+        409: {"description": "Run is active, completed, or has no resumable checkpoint"},
+        429: {"description": "Concurrency or daily paid-operation limit reached"},
+    },
+)
+def resume_run(
+    run_id: str,
+    request: ResumeRunRequest,
+    http_request: Request,
+) -> RunAccepted:
+    """Start an immutable child that reuses only validated source checkpoints.
+
+    A resume is a new paid operation, not an in-place process restart. The
+    failed source remains untouched for audit, fresh credentials cross the
+    subprocess boundary, and the worker independently validates every content
+    hash before skipping a node. A stale or corrupt prefix therefore falls
+    back to execution rather than becoming an unearned successful recovery.
+    """
+    _authorize_run_mutation(run_id, http_request)
+    matched = access.matching_code(http_request.headers.get("x-access-code"))
+    if matched is None and not request.byok and access.gate_enabled():
+        raise HTTPException(
+            status_code=401,
+            detail="Provide the access code, or fresh BYOK credentials to resume.",
+        )
+    owner = access.owner_id(matched) if matched else None
+    byok = (
+        runs.BYOKCredentials(
+            request.llm_provider, request.llm_api_key, request.serper_api_key
+        )
+        if request.byok
+        else None
+    )
+
+    try:
+        child_id, child_directory = runs.resume_run(
+            run_id, byok=byok, owner=owner
+        )
+    except runs.RunNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except runs.RunNotResumable as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except runs.ConcurrencyLimitReached as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=f"{exc}. Retry once another paid operation finishes.",
+        ) from exc
+    except runs.DailyCapReached as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=f"{exc}. The daily paid-operation budget resets at 00:00 UTC.",
+        ) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to resume worker: {exc}") from exc
+
+    # Read from the child's frozen contract rather than trusting status.json;
+    # the worker may not have produced its first status write before this 202.
+    topic = runs.RunSpec.load(child_directory).topic
+    return RunAccepted(
+        run_id=child_id,
+        state="running",
+        topic=topic,
+        resumed_from=run_id,
+    )
+
+
 
 @app.get("/api/runs", response_model=RunList, tags=["runs"])
 def list_runs(http_request: Request, limit: int = Query(default=50, ge=1, le=200)) -> RunList:
@@ -576,7 +650,7 @@ def delete_run(run_id: str, http_request: Request) -> dict:
     links, and a reader who was handed a report link should not thereby be
     able to delete it out from under its owner.
     """
-    _authorize_destructive(run_id, http_request)
+    _authorize_run_mutation(run_id, http_request)
 
     try:
         runs.cancel_run(run_id)
@@ -669,6 +743,8 @@ def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgres
         quality_review=state.get("quality_review"),
         consistency=state.get("consistency"),
         observability=state.get("observability"),
+        checkpointing=state.get("checkpointing"),
+        recovery=state.get("recovery"),
         steps=[StepEvent(**s) for s in runs.read_steps(run_id, since=since)],
         artifacts=state.get("artifacts", []),
     )

--- a/api/models.py
+++ b/api/models.py
@@ -62,6 +62,36 @@ class RunRequest(BaseModel):
     def byok(self) -> bool:
         return self.llm_provider is not None
 
+class ResumeRunRequest(BaseModel):
+    """Fresh credentials for POST /api/runs/{run_id}/resume."""
+
+    # Recovery never persists credentials from the source run. A BYOK caller
+    # must supply a complete fresh set, while an access-code caller leaves the
+    # body empty and uses the deployment's configured providers.
+    llm_provider: str | None = Field(
+        default=None,
+        description=f"Bring-your-own-key provider: one of {BYOK_PROVIDERS}.",
+    )
+    llm_api_key: str | None = Field(default=None, description="Fresh LLM API key.")
+    serper_api_key: str | None = Field(default=None, description="Fresh Serper API key.")
+
+    @model_validator(mode="after")
+    def _byok_is_all_or_nothing(self) -> "ResumeRunRequest":
+        fields = (self.llm_provider, self.llm_api_key, self.serper_api_key)
+        if any(fields) and not all(fields):
+            raise ValueError(
+                "llm_provider, llm_api_key and serper_api_key must be provided together, "
+                "or all omitted to use the deployment's own keys."
+            )
+        if self.llm_provider is not None and self.llm_provider not in BYOK_PROVIDERS:
+            raise ValueError(f"llm_provider must be one of {BYOK_PROVIDERS}.")
+        return self
+
+    @property
+    def byok(self) -> bool:
+        return self.llm_provider is not None
+
+
 
 class PaperExtraction(BaseModel):
     """Structured contribution extracted from an uploaded PDF.
@@ -169,6 +199,17 @@ class RunProgress(BaseModel):
                     "an attempt because OTLP provides no persistence "
                     "acknowledgement. Absent for runs created before tracing.",
     )
+    checkpointing: dict | None = Field(
+        default=None,
+        description="Durable node-output persistence state. 'degraded' means the "
+                    "assessment may still finish but a later process cannot safely "
+                    "reuse every validated node.",
+    )
+    recovery: dict | None = Field(
+        default=None,
+        description="Whether recovery was requested, which validated nodes were "
+                    "reused, and the first node that still had to execute.",
+    )
     output_language: str = "English"
     steps: list[StepEvent] = Field(default_factory=list)
     artifacts: list[str] = Field(default_factory=list)
@@ -180,6 +221,7 @@ class RunAccepted(BaseModel):
     run_id: str
     state: RunState
     topic: str
+    resumed_from: str | None = None
 
 
 class RunStatus(BaseModel):
@@ -247,6 +289,17 @@ class RunStatus(BaseModel):
                     "run. 'active' means configured, while delivery remains "
                     "an attempt because OTLP provides no persistence "
                     "acknowledgement. Absent for runs created before tracing.",
+    )
+    checkpointing: dict | None = Field(
+        default=None,
+        description="Durable node-output persistence state. 'degraded' means the "
+                    "assessment may still finish but a later process cannot safely "
+                    "reuse every validated node.",
+    )
+    recovery: dict | None = Field(
+        default=None,
+        description="Whether recovery was requested, which validated nodes were "
+                    "reused, and the first node that still had to execute.",
     )
     artifacts: list[str] = Field(
         default_factory=list,

--- a/api/runs.py
+++ b/api/runs.py
@@ -29,6 +29,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 from academic_agent.run_output import DEFAULT_OUTPUT_ROOT, create_run_id
+from academic_agent.run_spec import RESUME_SNAPSHOT_DIRECTORY, RunSpec
 
 # A run is killed after this long. The bound belongs to the worker contract,
 # not to whichever client submitted or polls the run.
@@ -263,6 +264,10 @@ class RunStillActive(Exception):
     """Raised when delete_run is asked to remove a run that has not stopped."""
 
 
+class RunNotResumable(Exception):
+    """Raised when a run has no safe checkpoint recovery contract."""
+
+
 _registry: dict[str, _Handle] = {}
 
 # Inline paid operations live in the API process rather than a subprocess, so
@@ -424,13 +429,12 @@ def _is_valid_run_id(run_id: str) -> bool:
     )
 
 
-def start_run(
-    topic: str,
-    language: str | None = None,
-    weight_profile: str | None = None,
-    paper_json_path: str | None = None,
+def _start_run_from_spec(
+    spec: RunSpec,
+    *,
     byok: BYOKCredentials | None = None,
     owner: str | None = None,
+    resume_from: str | None = None,
 ) -> tuple[str, Path]:
     """Launch a worker subprocess. Returns (run_id, run_dir).
 
@@ -464,7 +468,7 @@ def start_run(
         )
         try:
             _registry[run_id] = _Handle(
-                run_id=run_id, topic=topic, proc=_PendingProcess(), log_file=None,
+                run_id=run_id, topic=spec.topic, proc=_PendingProcess(), log_file=None,
                 byok=byok is not None,
             )
         except BaseException:
@@ -482,16 +486,44 @@ def start_run(
     # it short of restarting the process.
     try:
         run_dir.mkdir(parents=True, exist_ok=True)
+        spec_path = spec.save(run_dir)
         if owner is not None:
             (run_dir / _OWNER_FILE).write_text(owner, encoding="utf-8")
+        if resume_from is not None:
+            # Snapshot before Popen. The source can be deleted manually or by
+            # retention while the child is starting; making the worker read
+            # it later would turn a valid recovery request into a race. The
+            # child copy contains only manifests and non-secret outputs.
+            if not _is_valid_run_id(resume_from):
+                raise RunNotFound(f"Invalid run id: {resume_from!r}")
+            source_directory = run_dir_for(resume_from).resolve(strict=True)
+            output_root = DEFAULT_OUTPUT_ROOT.resolve()
+            if source_directory.parent != output_root:
+                raise RunNotFound(f"No run with id {resume_from}")
+            source_checkpoints = (source_directory / "checkpoints").resolve(strict=True)
+            if source_checkpoints.parent != source_directory:
+                raise OSError("Source checkpoint directory escaped its run directory.")
+            snapshot_root = run_dir / RESUME_SNAPSHOT_DIRECTORY
+            shutil.copytree(source_checkpoints, snapshot_root / "checkpoints")
 
-        cmd = [sys.executable, "-m", "academic_agent.pipeline_worker", run_id, topic.strip()]
-        if language:
-            cmd += ["--language", language]
-        if weight_profile:
-            cmd += ["--weight-profile", weight_profile]
-        if paper_json_path and Path(paper_json_path).exists():
-            cmd += ["--paper-json", paper_json_path]
+
+        cmd = [
+            sys.executable, "-m", "academic_agent.pipeline_worker",
+            run_id, spec.topic, "--run-spec", str(spec_path),
+        ]
+        # Keep the explicit flags for CLI/process introspection and backwards
+        # compatibility, while RunSpec remains the worker's authoritative
+        # contract. The worker verifies and then overwrites these values from
+        # the frozen spec, so duplicated argv cannot cause identity drift.
+        if spec.language is not None:
+            cmd += ["--language", spec.language]
+        if spec.weight_profile is not None:
+            cmd += ["--weight-profile", spec.weight_profile]
+
+        if resume_from is not None:
+            # The id remains provenance; the worker reads the immutable local
+            # snapshot above rather than racing the source directory.
+            cmd += ["--resume-from", resume_from]
 
         # BYOK credentials travel as env, never as argv: command-line arguments
         # are visible to any other process on the same host via `ps`/the process
@@ -519,10 +551,104 @@ def start_run(
         # the process actually started — so the limit would only ever see runs
         # that had not launched yet, which is to say none of them.
         _registry[run_id] = _Handle(
-            run_id=run_id, topic=topic, proc=proc, log_file=log_file,
+            run_id=run_id, topic=spec.topic, proc=proc, log_file=log_file,
             byok=byok is not None,
         )
     return run_id, run_dir
+
+def _spec_from_submission(
+    topic: str,
+    language: str | None,
+    weight_profile: str | None,
+    paper_json_path: str | None,
+) -> RunSpec:
+    """Freeze a submission before reserving money or starting its worker."""
+
+    paper_contribution = None
+    if paper_json_path is not None:
+        path = Path(paper_json_path)
+        if not path.is_file():
+            raise OSError(f"Paper contribution no longer exists: {path.name}")
+        try:
+            candidate = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise OSError(f"Could not read paper contribution: {exc}") from exc
+        if not isinstance(candidate, dict):
+            raise OSError("Paper contribution must be a JSON object.")
+        paper_contribution = candidate
+
+    return RunSpec(
+        topic=topic,
+        language=language,
+        weight_profile=weight_profile,
+        paper_contribution=paper_contribution,
+    )
+
+
+def start_run(
+    topic: str,
+    language: str | None = None,
+    weight_profile: str | None = None,
+    paper_json_path: str | None = None,
+    byok: BYOKCredentials | None = None,
+    owner: str | None = None,
+) -> tuple[str, Path]:
+    """Launch a new worker from a durable, non-secret input contract."""
+
+    spec = _spec_from_submission(topic, language, weight_profile, paper_json_path)
+    return _start_run_from_spec(spec, byok=byok, owner=owner)
+
+
+def resume_run(
+    source_run_id: str,
+    *,
+    byok: BYOKCredentials | None = None,
+    owner: str | None = None,
+) -> tuple[str, Path]:
+    """Launch an immutable child run that may reuse the source's checkpoints.
+
+    The failed source directory is never rewritten.  That preserves the crash
+    evidence and avoids a restarted worker racing a reader of the original
+    capability URL.  The child receives fresh credentials through the normal
+    subprocess boundary and copies each reused checkpoint into its own run.
+    """
+
+    if not _is_valid_run_id(source_run_id):
+        raise RunNotFound(f"Invalid run id: {source_run_id!r}")
+    source_directory = run_dir_for(source_run_id)
+    if not source_directory.is_dir():
+        raise RunNotFound(f"No run with id {source_run_id}")
+
+    state = get_state(source_run_id)["state"]
+    if state not in {"failed", "cancelled", "timeout"}:
+        if state == "running":
+            raise RunNotResumable("A running assessment cannot be resumed.")
+        if state == "completed":
+            raise RunNotResumable("A completed assessment has no unfinished work to resume.")
+        raise RunNotResumable(
+            "An assessment with unreadable state cannot be resumed safely."
+        )
+
+    try:
+        spec = RunSpec.load(source_directory)
+    except (OSError, ValueError) as exc:
+        raise RunNotResumable(
+            "This run predates durable input contracts or its contract is unreadable."
+        ) from exc
+
+    # Retrieval is the root of every task identity.  Starting a paid child
+    # without even that commit could only produce a full rerun while claiming
+    # to be recovery, so old/pre-checkpoint runs fail explicitly instead.
+    retrieval_manifest = source_directory / "checkpoints" / "retrieval" / "manifest.json"
+    if not retrieval_manifest.is_file():
+        raise RunNotResumable("This run has no validated retrieval checkpoint to resume.")
+
+    return _start_run_from_spec(
+        spec,
+        byok=byok,
+        owner=owner,
+        resume_from=source_run_id,
+    )
 
 
 def cancel_run(run_id: str) -> None:
@@ -810,6 +936,12 @@ def get_state(run_id: str) -> dict:
         # collector persisted a span because OTLP gives this process no such
         # acknowledgement.
         "observability": status.get("observability"),
+        # Persisting a node and reusing it are different claims. Both remain
+        # explicit so a failed auxiliary write cannot look like successful
+        # recovery, and a cold start cannot look like a cache hit simply
+        # because checkpointing itself was healthy.
+        "checkpointing": status.get("checkpointing"),
+        "recovery": status.get("recovery"),
         "artifacts": available_artifacts(run_dir),
     }
 

--- a/docs/checkpoint-recovery.md
+++ b/docs/checkpoint-recovery.md
@@ -1,0 +1,140 @@
+# Node-level checkpoint recovery
+
+Long assessments make several paid provider calls. A process crash after a
+validated node used to discard every completed result, so the only recovery
+option was a full rerun. The recovery contract now persists validated outputs
+at the task boundary and starts an immutable child run from the longest safe
+prefix.
+
+This is a runtime reliability feature, not a result cache. It does not change
+the six-stage topology, prompts, guardrails, score formula, retrieval rules, or
+the benchmark baseline.
+
+## Contract
+
+Every API run writes a non-secret `.run-spec.json` before its worker starts.
+The contract freezes the topic, requested language, weight profile, and the
+bounded paper contribution (when present). Provider credentials are never
+fields in this file; a resumed BYOK run must supply fresh credentials.
+
+After validation, each node publishes a content-addressed payload and a
+manifest under `outputs/<run_id>/checkpoints/<node>/`:
+
+```text
+retrieval -> academic -> patent -> market -> writer -> reviewer -> scorer
+```
+
+The first three LLM tasks still execute in parallel. The order above is the
+logical recovery order used by CrewAI's sequential task scheduler.
+
+A checkpoint is reusable only when all of these still match:
+
+- immutable run input and the validated evidence collection;
+- the node's explicit task/agent projection and non-secret model identity;
+- every declared upstream output hash;
+- pipeline revision and UTC collection date;
+- manifest schema, output length, content hash, and expected JSON/Markdown
+  payload form.
+
+The implementation deliberately projects fields instead of serializing
+CrewAI's runtime objects. CrewAI 1.14.7 includes `BaseLLM.api_key` in its model
+state, so using its native serializer would put credentials at risk.
+
+## Recovery lifecycle
+
+`POST /api/runs/{run_id}/resume` accepts only a failed, cancelled, or timed-out
+run with a readable RunSpec and a committed retrieval checkpoint. It creates a
+new run id and never rewrites the failed source. Before the worker starts, the
+API copies the source checkpoints into the child's private `.resume-source/`
+snapshot; deleting or pruning the parent after the `202` response therefore
+cannot invalidate the child.
+
+The worker validates retrieval first and then restores only the **longest
+contiguous matching task prefix**. The first missing, mismatched, or corrupt
+node ends reuse; that node and every later node execute normally. Arbitrary
+non-contiguous reuse was rejected because CrewAI 1.14.7 has no supported
+scheduler contract for it and reproducing callback, context, tracing, and
+rate-limit semantics would require a second executor.
+
+Every reused checkpoint is republished into the child, making the child
+independently resumable. A Reviewer fallback that merely ships the Writer's
+validated draft is not recorded as a Reviewer checkpoint: the review did not
+happen. A scorer that completes through the bounded fallback path is committed
+because its own guardrail still ran.
+
+## API and credentials
+
+```bash
+curl -X POST http://localhost:8000/api/runs/<failed-run-id>/resume \
+     -H 'Content-Type: application/json' \
+     -H 'X-Access-Code: <the-source-owner-code>' \
+     -d '{}'
+```
+
+For BYOK, send a fresh complete credential set in the JSON body:
+
+```json
+{
+  "llm_provider": "deepseek",
+  "llm_api_key": "...",
+  "serper_api_key": "..."
+}
+```
+
+Credentials cross only the child subprocess environment. They are absent from
+argv, RunSpec, checkpoint manifests, checkpoint payloads, and status files.
+Code-owned runs require the same owner code (or the admin code) for mutation;
+sharing a read-only capability URL does not grant recovery or deletion rights.
+Ownerless BYOK runs have no separate server-side identity, so their random run
+id remains their mutation capability and fresh BYOK keys are still required.
+
+Resume admission uses the same global concurrency, BYOK concurrency, and daily
+operator-funded limits as a new run. A resume is potentially paid work even
+when every node is expected to match, so it never bypasses that boundary.
+
+## Observable states
+
+Both `/api/runs/{id}` and `/api/runs/{id}/progress` expose separate fields:
+
+- `checkpointing.state`: `partial`, `complete`, or `degraded`, plus committed
+  nodes and persistence errors;
+- `recovery.state`: `not_requested`, `cold_start`, `reused`, or `unavailable`,
+  plus the source id, reused nodes, first node still requiring execution, and
+  explicit inspection results.
+
+The browser shows reused-stage counts and checkpoint degradation. It offers
+the resume action only for a terminal failure that reports a committed
+retrieval checkpoint. "No reusable checkpoint" and "recovery not requested"
+therefore cannot be mistaken for a successful cache hit.
+
+## Failure boundary
+
+Atomic publication protects an existing checkpoint from torn writes, but this
+system does **not** claim exactly-once provider execution. A process can die
+after a provider accepted or returned a response and before the validated
+output manifest became durable. Retrying that node is at-least-once at the
+external provider boundary and can incur one duplicate call.
+
+Checkpoint disk failure is non-blocking for report delivery: a paid,
+guardrail-validated report is not discarded because an auxiliary write failed.
+The run is marked `checkpointing.degraded` so the loss of future recoverability
+is visible rather than presented as success.
+
+## Verification
+
+The zero-network suite covers the storage and client seams separately:
+
+- corrupt, stale, mismatched, and path-escaping manifests;
+- contiguous-prefix restoration and child republishing;
+- a real pinned CrewAI kickoff whose provider double raises if hydration is
+  ignored;
+- fresh BYOK isolation and code-owner authorization;
+- parent deletion immediately after the API returns `202`;
+- a complete worker fault/restart path in which the child executes zero of six
+  already-validated LLM nodes;
+- propagation of checkpoint and recovery state through both API responses and
+  the shipped browser.
+
+The tests prove recovery mechanics without network or model spend. They do not
+yet establish a production recovery-rate, token-saving, or cost-saving claim;
+those numbers require controlled fault injection over real paid runs.

--- a/src/academic_agent/checkpoint_runtime.py
+++ b/src/academic_agent/checkpoint_runtime.py
@@ -1,0 +1,536 @@
+"""Runtime adapter between validated CrewAI tasks and durable checkpoints.
+
+The storage primitive in :mod:`academic_agent.checkpoints` intentionally knows
+nothing about CrewAI.  This module owns the missing policy: what contributes to
+a task identity, when a post-guardrail output is safe to commit, and which old
+outputs may be placed back into a new crew.
+
+Recovery is deliberately a *contiguous-prefix* operation.  CrewAI 1.14.7 can
+resume from the first task whose ``output`` is absent, but it cannot safely
+skip an arbitrary later task.  Reusing a patent result while re-running the
+academic task would require a second scheduler and would change callback,
+context, tracing, and rate-limit semantics.  The small amount of extra recall
+is not worth that unmeasured execution path: the first missing, mismatched, or
+corrupt node ends reuse for the run.
+
+CrewAI also ships a native checkpoint serializer.  It is not used here because
+its runtime state serializes each LLM object, and CrewAI's ``BaseLLM`` includes
+``api_key`` as a model field.  This adapter persists only the non-secret model
+identity defined by our own contract and hydrates only ``TaskOutput.raw``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any, Final, cast
+
+from crewai.tasks.task_output import TaskOutput
+
+from academic_agent.checkpoints import (
+    CheckpointIdentity,
+    CheckpointStore,
+    ModelIdentity,
+    NodeId,
+    OutputFormat,
+    hash_bytes,
+    hash_json,
+    hash_text,
+)
+from academic_agent.run_spec import RunSpec
+
+
+TASK_NODES: Final[tuple[NodeId, ...]] = (
+    "academic",
+    "patent",
+    "market",
+    "writer",
+    "reviewer",
+    "scorer",
+)
+_ALL_NODES: Final[tuple[NodeId, ...]] = ("retrieval", *TASK_NODES)
+_OUTPUT_FORMATS: Final[dict[NodeId, OutputFormat]] = {
+    "retrieval": "json",
+    "academic": "json",
+    "patent": "json",
+    "market": "json",
+    "writer": "markdown",
+    "reviewer": "markdown",
+    "scorer": "json",
+}
+_UPSTREAMS: Final[dict[NodeId, tuple[NodeId, ...]]] = {
+    "retrieval": (),
+    "academic": ("retrieval",),
+    "patent": ("retrieval",),
+    "market": ("retrieval",),
+    "writer": ("academic", "patent", "market"),
+    "reviewer": ("academic", "patent", "market", "writer"),
+    # Scoring is intentionally independent of prose.  Including writer or
+    # reviewer here would retire valid score checkpoints when wording changed.
+    "scorer": ("academic", "patent", "market"),
+}
+_REVISION_ENV_VARS: Final[tuple[str, ...]] = (
+    "RAILWAY_GIT_COMMIT_SHA",
+    "GITHUB_SHA",
+    "SOURCE_VERSION",
+)
+_COMMIT_PATTERN = re.compile(r"[0-9a-fA-F]{7,64}")
+
+
+def pipeline_revision() -> str:
+    """Return the deployed commit, or a source-content fallback outside CI.
+
+    A package version is too weak here: this project does not bump its version
+    for every prompt or guardrail edit.  Railway and GitHub expose the commit;
+    local/other-container runs hash the exact files that shape retrieval,
+    prompts, validation, and this recovery adapter instead.
+    """
+
+    for name in _REVISION_ENV_VARS:
+        candidate = os.getenv(name, "").strip()
+        if _COMMIT_PATTERN.fullmatch(candidate):
+            return f"git:{candidate.lower()}"
+
+    package = Path(__file__).resolve().parent
+    relevant = (
+        package / "checkpoint_runtime.py",
+        package / "checkpoints.py",
+        package / "crew.py",
+        package / "evidence.py",
+        package / "llm_config.py",
+        package / "pipeline_worker.py",
+        package / "run_spec.py",
+        package / "source_pipeline.py",
+        package / "config" / "agents.yaml",
+        package / "config" / "tasks.yaml",
+    )
+    payload = bytearray()
+    for path in relevant:
+        # A missing production file is itself a different revision.  Recording
+        # the marker keeps the hash deterministic and lets the later import
+        # raise the useful error rather than hiding it here.
+        relative = path.relative_to(package).as_posix().encode("utf-8")
+        payload.extend(len(relative).to_bytes(4, "big"))
+        payload.extend(relative)
+        if path.is_file():
+            content = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            payload.extend(len(content).to_bytes(8, "big"))
+            payload.extend(content)
+        else:
+            payload.extend((0).to_bytes(8, "big"))
+    return f"source:{hash_bytes(bytes(payload))}"
+
+
+def retrieval_identity(
+    spec: RunSpec,
+    *,
+    revision: str,
+    as_of_date: date,
+) -> CheckpointIdentity:
+    """Identity for the deterministic retrieval-and-localisation stage.
+
+    Search credentials and backend availability are intentionally not part of
+    this identity.  They affect how the already-committed source collection was
+    obtained, not whether that exact validated collection can be reused after
+    a crash.  The one-day boundary prevents an old collection being presented
+    as a fresh search on a later date.
+    """
+
+    return CheckpointIdentity(
+        node_id="retrieval",
+        input_sha256=hash_json(spec),
+        evidence_sha256=hash_json(spec.paper_contribution or {}),
+        config_sha256=hash_json({"stage": "source_collection", "contract": 1}),
+        upstream_sha256={},
+        pipeline_revision=revision,
+        as_of_date=as_of_date,
+        model=None,
+    )
+
+
+def _bounded_response_format(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, type):
+        text = f"{value.__module__}.{value.__qualname__}"
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            text = str(value)
+    text = text.strip()
+    if not text:
+        return None
+    return text if len(text) <= 100 else f"sha256:{hash_text(text)}"
+
+
+def _model_identity(task: Any) -> ModelIdentity:
+    agent = getattr(task, "agent", None)
+    llm = getattr(agent, "llm", None)
+    if llm is None:
+        raise ValueError("checkpointed task has no configured LLM")
+
+    provider = str(getattr(llm, "provider", "") or type(llm).__module__).strip()
+    model = str(getattr(llm, "model", "") or type(llm).__qualname__).strip()
+    endpoint = str(getattr(llm, "base_url", "") or "").strip().rstrip("/")
+    temperature = getattr(llm, "temperature", None)
+    if temperature is not None:
+        temperature = float(temperature)
+
+    response_format = getattr(llm, "response_format", None)
+    if response_format is None:
+        additional = getattr(llm, "additional_params", None)
+        if isinstance(additional, Mapping):
+            response_format = additional.get("response_format")
+
+    return ModelIdentity(
+        provider=provider,
+        model=model,
+        endpoint_sha256=hash_text(endpoint) if endpoint else None,
+        temperature=temperature,
+        response_format=_bounded_response_format(response_format),
+    )
+
+
+def _type_name(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+    return f"{type(value).__module__}.{type(value).__qualname__}"
+
+
+def _task_config(task: Any, task_indices: Mapping[int, int]) -> dict[str, Any]:
+    """Select output-affecting task fields without serializing CrewAI state.
+
+    Serializing ``task`` or ``agent`` wholesale would reintroduce the native
+    checkpoint's secret leak through ``agent.llm.api_key``.  This explicit
+    projection is longer but auditable and stable across platforms.
+    """
+
+    agent = getattr(task, "agent", None)
+    context = list(getattr(task, "context", None) or [])
+    tools = list(getattr(task, "tools", None) or getattr(agent, "tools", None) or [])
+    return {
+        "description": str(getattr(task, "description", "")),
+        "expected_output": str(getattr(task, "expected_output", "")),
+        "async_execution": bool(getattr(task, "async_execution", False)),
+        "context_indices": [task_indices.get(id(item), -1) for item in context],
+        "guardrail_present": getattr(task, "guardrail", None) is not None,
+        "guardrail_max_retries": int(getattr(task, "guardrail_max_retries", 0) or 0),
+        "output_json": _type_name(getattr(task, "output_json", None)),
+        "output_pydantic": _type_name(getattr(task, "output_pydantic", None)),
+        "agent": {
+            "role": str(getattr(agent, "role", "")),
+            "goal": str(getattr(agent, "goal", "")),
+            "backstory": str(getattr(agent, "backstory", "")),
+            "inject_date": bool(getattr(agent, "inject_date", False)),
+            "allow_delegation": bool(getattr(agent, "allow_delegation", False)),
+            "tools": [str(getattr(tool, "name", type(tool).__qualname__)) for tool in tools],
+        },
+    }
+
+
+def _validated_payload(text: str, output_format: OutputFormat) -> bool:
+    if not text.strip():
+        return False
+    if output_format != "json":
+        return True
+    try:
+        json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return True
+
+
+class CheckpointRuntime:
+    """Commit validated task outputs and hydrate a safe prior-run prefix."""
+
+    def __init__(
+        self,
+        *,
+        crew: Any,
+        source_collection: Any,
+        crew_inputs: Mapping[str, Any],
+        destination_run_directory: Path | str,
+        retrieval_output_sha256: str,
+        revision: str,
+        as_of_date: date,
+        resume_run_id: str | None = None,
+        resume_run_directory: Path | str | None = None,
+        retrieval_committed: bool = True,
+        initial_errors: Sequence[str] = (),
+        retrieval_reused: bool = False,
+        retrieval_inspection: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.crew = crew
+        self.tasks = list(getattr(crew, "tasks", ()) or ())
+        self.destination_store = CheckpointStore(destination_run_directory)
+        self.resume_store = (
+            CheckpointStore(resume_run_directory)
+            if resume_run_directory is not None
+            else None
+        )
+        self.resume_run_id = resume_run_id
+        self.revision = revision
+        self.as_of_date = as_of_date
+        self.input_sha256 = hash_json(dict(crew_inputs))
+        evidence_payload = source_collection.model_dump(mode="json")
+        if not isinstance(evidence_payload, dict):
+            # Production supplies SourceCollection, but lightweight orchestration
+            # tests and third-party callers may provide a duck-typed collection.
+            # Hash the exact Crew input in that degraded topology rather than
+            # failing an otherwise valid report solely in auxiliary recovery.
+            evidence_payload = dict(crew_inputs)
+        self.evidence_sha256 = hash_json(evidence_payload)
+        self._output_hashes: dict[NodeId, str] = {
+            "retrieval": retrieval_output_sha256,
+        }
+        self._committed: set[NodeId] = {"retrieval"} if retrieval_committed else set()
+        self._reused: list[NodeId] = ["retrieval"] if retrieval_reused else []
+        self._inspections: dict[NodeId, dict[str, Any]] = (
+            {"retrieval": dict(retrieval_inspection)}
+            if retrieval_inspection is not None
+            else {}
+        )
+        self._errors: list[str] = list(initial_errors)
+        self._lock = threading.RLock()
+        self._callbacks_installed = False
+        self._reused_prefix = 0
+
+        if len(self.tasks) == len(TASK_NODES):
+            indices = {id(task): index for index, task in enumerate(self.tasks)}
+            self._config_hashes = {
+                node: hash_json(_task_config(task, indices))
+                for node, task in zip(TASK_NODES, self.tasks, strict=True)
+            }
+            self._models = {
+                node: _model_identity(task)
+                for node, task in zip(TASK_NODES, self.tasks, strict=True)
+            }
+        else:
+            # Production has exactly six tasks.  A topology drift must be
+            # visible as degraded checkpointing, not silently treated as a
+            # successful run with no recoverable nodes.  Several orchestration
+            # tests use a minimal MagicMock crew, so the report path still runs.
+            self._config_hashes: dict[NodeId, str] = {}
+            self._models: dict[NodeId, ModelIdentity] = {}
+            self._errors.append(
+                f"topology:expected_{len(TASK_NODES)}_tasks_got_{len(self.tasks)}"
+            )
+
+    @property
+    def reusable_prefix(self) -> int:
+        return self._reused_prefix
+
+    @property
+    def enabled(self) -> bool:
+        return len(self.tasks) == len(TASK_NODES)
+
+    def _identity(self, node: NodeId) -> CheckpointIdentity:
+        upstream: dict[NodeId, str] = {}
+        missing = []
+        for dependency in _UPSTREAMS[node]:
+            digest = self._output_hashes.get(dependency)
+            if digest is None:
+                missing.append(dependency)
+            else:
+                upstream[dependency] = digest
+        if missing:
+            raise RuntimeError(
+                f"{node} checkpoint missing upstream output hashes: {', '.join(missing)}"
+            )
+        return CheckpointIdentity(
+            node_id=node,
+            input_sha256=self.input_sha256,
+            evidence_sha256=self.evidence_sha256,
+            config_sha256=self._config_hashes[node],
+            upstream_sha256=upstream,
+            pipeline_revision=self.revision,
+            as_of_date=self.as_of_date,
+            model=self._models[node],
+        )
+
+    def restore_contiguous_prefix(self) -> int:
+        """Hydrate only the longest reusable prefix from the source run."""
+
+        if self.resume_store is None or not self.enabled:
+            return 0
+
+        with self._lock:
+            for node, task in zip(TASK_NODES, self.tasks, strict=True):
+                expected = self._identity(node)
+                inspection = self.resume_store.inspect(expected)
+                self._inspections[node] = {
+                    "state": inspection.state,
+                    "reasons": list(inspection.reasons),
+                }
+                if inspection.state != "reusable" or inspection.manifest is None:
+                    break
+
+                text = inspection.text()
+                output_format = _OUTPUT_FORMATS[node]
+                if not _validated_payload(text, output_format):
+                    self._inspections[node] = {
+                        "state": "corrupt",
+                        "reasons": ["payload_format"],
+                    }
+                    break
+
+                task.output = TaskOutput(
+                    description=str(getattr(task, "description", "")),
+                    expected_output=str(getattr(task, "expected_output", "")),
+                    raw=text,
+                    agent=str(getattr(getattr(task, "agent", None), "role", "")),
+                )
+                # CrewAI Task has no output_format before execution in 1.14.7,
+                # and these production tasks consume exact post-guardrail raw
+                # text. Inferring CrewAI JSON from the checkpoint's storage
+                # format would make TaskOutput.__str__ prefer json_dict and
+                # change the downstream context bytes. RAW is its default and
+                # faithfully preserves the validated text.
+                self._output_hashes[node] = inspection.manifest.output_sha256
+                self._reused.append(node)
+                self._reused_prefix += 1
+
+                # A child run must become independently resumable.  Copy by
+                # recommitting the already-verified bytes rather than storing a
+                # parent path that can be pruned out from underneath it.
+                try:
+                    self.destination_store.commit(
+                        expected,
+                        text,
+                        output_format=output_format,
+                        usage=inspection.manifest.usage,
+                        completed_at=inspection.manifest.completed_at,
+                    )
+                    self._committed.add(node)
+                except (OSError, TypeError, ValueError) as exc:
+                    self._errors.append(
+                        f"{node}:copy:{type(exc).__name__}:{str(exc)[:160]}"
+                    )
+
+            if self._reused_prefix:
+                # CrewAI 1.14.7's sequential executor checks this field and
+                # then starts at the first task whose output is None.  The
+                # pinned-version seam is covered by a real Crew kickoff test;
+                # upgrading CrewAI remains explicitly forbidden on main.
+                self.crew.checkpoint_kickoff_event_id = (
+                    f"academic-agent:{self.resume_run_id or 'external'}"
+                )
+        return self._reused_prefix
+
+    def _commit_output(self, node: NodeId, task_output: Any) -> None:
+        raw = getattr(task_output, "raw", None)
+        if not isinstance(raw, str) or not _validated_payload(raw, _OUTPUT_FORMATS[node]):
+            with self._lock:
+                self._errors.append(f"{node}:callback_payload_invalid")
+            return
+
+        with self._lock:
+            # Set the digest before publishing.  A downstream task may start as
+            # soon as this callback returns; even if the checkpoint disk write
+            # fails, its identity must still bind the exact upstream bytes it
+            # received rather than pretending no dependency existed.
+            self._output_hashes[node] = hash_text(raw)
+            try:
+                identity = self._identity(node)
+                manifest = self.destination_store.commit(
+                    identity,
+                    raw,
+                    output_format=_OUTPUT_FORMATS[node],
+                )
+                self._output_hashes[node] = manifest.output_sha256
+                self._committed.add(node)
+            except (OSError, TypeError, ValueError, RuntimeError) as exc:
+                # Checkpointing improves recovery but is not report validity.
+                # Raising here would discard a paid, guardrail-validated task
+                # solely because an auxiliary disk write failed.  The terminal
+                # status exposes the degradation instead.
+                self._errors.append(
+                    f"{node}:commit:{type(exc).__name__}:{str(exc)[:160]}"
+                )
+
+    def install_task_callbacks(self) -> None:
+        """Attach post-validation persistence without doubling progress calls."""
+
+        if not self.enabled or self._callbacks_installed:
+            return
+        crew_callback = getattr(self.crew, "task_callback", None)
+        for node, task in zip(TASK_NODES, self.tasks, strict=True):
+            original = getattr(task, "callback", None)
+
+            def checkpoint_callback(
+                output: Any,
+                *,
+                node_id: NodeId = node,
+                previous: Callable[[Any], None] | None = original,
+            ) -> None:
+                self._commit_output(node_id, output)
+                # CrewAI invokes crew.task_callback after task.callback when
+                # the two objects differ.  Calling the same callback here too
+                # would advance the UI twice for one paid node.
+                if previous is not None and previous is not crew_callback:
+                    previous(output)
+
+            task.callback = checkpoint_callback
+        self._callbacks_installed = True
+
+    def commit_manual_output(self, node: NodeId, task_output: Any) -> None:
+        """Commit a validated output executed outside normal Crew callbacks."""
+
+        if node not in TASK_NODES or not self.enabled:
+            return
+        self._commit_output(node, task_output)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return distinct checkpointing and recovery states for status.json."""
+
+        with self._lock:
+            committed = [node for node in _ALL_NODES if node in self._committed]
+            if self._errors:
+                checkpoint_state = "degraded"
+            elif len(committed) == len(_ALL_NODES):
+                checkpoint_state = "complete"
+            else:
+                checkpoint_state = "partial"
+
+            if self.resume_store is None:
+                recovery_state = "not_requested"
+            elif not self.enabled:
+                recovery_state = "unavailable"
+            elif self._reused:
+                recovery_state = "reused"
+            else:
+                recovery_state = "cold_start"
+
+            next_node: NodeId | None = (
+                TASK_NODES[self._reused_prefix]
+                if self._reused_prefix < len(TASK_NODES)
+                else None
+            )
+            return {
+                "checkpointing": {
+                    "state": checkpoint_state,
+                    "committed_nodes": committed,
+                    "errors": list(self._errors),
+                },
+                "recovery": {
+                    "state": recovery_state,
+                    "source_run_id": self.resume_run_id,
+                    "reused_nodes": list(self._reused),
+                    "next_node": next_node,
+                    "inspections": dict(self._inspections),
+                },
+            }
+
+
+def task_node(index: int) -> NodeId:
+    """Typed task-index mapping used by recovery/fallback integration."""
+
+    return cast(NodeId, TASK_NODES[index])

--- a/src/academic_agent/pipeline_worker.py
+++ b/src/academic_agent/pipeline_worker.py
@@ -15,6 +15,8 @@ import sys
 import threading
 import traceback
 from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 for stream in (sys.stdout, sys.stderr):
@@ -34,6 +36,24 @@ _SEQUENTIAL_STAGES = [
 # scoring(5).
 _IDX_REVIEW = 4
 _IDX_SCORING = 5
+
+def _resolve_resume_directory(output_root: Path, run_id: str) -> Path:
+    """Resolve a source run id without allowing an arbitrary checkpoint path.
+
+    The API supplies this value, but the worker is also a public CLI module.
+    Treating it as a path would let ``--resume-from ..\\...`` read manifests
+    outside ``outputs`` before checkpoint integrity checks had a chance to run.
+    """
+
+    if not run_id or run_id != Path(run_id).name or ".." in run_id:
+        raise ValueError(f"Invalid resume run id: {run_id!r}")
+    root = output_root.resolve()
+    candidate = (root / run_id).resolve(strict=True)
+    if candidate.parent != root or not candidate.is_dir():
+        raise ValueError(f"Resume run is outside the output root: {run_id!r}")
+    return candidate
+
+
 
 
 def _select_report_and_scores(
@@ -65,6 +85,7 @@ def _recover_from_reviewer_failure(
     error: Exception,
     *,
     task_complete: Callable[[Any], None] | None = None,
+    checkpoint_complete: Callable[[int, Any], None] | None = None,
 ) -> tuple[list[Any], dict[str, str]] | None:
     """Deliver Task 4's validated draft when only Task 5 failed.
 
@@ -79,7 +100,10 @@ def _recover_from_reviewer_failure(
     executed through CrewAI's public Task API without weakening its guardrail.
     Both callback locations are temporarily disabled to avoid counting the
     manually executed task twice; this helper emits the two missing completion
-    events explicitly after their outputs exist.
+    events explicitly after their outputs exist.  Only the independently
+    validated scorer output is checkpointed.  The copied draft is deliberately
+    not published as a reviewer checkpoint: a future resume must not mistake a
+    review that never happened for a completed quality inspection.
     """
     tasks = list(getattr(crew_obj, "tasks", ()) or ())
     if len(tasks) <= _IDX_SCORING:
@@ -112,6 +136,8 @@ def _recover_from_reviewer_failure(
     finally:
         scoring_task.callback = original_task_callback
         crew_obj.task_callback = original_crew_callback
+    if checkpoint_complete is not None:
+        checkpoint_complete(_IDX_SCORING, scoring_output)
 
     if task_complete is not None:
         task_complete(scoring_output)
@@ -177,6 +203,28 @@ class ProgressTracker:
         with self._lock:
             return self._parallel_done + self._sequential_done
 
+    def restore_completed_prefix(self, count: int) -> None:
+        """Seed progress for tasks skipped from validated checkpoints.
+
+        CrewAI does not fire completion callbacks for restored tasks.  Without
+        this seed, the next real callback would label the writer as evidence
+        Agent 1 and the browser would finish with fewer than six completions
+        even though all six outputs reached it.
+        """
+
+        if not 0 <= count <= self._total:
+            raise ValueError(f"completed prefix must be between 0 and {self._total}")
+        with self._lock:
+            if self._parallel_done or self._sequential_done:
+                raise RuntimeError("progress can only be restored before callbacks begin")
+            self._parallel_done = min(count, self._parallel_count)
+            self._sequential_done = max(0, count - self._parallel_count)
+
+    def next_incomplete(self) -> int | None:
+        """Agent index to announce after restored completion events."""
+
+        completed = self.completed
+        return completed if completed < self._total else None
     def on_complete(self) -> tuple[int, str, int | None]:
         """Record one completion. Returns (finished_idx, stage, next_idx)."""
         with self._lock:
@@ -234,6 +282,7 @@ def _merge_status_fields(
         "claim_grounding", "consistency", "observability", "authority_coverage",
         "component_coverage",
         "quality_review",
+        "checkpointing", "recovery",
     ):
         if existing.get(sticky) is not None:
             data[sticky] = existing[sticky]
@@ -251,6 +300,14 @@ def main() -> None:
     parser.add_argument("--language", default="", help="Force output language (overrides auto-detect)")
     parser.add_argument("--weight-profile", default="", help="Force scoring weight profile (overrides auto-detect)")
     parser.add_argument("--paper-json", default="", help="Path to JSON file containing PaperContribution data")
+    parser.add_argument(
+        "--run-spec", default="",
+        help="Path to the durable RunSpec stored inside this run directory",
+    )
+    parser.add_argument(
+        "--resume-from", default="",
+        help="Prior run id whose validated checkpoint prefix may be reused",
+    )
     args = parser.parse_args()
 
     _max_rpm_env = os.getenv("MAX_RPM", "6")
@@ -266,6 +323,16 @@ def main() -> None:
         ToolUsageStartedEvent,
     )
 
+    from academic_agent.checkpoint_runtime import (
+        CheckpointRuntime,
+        pipeline_revision,
+        retrieval_identity,
+        task_node,
+    )
+    from academic_agent.checkpoints import CheckpointStore, hash_text
+    from academic_agent.run_spec import (
+        RESUME_SNAPSHOT_DIRECTORY, RUN_SPEC_FILENAME, RunSpec,
+    )
     from academic_agent.observability import start_run_telemetry
     from academic_agent.crew import AcademicAgent
     from academic_agent.run_output import (
@@ -282,7 +349,9 @@ def main() -> None:
         save_source_collection,
     )
     from academic_agent.pdf_extractor import PaperContribution, paper_to_evidence_source
-    from academic_agent.source_pipeline import SourceCollectionError, collect_source_collection
+    from academic_agent.source_pipeline import (
+        SourceCollection, SourceCollectionError, collect_source_collection,
+    )
     from academic_agent.token_usage import collect_usage
 
     run_dir = DEFAULT_OUTPUT_ROOT / args.run_id
@@ -306,6 +375,8 @@ def main() -> None:
         consistency: dict | None = None,
         authority_coverage: dict | None = None,
         component_coverage: dict | None = None,
+        checkpointing: dict | None = None,
+        recovery: dict | None = None,
         quality_review: dict | None = None,
     ) -> None:
         try:
@@ -336,6 +407,10 @@ def main() -> None:
                 data["component_coverage"] = component_coverage
             if quality_review is not None:
                 data["quality_review"] = quality_review
+            if checkpointing is not None:
+                data["checkpointing"] = checkpointing
+            if recovery is not None:
+                data["recovery"] = recovery
             # Atomic: the API polls this file while the worker rewrites it on
             # every stage transition. A plain write leaves a window where the
             # reader sees a truncated document, and an unreadable status was
@@ -363,6 +438,8 @@ def main() -> None:
     # someone wants to know what it cost, and it is also the only case where
     # this name might never be assigned.
     crew_obj = None
+    checkpoint_runtime = None
+    checkpoint_snapshot: dict[str, Any] = {}
 
     def snapshot_usage() -> dict | None:
         if crew_obj is None:
@@ -378,6 +455,101 @@ def main() -> None:
         return usage.as_dict()
 
     try:
+        if args.run_spec:
+            expected_spec = (run_dir / RUN_SPEC_FILENAME).resolve()
+            supplied_spec = Path(args.run_spec).resolve()
+            if supplied_spec != expected_spec:
+                raise ValueError("RunSpec must be stored inside the current run directory.")
+            spec = RunSpec.load(run_dir)
+            if spec.topic != args.topic.strip():
+                raise ValueError("RunSpec topic does not match the worker topic argument.")
+        else:
+            paper_contribution = None
+            if args.paper_json:
+                paper_path = Path(args.paper_json)
+                if paper_path.is_file():
+                    candidate = json.loads(paper_path.read_text(encoding="utf-8"))
+                    if not isinstance(candidate, dict):
+                        raise ValueError("Paper contribution must be a JSON object.")
+                    paper_contribution = candidate
+            spec = RunSpec(
+                topic=args.topic,
+                language=args.language or None,
+                weight_profile=args.weight_profile or None,
+                paper_contribution=paper_contribution,
+            )
+            spec.save(run_dir)
+
+        # From this point the persisted contract, not a second interpretation of
+        # argv, is the source of truth for both normal execution and recovery.
+        args.language = spec.language or ""
+        args.weight_profile = spec.weight_profile or ""
+        revision = pipeline_revision()
+        checkpoint_date = datetime.now(UTC).date()
+        retrieval_contract = retrieval_identity(
+            spec, revision=revision, as_of_date=checkpoint_date
+        )
+        resume_directory = None
+        if args.resume_from:
+            local_snapshot = (run_dir / RESUME_SNAPSHOT_DIRECTORY).resolve()
+            if (
+                local_snapshot.is_dir()
+                and local_snapshot.parent == run_dir.resolve()
+            ):
+                resume_directory = local_snapshot
+            else:
+                resume_directory = _resolve_resume_directory(
+                    DEFAULT_OUTPUT_ROOT, args.resume_from
+                )
+        if resume_directory == run_dir.resolve():
+            raise ValueError("A run cannot resume from its own directory.")
+
+        source_collection: SourceCollection | None = None
+        retrieval_reused = False
+        retrieval_payload = ""
+        retrieval_inspection: dict[str, Any] | None = None
+        if resume_directory is not None:
+            prior = CheckpointStore(resume_directory).inspect(retrieval_contract)
+            retrieval_inspection = {
+                "state": prior.state,
+                "reasons": list(prior.reasons),
+            }
+            if prior.state == "reusable":
+                try:
+                    source_collection = SourceCollection.model_validate_json(prior.text())
+                except ValueError as exc:
+                    retrieval_inspection = {
+                        "state": "corrupt",
+                        "reasons": [f"payload_model:{type(exc).__name__}"],
+                    }
+                else:
+                    retrieval_reused = True
+                    retrieval_payload = prior.text()
+
+        retrieval_errors: list[str] = []
+        retrieval_committed = False
+        retrieval_output_sha256 = ""
+        checkpoint_snapshot = {
+            "checkpointing": {
+                "state": "partial",
+                "committed_nodes": [],
+                "errors": [],
+            },
+            "recovery": {
+                "state": (
+                    "reused" if retrieval_reused
+                    else "cold_start" if resume_directory is not None
+                    else "not_requested"
+                ),
+                "source_run_id": args.resume_from or None,
+                "reused_nodes": ["retrieval"] if retrieval_reused else [],
+                "next_node": "academic",
+                "inspections": (
+                    {"retrieval": retrieval_inspection}
+                    if retrieval_inspection is not None else {}
+                ),
+            },
+        }
         # "Auto (detect from topic)" is the UI's own label for "no preference",
         # not a profile name — resolved to None here so the one place that
         # knows the profile names does not have to know the dropdown's.
@@ -388,24 +560,21 @@ def main() -> None:
         )
         paper_seed = None
         extra_market_queries = None
-        if args.paper_json:
-            import pathlib
-            _pj = pathlib.Path(args.paper_json)
-            if _pj.exists():
-                _pc_data = json.loads(_pj.read_text(encoding="utf-8"))
-                paper_seed = paper_to_evidence_source(PaperContribution(**_pc_data))
-                _domain = _pc_data.get("application_domain", "").strip()
-                if _domain:
-                    # Non-ASCII domain (e.g. Chinese) produces queries whose
-                    # results are rejected by the English keyword relevance filter.
-                    # Translate to English so Serper results are filterable.
-                    if any(ord(c) > 127 for c in _domain):
-                        from academic_agent.language import translate_to_english
-                        _domain = translate_to_english(_domain) or _domain
-                    extra_market_queries = [
-                        f"{_domain} commercial product company revenue manufacturer 2024 2025",
-                        f"{_domain} startup investment funding market leader industry",
-                    ]
+        if spec.paper_contribution is not None:
+            _pc_data = spec.paper_contribution
+            paper_seed = paper_to_evidence_source(PaperContribution(**_pc_data))
+            _domain = _pc_data.get("application_domain", "").strip()
+            if _domain:
+                # Non-ASCII domain (e.g. Chinese) produces queries whose
+                # results are rejected by the English keyword relevance filter.
+                # Translate to English so Serper results are filterable.
+                if any(ord(c) > 127 for c in _domain):
+                    from academic_agent.language import translate_to_english
+                    _domain = translate_to_english(_domain) or _domain
+                extra_market_queries = [
+                    f"{_domain} commercial product company revenue manufacturer 2024 2025",
+                    f"{_domain} startup investment funding market leader industry",
+                ]
 
         # Passed in rather than assigned to the returned collection, which is
         # where it used to happen. Retrieval branches on the profile — the
@@ -418,13 +587,13 @@ def main() -> None:
             "RETRIEVER",
             {"academic_agent.source.paper_seeded": paper_seed is not None},
         ):
-            source_collection = collect_source_collection(
+            source_collection = source_collection or collect_source_collection(
                 args.topic,
                 paper_seed=paper_seed,
                 extra_market_queries=extra_market_queries,
                 weight_profile=requested_profile,
             )
-        if args.language and args.language != "Auto (detect from topic)":
+        if not retrieval_reused and args.language and args.language != "Auto (detect from topic)":
             # Map UI dropdown values to canonical API language names.
             _UI_TO_API_LANG: dict[str, str] = {"Chinese": "Simplified Chinese"}
             canonical_lang = _UI_TO_API_LANG.get(args.language, args.language)
@@ -454,8 +623,35 @@ def main() -> None:
                     )
                     if translated_topic and translated_topic != source_collection.display_topic:
                         source_collection.display_topic = translated_topic
+        source_json = source_collection.model_dump_json(indent=2)
+        if not retrieval_payload:
+            retrieval_payload = source_json
+        try:
+            retrieval_manifest = CheckpointStore(run_dir).commit(
+                retrieval_contract,
+                retrieval_payload,
+                output_format="json",
+            )
+            retrieval_output_sha256 = retrieval_manifest.output_sha256
+            retrieval_committed = True
+        except (OSError, TypeError, ValueError) as exc:
+            # Retrieval remains usable for this process.  The terminal status
+            # reports that a later process cannot safely resume from it.
+            retrieval_output_sha256 = hash_text(retrieval_payload)
+            retrieval_errors.append(
+                f"retrieval:commit:{type(exc).__name__}:{str(exc)[:160]}"
+            )
+        telemetry.set_attributes({
+            "academic_agent.checkpoint.retrieval.reused": retrieval_reused,
+            "academic_agent.checkpoint.retrieval.committed": retrieval_committed,
+        })
+        checkpoint_snapshot["checkpointing"] = {
+            "state": "degraded" if retrieval_errors else "partial",
+            "committed_nodes": ["retrieval"] if retrieval_committed else [],
+            "errors": list(retrieval_errors),
+        }
         save_source_collection(
-            source_collection.model_dump_json(indent=2), run_id=args.run_id, output_root=DEFAULT_OUTPUT_ROOT,
+            source_json, run_id=args.run_id, output_root=DEFAULT_OUTPUT_ROOT,
         )
         if source_collection.failed_domains:
             # An empty domain reads as a fact about the technology; this says
@@ -487,6 +683,7 @@ def main() -> None:
             component_coverage=source_collection.component_coverage.model_dump(
                 mode="json"
             ),
+            **checkpoint_snapshot,
         )
 
         tracker = ProgressTracker(
@@ -511,12 +708,45 @@ def main() -> None:
                 _write_step({"agent_idx": next_idx, "type": "action",
                              "thought": "", "tool": "reasoning",
                              "tool_input": "", "result": ""})
-            write_status(stage, output_language=source_collection.output_language)
+            current_checkpoint_snapshot = (
+                checkpoint_runtime.snapshot()
+                if checkpoint_runtime is not None else checkpoint_snapshot
+            )
+            write_status(
+                stage,
+                output_language=source_collection.output_language,
+                **current_checkpoint_snapshot,
+            )
 
         crew_obj = AcademicAgent(
             source_collection,
             task_callback=on_task_complete,
         ).crew()
+        crew_inputs = source_collection.crew_inputs()
+        checkpoint_runtime = CheckpointRuntime(
+            crew=crew_obj,
+            source_collection=source_collection,
+            crew_inputs=crew_inputs,
+            destination_run_directory=run_dir,
+            retrieval_output_sha256=retrieval_output_sha256,
+            revision=revision,
+            as_of_date=checkpoint_date,
+            resume_run_id=args.resume_from or None,
+            resume_run_directory=resume_directory,
+            retrieval_committed=retrieval_committed,
+            initial_errors=retrieval_errors,
+            retrieval_reused=retrieval_reused,
+            retrieval_inspection=retrieval_inspection,
+        )
+        reused_prefix = checkpoint_runtime.restore_contiguous_prefix()
+        tracker.restore_completed_prefix(reused_prefix)
+        checkpoint_runtime.install_task_callbacks()
+        checkpoint_snapshot = checkpoint_runtime.snapshot()
+        write_status(
+            _PARALLEL_STAGE,
+            output_language=source_collection.output_language,
+            **checkpoint_snapshot,
+        )
 
         # Build role → agent index mapping for event handlers.
         # CrewAI 1.14.7 uses AgentExecutor (event-bus-based) by default;
@@ -554,21 +784,45 @@ def main() -> None:
                         "result": str(event.output or "").strip()[:400],
                     })
 
-                # Pre-seed "started" action entries for all three parallel agents so
-                # Phase 1 shows live activity even when agent events do not fire
-                # consistently across threads. Empty tool signals "analyzing" state.
-                for _i in range(_PARALLEL_COUNT):
+                # CrewAI does not emit completion callbacks for hydrated tasks,
+                # so reflect the restored prefix explicitly before announcing
+                # only the work that will really execute. This is a client
+                # seam: without it recovery succeeds on disk while the browser
+                # still reports the wrong agent and completion count.
+                for _i in range(reused_prefix):
+                    _write_step({
+                        "agent_idx": _i,
+                        "type": "finish",
+                        "thought": "Reused validated checkpoint",
+                    })
+                for _i in range(reused_prefix, _PARALLEL_COUNT):
                     _write_step({"agent_idx": _i, "type": "action", "thought": "",
                                  "tool": "", "tool_input": "", "result": ""})
+                if reused_prefix >= _PARALLEL_COUNT:
+                    next_idx = tracker.next_incomplete()
+                    if next_idx is not None:
+                        _write_step({
+                            "agent_idx": next_idx,
+                            "type": "action",
+                            "thought": "",
+                            "tool": "reasoning",
+                            "tool_input": "",
+                            "result": "",
+                        })
 
                 with telemetry.span(
                     "crew_execution", "CHAIN", {"academic_agent.pipeline.agents": 6}
                 ):
-                    result = crew_obj.kickoff(inputs=source_collection.crew_inputs())
+                    result = crew_obj.kickoff(inputs=crew_inputs)
             tasks_output = getattr(result, "tasks_output", None) or []
         except Exception as crew_error:  # noqa: BLE001 - narrow recovery below
             recovered = _recover_from_reviewer_failure(
-                crew_obj, crew_error, task_complete=on_task_complete
+                crew_obj,
+                crew_error,
+                task_complete=on_task_complete,
+                checkpoint_complete=lambda index, output: (
+                    checkpoint_runtime.commit_manual_output(task_node(index), output)
+                ),
             )
             if recovered is None:
                 raise
@@ -647,6 +901,10 @@ def main() -> None:
             ),
         })
         telemetry.finish()
+        checkpoint_snapshot = (
+            checkpoint_runtime.snapshot()
+            if checkpoint_runtime is not None else checkpoint_snapshot
+        )
         write_status(
             "Done", done=True,
             output_language=source_collection.output_language,
@@ -656,6 +914,7 @@ def main() -> None:
             consistency=consistency,
             observability=telemetry.snapshot(),
             quality_review=quality_review,
+            **checkpoint_snapshot,
         )
 
     except Exception as exc:
@@ -681,10 +940,15 @@ def main() -> None:
         print(error_details, file=sys.stderr, flush=True)
         error_usage = snapshot_usage()
         telemetry.finish(exc)
+        checkpoint_snapshot = (
+            checkpoint_runtime.snapshot()
+            if checkpoint_runtime is not None else checkpoint_snapshot
+        )
         write_status(
             "Error", done=True, error=str(exc)[:400],
             usage=error_usage,
             observability=telemetry.snapshot(),
+            **checkpoint_snapshot,
         )
         sys.exit(1)
 

--- a/src/academic_agent/run_spec.py
+++ b/src/academic_agent/run_spec.py
@@ -1,0 +1,92 @@
+"""Non-secret, durable input contract for one assessment run.
+
+The API used to retain the topic in ``status.json`` but not the language,
+weight-profile choice, or extracted paper contribution that shaped retrieval.
+That was enough to display a failed run and not enough to reproduce it safely.
+A recovery process must never guess those missing values: a guess can make an
+old checkpoint appear applicable to a different request and skip a paid node.
+
+``RunSpec`` is therefore persisted beside every new run before its worker is
+started.  It deliberately contains the extracted paper contribution rather
+than the uploaded PDF or a path into the short-lived upload store.  The
+contribution is already an input to the pipeline, is bounded JSON, and lets a
+child recovery run survive upload pruning without retaining another PDF copy.
+Provider credentials are not model fields and Pydantic rejects any extra key,
+so BYOK secrets cannot enter this artifact by accident.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+RUN_SPEC_FILENAME = ".run-spec.json"
+RESUME_SNAPSHOT_DIRECTORY = ".resume-source"
+
+
+class RunSpec(BaseModel):
+    """Frozen request values needed to repeat or resume a run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    topic: str = Field(min_length=1, max_length=300)
+    language: str | None = Field(default=None, max_length=100)
+    weight_profile: str | None = Field(default=None, max_length=100)
+    paper_contribution: dict[str, Any] | None = None
+
+    @field_validator("topic")
+    @classmethod
+    def _strip_topic(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("topic must contain at least one non-space character")
+        return stripped
+
+    @field_validator("language", "weight_profile")
+    @classmethod
+    def _normalise_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    def save(self, run_directory: Path | str) -> Path:
+        """Atomically publish the spec before a worker can observe the run.
+
+        This is not a cache write: losing it means a failed run cannot be
+        resumed safely.  A same-directory replace keeps readers from seeing a
+        truncated JSON document if the host dies during publication.
+        """
+
+        directory = Path(run_directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / RUN_SPEC_FILENAME
+        temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        payload = (self.model_dump_json(indent=2) + "\n").encode("utf-8")
+        try:
+            with temporary.open("xb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # The committed spec, or the original publication error, is
+                # more useful than a cleanup failure for an unreferenced temp.
+                pass
+        return path
+
+    @classmethod
+    def load(cls, run_directory: Path | str) -> "RunSpec":
+        """Load and strictly validate a previously persisted run contract."""
+
+        path = Path(run_directory) / RUN_SPEC_FILENAME
+        return cls.model_validate_json(path.read_bytes())

--- a/tests/test_checkpoint_api.py
+++ b/tests/test_checkpoint_api.py
@@ -1,0 +1,244 @@
+"""HTTP recovery tests at the paid-operation and filesystem seams.
+
+No provider or worker process is started. The source and checkpoint files are
+real so the test proves an accepted child owns an immutable snapshot rather
+than retaining a path to a parent that can disappear.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from academic_agent.checkpoint_runtime import retrieval_identity
+from academic_agent.checkpoints import CheckpointStore
+from academic_agent.run_spec import RESUME_SNAPSHOT_DIRECTORY, RunSpec
+from api import access, runs
+from api.main import app
+
+
+def _run_id(suffix: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{suffix}"
+
+
+@pytest.fixture
+def recovery_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> TestClient:
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(access, "ACCESS_CODE", None)
+    monkeypatch.setattr(access, "ACCESS_CODES", None)
+    runs._registry.clear()
+    runs._inline_paid_operations.clear()
+    yield TestClient(app)
+    runs.shutdown_all()
+    runs._registry.clear()
+    runs._inline_paid_operations.clear()
+
+
+def _failed_source(
+    root: Path,
+    *,
+    suffix: str = "checkpointsource",
+    with_checkpoint: bool = True,
+    state: str = "failed",
+) -> tuple[str, Path, RunSpec]:
+    run_id = _run_id(suffix)
+    run_directory = root / run_id
+    run_directory.mkdir(parents=True)
+    spec = RunSpec(
+        topic="solid-state battery recycling",
+        language="Simplified Chinese",
+        weight_profile="clean_tech",
+    )
+    spec.save(run_directory)
+    status = {
+        "topic": spec.topic,
+        "stage": "Error" if state == "failed" else "Done",
+        "done": True,
+        "error": "injected crash" if state == "failed" else None,
+    }
+    (run_directory / "status.json").write_text(json.dumps(status), encoding="utf-8")
+    if with_checkpoint:
+        CheckpointStore(run_directory).commit(
+            retrieval_identity(
+                spec,
+                revision="git:abcdef0123456789",
+                as_of_date=date(2026, 8, 23),
+            ),
+            '{"topic":"solid-state battery recycling"}',
+            output_format="json",
+        )
+    return run_id, run_directory, spec
+
+
+def _live_process() -> MagicMock:
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+    return process
+
+
+def test_resume_endpoint_snapshots_parent_before_starting_worker(
+    recovery_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    source_id, source_directory, spec = _failed_source(tmp_path)
+    process = _live_process()
+
+    with patch("api.runs.subprocess.Popen", return_value=process) as popen:
+        response = recovery_client.post(f"/api/runs/{source_id}/resume", json={})
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["state"] == "running"
+    assert body["topic"] == spec.topic
+    assert body["resumed_from"] == source_id
+    child_directory = tmp_path / body["run_id"]
+    snapshot_manifest = child_directory / RESUME_SNAPSHOT_DIRECTORY / "checkpoints" / "retrieval" / "manifest.json"
+    assert snapshot_manifest.is_file()
+    assert RunSpec.load(child_directory) == spec
+
+    command = popen.call_args.args[0]
+    assert command[command.index("--resume-from") + 1] == source_id
+    assert "--run-spec" in command
+
+    # This is the race the snapshot exists to close. Once the API has returned
+    # 202, deleting the failed parent must not invalidate the child's inputs.
+    shutil.rmtree(source_directory)
+    assert snapshot_manifest.is_file()
+
+
+def test_resume_rejects_completed_unknown_or_pre_checkpoint_runs_without_spawning(
+    recovery_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    completed_id, _, _ = _failed_source(tmp_path, suffix="completedsource", state="completed")
+    old_id, _, _ = _failed_source(tmp_path, suffix="oldsource", with_checkpoint=False)
+    unknown_id, unknown_directory, _ = _failed_source(tmp_path, suffix="unknownsource")
+    # Unknown explicitly means the status may merely be unreadable while the
+    # original run actually completed. Recovery must not turn that ambiguity
+    # into a second paid run.
+    (unknown_directory / "status.json").write_text("{", encoding="utf-8")
+
+    with patch("api.runs.subprocess.Popen") as popen:
+        completed = recovery_client.post(f"/api/runs/{completed_id}/resume", json={})
+        old = recovery_client.post(f"/api/runs/{old_id}/resume", json={})
+        unknown = recovery_client.post(f"/api/runs/{unknown_id}/resume", json={})
+
+    assert completed.status_code == 409
+    assert old.status_code == 409
+    assert unknown.status_code == 409
+    popen.assert_not_called()
+
+
+def test_resume_byok_secrets_reach_env_not_argv_or_snapshot(
+    recovery_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    source_id, _, _ = _failed_source(tmp_path, suffix="byoksource")
+    process = _live_process()
+    body = {
+        "llm_provider": "deepseek",
+        "llm_api_key": "fresh-llm-secret",
+        "serper_api_key": "fresh-search-secret",
+    }
+
+    with patch("api.runs.subprocess.Popen", return_value=process) as popen:
+        response = recovery_client.post(f"/api/runs/{source_id}/resume", json=body)
+
+    assert response.status_code == 202
+    command = popen.call_args.args[0]
+    environment = popen.call_args.kwargs["env"]
+    assert "fresh-llm-secret" not in " ".join(command)
+    assert "fresh-search-secret" not in " ".join(command)
+    assert environment["DEEPSEEK_API_KEY"] == "fresh-llm-secret"
+    assert environment["SERPER_API_KEY"] == "fresh-search-secret"
+    child_directory = tmp_path / response.json()["run_id"]
+    persisted = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in child_directory.rglob("*")
+        if path.is_file() and path.name != "process.log"
+    )
+    assert "fresh-llm-secret" not in persisted
+    assert "fresh-search-secret" not in persisted
+
+
+def test_checkpoint_and_recovery_fields_reach_both_status_endpoints(
+    recovery_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    run_id = _run_id("statusseam")
+    run_directory = tmp_path / run_id
+    run_directory.mkdir()
+    checkpointing = {
+        "state": "degraded",
+        "committed_nodes": ["retrieval", "academic"],
+        "errors": ["patent:commit:OSError:disk full"],
+    }
+    recovery = {
+        "state": "reused",
+        "source_run_id": "parent",
+        "reused_nodes": ["retrieval", "academic"],
+        "next_node": "patent",
+        "inspections": {},
+    }
+    (run_directory / "status.json").write_text(
+        json.dumps(
+            {
+                "topic": "checkpoint seam",
+                "stage": "Error",
+                "done": True,
+                "error": "injected",
+                "checkpointing": checkpointing,
+                "recovery": recovery,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = recovery_client.get(f"/api/runs/{run_id}").json()
+    progress = recovery_client.get(f"/api/runs/{run_id}/progress").json()
+
+    assert status["checkpointing"] == checkpointing
+    assert progress["checkpointing"] == checkpointing
+    assert status["recovery"] == recovery
+    assert progress["recovery"] == recovery
+
+
+def test_owned_source_cannot_be_resumed_from_a_leaked_capability_url(
+    recovery_client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_id, source_directory, _ = _failed_source(tmp_path, suffix="ownedsource")
+    owner = access.owner_id("alice-code")
+    (source_directory / runs._OWNER_FILE).write_text(owner, encoding="utf-8")
+    monkeypatch.setattr(access, "ACCESS_CODE", "alice-code")
+    monkeypatch.setattr(access, "ACCESS_CODES", None)
+    process = _live_process()
+    byok = {
+        "llm_provider": "deepseek",
+        "llm_api_key": "attacker-key",
+        "serper_api_key": "attacker-search",
+    }
+
+    with patch("api.runs.subprocess.Popen", return_value=process) as popen:
+        denied = recovery_client.post(f"/api/runs/{source_id}/resume", json=byok)
+        allowed = recovery_client.post(
+            f"/api/runs/{source_id}/resume",
+            json={},
+            headers={"X-Access-Code": "alice-code"},
+        )
+
+    assert denied.status_code == 404
+    assert allowed.status_code == 202
+    popen.assert_called_once()

--- a/tests/test_checkpoint_runtime.py
+++ b/tests/test_checkpoint_runtime.py
@@ -1,0 +1,320 @@
+"""Recovery policy tests at the CrewAI task and disk boundaries.
+
+These are intentionally separate from the storage-primitive tests. A manifest
+can be perfectly valid while orchestration never hydrates it, or while CrewAI
+ignores the hydrated output and calls the provider again. Both defects would
+repeat paid work, so the assertions sit on those two seams.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from crewai import Agent, Crew, Process, Task
+from crewai.llms.base_llm import BaseLLM
+from crewai.tasks.task_output import OutputFormat as CrewOutputFormat
+from crewai.tasks.task_output import TaskOutput
+from pydantic import BaseModel
+
+from academic_agent.checkpoint_runtime import CheckpointRuntime, TASK_NODES
+from academic_agent.checkpoints import CheckpointStore
+from academic_agent.run_spec import RunSpec
+
+
+_TEST_DATE = date(2026, 8, 23)
+_REVISION = "git:abcdef0123456789"
+
+
+class _SourceCollection(BaseModel):
+    """Small JSON source model sufficient to exercise identity hashing."""
+
+    topic: str = "checkpoint test"
+    evidence: list[str] = ["A1", "P1", "M1"]
+
+
+class _ExplodingLLM(BaseLLM):
+    """Provider double: any invocation means CrewAI failed to skip the task."""
+
+    def call(self, *args: Any, **kwargs: Any) -> str:
+        raise AssertionError("provider must not be called for a hydrated task")
+
+
+def _task_output(node: str) -> TaskOutput:
+    raw = (
+        json.dumps({"node": node, "finding": "validated"}, sort_keys=True)
+        if node in {"academic", "patent", "market", "scorer"}
+        else f"# {node.title()}\n\nValidated output."
+    )
+    output_format = (
+        CrewOutputFormat.JSON if node in {"academic", "patent", "market", "scorer"} else CrewOutputFormat.RAW
+    )
+    return TaskOutput(
+        description=f"{node} description",
+        expected_output=f"{node} expected",
+        raw=raw,
+        agent=f"{node} agent",
+        output_format=output_format,
+    )
+
+
+def _fake_tasks(*, patent_description: str = "patent description") -> list[Any]:
+    llm = SimpleNamespace(
+        provider="deepseek",
+        model="deepseek-chat",
+        base_url="https://api.deepseek.com",
+        temperature=0,
+        response_format=None,
+        api_key="must-never-be-persisted",
+    )
+    tasks: list[Any] = []
+    for node in TASK_NODES:
+        agent = SimpleNamespace(
+            role=f"{node} agent",
+            goal=f"{node} goal",
+            backstory=f"{node} backstory",
+            inject_date=False,
+            allow_delegation=False,
+            tools=[],
+            llm=llm,
+        )
+        task = SimpleNamespace(
+            description=(patent_description if node == "patent" else f"{node} description"),
+            expected_output=f"{node} expected",
+            async_execution=node in {"academic", "patent", "market"},
+            context=[],
+            guardrail=object(),
+            guardrail_max_retries=1,
+            output_json=None,
+            output_pydantic=None,
+            output_format=(
+                CrewOutputFormat.JSON if node in {"academic", "patent", "market", "scorer"} else CrewOutputFormat.RAW
+            ),
+            agent=agent,
+            tools=[],
+            callback=None,
+            output=None,
+        )
+        tasks.append(task)
+
+    tasks[3].context = tasks[:3]
+    tasks[4].context = tasks[:4]
+    tasks[5].context = tasks[:3]
+    return tasks
+
+
+def _runtime(
+    run_directory: Path,
+    *,
+    tasks: list[Any],
+    source: _SourceCollection,
+    retrieval_sha256: str,
+    resume_directory: Path | None = None,
+    progress_callback: Any = None,
+) -> CheckpointRuntime:
+    crew = SimpleNamespace(
+        tasks=tasks,
+        task_callback=progress_callback,
+        checkpoint_kickoff_event_id=None,
+    )
+    return CheckpointRuntime(
+        crew=crew,
+        source_collection=source,
+        crew_inputs={"topic": source.topic, "evidence": source.evidence},
+        destination_run_directory=run_directory,
+        retrieval_output_sha256=retrieval_sha256,
+        revision=_REVISION,
+        as_of_date=_TEST_DATE,
+        resume_run_id="source-run" if resume_directory is not None else None,
+        resume_run_directory=resume_directory,
+    )
+
+
+def _seed_validated_prefix(
+    source_run: Path,
+    *,
+    count: int,
+    patent_description: str = "patent description",
+) -> tuple[_SourceCollection, str]:
+    source = _SourceCollection()
+    retrieval_payload = source.model_dump_json()
+    spec = RunSpec(topic=source.topic)
+    from academic_agent.checkpoint_runtime import retrieval_identity
+
+    retrieval = CheckpointStore(source_run).commit(
+        retrieval_identity(spec, revision=_REVISION, as_of_date=_TEST_DATE),
+        retrieval_payload,
+        output_format="json",
+    )
+    runtime = _runtime(
+        source_run,
+        tasks=_fake_tasks(patent_description=patent_description),
+        source=source,
+        retrieval_sha256=retrieval.output_sha256,
+    )
+    runtime.install_task_callbacks()
+    for index in range(count):
+        runtime.tasks[index].callback(_task_output(TASK_NODES[index]))
+    return source, retrieval.output_sha256
+
+
+def test_runtime_restores_and_republishes_only_the_validated_prefix(
+    tmp_path: Path,
+) -> None:
+    source_run = tmp_path / "source"
+    child_run = tmp_path / "child"
+    source, retrieval_sha256 = _seed_validated_prefix(source_run, count=4)
+    tasks = _fake_tasks()
+    runtime = _runtime(
+        child_run,
+        tasks=tasks,
+        source=source,
+        retrieval_sha256=retrieval_sha256,
+        resume_directory=source_run,
+    )
+
+    reused = runtime.restore_contiguous_prefix()
+
+    assert reused == 4
+    assert [task.output is not None for task in tasks] == [True, True, True, True, False, False]
+    assert runtime.crew.checkpoint_kickoff_event_id == "academic-agent:source-run"
+    assert runtime.snapshot()["recovery"]["reused_nodes"] == ["academic", "patent", "market", "writer"]
+    for node in TASK_NODES[:4]:
+        assert (child_run / "checkpoints" / node / "manifest.json").is_file()
+
+
+def test_first_mismatch_stops_before_a_later_reusable_checkpoint(
+    tmp_path: Path,
+) -> None:
+    source_run = tmp_path / "source"
+    source, retrieval_sha256 = _seed_validated_prefix(source_run, count=3)
+    tasks = _fake_tasks(patent_description="changed patent prompt")
+    runtime = _runtime(
+        tmp_path / "child",
+        tasks=tasks,
+        source=source,
+        retrieval_sha256=retrieval_sha256,
+        resume_directory=source_run,
+    )
+
+    reused = runtime.restore_contiguous_prefix()
+    snapshot = runtime.snapshot()["recovery"]
+
+    assert reused == 1
+    assert tasks[0].output is not None
+    assert tasks[1].output is None
+    assert tasks[2].output is None
+    assert snapshot["inspections"]["patent"]["state"] == "mismatch"
+    # Market is valid on disk, but non-contiguous reuse would change CrewAI's
+    # scheduler semantics. It must not even be inspected after patent diverges.
+    assert "market" not in snapshot["inspections"]
+
+
+def test_task_callback_commits_without_advancing_progress_twice(
+    tmp_path: Path,
+) -> None:
+    progress_outputs: list[Any] = []
+    source = _SourceCollection()
+    runtime = _runtime(
+        tmp_path,
+        tasks=_fake_tasks(),
+        source=source,
+        retrieval_sha256="0" * 64,
+        progress_callback=progress_outputs.append,
+    )
+    runtime.install_task_callbacks()
+
+    runtime.tasks[0].callback(_task_output("academic"))
+
+    assert progress_outputs == []
+    assert (tmp_path / "checkpoints" / "academic" / "manifest.json").is_file()
+    manifest = (tmp_path / "checkpoints" / "academic" / "manifest.json").read_text(encoding="utf-8")
+    assert "must-never-be-persisted" not in manifest
+    assert "api_key" not in manifest.lower()
+
+
+def test_pinned_crewai_executor_skips_runtime_restored_prefix_without_provider_call(
+    tmp_path: Path,
+) -> None:
+    """Exercise the whole adapter against CrewAI 1.14.7's real scheduler.
+
+    The six tasks include the production-shaped asynchronous evidence prefix.
+    Removing either runtime hydration or checkpoint_kickoff_event_id makes
+    CrewAI call _ExplodingLLM, so this proves the paid-provider seam rather
+    than merely asserting that fields were assigned.
+    """
+
+    def real_crew() -> Crew:
+        llm = _ExplodingLLM(model="never-called", temperature=0)
+        agents: list[Agent] = []
+        tasks: list[Task] = []
+        for node in TASK_NODES:
+            agent = Agent(
+                role=f"{node} restored agent",
+                goal=f"Return the restored {node} output",
+                backstory="This agent must never execute during the test.",
+                llm=llm,
+                allow_delegation=False,
+                verbose=False,
+            )
+            context = None
+            if node in {"writer", "scorer"}:
+                context = tasks[:3]
+            elif node == "reviewer":
+                context = tasks[:4]
+            task = Task(
+                description=f"{node} description",
+                expected_output=f"{node} expected",
+                agent=agent,
+                async_execution=node in {"academic", "patent", "market"},
+                context=context,
+            )
+            agents.append(agent)
+            tasks.append(task)
+        return Crew(
+            agents=agents,
+            tasks=tasks,
+            process=Process.sequential,
+            verbose=False,
+        )
+
+    source = _SourceCollection()
+    crew_inputs = {"topic": source.topic, "evidence": source.evidence}
+    retrieval_sha256 = "0" * 64
+    source_crew = real_crew()
+    source_runtime = CheckpointRuntime(
+        crew=source_crew,
+        source_collection=source,
+        crew_inputs=crew_inputs,
+        destination_run_directory=tmp_path / "source",
+        retrieval_output_sha256=retrieval_sha256,
+        revision=_REVISION,
+        as_of_date=_TEST_DATE,
+    )
+    source_runtime.install_task_callbacks()
+    for node, task in zip(TASK_NODES, source_crew.tasks, strict=True):
+        assert task.callback is not None
+        task.callback(_task_output(node))
+
+    child_crew = real_crew()
+    child_runtime = CheckpointRuntime(
+        crew=child_crew,
+        source_collection=source,
+        crew_inputs=crew_inputs,
+        destination_run_directory=tmp_path / "child",
+        retrieval_output_sha256=retrieval_sha256,
+        revision=_REVISION,
+        as_of_date=_TEST_DATE,
+        resume_run_id="source-run",
+        resume_run_directory=tmp_path / "source",
+    )
+    reused = child_runtime.restore_contiguous_prefix()
+    child_runtime.install_task_callbacks()
+
+    result = child_crew.kickoff(inputs=crew_inputs)
+
+    assert reused == len(TASK_NODES)
+    assert result.raw == _task_output("scorer").raw

--- a/tests/test_checkpoint_web.py
+++ b/tests/test_checkpoint_web.py
@@ -1,0 +1,38 @@
+"""Browser seams for checkpoint recovery.
+
+The backend tests prove reuse. These assertions prove the values and the new
+child id reach the shipped client, which is where earlier features disappeared
+despite being computed and stored correctly.
+"""
+
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parents[1]
+_API_JS = (_REPO / "web" / "static" / "js" / "api.js").read_text(encoding="utf-8")
+_APP_JS = (_REPO / "web" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+_INDEX = (_REPO / "web" / "index.html").read_text(encoding="utf-8")
+
+
+def test_terminal_action_calls_the_resume_endpoint_and_opens_the_child() -> None:
+    assert "`/api/runs/${runId}/resume`" in _API_JS
+    assert "const accepted = await api.resumeRun(sourceRunId)" in _APP_JS
+    assert "openRun(accepted.run_id, { known: accepted })" in _APP_JS
+
+
+def test_byok_recovery_keeps_the_new_child_in_session_history() -> None:
+    assert "if (byokMode) api.addByokRun(accepted.run_id, accepted.topic)" in _APP_JS
+
+
+def test_resume_button_depends_on_a_persisted_retrieval_checkpoint() -> None:
+    assert 'checkpointing?.committed_nodes?.includes("retrieval")' in _APP_JS
+    assert "paintActions(progress.state, progress.checkpointing)" in _APP_JS
+
+
+def test_reuse_and_degradation_reach_the_visible_run_header() -> None:
+    """A cache hit must not hide a simultaneous checkpoint write failure."""
+
+    assert 'id="run-recovery"' in _INDEX
+    assert 'recovery?.state === "reused"' in _APP_JS
+    assert 'checkpointing?.state === "degraded"' in _APP_JS
+    assert 'badges.join(" · ")' in _APP_JS

--- a/tests/test_checkpoint_worker.py
+++ b/tests/test_checkpoint_worker.py
@@ -1,0 +1,208 @@
+"""Worker-level proof that a restarted process skips validated paid nodes."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from crewai.tasks.task_output import OutputFormat as CrewOutputFormat
+from crewai.tasks.task_output import TaskOutput
+
+from academic_agent.checkpoint_runtime import TASK_NODES
+from academic_agent.evidence import EvidenceSource
+from academic_agent.run_spec import RESUME_SNAPSHOT_DIRECTORY
+from academic_agent.source_pipeline import SourceCollection
+
+
+def _source_collection() -> SourceCollection:
+    source = EvidenceSource(
+        source_id="A1",
+        title="Validated checkpoint source for worker recovery",
+        url="https://example.com/checkpoint-source",
+        publisher="Example University",
+        published_date=date(2026, 1, 10),
+        accessed_date=date.today(),
+        source_type="academic_paper",
+        credibility_tier="high",
+        credibility_reason="Peer-reviewed institutional source used only by an offline test.",
+        evidence_summary=(
+            "This deliberately long summary provides enough validated source text "
+            "for the source model while no external request is ever performed."
+        ),
+        summary_source="abstract",
+    )
+    return SourceCollection(
+        topic="solid-state battery recycling",
+        display_topic="solid-state battery recycling",
+        collected_at=datetime.now(UTC),
+        academic_sources=[source],
+        academic_queries=["solid-state battery recycling"],
+        patent_queries=["solid-state battery recycling patent"],
+        market_queries=["solid-state battery recycling market"],
+    )
+
+
+def _output(node: str) -> TaskOutput:
+    raw = (
+        json.dumps({"node": node, "findings": []}, sort_keys=True)
+        if node in {"academic", "patent", "market", "scorer"}
+        else f"# {node.title()}\n\nValidated checkpoint report."
+    )
+    return TaskOutput(
+        description=f"{node} description",
+        expected_output=f"{node} expected",
+        raw=raw,
+        agent=f"{node} agent",
+        output_format=(
+            CrewOutputFormat.JSON if node in {"academic", "patent", "market", "scorer"} else CrewOutputFormat.RAW
+        ),
+    )
+
+
+def _tasks() -> list[Any]:
+    llm = SimpleNamespace(
+        provider="deepseek",
+        model="deepseek-chat",
+        base_url="https://api.deepseek.com",
+        temperature=0,
+        response_format=None,
+    )
+    tasks: list[Any] = []
+    for node in TASK_NODES:
+        agent = SimpleNamespace(
+            role=f"{node} agent",
+            goal=f"{node} goal",
+            backstory=f"{node} backstory",
+            inject_date=False,
+            allow_delegation=False,
+            tools=[],
+            llm=llm,
+        )
+        tasks.append(
+            SimpleNamespace(
+                description=f"{node} description",
+                expected_output=f"{node} expected",
+                async_execution=node in {"academic", "patent", "market"},
+                context=[],
+                guardrail=object(),
+                guardrail_max_retries=1,
+                output_json=None,
+                output_pydantic=None,
+                output_format=(
+                    CrewOutputFormat.JSON
+                    if node in {"academic", "patent", "market", "scorer"}
+                    else CrewOutputFormat.RAW
+                ),
+                agent=agent,
+                tools=[],
+                callback=None,
+                output=None,
+            )
+        )
+    tasks[3].context = tasks[:3]
+    tasks[4].context = tasks[:4]
+    tasks[5].context = tasks[:3]
+    return tasks
+
+
+class _FakeCrew:
+    """Minimal executor that honours the same hydrated-output seam as CrewAI."""
+
+    def __init__(self) -> None:
+        self.tasks = _tasks()
+        self.agents = [task.agent for task in self.tasks]
+        self.task_callback = None
+        self.checkpoint_kickoff_event_id = None
+        self.executed: list[str] = []
+
+    def kickoff(self, *, inputs: dict[str, str]) -> SimpleNamespace:
+        del inputs
+        for node, task in zip(TASK_NODES, self.tasks, strict=True):
+            if task.output is not None:
+                continue
+            output = _output(node)
+            task.output = output
+            self.executed.append(node)
+            if task.callback is not None:
+                task.callback(output)
+            if self.task_callback is not None and self.task_callback is not task.callback:
+                self.task_callback(output)
+        outputs = [task.output for task in self.tasks]
+        return SimpleNamespace(tasks_output=outputs, raw=outputs[-1].raw)
+
+
+def _run_worker(
+    output_root: Path,
+    run_id: str,
+    source_collection: SourceCollection,
+    crew: _FakeCrew,
+    *,
+    resume_from: str | None = None,
+) -> Path:
+    argv = ["pipeline_worker.py", run_id, source_collection.topic]
+    if resume_from is not None:
+        argv += ["--resume-from", resume_from]
+
+    empty_usage = SimpleNamespace(agents=[], collection_error=None)
+    with (
+        patch.object(sys, "argv", argv),
+        patch("academic_agent.run_output.DEFAULT_OUTPUT_ROOT", output_root),
+        patch(
+            "academic_agent.source_pipeline.collect_source_collection",
+            return_value=source_collection,
+        ),
+        patch("academic_agent.crew.AcademicAgent") as agent_class,
+        patch("academic_agent.token_usage.collect_usage", return_value=empty_usage),
+    ):
+        agent_class.return_value.crew.return_value = crew
+        from academic_agent.pipeline_worker import main
+
+        main()
+    return output_root / run_id
+
+
+def test_restarted_worker_reuses_all_nodes_after_parent_directory_disappears(
+    tmp_path: Path,
+) -> None:
+    source_collection = _source_collection()
+    source_id = "20260823T010101Z-checkpointsource"
+    source_crew = _FakeCrew()
+    source_directory = _run_worker(tmp_path, source_id, source_collection, source_crew)
+
+    assert source_crew.executed == list(TASK_NODES)
+    for node in ("retrieval", *TASK_NODES):
+        assert (source_directory / "checkpoints" / node / "manifest.json").is_file()
+
+    child_id = "20260823T020202Z-checkpointchild"
+    child_directory = tmp_path / child_id
+    snapshot = child_directory / RESUME_SNAPSHOT_DIRECTORY
+    shutil.copytree(
+        source_directory / "checkpoints",
+        snapshot / "checkpoints",
+    )
+    # The accepted child owns its snapshot. The worker must not reopen the
+    # capability URL's directory after this point.
+    shutil.rmtree(source_directory)
+
+    child_crew = _FakeCrew()
+    _run_worker(
+        tmp_path,
+        child_id,
+        source_collection,
+        child_crew,
+        resume_from=source_id,
+    )
+
+    status = json.loads((child_directory / "status.json").read_text(encoding="utf-8"))
+    assert child_crew.executed == []
+    assert status["stage"] == "Done"
+    assert status["checkpointing"]["state"] == "complete"
+    assert status["recovery"]["state"] == "reused"
+    assert status["recovery"]["reused_nodes"] == ["retrieval", *TASK_NODES]
+    assert status["recovery"]["next_node"] is None

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -386,6 +386,11 @@ class MainEndToEndTests(unittest.TestCase):
         status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
         self.assertEqual(status["stage"], "Error")
         self.assertEqual(status["topic"], "a topic")
+        self.assertEqual(status["checkpointing"]["state"], "partial")
+        self.assertEqual(
+            status["checkpointing"]["committed_nodes"], ["retrieval"]
+        )
+        self.assertEqual(status["recovery"]["state"], "not_requested")
 
     def test_partial_completion_still_saves_the_report(self):
         """Five tasks: the reviewer produced a report, the scorer never ran.

--- a/web/index.html
+++ b/web/index.html
@@ -174,6 +174,7 @@
             <span class="tabular" id="run-elapsed">0:00</span>
             <span id="run-sources"></span>
             <span id="run-usage" class="tabular"></span>
+            <span id="run-recovery"></span>
           </div>
         </div>
         <div class="pane__actions" id="run-actions"></div>

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -151,6 +151,19 @@ export const startRun = ({ topic, language, weight_profile, paper_id }) => {
   }));
 };
 
+export const resumeRun = (runId) => {
+  // Credentials are intentionally supplied again. The source run retains no
+  // BYOK secret, and an access-code run is authorized by the normal header.
+  const byok = getByok();
+  return request(`/api/runs/${runId}/resume`, json({
+    ...(byok ? {
+      llm_provider: byok.provider,
+      llm_api_key: byok.llmKey,
+      serper_api_key: byok.serperKey,
+    } : {}),
+  }));
+};
+
 export const getRun = (runId) => request(`/api/runs/${runId}`);
 
 export const getProgress = (runId, since = 0) =>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -91,7 +91,9 @@ function startClock(fromSeconds) {
   clock = setInterval(paint, 1000);
 }
 
-function paintHeader({ topic, state, elapsed_seconds, source_counts, usage }) {
+function paintHeader({
+  topic, state, elapsed_seconds, source_counts, usage, checkpointing, recovery,
+}) {
   if (topic) $("#run-title").textContent = topic;
 
   const pill = $("#run-pill");
@@ -115,9 +117,26 @@ function paintHeader({ topic, state, elapsed_seconds, source_counts, usage }) {
   const spendEl = $("#run-usage");
   spendEl.textContent = spend ? `· ${spend}` : "";
   spendEl.title = spend ? runView.usageTitle(usage) : "";
+
+  const recoveryEl = $("#run-recovery");
+  const reused = recovery?.reused_nodes?.length ?? 0;
+  const badges = [];
+  const details = [];
+  if (recovery?.state === "reused" && reused > 0) {
+    badges.push(t("recovery_reused_short").replace("{count}", String(reused)));
+    if (recovery.source_run_id) details.push(recovery.source_run_id);
+  }
+  // Reuse and a failed child-side checkpoint write can coexist. Showing only
+  // the cache hit would turn degraded recoverability into an apparent pass.
+  if (checkpointing?.state === "degraded") {
+    badges.push(t("recovery_degraded_short"));
+    details.push(...(checkpointing.errors ?? []));
+  }
+  recoveryEl.textContent = badges.length ? `· ${badges.join(" · ")}` : "";
+  recoveryEl.title = details.join("\n");
 }
 
-function paintActions(state) {
+function paintActions(state, checkpointing = null) {
   const actions = $("#run-actions");
   actions.innerHTML = "";
 
@@ -165,6 +184,31 @@ function paintActions(state) {
     }
   }
 
+  const canResume = (
+    new Set(["failed", "cancelled", "timeout"]).has(state)
+    && checkpointing?.committed_nodes?.includes("retrieval")
+  );
+  if (canResume) {
+    const sourceRunId = activeRunId;
+    const resume = document.createElement("button");
+    resume.type = "button";
+    resume.className = "btn btn--secondary";
+    resume.textContent = t("resume");
+    resume.addEventListener("click", async () => {
+      resume.disabled = true;
+      try {
+        const accepted = await api.resumeRun(sourceRunId);
+        if (byokMode) api.addByokRun(accepted.run_id, accepted.topic);
+        toast(t("msg_resumed"), "success");
+        openRun(accepted.run_id, { known: accepted });
+      } catch (err) {
+        resume.disabled = false;
+        toast(err.message, "error");
+      }
+    });
+    actions.append(resume);
+  }
+
   // Every terminal state — completed, failed, cancelled, timeout — can be
   // permanently removed; only a still-running one (handled above, which
   // already returned) cannot.
@@ -183,18 +227,18 @@ async function openRun(runId, { known } = {}) {
   const body = $("#run-body");
   body.innerHTML = "";
   paintHeader({ topic: known?.topic ?? "…", state: known?.state ?? "running" });
-  paintActions(known?.state ?? "running");
+  paintActions(known?.state ?? "running", known?.checkpointing);
   history.pushState({}, "", `/run/${runId}`);
 
   follower = runView.follow(runId, {
     onUpdate(progress) {
       paintHeader(progress);
-      paintActions(progress.state);
+      paintActions(progress.state, progress.checkpointing);
       runView.renderStages(body, runView.stageStates(progress.stage, progress.state));
     },
     onDone(progress) {
       paintHeader(progress);
-      paintActions(progress.state);
+      paintActions(progress.state, progress.checkpointing);
       runView.renderStages(body, runView.stageStates(progress.stage, progress.state));
       refreshSidebar();
 

--- a/web/static/js/i18n.js
+++ b/web/static/js/i18n.js
@@ -43,12 +43,15 @@ const STRINGS = {
 
     // Run pane
     cancel: "Cancel",
+    resume: "Resume from checkpoint",
     delete_run: "Delete",
     confirm_delete_run: "Delete this run permanently? The report and every other artifact will be gone for good.",
     confirm_broad_topic: "This topic may be too broad for reliable academic, patent, and market retrieval. Add a specific technology and use case for a stronger report.\n\nRun it anyway?",
     msg_deleted: "Run deleted.",
     download_report: "Report",
     sources_suffix: "sources",
+    recovery_reused_short: "{count} checkpoint stages reused",
+    recovery_degraded_short: "checkpointing degraded",
     academic: "academic",
     patent: "patent",
     market: "market",
@@ -151,6 +154,7 @@ const STRINGS = {
     // Messages
     msg_complete: "Analysis complete.",
     msg_cancelled: "Run cancelled.",
+    msg_resumed: "Recovery run started with fresh credentials.",
     msg_busy: "Both run slots are busy. Try again when one finishes.",
     msg_paper_attached: "Paper attached.",
     msg_not_pdf: "That is not a PDF.",
@@ -220,12 +224,15 @@ const STRINGS = {
     stage_scoring: "评估商业化就绪度",
 
     cancel: "取消",
+    resume: "从检查点续跑",
     delete_run: "删除",
     confirm_delete_run: "确定要永久删除这条记录吗？报告和其他所有产出文件都会一并清除，无法恢复。",
     confirm_broad_topic: "这个主题可能过于宽泛，难以稳定检索学术、专利和市场证据。建议补充具体技术与应用场景，以获得更可靠的报告。\n\n仍要继续运行吗？",
     msg_deleted: "记录已删除。",
     download_report: "报告",
     sources_suffix: "条来源",
+    recovery_reused_short: "已复用 {count} 个检查点阶段",
+    recovery_degraded_short: "检查点持久化已降级",
     academic: "学术",
     patent: "专利",
     market: "市场",
@@ -312,6 +319,7 @@ const STRINGS = {
 
     msg_complete: "分析完成。",
     msg_cancelled: "运行已取消。",
+    msg_resumed: "已使用新凭据启动恢复运行。",
     msg_busy: "两个运行槽位都在忙，等一个结束后再试。",
     msg_paper_attached: "论文已附加。",
     msg_not_pdf: "这不是 PDF 文件。",


### PR DESCRIPTION
## Why

An interrupted assessment previously discarded every validated node and forced a full paid rerun. The storage primitive from the preceding change made atomic node artifacts possible, but it was not yet connected to the real CrewAI scheduler, API ownership boundary, worker lifecycle, or browser.

This change adds recovery without changing prompts, guardrails, scoring, retrieval policy, or the calibrated benchmark. It intentionally treats recovery as a reliability feature rather than a result cache.

## What changed

- Freeze every API submission in a strict, non-secret RunSpec before the worker starts.
- Bind each validated node to input, evidence, task, model, upstream-output, UTC-date, and pipeline-revision identities.
- Restore only the longest contiguous prefix supported by the pinned CrewAI 1.14.7 scheduler.
- Create an immutable child run and snapshot the parent's checkpoints before Popen, closing the parent deletion and retention race.
- Republish reused nodes into the child so it can later recover independently.
- Keep Reviewer fallback semantics honest: a copied Writer draft is not a completed review, while an independently guarded scorer result can be committed.
- Add POST /api/runs/{run_id}/resume with source-owner authorization, normal paid-operation admission, fresh BYOK credentials, and no secret persistence.
- Surface checkpointing and recovery independently through both status endpoints and the browser. Reuse no longer hides simultaneous persistence degradation.
- Reject unknown source state because an unreadable status may belong to a run that already completed; starting a child in that ambiguity could duplicate paid work.

## Security and failure semantics

The adapter does not use CrewAI's native checkpoint serializer because BaseLLM includes api_key in its model state. It persists an explicit non-secret projection and hydrates only validated raw TaskOutput content. Fresh BYOK keys cross only the child process environment and are absent from argv, RunSpec, manifests, payload metadata, and status files.

Atomic manifests prevent torn checkpoint publication, but this does not claim exactly-once provider execution. A crash after provider acceptance and before checkpoint commit remains an at-least-once boundary and may repeat one call. Checkpoint disk failure remains non-blocking for report delivery and is exposed as degraded instead of silently reported as a pass.

## Verification

- uv run pytest -q: 1280 passed, 551 subtests passed
- uv run --with ruff ruff check .: passed
- CI-equivalent narrow Pylint checks: passed
- Real pinned CrewAI kickoff test fails if restored tasks reach the provider double
- Worker restart test reuses all six validated LLM nodes after the parent directory is deleted
- API tests cover owner isolation, fresh BYOK env-only transport, paid admission, immutable snapshots, and unknown-state rejection
- Browser seam tests cover child navigation, session history, resume eligibility, and simultaneous reuse/degradation display
- The unknown-state and hidden-degradation defects were each re-injected; their new tests failed before the fixes and passed after restoration

No network or paid model call is required by this verification. Production recovery rate, duplicate-call rate, token savings, and cost savings remain deliberately unclaimed until a controlled paid fault-injection experiment is run.
