### PR TITLE
Measure paid same-revision checkpoint recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,12 +176,18 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   One authorized Railway resume on 2026-08-24 then completed the paid workflow,
   but `identity.pipeline_revision` differed across PR #24 and PR #25, so the
   child correctly reported `cold_start` and reused zero nodes. This closes the
-  post-fix paid startup path and fail-safe cross-revision invalidation only:
-  there is still no paid same-revision reuse or production fault injection.
-  Do not turn either result into token reduction, cost reduction, latency,
+  post-fix paid startup path and fail-safe cross-revision invalidation only.
+  A later pre-registered production canary reached a four-node checkpoint
+  prefix and restarted the same Railway revision successfully. The source
+  became failed with that prefix intact, but the only child admission was
+  rejected before provider work by the three-operation daily cap. This is a
+  non-pass, not paid same-revision reuse evidence; all source checkpoint
+  `usage` fields were null, so partial tokens and cost are not inspectable.
+  Do not turn these results into token reduction, cost reduction, latency,
   production-SLO, or exactly-once claims. See
   `docs/results-2026-08-23-checkpoint-fault-recovery.md` and
-  `docs/results-2026-08-24-production-checkpoint-follow-up.md`.
+  `docs/results-2026-08-24-production-checkpoint-follow-up.md`, plus
+  `docs/results-2026-08-24-paid-same-revision-recovery.md`.
 - The 30-run calibration benchmark still has no report-output evidence for
   Chinese, very short, or non-technical topics. A pre-registered zero-network
   public-boundary contract now distinguishes them: specific Chinese input is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1339 tests (578 subtests), CI green on Linux + Windows × Python
