### PR TITLE
Fix checkpoint startup for omitted CrewAI task context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1331 tests (564 subtests), CI green on Linux + Windows × Python
+Current state: 1332 tests (564 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/src/academic_agent/checkpoint_runtime.py
+++ b/src/academic_agent/checkpoint_runtime.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Final, cast
 
 from crewai.tasks.task_output import TaskOutput
+from crewai.utilities.constants import NOT_SPECIFIED
 
 from academic_agent.checkpoints import (
     CheckpointIdentity,
@@ -214,7 +215,16 @@ def _task_config(task: Any, task_indices: Mapping[int, int]) -> dict[str, Any]:
     """
 
     agent = getattr(task, "agent", None)
-    context = list(getattr(task, "context", None) or [])
+    raw_context = getattr(task, "context", None)
+    # CrewAI 1.14.7 deliberately distinguishes an omitted context from an
+    # explicit None with this singleton. Both mean "no upstream task" to the
+    # scheduler, so they must produce the same checkpoint identity. Checking
+    # the exported singleton by identity keeps malformed context values loud.
+    context = (
+        []
+        if raw_context is None or raw_context is NOT_SPECIFIED
+        else list(raw_context)
+    )
     tools = list(getattr(task, "tools", None) or getattr(agent, "tools", None) or [])
     return {
         "description": str(getattr(task, "description", "")),

--- a/tests/test_checkpoint_runtime.py
+++ b/tests/test_checkpoint_runtime.py
@@ -161,6 +161,49 @@ def _seed_validated_prefix(
     return source, retrieval.output_sha256
 
 
+def test_runtime_accepts_crewai_omitted_context_default(tmp_path: Path) -> None:
+    """Catch the production crash caused by treating NOT_SPECIFIED as iterable.
+
+    CrewAI 1.14.7 preserves a private sentinel when ``context`` is omitted,
+    which is how the three independent evidence tasks are constructed from the
+    production YAML. Passing ``context=None`` here would hide that integration
+    seam and repeat the Railway failure before the first paid model request.
+    """
+
+    llm = _ExplodingLLM(model="never-called", temperature=0)
+    agent = Agent(
+        role="checkpoint identity agent",
+        goal="Provide a model identity without making a provider call",
+        backstory="This agent exists only at the CrewAI checkpoint boundary.",
+        llm=llm,
+        allow_delegation=False,
+        verbose=False,
+    )
+    tasks: list[Task] = []
+    for node in TASK_NODES:
+        task_kwargs: dict[str, Any] = {
+            "description": f"{node} description",
+            "expected_output": f"{node} expected",
+            "agent": agent,
+            "async_execution": node in {"academic", "patent", "market"},
+        }
+        if node in {"writer", "scorer"}:
+            task_kwargs["context"] = tasks[:3]
+        elif node == "reviewer":
+            task_kwargs["context"] = tasks[:4]
+        tasks.append(Task(**task_kwargs))
+
+    runtime = _runtime(
+        tmp_path,
+        tasks=tasks,
+        source=_SourceCollection(),
+        retrieval_sha256="0" * 64,
+    )
+
+    assert runtime.enabled is True
+    assert runtime.snapshot()["checkpointing"]["errors"] == []
+
+
 def test_runtime_restores_and_republishes_only_the_validated_prefix(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- treat CrewAI 1.14.7's exported `NOT_SPECIFIED` context singleton as the same no-dependency state as explicit `None`
- keep actual dependency ordering in the checkpoint configuration hash and continue raising on malformed context values
- add a real CrewAI `Task` regression test that omits `context`, matching production YAML construction
- update the exact zero-network suite count to 1332 tests

## Why

Production run `20260824T004956Z-c2695db895655245d5a51bb636a1322f` completed retrieval but failed while constructing `CheckpointRuntime`, before any provider request. CrewAI's omitted `Task.context` is a truthy, non-iterable `_NotSpecified` singleton, so `list(task.context or [])` raised `TypeError`.

The fix uses CrewAI's own exported singleton identity rather than broad exception handling or duck typing. This preserves a loud failure for unsupported values and does not change checkpoint hashes for declared task dependencies.

## Verification

- baseline: 1331 passed, 564 subtests passed
- regression test failed on the original implementation with the production `_NotSpecified` traceback
- exact defect re-injection made the new test fail again
- checkpoint runtime module: 5 passed
- full suite: 1332 passed, 564 subtests passed
- coverage: 86.74% (85% required)
- `uv run --with ruff ruff check .`
- CI-equivalent narrow Pylint checks