+Current state: 1341 tests (578 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -198,6 +198,13 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   observed, but end-to-end paid recovery is not; source usage remains null, so
   total cost is also uninspectable. See
   `docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md`.
+  Recovery now reconstructs reused evidence JSON as `EvidenceReport` only
+  after repeating schema and evidence-integrity validation. A real Writer
+  guardrail seam test reaches the short-report check, and schema-invalid JSON
+  is exposed as `corrupt` instead of being reused as raw-only context. This is
+  zero-network repair evidence, not a completed production recovery. A
+  separately pre-registered post-fix paid child still has to complete the
+  Writer/Reviewer/Scorer suffix before end-to-end paid recovery can be claimed.
 - The 30-run calibration benchmark still has no report-output evidence for
   Chinese, very short, or non-technical topics. A pre-registered zero-network
   public-boundary contract now distinguishes them: specific Chinese input is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,16 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-23-checkpoint-fault-recovery.md` and
   `docs/results-2026-08-24-production-checkpoint-follow-up.md`, plus
   `docs/results-2026-08-24-paid-same-revision-recovery.md`.
+  A separately pre-registered second-code follow-up then admitted a child on
+  the same revision and reused the exact four-node prefix with byte-identical
+  output hashes. The three reused evidence agents made zero new child
+  requests. The child still failed: hydration restored `TaskOutput.raw` but
+  not the typed `EvidenceReport`, while the Writer guardrail builds its source
+  registry only from `TaskOutput.pydantic`. Both Writer attempts were rejected
+  as having no validated evidence context. Paid same-revision reuse is now
+  observed, but end-to-end paid recovery is not; source usage remains null, so
+  total cost is also uninspectable. See
+  `docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md`.
 - The 30-run calibration benchmark still has no report-output evidence for
   Chinese, very short, or non-technical topics. A pre-registered zero-network
   public-boundary contract now distinguishes them: specific Chinese input is

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ latency, exactly-once, or Railway SLO result. See the
 [result](docs/results-2026-08-23-checkpoint-fault-recovery.md), and
 [sanitized 30-row evidence](evals/checkpoint_recovery/checkpoint-fault-recovery-offline-v1.csv).
 
+A later pre-registered Railway canary reached a same-revision four-node prefix
+and restarted the production service without a rebuild. The failed source
+retained that exact prefix, but the only recovery request was rejected by the
+three-operation daily paid cap before a child or provider call began. This is a
+**non-pass**, not evidence of paid checkpoint reuse: it verifies production
+restart persistence and fail-closed admission only. The source checkpoint
+manifests stored no usage values, so partial tokens and cost remain
+`not_inspectable`. See the
+[protocol](docs/prereg-2026-08-24-paid-same-revision-recovery.md) and
+[result](docs/results-2026-08-24-paid-same-revision-recovery.md).
+
 The zero-network operational audit reads the run directories already on disk:
 
 ```bash
@@ -998,6 +1009,15 @@ ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-2
 exactly-once 或 Railway SLO。详见[预注册](docs/prereg-2026-08-23-checkpoint-fault-recovery.md)、
 [结果](docs/results-2026-08-23-checkpoint-fault-recovery.md)和
 [30 行脱敏证据](evals/checkpoint_recovery/checkpoint-fault-recovery-offline-v1.csv)。
+
+后续一组预注册 Railway canary 在同一代码版本下到达四节点连续前缀，并在不
+重新构建的情况下重启生产服务。失败的源运行完整保留该前缀，但唯一一次恢复
+请求在创建子运行或调用供应商之前，被每日 3 次付费操作上限拒绝。因此本次
+结果是**未通过**，不能作为真实付费 Checkpoint 复用证据；它只验证生产重启后
+持久化正常，以及付费准入能够 fail closed。源运行的 Checkpoint manifest 未
+记录 usage，部分 Token 与成本只能标记为 `not_inspectable`。详见
+[预注册](docs/prereg-2026-08-24-paid-same-revision-recovery.md)和
+[结果](docs/results-2026-08-24-paid-same-revision-recovery.md)。
 
 零网络运维审计直接读取磁盘上已有的运行目录：
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ manifests stored no usage values, so partial tokens and cost remain
 [protocol](docs/prereg-2026-08-24-paid-same-revision-recovery.md) and
 [result](docs/results-2026-08-24-paid-same-revision-recovery.md).
 
+An independently pre-registered second-code follow-up then admitted a child on
+the same revision and reused the exact four-node prefix. The three evidence
+agents made **0 new child requests**; only the Writer ran. The child still
+failed because recovery restored validated evidence JSON into
+`TaskOutput.raw` without reconstructing the typed `EvidenceReport` values
+that the report guardrail uses to build its source registry. This is direct
+paid evidence for prefix reuse, but another **non-pass** for complete recovery.
+The child used 31,642 tokens across two Writer requests at an estimated
+$0.014576; interrupted-source usage is uninspectable, so this is not a total
+cost or savings claim. See the
+[follow-up protocol](docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)
+and [result](docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md).
+
 The zero-network operational audit reads the run directories already on disk:
 
 ```bash
@@ -1018,6 +1031,16 @@ exactly-once 或 Railway SLO。详见[预注册](docs/prereg-2026-08-23-checkpoi
 记录 usage，部分 Token 与成本只能标记为 `not_inspectable`。详见
 [预注册](docs/prereg-2026-08-24-paid-same-revision-recovery.md)和
 [结果](docs/results-2026-08-24-paid-same-revision-recovery.md)。
+
+随后一组独立预注册、使用第二口令的实验在同一版本上成功创建子运行，并精确
+复用了四节点连续前缀。三个证据 Agent 在子运行中产生 **0 次新请求**，只有
+Writer 被执行。但恢复逻辑只把已验证证据 JSON 还原到 `TaskOutput.raw`，没有
+重建报告 Guardrail 用来建立来源注册表的 `EvidenceReport` 类型值，因此
+Writer 最终失败。这是前缀真实付费复用的直接证据，但完整恢复依然**未通过**。
+子运行的两次 Writer 请求共 31,642 Token，估算 $0.014576；中断源运行的 usage
+不可检查，因此这不是实验总成本或节省结论。详见
+[后续预注册](docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)和
+[完整结果](docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md)。
 
 零网络运维审计直接读取磁盘上已有的运行目录：
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ cost or savings claim. See the
 [follow-up protocol](docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)
 and [result](docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md).
 
+The recovery adapter now reconstructs reused evidence JSON as typed
+`EvidenceReport` objects only after repeating schema and evidence-integrity
+validation. Two zero-network regressions exercise the actual Writer guardrail
+seam and fail closed on schema-invalid evidence checkpoints. This repairs the
+observed raw-only hydration path without changing CrewAI's raw model context,
+but no separately pre-registered post-fix paid canary has completed the suffix;
+end-to-end paid recovery therefore remains unproven.
+
 The zero-network operational audit reads the run directories already on disk:
 
 ```bash
@@ -1041,6 +1049,13 @@ Writer 最终失败。这是前缀真实付费复用的直接证据，但完整�
 不可检查，因此这不是实验总成本或节省结论。详见
 [后续预注册](docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)和
 [完整结果](docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md)。
+
+恢复适配器现已在重复执行 Schema 与证据完整性校验后，把复用的证据 JSON 重建为
+`EvidenceReport` 类型对象。两条零网络回归测试分别覆盖真实 Writer Guardrail
+接缝，以及结构错误证据 Checkpoint 的 fail-closed 行为；CrewAI 发送给模型的
+原始上下文字节保持不变。该修改修复了已观测到的 raw-only 恢复路径，但尚未
+执行另一次独立预注册的修复后付费 canary，因此完整的端到端付费恢复仍未得到
+证明。
 
 零网络运维审计直接读取磁盘上已有的运行目录：
 

--- a/checkpoint_fault_audit.py
+++ b/checkpoint_fault_audit.py
@@ -22,13 +22,18 @@ import sys
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Final
 from unittest.mock import patch
 
 from academic_agent.checkpoint_runtime import TASK_NODES
+from academic_agent.evidence import (
+    EvidenceFinding,
+    EvidenceReport,
+    EvidenceSource,
+)
 from academic_agent.run_spec import RESUME_SNAPSHOT_DIRECTORY, RUN_SPEC_FILENAME
 
 
@@ -264,18 +269,61 @@ class _OfflineTelemetry:
         return {"state": "disabled", "reason": "offline_checkpoint_fault_audit"}
 
 
+def _evidence_output(prefix: str) -> str:
+    """Return the post-guardrail JSON shape required by typed recovery."""
+    source_id = f"{prefix}1"
+    source_types = {
+        "A": "academic_paper",
+        "P": "patent",
+        "M": "market_report",
+    }
+    source = EvidenceSource(
+        source_id=source_id,
+        title=f"Deterministic checkpoint source {source_id}",
+        url=f"https://example.com/checkpoint-{source_id.lower()}",
+        publisher="Example Research Institute",
+        published_date=date(2026, 1, 10),
+        accessed_date=date(2026, 8, 23),
+        source_type=source_types[prefix],
+        evidence_summary=(
+            "This deterministic source summary represents already validated "
+            "evidence at the offline checkpoint worker boundary."
+        ),
+    )
+    findings = [
+        EvidenceFinding(
+            finding_id=f"{prefix}F{index}",
+            category="technology maturity",
+            claim="A deterministic checkpoint finding that remains supportable.",
+            claim_type="observed_fact",
+            source_ids=[source_id],
+            confidence="high",
+            commercial_implication="This affects the commercialization pathway.",
+        )
+        for index in range(1, 4)
+    ]
+    report = EvidenceReport(
+        topic="solid-state battery recycling",
+        scope_summary="A bounded deterministic review for checkpoint recovery.",
+        search_queries=["solid-state battery recycling commercial maturity"],
+        findings=findings,
+        sources=[source],
+        limitations=["The fixture replaces every external provider boundary."],
+    )
+    return report.model_dump_json()
+
+
 def _task_output(node: str):
     from crewai.tasks.task_output import OutputFormat as CrewOutputFormat
     from crewai.tasks.task_output import TaskOutput
 
-    raw = (
-        json.dumps(
-            {"node": node, "findings": [], "audit_payload": True},
-            sort_keys=True,
-        )
-        if node in {"academic", "patent", "market", "scorer"}
-        else f"# {node.title()}\n\nValidated offline checkpoint audit output."
-    )
+    if node in {"academic", "patent", "market"}:
+        prefix = {"academic": "A", "patent": "P", "market": "M"}[node]
+        raw = _evidence_output(prefix)
+    elif node == "scorer":
+        raw = json.dumps({"node": node, "audit_payload": True}, sort_keys=True)
+    else:
+        raw = f"# {node.title()}\n\nValidated offline checkpoint audit output."
     return TaskOutput(
         description=f"{node} description",
         expected_output=f"{node} expected",

--- a/docs/checkpoint-recovery.md
+++ b/docs/checkpoint-recovery.md
@@ -56,6 +56,16 @@ non-contiguous reuse was rejected because CrewAI 1.14.7 has no supported
 scheduler contract for it and reproducing callback, context, tracing, and
 rate-limit semantics would require a second executor.
 
+For the academic, patent, and market nodes, recovery also reconstructs the
+`EvidenceReport` object that the live evidence guardrail attaches. It repeats
+both Pydantic schema validation and the node-prefix evidence-integrity checks,
+while preserving the checkpoint text in `TaskOutput.raw`; CrewAI therefore
+receives byte-identical model context and the deterministic Writer guardrail
+receives the trusted typed source registry it expects. A JSON payload that
+passes storage-format checks but fails this typed validation is reported as
+`corrupt` with `payload_schema`, and reuse stops at that node rather than
+silently presenting unvalidated raw text as evidence.
+
 Every reused checkpoint is republished into the child, making the child
 independently resumable. A Reviewer fallback that merely ships the Writer's
 validated draft is not recorded as a Reviewer checkpoint: the review did not
@@ -128,6 +138,9 @@ The zero-network suite covers the storage and client seams separately:
 - contiguous-prefix restoration and child republishing;
 - a real pinned CrewAI kickoff whose provider double raises if hydration is
   ignored;
+- restored evidence reaches the real Writer guardrail as typed source context;
+- schema-invalid evidence JSON fails closed as a corrupt checkpoint instead of
+  being reused;
 - fresh BYOK isolation and code-owner authorization;
 - parent deletion immediately after the API returns `202`;
 - a complete worker fault/restart path in which the child executes zero of six
@@ -202,8 +215,16 @@ final-report guardrail deliberately trusts only typed evidence when building
 its allowed-source registry. Raw model context was therefore present, but
 guardrail context was empty.
 
-This is a non-pass for end-to-end paid recovery, despite directly observing
-paid same-revision prefix reuse and zero repeated evidence-agent requests.
+This remains a non-pass for end-to-end paid recovery, despite directly
+observing same-revision prefix reuse and zero repeated evidence-agent requests.
 Source checkpoint usage remained null, so total experiment cost is also
-uninspectable. A fix needs a typed-hydration seam test before any new paid
-canary. See the
+uninspectable.
+
+The recovery adapter subsequently added typed hydration with repeated schema
+and evidence-integrity validation. The regression suite now feeds three
+restored production-shaped `EvidenceReport` values into the actual Writer
+guardrail, and separately proves that schema-invalid JSON stops reuse as
+`corrupt`. This is code-level, zero-network repair evidence only; no post-fix
+paid canary has completed the remaining suffix. See the
+[frozen production result](results-2026-08-24-paid-same-revision-recovery-follow-up.md)
+for the original observation and its claim limits.

--- a/docs/checkpoint-recovery.md
+++ b/docs/checkpoint-recovery.md
@@ -183,3 +183,27 @@ tokens and cost are not inspectable and must not be presented as zero.
 The frozen protocol, exact timeline, run and deployment identities, and claim
 limits are recorded in
 [the same-revision canary result](results-2026-08-24-paid-same-revision-recovery.md).
+
+### Production observation: reuse exposed a typed-context seam
+
+An independently pre-registered follow-up used a second validated owner code
+for both a new source and its immutable child. After another same-revision
+restart, the child reported `recovery.state=reused` with the exact four-node
+prefix and `next_node=writer`. Source and child output hashes matched for
+every reused node. Child usage recorded zero requests for the academic, patent,
+and market agents, then two Writer requests.
+
+The child did not complete. Both Writer attempts failed the final-report
+guardrail with `No validated evidence sources are available in task context.`
+The live evidence guardrails populate `TaskOutput.pydantic` with validated
+`EvidenceReport` objects. Recovery restored the same validated JSON into
+`TaskOutput.raw` but did not reconstruct those typed values, while the
+final-report guardrail deliberately trusts only typed evidence when building
+its allowed-source registry. Raw model context was therefore present, but
+guardrail context was empty.
+
+This is a non-pass for end-to-end paid recovery, despite directly observing
+paid same-revision prefix reuse and zero repeated evidence-agent requests.
+Source checkpoint usage remained null, so total experiment cost is also
+uninspectable. A fix needs a typed-hydration seam test before any new paid
+canary. See the

--- a/docs/checkpoint-recovery.md
+++ b/docs/checkpoint-recovery.md
@@ -162,3 +162,24 @@ cross-revision invalidation. It does not close paid checkpoint reuse or
 production fault injection. The exact run ids, artifact checks, and limits
 are recorded in
 [the production follow-up result](results-2026-08-24-production-checkpoint-follow-up.md).
+
+### Production observation: same-revision restart preserved the prefix
+
+A second pre-registered Railway canary reached a four-node prefix
+(`retrieval`, `academic`, `patent`, and `market`) while the source was
+still running, then restarted the service without a rebuild. Railway returned
+the same deployment, image, instance, and `f9e3b61` revision. After readiness
+returned, the interrupted source was failed and both public status surfaces
+still reported the exact prefix with no checkpoint errors.
+
+The only recovery request was rejected with HTTP 429 before child creation
+because the owner had reached the configured three-operation daily paid cap.
+No alternate code, BYOK bypass, replacement source, or retry was used. The
+result is therefore a **non-pass** for paid same-revision reuse: it establishes
+real restart persistence and fail-closed paid admission, but no child executed
+the remaining suffix. The four manifests also stored `usage=null`, so source
+tokens and cost are not inspectable and must not be presented as zero.
+
+The frozen protocol, exact timeline, run and deployment identities, and claim
+limits are recorded in
+[the same-revision canary result](results-2026-08-24-paid-same-revision-recovery.md).

--- a/docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md
+++ b/docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md
@@ -1,0 +1,102 @@
+# Pre-registration: second-code same-revision Railway recovery canary
+
+**Frozen:** 2026-08-24, before the new paid source is submitted
+**Relationship to the first canary:** independent follow-up, not a retry or an
+amendment
+**Production revision:** `f9e3b611779af1e3148cad1d5552758bd67ea274`
+**Maximum attempts:** one new source run and, only if safely resumable, one
+immutable child
+**Soft spending stop:** `$0.10` total estimated LLM cost; one in-flight
+request may finish slightly above the stop
+
+## Why this is a separate experiment
+
+The first pre-registered canary ended as a non-pass after its only child
+admission was rejected by that owner's daily paid-operation cap. Its result is
+frozen in `results-2026-08-24-paid-same-revision-recovery.md` and will not be
+rewritten.
+
+The study owner has now supplied a second validated operator code. A code-owned
+run cannot change owner identity at recovery, so that code cannot resume the
+first source. This follow-up must create a new source owned by the second code
+and use that same code for its only child request. Neither the code nor its
+hash is retained in study artifacts.
+
+## Frozen question
+
+After a real Railway process restart occurs only after a durable contiguous
+checkpoint prefix exists, can a fresh immutable child owned by the same second
+code reuse that prefix on the exact same deployed revision and complete the
+remaining paid workflow without executing already-validated nodes again?
+
+## Frozen input and preconditions
+
+- Topic: `solid-state batteries for electric vehicles`
+- Language and weight profile: auto-detect
+- Uploaded paper: none
+- Provider mode: operator-funded DeepSeek with Railway's configured search
+  provider
+- Public service:
+  `https://academic-commercialization-agent.up.railway.app`
+- Required revision before source admission and after restart:
+  `f9e3b611779af1e3148cad1d5552758bd67ea274`
+- Required readiness: HTTP 200, `ready=true`, all readiness checks `ok`,
+  zero active runs, and zero active paid operations
+
+The topic remains benchmark case 03 so retrieval instability is less likely to
+consume the one allowed attempt before the recovery seam is reached.
+
+## Fixed protocol
+
+1. Confirm readiness, zero active work, and the exact Railway deployment
+   revision before admission.
+2. Submit exactly one new operator-funded source with the second code.
+3. Poll both public status surfaces. The restart boundary is eligible only
+   while the source is still `running` and the committed prefix contains at
+   least `retrieval`, `academic`, `patent`, and `market`.
+4. Immediately restart Railway without rebuild. Record every node visible at
+   the boundary; an additional contiguous node that races to commit must be
+   included in the expected prefix.
+5. Wait for readiness, then verify the deployment commit is unchanged.
+6. Re-read the source. It must be terminal, not completed, and expose an intact
+   retrieval checkpoint. Otherwise stop with no replacement source.
+7. Submit exactly one recovery child with the same second code. Do not retry
+   any rejected or failed admission and do not use another identity or BYOK.
+8. Poll the child to a terminal state and retain both status surfaces, report
+   response, checkpoint manifests, recovery inspection, provider execution
+   evidence, and usage. Missing evidence is `not_inspectable`, never zero.
+
+## Pass criteria
+
+The follow-up passes only if all conditions hold:
+
+1. The source was running with the eligible committed prefix before restart.
+2. Railway and readiness returned on the exact frozen revision.
+3. The source became terminal without completion and exactly one child was
+   admitted.
+4. The child reports `recovery.state=reused`; `reused_nodes` equal the
+   longest validated contiguous prefix and include retrieval plus all three
+   evidence nodes.
+5. Reused nodes are absent from newly executed child provider work. If
+   execution evidence cannot establish this, the criterion does not pass.
+6. The child completes, serves a non-empty report, and commits all seven
+   checkpoints with `checkpointing.state=complete`.
+7. Inspectable source-plus-child cost remains within the soft stop except for a
+   documented single in-flight overshoot.
+
+There is no partial pass. A cold start, an admission rejection, a completed
+source, an invalid checkpoint, an uninspectable execution boundary, or an
+incomplete child is a non-pass.
+
+## Abort and claim limits
+
+- No second source or child is allowed.
+- No access-code substitution, BYOK bypass, rebuild, or production code change
+  is allowed after the source is admitted.
+- Do not restart before the eligible prefix is publicly visible.
+- Do not merge PR #27 or otherwise deploy a new revision before this follow-up
+  reaches a terminal result.
+- Even a pass supports only this one provider-backed same-revision recovery
+  observation. It does not establish exactly-once execution, a production SLO
+  or recovery rate, general savings, report correctness, or six-stage
+  necessity.

--- a/docs/prereg-2026-08-24-paid-same-revision-recovery.md
+++ b/docs/prereg-2026-08-24-paid-same-revision-recovery.md
@@ -1,0 +1,129 @@
+# Pre-registration: paid same-revision Railway recovery canary
+
+**Frozen:** 2026-08-24, before either paid operation  
+**Study type:** one operator-funded production fault/recovery canary  
+**Production revision:** `f9e3b611779af1e3148cad1d5552758bd67ea274`  
+**Maximum attempts:** one source run and, only if it is safely resumable, one child  
+**Soft spending stop:** `$0.10` total estimated LLM cost; one in-flight request
+may finish slightly above the stop
+
+## Question
+
+After a real Railway process restart occurs only after a durable contiguous
+checkpoint prefix exists, can a fresh immutable child on the **same deployed
+revision** reuse that prefix and complete the remaining paid workflow without
+executing the already-validated nodes again?
+
+The offline 30-unit audit already established the storage and worker mechanics.
+The earlier production follow-up established only fail-safe cross-revision
+invalidation: it reused zero nodes. This canary is intentionally limited to the
+one missing provider-backed seam. It is not another reliability benchmark.
+
+## Frozen input and deployment
+
+- Topic: `solid-state batteries for electric vehicles`
+- Language: auto-detect
+- Weight profile: auto-detect
+- Uploaded paper: none
+- LLM/search credentials: operator-funded Railway configuration; secrets and
+  the access code are never copied into the study record
+- Public service: `academic-commercialization-agent.up.railway.app`
+- Railway project: `refreshing-solace`
+- Railway service: `academic-commercialization-agent`
+- Required deployment revision before the source starts and after the restart:
+  `f9e3b611779af1e3148cad1d5552758bd67ea274`
+
+The topic is benchmark case 03, which completed three of three frozen baseline
+runs and stayed inside its pre-declared TRL interval. Choosing an already
+stable retrieval topic reduces the chance that this recovery experiment spends
+money while answering a source-availability question instead.
+
+## Fixed protocol
+
+1. Confirm `/health/ready` returns HTTP 200 with `ready=true`, the latest
+   Railway deployment is `SUCCESS`/`RUNNING` at the required commit, and no
+   other paid operation is active.
+2. Submit exactly one operator-funded source run. Poll its public status; do
+   not infer progress from elapsed time or UI copy.
+3. The fault boundary is eligible only while the source is still `running` and
+   `checkpointing.committed_nodes` contains, at minimum, `retrieval`,
+   `academic`, `patent`, and `market`. Record the complete observed list; a
+   later contiguous node that commits before the restart is allowed and must
+   also be accounted for.
+4. Immediately request a Railway **restart without rebuild**. This deliberately
+   terminates the API and its child worker through the production shutdown
+   path. It must not create a deployment with a different commit.
+5. Wait for `/health/ready` to recover, then re-read Railway deployment state
+   and verify the commit is unchanged.
+6. Re-read the source. It must be terminal, not completed, and must retain an
+   intact retrieval checkpoint. If it completed before the restart, never
+   reached the eligible boundary, or becomes uninspectable, the canary is
+   invalid and no replacement source is allowed.
+7. Submit exactly one immutable child through
+   `POST /api/runs/{source_id}/resume` with the same owner code. No retry is
+   allowed if admission or execution fails.
+8. Poll the child to a terminal state. Fetch both status surfaces, the report
+   endpoint, and persisted checkpoint evidence. Record absent evidence as
+   `not_inspectable`, never as zero.
+
+## Pass criteria
+
+The canary passes only if every condition below is observed:
+
+1. The eligible committed prefix was visible before the restart and the source
+   was not already terminal.
+2. Railway returned to `SUCCESS`/`RUNNING` on the exact same commit, and the
+   readiness endpoint returned HTTP 200 after the restart.
+3. The source became terminal without reporting a completed assessment, and
+   the resume endpoint accepted one immutable child.
+4. The child reports `recovery.state=reused`. Its `reused_nodes` equal the
+   longest contiguous reusable prefix observed in persisted source manifests,
+   include at least `retrieval`, `academic`, `patent`, and `market`, and its
+   `next_node` is the first missing task.
+5. No node named in `reused_nodes` appears as a newly executed provider node in
+   the child evidence. Missing execution or usage evidence makes this criterion
+   uninspectable and therefore non-passing.
+6. The child reaches `state=completed`, publishes a non-empty report through an
+   HTTP 200 endpoint, and finishes with `checkpointing.state=complete` and all
+   seven nodes committed.
+7. Source plus child estimated cost remains at or below the `$0.10` soft stop,
+   except for a documented overshoot caused by a request already in flight.
+
+There is no partial pass. A completed child with zero reused nodes is a
+fail-safe cold start, not a successful recovery result.
+
+## Abort and no-retry rules
+
+- Abort before submission if the production revision, readiness, or paid-slot
+  checks do not match the frozen conditions.
+- Do not restart the service unless the eligible checkpoint boundary is
+  visible on the source while it is still running.
+- Do not create a child if the source is completed, still running after the
+  service returns, lacks a reusable retrieval checkpoint, or the observed
+  source cost has already crossed the soft stop.
+- Do not start a second source or child to turn an operational failure into a
+  cleaner result. The failure is the result.
+
+## Evidence to retain
+
+- source and child run IDs and their public capability URLs;
+- UTC timestamps for admission, eligible boundary, restart, readiness return,
+  resume admission, and terminal child state;
+- Railway deployment and instance IDs plus commit hashes before and after;
+- source and child status/progress payloads;
+- the persisted checkpoint node list, inspection reasons, and per-node usage
+  when available;
+- child report HTTP status and report length;
+- observed provider requests, tokens, and estimated cost, with missing partial
+  source accounting labelled explicitly.
+
+Credentials, owner hashes, raw provider bodies, and absolute host paths are not
+study artifacts.
+
+## Claims this canary cannot support
+
+Even a pass does not establish exactly-once provider execution, a Railway SLO,
+an incident recovery rate, general token/cost/latency savings, report factual
+correctness, or the necessity of six stages. It establishes only that this one
+same-revision production restart reused its validated prefix and completed its
+remaining suffix under the frozen conditions.

--- a/docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md
+++ b/docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md
@@ -1,0 +1,180 @@
+# Result: same-revision reuse succeeded but typed context was not restored
+
+**Date:** 2026-08-24
+**Pre-registration commit:** `9c22fde`
+**Production revision:** `f9e3b611779af1e3148cad1d5552758bd67ea274`
+**Source run:** `20260824T073315Z-a214ab4947f0b78f7ff2bcf8d8b3dc4d`
+**Child run:** `20260824T073632Z-6d42b05a6a46c605d8c7e16342395844`
+**Result:** **NON-PASS — four nodes were reused, but the child failed at the
+Writer guardrail**
+
+## Decision
+
+This follow-up closes one narrower question and exposes a new production seam.
+The immutable child reused the exact same-revision retrieval, academic, patent,
+and market checkpoints. Its usage record shows zero requests for all three
+evidence agents, and the child began paid work at the Writer. That is direct
+provider-backed evidence that contiguous-prefix reuse itself worked.
+
+The end-to-end recovery still did not pass. The restored evidence
+`TaskOutput` objects contained their validated raw JSON but not their typed
+`EvidenceReport` values. The final-report guardrail reads only those typed
+values when it builds the allowed-source registry, so it rejected both Writer
+attempts with:
+
+> No validated evidence sources are available in task context.
+
+No retry, replacement source, alternate identity, BYOK bypass, or production
+change was used. Do not describe this result as a completed paid recovery.
+
+## Frozen relationship to the first canary
+
+The [first canary](results-2026-08-24-paid-same-revision-recovery.md) remains a
+separate non-pass: its only child admission was rejected by that owner's daily
+wallet cap. The study owner later supplied another validated operator code.
+Because code-owned runs cannot change owner identity at recovery, the
+[follow-up protocol](prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)
+froze a new source and required the second code to own both source and child.
+The code and its hash are absent from every retained artifact.
+
+## Preconditions
+
+Immediately before the new source:
+
+- `/health` reported zero active runs and zero active paid operations;
+- `/health/ready` returned HTTP 200 with `ready=true`, and LLM, search,
+  outputs, and paid accounting were all `ok`;
+- the second code passed a read-only authentication request and saw zero runs;
+- Railway reported deployment
+  `a65d414c-33ed-415b-a9f0-33786c9cdb92` as `SUCCESS`, instance
+  `71e5ba8b-719a-4a4a-be2e-449e2d7923a5` as `RUNNING`, and the frozen
+  `f9e3b61` commit;
+- the mounted output volume was `/app/outputs`.
+
+All seven CI jobs for the pushed pre-registration were green before source
+admission.
+
+## Observed sequence
+
+1. The source was admitted between `07:33:15.2120472Z` and
+   `07:33:15.6283163Z`.
+2. Public polling first observed retrieval committed at
+   `07:34:31.1880691Z`, patent at `07:34:40.5485204Z`, academic at
+   `07:34:45.2109653Z`, and the exact four-node prefix at
+   `07:34:49.8866464Z`. These are observation times, not claimed manifest
+   commit times.
+3. At the four-node observation the source was still running at
+   `Agent 4 — Report Writing`, with 8 academic, 8 patent, and 7 market
+   sources and no failed retrieval domain.
+4. Railway accepted the immediate restart without rebuild and returned the
+   same deployment id. Readiness was first recorded again at
+   `07:35:37.9284618Z`; the deployment, instance, image, commit, and volume
+   mount were unchanged.
+5. The source was observed failed at `07:36:13.7034967Z`, still exposing the
+   exact four-node prefix with no checkpoint errors.
+6. The only child was admitted between `07:36:32.0864128Z` and
+   `07:36:32.5946014Z`.
+7. At `07:36:48.7250518Z`, both public status surfaces reported
+   `recovery.state=reused`, the exact four reused nodes, and
+   `next_node=writer`. The Writer checkpoint was correctly reported missing.
+8. The child failed at `07:37:55.9955812Z` after two Writer requests. It
+   committed no later node and produced no report.
+9. After the audit, `/health` again reported zero active runs and zero active
+   paid operations. The second code's scoped history contained exactly the
+   failed source and failed child.
+
+## Persisted and client evidence
+
+The source and child manifest pairs carry the same `git:f9e3b611...`
+revision and exact matching output hashes:
+
+| Node | Matching source/child output SHA-256 |
+|---|---|
+| retrieval | `f2ea292ef5b06e94e8bbaaefee3c107504e7208f6d2f2cf0d6470ddd569cee63` |
+| academic | `60c2fe0c55dabd9251bd3b94755549648e1fdd4727c737dfcb737e5c2ce5dc5e` |
+| patent | `67fc17f4f55a90d341e05cf4f7aa7c771b1852f54ac6a2e7e7c40e644af5fbda` |
+| market | `9451e91df3a30e42f2163cff5bd355d8e077203418c9a84b816e74d82fb44a6e` |
+
+The child progress stream represented the three evidence agents as
+`Reused validated checkpoint` and then emitted a Writer action. Final usage
+reported:
+
+| Measure | Child observation |
+|---|---|
+| Total requests | 2 |
+| Total tokens | 31,642 |
+| Cached prompt tokens | 15,104 |
+| Estimated cost | $0.014576 |
+| Academic agent | 0 requests / 0 tokens |
+| Patent agent | 0 requests / 0 tokens |
+| Market agent | 0 requests / 0 tokens |
+| Writer | 2 requests / 31,642 tokens |
+| Reviewer / Scorer | 0 requests / 0 tokens |
+| Usage completeness | `true` for the child |
+
+The report endpoint returned HTTP 409 because the child failed. The sources and
+steps endpoints remained readable at HTTP 200, with 61,060 and 334 UTF-8 bytes
+respectively.
+
+All four source and child checkpoint manifests recorded `usage=null`.
+Consequently the interrupted source's provider usage cannot be reconstructed,
+and total source-plus-child cost is `not_inspectable`. The child's
+`$0.014576` is below the soft stop but is not the experiment total.
+
+## Pre-registered criteria
+
+| Criterion | Result |
+|---|---|
+| Eligible prefix visible while source was running | pass |
+| Same revision and readiness after restart | pass |
+| Source terminal and exactly one child admitted | pass |
+| Child reports the exact reusable contiguous prefix | pass |
+| Reused evidence nodes did not execute new child provider work | pass |
+| Child completes report and all seven checkpoints | **fail** |
+| Total source plus child cost is within the soft stop | not inspectable |
+
+The aggregate result is non-pass because the frozen protocol has no
+partial-pass threshold.
+
+## Root cause
+
+The failure is deterministic and sits between checkpoint hydration and the
+existing report guardrail:
+
+1. Evidence guardrails set `output.pydantic` to an `EvidenceReport` after
+   validating each live evidence-agent response.
+2. `CheckpointRuntime.restore_contiguous_prefix()` reconstructs each reused
+   `TaskOutput` with `description`, `expected_output`, `raw`, and
+   `agent`, but does not reconstruct `pydantic`.
+3. `collect_context_sources()` and `collect_context_finding_sources()` read
+   only `task.output.pydantic` values that are `EvidenceReport` instances;
+   they deliberately do not trust unvalidated arbitrary raw text.
+4. The Writer received the raw context and generated output, but its guardrail
+   built an empty allowed-source registry from the restored tasks. Both allowed
+   Writer attempts were therefore rejected before later stages could run.
+
+The existing offline recovery tests assert that hydrated tasks are skipped,
+republished, and visible through status seams. They do not feed a partially
+restored production `EvidenceReport` prefix into the real final-report
+guardrail. That missing seam assertion allowed 1,339 tests to pass while this
+production-only path remained broken.
+
+## What this establishes
+
+- A real same-revision Railway restart preserved and reused an exact four-node
+  prefix.
+- The immutable child republished byte-identical checkpoint outputs.
+- The three reused evidence agents made zero new child provider requests.
+- Typed guardrail context is part of the recovery contract even when raw task
+  context is sufficient for model generation.
+
+## What remains open
+
+End-to-end paid recovery remains unproven until typed evidence outputs are
+reconstructed from already validated checkpoint JSON, a seam test reproduces
+this exact failure, and a separately pre-registered post-fix canary completes
+the remaining Writer, Reviewer, and Scorer suffix.
+
+This result does not support general token, cost, or latency savings; a
+production recovery rate or SLO; exactly-once execution; report correctness; or
+six-stage necessity.

--- a/docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md
+++ b/docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md
@@ -178,3 +178,16 @@ the remaining Writer, Reviewer, and Scorer suffix.
 This result does not support general token, cost, or latency savings; a
 production recovery rate or SLO; exactly-once execution; report correctness; or
 six-stage necessity.
+
+## Post-result repair status
+
+After this frozen non-pass, the recovery adapter was changed to reconstruct
+each reused academic, patent, and market payload as an `EvidenceReport` only
+after repeating schema and node-prefix evidence-integrity validation. The
+regression test feeds three restored production-shaped reports into the actual
+Writer guardrail and reaches its short-report check; removing the typed value
+reproduces the exact no-validated-sources failure. A second test proves that
+schema-invalid JSON is reported as a corrupt checkpoint and stops reuse.
+
+These are zero-network code and seam-test results. They do not rewrite the
+production outcome above, and no post-fix paid canary result is claimed here.

--- a/docs/results-2026-08-24-paid-same-revision-recovery.md
+++ b/docs/results-2026-08-24-paid-same-revision-recovery.md
@@ -1,0 +1,123 @@
+# Result: same-revision Railway restart reached recovery admission only
+
+**Date:** 2026-08-24
+**Pre-registration commit:** `2f48232`
+**Production revision:** `f9e3b611779af1e3148cad1d5552758bd67ea274`
+**Source run:** `20260824T064715Z-e18f9f219ecb6dc974cee792deefe0df`
+**Child run:** none
+**Result:** **NON-PASS — the recovery child was not admitted**
+
+## Decision
+
+Do not claim paid same-revision checkpoint reuse from this canary. The source
+reached the frozen four-node boundary, the production restart preserved that
+prefix on the Railway volume, and the source became safely resumable. The one
+allowed resume request was then rejected before child creation because this
+owner had already reached the configured daily limit of three operator-funded
+paid operations.
+
+That rejection is a correct wallet boundary, not a damaged checkpoint. It also
+means the canary stopped before the seam it was meant to measure. No replacement
+source, alternate access code, BYOK bypass, or second resume attempt was used.
+
+## Frozen protocol
+
+The [pre-registration](prereg-2026-08-24-paid-same-revision-recovery.md) was
+committed and pushed before the source was submitted. It fixed:
+
+- benchmark case 03, `solid-state batteries for electric vehicles`;
+- deployment revision `f9e3b61`;
+- a minimum prefix of retrieval plus all three evidence nodes;
+- one source, one child, no retries;
+- a `$0.10` soft LLM-cost stop;
+- a Railway restart without rebuild as the production fault.
+
+The draft PR containing that record passed all seven CI jobs before the paid
+source began.
+
+## Observed sequence
+
+1. Immediately before submission, `/health` reported zero active runs and zero
+   active paid operations. `/health/ready` returned `ready=true`; LLM, search,
+   outputs, and paid accounting were all `ok`. Railway reported deployment
+   `c6f944cd-bd26-4942-ae70-458a431e1fb8` as `SUCCESS`/`RUNNING` at the frozen
+   commit.
+2. The source was admitted at `2026-08-24T06:47:15Z`.
+3. Retrieval committed at `06:48:21.241880Z`, patent at `06:48:34.783627Z`,
+   market at `06:48:41.766719Z`, and academic at `06:48:43.613136Z`.
+4. At `06:48:43.955233Z`, both the source state and the persisted manifests
+   showed exactly `retrieval, academic, patent, market`. The source was still
+   running in `Agent 4 — Report Writing`; its event stream showed all three
+   evidence agents finished and the writer started.
+5. Railway accepted an immediate restart without rebuild and returned the same
+   deployment id. The first recorded post-restart readiness success was
+   `06:49:29.494031Z`. This 45.5-second interval begins at boundary observation,
+   not at proven unavailability, and is not an outage or SLO measurement.
+6. After restart, Railway still reported the same deployment, instance, image,
+   and commit. The source was `failed`, not completed, while both status APIs
+   still exposed the exact four-node prefix with no checkpoint errors.
+7. The only resume request returned HTTP 429: `3 operator-funded paid
+   operations already admitted today`. It returned no child id. The sanitized
+   durable ledger confirmed schema 1, date `2026-08-24`, and one anonymous
+   count of 3.
+8. The subsequent run list contained the source and no child. `/health` again
+   reported zero active runs and zero active paid operations.
+
+## Evidence summary
+
+| Measure | Observation |
+|---|---|
+| Source terminal state | `failed` after restart |
+| Source stage | `Agent 4 — Report Writing` |
+| Sources | 8 academic / 8 patent / 7 market |
+| Persisted prefix | retrieval + academic + patent + market |
+| Manifest revision | `git:f9e3b611...` on all four nodes |
+| Checkpoint errors | none |
+| Railway revision after restart | unchanged (`f9e3b611...`) |
+| Readiness after restart | HTTP 200, all four checks `ok` |
+| Resume response | HTTP 429 daily paid-operation cap |
+| Child run/provider calls | none; admission stopped before child creation |
+| Source checkpoint usage | `null` on all four manifests |
+| Exact source tokens/cost | `not_inspectable`, not zero |
+| Report | none, because no child executed the suffix |
+
+The source manifest `usage` fields being null is consequential: the three
+completed provider-backed evidence nodes certainly ran, but their partial
+tokens and cost cannot be reconstructed from the persisted checkpoint record.
+The `$0.10` stop therefore cannot be evaluated as an exact total. The one
+failed resume admission did not start a provider call.
+
+## Pre-registered criteria
+
+| Criterion | Result |
+|---|---|
+| Eligible prefix visible while source was running | pass |
+| Same revision and readiness after Railway restart | pass |
+| Source terminal and one child accepted | **fail** — source terminal, child rejected |
+| Child reports exact contiguous-prefix reuse | not run |
+| Reused nodes absent from child provider execution | not run |
+| Child completes report and all seven checkpoints | not run |
+| Exact source + child cost stays within soft stop | not inspectable |
+
+The aggregate verdict is non-pass because the protocol has no partial-pass
+threshold.
+
+## What this establishes
+
+- A real restart of the deployed Railway service preserved the four committed
+  source manifests on the mounted volume.
+- The restarted API derived the interrupted source as failed and exposed the
+  same checkpoint state through both client status surfaces.
+- Paid-operation accounting survived the restart and failed closed before an
+  over-cap recovery could create a child or reach a provider.
+
+## What remains open
+
+Paid same-revision reuse is still unmeasured. A future, separately authorized
+follow-up could resume this existing failed source after the UTC ledger resets,
+provided production still runs the exact same revision and the protocol is
+frozen separately. It must not be described as a retry of this non-pass or as
+evidence that the source cost was below the stop.
+
+This result does not support exactly-once execution, token/cost/latency savings,
+a Railway recovery rate or SLO, report correctness, or six-stage necessity.

--- a/src/academic_agent/checkpoint_runtime.py
+++ b/src/academic_agent/checkpoint_runtime.py
@@ -43,6 +43,7 @@ from academic_agent.checkpoints import (
     hash_json,
     hash_text,
 )
+from academic_agent.evidence import EvidenceReport, validate_evidence_report
 from academic_agent.run_spec import RunSpec
 
 
@@ -55,6 +56,11 @@ TASK_NODES: Final[tuple[NodeId, ...]] = (
     "scorer",
 )
 _ALL_NODES: Final[tuple[NodeId, ...]] = ("retrieval", *TASK_NODES)
+_EVIDENCE_PREFIXES: Final[dict[NodeId, str]] = {
+    "academic": "A",
+    "patent": "P",
+    "market": "M",
+}
 _OUTPUT_FORMATS: Final[dict[NodeId, OutputFormat]] = {
     "retrieval": "json",
     "academic": "json",
@@ -258,6 +264,19 @@ def _validated_payload(text: str, output_format: OutputFormat) -> bool:
     return True
 
 
+def _restore_evidence_report(node: NodeId, text: str) -> EvidenceReport | None:
+    """Rebuild only the typed values attached by live evidence guardrails."""
+
+    prefix = _EVIDENCE_PREFIXES.get(node)
+    if prefix is None:
+        return None
+
+    report = EvidenceReport.model_validate_json(text)
+    if validate_evidence_report(report, prefix):
+        raise ValueError("restored evidence failed post-guardrail validation")
+    return report
+
+
 class CheckpointRuntime:
     """Commit validated task outputs and hydrate a safe prior-run prefix."""
 
@@ -391,19 +410,28 @@ class CheckpointRuntime:
                         "reasons": ["payload_format"],
                     }
                     break
+                try:
+                    pydantic_output = _restore_evidence_report(node, text)
+                except ValueError:
+                    self._inspections[node] = {
+                        "state": "corrupt",
+                        "reasons": ["payload_schema"],
+                    }
+                    break
 
                 task.output = TaskOutput(
                     description=str(getattr(task, "description", "")),
                     expected_output=str(getattr(task, "expected_output", "")),
                     raw=text,
                     agent=str(getattr(getattr(task, "agent", None), "role", "")),
+                    pydantic=pydantic_output,
                 )
-                # CrewAI Task has no output_format before execution in 1.14.7,
-                # and these production tasks consume exact post-guardrail raw
-                # text. Inferring CrewAI JSON from the checkpoint's storage
-                # format would make TaskOutput.__str__ prefer json_dict and
-                # change the downstream context bytes. RAW is its default and
-                # faithfully preserves the validated text.
+                # CrewAI 1.14.7 aggregates ``TaskOutput.raw`` for model context,
+                # so attaching the same typed object created by the live evidence
+                # guardrail does not alter prompt bytes. The deterministic Writer
+                # guardrail reads ``pydantic`` instead: raw-only hydration would
+                # reuse checkpoints yet reject both paid Writer attempts as having
+                # no validated sources.
                 self._output_hashes[node] = inspection.manifest.output_sha256
                 self._reused.append(node)
                 self._reused_prefix += 1

--- a/tests/test_checkpoint_runtime.py
+++ b/tests/test_checkpoint_runtime.py
@@ -22,6 +22,12 @@ from pydantic import BaseModel
 
 from academic_agent.checkpoint_runtime import CheckpointRuntime, TASK_NODES
 from academic_agent.checkpoints import CheckpointStore
+from academic_agent.evidence import (
+    EvidenceFinding,
+    EvidenceReport,
+    EvidenceSource,
+    make_final_report_guardrail,
+)
 from academic_agent.run_spec import RunSpec
 
 
@@ -43,12 +49,58 @@ class _ExplodingLLM(BaseLLM):
         raise AssertionError("provider must not be called for a hydrated task")
 
 
-def _task_output(node: str) -> TaskOutput:
-    raw = (
-        json.dumps({"node": node, "finding": "validated"}, sort_keys=True)
-        if node in {"academic", "patent", "market", "scorer"}
-        else f"# {node.title()}\n\nValidated output."
+def _evidence_report(prefix: str) -> EvidenceReport:
+    """Build the post-guardrail shape persisted by a production evidence task."""
+
+    sources = [
+        EvidenceSource(
+            source_id=f"{prefix}{index}",
+            title=f"Checkpoint source {prefix}{index}",
+            url=f"https://records.test-domain.org/{prefix.lower()}{index}",
+            publisher="Research Publisher",
+            published_date=date(2026, 1, index),
+            accessed_date=_TEST_DATE,
+            source_type="academic_paper",
+            evidence_summary=(
+                "This source directly supports the corresponding finding with "
+                "relevant experimental data and reported measurements."
+            ),
+        )
+        for index in range(1, 4)
+    ]
+    findings = [
+        EvidenceFinding(
+            finding_id=f"{prefix}F{index}",
+            category="technology maturity",
+            claim=(
+                "A sufficiently detailed and externally supportable research "
+                f"conclusion for checkpoint case {index}."
+            ),
+            claim_type="observed_fact",
+            source_ids=[f"{prefix}{index}"],
+            confidence="high",
+            commercial_implication="This affects the commercialization pathway.",
+        )
+        for index in range(1, 4)
+    ]
+    return EvidenceReport(
+        topic="Checkpoint recovery test",
+        scope_summary="A bounded review of technical maturity and published evidence.",
+        search_queries=["checkpoint recovery commercial maturity"],
+        findings=findings,
+        sources=sources,
+        limitations=["Publicly available evidence may omit private deployments."],
     )
+
+
+def _task_output(node: str) -> TaskOutput:
+    if node in {"academic", "patent", "market"}:
+        prefix = {"academic": "A", "patent": "P", "market": "M"}[node]
+        raw = _evidence_report(prefix).model_dump_json()
+    elif node == "scorer":
+        raw = json.dumps({"node": node, "finding": "validated"}, sort_keys=True)
+    else:
+        raw = f"# {node.title()}\n\nValidated output."
     output_format = (
         CrewOutputFormat.JSON if node in {"academic", "patent", "market", "scorer"} else CrewOutputFormat.RAW
     )
@@ -227,6 +279,86 @@ def test_runtime_restores_and_republishes_only_the_validated_prefix(
     assert runtime.snapshot()["recovery"]["reused_nodes"] == ["academic", "patent", "market", "writer"]
     for node in TASK_NODES[:4]:
         assert (child_run / "checkpoints" / node / "manifest.json").is_file()
+
+
+def test_restored_evidence_reaches_the_real_writer_guardrail(tmp_path: Path) -> None:
+    """Catch raw-only hydration that charged Writer but hid all source objects.
+
+    CrewAI sends ``TaskOutput.raw`` to the model, while the deterministic Writer
+    guardrail intentionally trusts only ``TaskOutput.pydantic``. A production
+    resume reused three valid evidence checkpoints but restored only their raw
+    JSON, so Writer made two paid calls before both attempts were rejected as
+    having no validated sources. Exercising the real guardrail proves the
+    typed value crosses the recovery seam instead of merely existing on disk.
+    """
+
+    source_run = tmp_path / "source"
+    source, retrieval_sha256 = _seed_validated_prefix(source_run, count=3)
+    tasks = _fake_tasks()
+    runtime = _runtime(
+        tmp_path / "child",
+        tasks=tasks,
+        source=source,
+        retrieval_sha256=retrieval_sha256,
+        resume_directory=source_run,
+    )
+
+    reused = runtime.restore_contiguous_prefix()
+    success, message = make_final_report_guardrail(tasks[:3])(
+        TaskOutput(
+            description="writer description",
+            expected_output="writer expected",
+            raw="Too short",
+            agent="writer agent",
+        )
+    )
+
+    assert reused == 3
+    assert success is False
+    assert message == "Final report is too short to be usable."
+    assert all(
+        isinstance(task.output.pydantic, EvidenceReport) for task in tasks[:3]
+    )
+
+
+def test_schema_invalid_evidence_checkpoint_stops_reuse(tmp_path: Path) -> None:
+    """Treat valid JSON without the post-guardrail schema as corrupt."""
+
+    source_run = tmp_path / "source"
+    source, retrieval_sha256 = _seed_validated_prefix(source_run, count=0)
+    source_runtime = _runtime(
+        source_run,
+        tasks=_fake_tasks(),
+        source=source,
+        retrieval_sha256=retrieval_sha256,
+    )
+    source_runtime.install_task_callbacks()
+    callback = source_runtime.tasks[0].callback
+    assert callback is not None
+    callback(
+        TaskOutput(
+            description="academic description",
+            expected_output="academic expected",
+            raw=json.dumps({"node": "academic", "finding": "not a report"}),
+            agent="academic agent",
+        )
+    )
+
+    tasks = _fake_tasks()
+    runtime = _runtime(
+        tmp_path / "child",
+        tasks=tasks,
+        source=source,
+        retrieval_sha256=retrieval_sha256,
+        resume_directory=source_run,
+    )
+
+    reused = runtime.restore_contiguous_prefix()
+    recovery = runtime.snapshot()["recovery"]
+
+    assert reused == 0
+    assert recovery["inspections"]["academic"]["state"] == "corrupt"
+    assert recovery["inspections"]["academic"]["reasons"] == ["payload_schema"]
 
 
 def test_first_mismatch_stops_before_a_later_reusable_checkpoint(

--- a/tests/test_checkpoint_worker.py
+++ b/tests/test_checkpoint_worker.py
@@ -15,7 +15,11 @@ from crewai.tasks.task_output import OutputFormat as CrewOutputFormat
 from crewai.tasks.task_output import TaskOutput
 
 from academic_agent.checkpoint_runtime import TASK_NODES
-from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence import (
+    EvidenceFinding,
+    EvidenceReport,
+    EvidenceSource,
+)
 from academic_agent.run_spec import RESUME_SNAPSHOT_DIRECTORY
 from academic_agent.source_pipeline import SourceCollection
 
@@ -48,12 +52,58 @@ def _source_collection() -> SourceCollection:
     )
 
 
-def _output(node: str) -> TaskOutput:
-    raw = (
-        json.dumps({"node": node, "findings": []}, sort_keys=True)
-        if node in {"academic", "patent", "market", "scorer"}
-        else f"# {node.title()}\n\nValidated checkpoint report."
+def _evidence_output(prefix: str) -> str:
+    """Return the post-guardrail JSON shape required by typed recovery."""
+    source_id = f"{prefix}1"
+    source_types = {
+        "A": "academic_paper",
+        "P": "patent",
+        "M": "market_report",
+    }
+    source = EvidenceSource(
+        source_id=source_id,
+        title=f"Deterministic checkpoint source {source_id}",
+        url=f"https://example.com/checkpoint-{source_id.lower()}",
+        publisher="Example Research Institute",
+        published_date=date(2026, 1, 10),
+        accessed_date=date(2026, 8, 23),
+        source_type=source_types[prefix],
+        evidence_summary=(
+            "This deterministic source summary represents already validated "
+            "evidence at the offline checkpoint worker boundary."
+        ),
     )
+    findings = [
+        EvidenceFinding(
+            finding_id=f"{prefix}F{index}",
+            category="technology maturity",
+            claim="A deterministic checkpoint finding that remains supportable.",
+            claim_type="observed_fact",
+            source_ids=[source_id],
+            confidence="high",
+            commercial_implication="This affects the commercialization pathway.",
+        )
+        for index in range(1, 4)
+    ]
+    report = EvidenceReport(
+        topic="solid-state battery recycling",
+        scope_summary="A bounded deterministic review for checkpoint recovery.",
+        search_queries=["solid-state battery recycling commercial maturity"],
+        findings=findings,
+        sources=[source],
+        limitations=["The fixture replaces every external provider boundary."],
+    )
+    return report.model_dump_json()
+
+
+def _output(node: str) -> TaskOutput:
+    if node in {"academic", "patent", "market"}:
+        prefix = {"academic": "A", "patent": "P", "market": "M"}[node]
+        raw = _evidence_output(prefix)
+    elif node == "scorer":
+        raw = json.dumps({"node": node, "findings": []}, sort_keys=True)
+    else:
+        raw = f"# {node.title()}\n\nValidated checkpoint report."
     return TaskOutput(
         description=f"{node} description",
         expected_output=f"{node} expected",


### PR DESCRIPTION
## Why

The offline recovery audit passed 30/30 units, but the first paid Railway
follow-up crossed a deployment revision and correctly reused zero nodes. PR
#27 records two pre-registered same-revision production canaries, the seam they
exposed, and the subsequent typed-hydration repair. It does not change scoring,
prompts, retrieval, or the pinned CrewAI version.

## Production evidence

### Canary 1 — recovery admission blocked

**NON-PASS.** The source reached and retained an exact four-node checkpoint
prefix across a same-revision Railway restart. Its only recovery request was
rejected by that owner's three-operation daily paid cap before child creation
or provider work.

- [Protocol](docs/prereg-2026-08-24-paid-same-revision-recovery.md)
- [Result](docs/results-2026-08-24-paid-same-revision-recovery.md)

### Canary 2 — reuse worked, typed context did not

An independent protocol froze one new source and one child on the same
`f9e3b611779af1e3148cad1d5552758bd67ea274` production revision.

**NON-PASS for end-to-end recovery, with a narrower reuse result:**

- The immutable child reported `recovery.state=reused` for retrieval,
  academic, patent, and market, with `next_node=writer`.
- Source and child output hashes matched for every reused node.
- Academic, patent, and market agents made **0 new child requests**.
- The child made two Writer requests, using 31,642 tokens at an estimated
  $0.014576, then failed the report guardrail.
- Interrupted-source usage remained `null`, so total cost is
  `not_inspectable` and no savings claim is made.

The failure exposed a missing seam: live evidence guardrails attach validated
`EvidenceReport` objects to `TaskOutput.pydantic`, while recovery restored only
`TaskOutput.raw`. The report guardrail deliberately reads typed evidence to
build its allowed-source registry, so both Writer attempts were rejected with
no validated evidence context.

- [Follow-up protocol](docs/prereg-2026-08-24-paid-same-revision-recovery-follow-up.md)
- [Frozen follow-up result](docs/results-2026-08-24-paid-same-revision-recovery-follow-up.md)
- [Recovery contract](docs/checkpoint-recovery.md)

## Repair

- Reconstruct `EvidenceReport` only for reused academic, patent, and market
  checkpoints, matching the types attached by their live guardrails.
- Repeat both Pydantic schema validation and the existing node-prefix
  evidence-integrity checks before attaching the typed value.
- Preserve the checkpoint text in `TaskOutput.raw`; CrewAI 1.14.7 continues to
  receive the same model-context bytes.
- Report schema-invalid evidence JSON as `corrupt` with `payload_schema` and
  stop contiguous reuse instead of trusting raw-only evidence.

## Regression evidence

- A real Writer-guardrail seam test restores three production-shaped evidence
  reports and reaches the guardrail's short-report check.
- Removing the typed assignment temporarily reproduces the exact
  no-validated-sources failure; restoring it returns the test to green.
- A separate regression proves schema-invalid JSON fails closed.
- The worker restart and hard-kill process doubles now emit post-guardrail
  evidence shapes while retaining their strict skipped-node assertions.

## Claim boundary

The frozen production result remains a non-pass. No retry, replacement source,
access-code substitution, BYOK bypass, or post-hoc criterion change was used.
The repair has zero-network seam evidence only; end-to-end paid recovery remains
open until a separately pre-registered post-fix child completes the Writer,
Reviewer, and Scorer suffix.

## Verification

- `uv run pytest -q` — 1,341 passed, 578 subtests passed
- `uv run --with ruff ruff check .` — all checks passed
- CI-equivalent narrow Pylint safety checks — passed
- Both temporary Railway SSH keys were revoked and both local key pairs deleted
