### PR TITLE
Add a zero-call evidence-gap shadow planning contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,17 @@ SERPER_API_KEY=your-serper-key-here
 # OTEL_EXPORTER_OTLP_HEADERS is a lower-level authentication-header alternative,
 # not a collector endpoint. Prefer PHOENIX_API_KEY for this Phoenix adapter.
 
+# ── Optional: evidence-gap shadow eligibility audit ───────────────────────────
+# Phase 1 only. When enabled, the worker records whether existing validated
+# evidence has an explicit authority, component, or failed-domain gap. It does
+# not call a planner model, execute a search tool, alter sources, or spend extra
+# provider budget. Unknown values are reported as a failed check rather than
+# silently treated as disabled. See the frozen protocol in
+# docs/prereg-2026-08-25-evidence-gap-shadow-planner.md.
+# EVIDENCE_GAP_SHADOW_ENABLED=false
+
+# A production evidence-gap tool executor does not exist in phase 1.
+
 # ── Legacy variable names (still accepted as fallbacks) ───────────────────────
 # OPENAI_API_KEY / OPENAI_API_BASE / OPENAI_MODEL_NAME all map to DeepSeek
 # when LLM_PROVIDER=deepseek, for backward compatibility with older setups.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1369 tests (592 subtests), CI green on Linux + Windows × Python
+Current state: 1370 tests (592 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1341 tests (578 subtests), CI green on Linux + Windows × Python
+Current state: 1369 tests (592 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -345,6 +345,18 @@ identity, authorization, failure, and observability contract.
 
 The scorecard (`commercialization_scores.json`) additionally contains: TRL score, patent strength, market accessibility, evidence confidence, overall score, key risks, and key opportunities.
 
+**Evidence-gap planning is currently phase-1 shadow instrumentation, not
+production Tool Calling.** With `EVIDENCE_GAP_SHADOW_ENABLED=true`, retrieval
+records whether explicit authority, compound-component, or failed-domain gaps
+make the run eligible for later planning. It invokes no planner model, executes
+zero supplementary searches, does not change `validated_sources.json`, and
+surfaces disabled / checked / failed states separately. The strict proposal
+schema, two-intent ceiling, trigger authorization and local idempotency keys are
+implemented for offline injection tests only. Reproduce the 30-run zero-network
+mechanics audit with `uv run python evidence_gap_audit.py outputs/benchmark
+outputs/evidence-gap-shadow-phase1 --expected-count 30`; see the
+[frozen protocol](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md).
+
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
 ---
@@ -540,6 +552,7 @@ outputs/
     ├── academic_evidence.json         # Task 1 findings, with source IDs and claim types
     ├── patent_evidence.json           # Task 2 findings
     ├── market_evidence.json           # Task 3 findings
+    ├── evidence_gap_shadow.json       # Zero-call gap eligibility audit (phase 1)
     ├── reviewer_notes.md              # Reviewer change log (separated from main report)
     ├── status.json                    # Pipeline stage + source counts (polled by UI)
     └── steps.jsonl                    # Per-agent step events (polled for live progress)
@@ -1218,6 +1231,16 @@ Step 6     Agent 6 — 量化评分（独立于报告；公式自动修正）
 
 评分卡（`commercialization_scores.json`）额外包含：TRL 评分、专利强度、市场可及性、证据置信度、综合评分、关键风险和机遇列表。
 
+**证据缺口规划目前仅为第一阶段影子观测，并非已上线的 Tool Calling。** 设置
+`EVIDENCE_GAP_SHADOW_ENABLED=true` 后，检索层只记录当前证据是否存在明确的
+权威来源、复合组件或失败领域缺口；它不会调用 Planner 模型，不会追加搜索，
+不会改变 `validated_sources.json`，并将“关闭 / 已检查 / 检查失败”分别呈现。
+严格 Proposal Schema、最多两个意图、触发授权和本地幂等键目前只供离线注入
+测试。可用 `uv run python evidence_gap_audit.py outputs/benchmark
+outputs/evidence-gap-shadow-phase1 --expected-count 30` 复现 30 次零网络机制审计；
+设计边界与后续上线阈值见
+[冻结协议](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md)。
+
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 
 ---
@@ -1389,6 +1412,7 @@ outputs/
     ├── academic_evidence.json        # Task 1 的发现，含来源 ID 与论断类型
     ├── patent_evidence.json          # Task 2 的发现
     ├── market_evidence.json          # Task 3 的发现
+    ├── evidence_gap_shadow.json      # 零调用证据缺口资格审计（第一阶段）
     ├── reviewer_notes.md             # 审查员修改记录（与正文分离）
     ├── status.json                   # 流水线阶段 + 来源数量（UI 轮询用）
     └── steps.jsonl                   # 每个 Agent 的步骤事件（实时进度用）

--- a/api/main.py
+++ b/api/main.py
@@ -815,6 +815,7 @@ def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgres
         claim_grounding=state.get("claim_grounding"),
         authority_coverage=state.get("authority_coverage"),
         component_coverage=state.get("component_coverage"),
+        evidence_gap_shadow=state.get("evidence_gap_shadow"),
         quality_review=state.get("quality_review"),
         consistency=state.get("consistency"),
         observability=state.get("observability"),

--- a/api/models.py
+++ b/api/models.py
@@ -195,6 +195,12 @@ class RunProgress(BaseModel):
         description="Coverage of independently searchable components in a combined "
                     "system. Incomplete is advisory and never proves absence.",
     )
+    evidence_gap_shadow: dict | None = Field(
+        default=None,
+        description="Zero-call phase-1 evidence-gap eligibility audit. States "
+                    "distinguish disabled, checked, and failed evaluation; no "
+                    "supplementary search is executed.",
+    )
     quality_review: dict | None = Field(
         default=None,
         description="Whether the independent reviewer completed. 'fallback' means "
@@ -287,6 +293,12 @@ class RunStatus(BaseModel):
         default=None,
         description="Coverage of independently searchable components in a combined "
                     "system. Incomplete is advisory and never proves absence.",
+    )
+    evidence_gap_shadow: dict | None = Field(
+        default=None,
+        description="Zero-call phase-1 evidence-gap eligibility audit. States "
+                    "distinguish disabled, checked, and failed evaluation; no "
+                    "supplementary search is executed.",
     )
     quality_review: dict | None = Field(
         default=None,

--- a/api/runs.py
+++ b/api/runs.py
@@ -120,6 +120,7 @@ _ARTIFACTS = {
     # Present only when collection failed before validated_sources.json could
     # exist; preserves the search plan, candidate counts, and rejection audit.
     "retrieval": "retrieval_diagnostics.json",
+    "gap-shadow": "evidence_gap_shadow.json",
 }
 
 
@@ -1184,6 +1185,10 @@ def get_state(run_id: str) -> dict:
         # while silently missing another. This advisory field exposes that
         # bounded-set coverage without turning it into an absence claim.
         "component_coverage": status.get("component_coverage"),
+        # Zero-call phase-1 eligibility audit. None means the run predates the
+        # feature; disabled, checked, and failed states remain explicit inside
+        # the object so an unperformed planner never reads as a passing check.
+        "evidence_gap_shadow": status.get("evidence_gap_shadow"),
 
         # Review is a separate model pass after the draft's deterministic
         # validation. A fallback remains a completed run, but it must not look

--- a/docs/prereg-2026-08-25-evidence-gap-shadow-planner.md
+++ b/docs/prereg-2026-08-25-evidence-gap-shadow-planner.md
@@ -1,0 +1,110 @@
+# Evidence-gap shadow planner — phase 1 pre-registration
+
+**Frozen:** 2026-08-25, before the phase-1 implementation was written
+**Production evidence changes authorized:** no
+**LLM or search calls authorized by this phase:** no
+
+## Question
+
+Can the existing deterministic retrieval diagnostics identify a small,
+auditable set of runs that are eligible for a later evidence-gap planner,
+without changing accepted sources, adding provider calls, or presenting an
+unperformed check as a pass?
+
+This phase does **not** test whether an LLM can choose a useful tool call and
+does **not** test whether supplementary retrieval improves a report. It builds
+the contract and observation seam needed to measure those questions later.
+
+## Development-set observation disclosed in advance
+
+The 30 stored calibration runs were inspected before this pre-registration, so
+they are a development set, not a held-out evaluation set. Under the current
+coverage functions:
+
+- academic source count: minimum 3, median 6, maximum 8;
+- patent source count: 8 in every run;
+- market source count: minimum 4, median 8, maximum 8;
+- no run has a failed retrieval domain;
+- component coverage is complete in 30/30 runs; and
+- authority coverage is incomplete in 9/30 runs, consisting of three
+  biomedical topics repeated three times.
+
+The nine authority cases come from older evidence collections that lack both
+regulator and clinical-registry records. Current retrieval already issues
+bounded FDA, EMA, and ClinicalTrials.gov queries. A future planner merely
+rediscovering those same queries is duplication, not evidence of value.
+
+## Frozen phase-1 gate
+
+A successfully collected `SourceCollection` is eligible only for one or more
+of these high-precision signals:
+
+1. an explicitly required authority category is missing;
+2. a discriminating compound-topic component is explicitly `incomplete`; or
+3. a known retrieval domain is recorded in `failed_domains`.
+
+The following do **not** make a run eligible:
+
+- source count alone;
+- `partial` or `unchecked` component coverage;
+- a non-applicable authority check;
+- an unknown failed-domain label; or
+- a fatal pre-collection academic shortage, because no `SourceCollection`
+  exists at this seam. A separate pre-collection recovery design would be
+  required for that case.
+
+## Phase-1 behaviour
+
+- The feature is disabled unless `EVIDENCE_GAP_SHADOW_ENABLED=true` (or an
+  equivalent explicit truthy value) is set.
+- Disabled, checked-with-no-gap, eligible, and failed evaluation are distinct
+  states.
+- The production worker records only eligibility. It does not invoke a planner
+  model and does not execute a search tool.
+- A strict Pydantic proposal contract allows at most two read-only search
+  intents. A proposal is valid only when every intent refers to a real trigger
+  and uses a tool authorized for that trigger.
+- Valid proposals receive deterministic idempotency keys derived from the
+  source-collection hash, tool, normalized query, result bound, and trigger
+  ids. This suppresses local duplicate intents; it is not a claim of network
+  exactly-once execution.
+- An eligible run may produce `search` or `abstain`; `no_gap` is reserved for a
+  gate with no signals. Planner parse/validation failure is recorded as
+  `failed`, never as `no_gap`.
+- The audit records zero executed calls, zero added search cost, and whether
+  the source-collection hash changed. Any mutation fails the phase-1 audit.
+- The audit artifact and both run-status endpoints carry the same state. A
+  missing artifact is not silently described as persisted.
+
+## Phase-1 acceptance checks
+
+The implementation qualifies for merge only if all of the following pass:
+
+1. the existing zero-network suite and Ruff remain green;
+2. strict schema tests reject unknown fields, a third intent, duplicate
+   intents, invented trigger ids, and unauthorized tool/trigger pairs;
+3. a planner exception is exposed as `planner_state=failed`;
+4. runtime-disabled mode and runtime-enabled eligibility both make zero tool
+   calls and do not mutate evidence;
+5. the API status and progress endpoints return the same shadow state;
+6. the frozen 30-run audit loads exactly 30 collections, is deterministic,
+   executes zero calls, and leaves every input hash unchanged; and
+7. a deliberate reintroduction of one contract defect makes its targeted test
+   fail before the defect is removed.
+
+## Criteria reserved for phase 2
+
+No production tool adapter is authorized by this document. Before one is
+connected, a separately frozen challenge set and planner run must report:
+
+- trigger precision of at least 90%;
+- at most two **actual outbound requests**, not merely two logical tool names;
+- zero invalid, unregistered, or policy-rejected sources entering evidence;
+- wrong-source rate no greater than 5%;
+- novel validated evidence in at least 50% of triggered cases;
+- complete incremental latency, token, search-cost, rejection, and trace
+  accounting; and
+- no regression to the existing 30-run calibration outputs when the feature is
+  disabled.
+
+Those thresholds are future falsification criteria, not current results.

--- a/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
+++ b/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
@@ -1,0 +1,71 @@
+# Evidence-gap shadow planner — phase 1 result
+
+**Run date:** 2026-08-25
+**Protocol:** [phase-1 pre-registration](prereg-2026-08-25-evidence-gap-shadow-planner.md)
+**Network, LLM, and search calls:** 0
+
+## Result
+
+The zero-network replay loaded exactly 30 stored benchmark source collections
+and passed every phase-1 mechanics check:
+
+| Measure | Observed |
+|---|---:|
+| Collections checked | 30/30 |
+| Eligible | 9 |
+| No explicit gap | 21 |
+| Deterministic second pass | 30/30 identical |
+| Tool calls executed | 0 |
+| Input or evidence mutations | 0 |
+| Failed checks | 0 |
+
+The nine eligible collections contained 18
+`authority_category_missing` signals: the three older biomedical benchmark
+topics, each repeated three times, lacked both regulator and
+clinical-registry records. No component or failed-domain signal occurred in
+this development set.
+
+Command:
+
+```bash
+uv run python evidence_gap_audit.py outputs/benchmark \
+  outputs/evidence-gap-shadow-phase1-20260825 --expected-count 30
+```
+
+The generated `result.json` retains every fixture SHA-256 and `cases.csv`
+retains every decision. The directory is intentionally under ignored
+`outputs/`: it contains a local replay artifact, while this result record and
+the executable checker travel with the repository.
+
+## Verification
+
+- Full zero-network suite: **1,369 passed and 592 subtests passed**.
+- CI-equivalent coverage: **86.92%**, above the frozen 85% threshold.
+- Latest Ruff and the CI-specific Pylint exception-order checks passed.
+- A deliberate change from the two-intent ceiling to three made the targeted
+  contract test fail; restoring the ceiling made it pass again. This confirms
+  that the test detects the original boundary rather than merely exercising
+  the happy path.
+
+## What this establishes
+
+- The feature can distinguish disabled, checked-with-no-gap, eligible, and
+  failed states.
+- The runtime observation path adds no planner or search request.
+- Strict proposals cannot exceed two intents or reference invented and
+  unauthorized triggers.
+- The eligibility value reaches both HTTP status boundaries and a downloadable
+  per-run artifact.
+
+## What this does not establish
+
+This is the same stored evidence that informed gate development. It is not a
+held-out trigger-precision result, not evidence that supplementary search adds
+useful sources, and not evidence that Tool Calling improves a report. Current
+retrieval already sends FDA, EMA, and ClinicalTrials.gov queries for applicable
+new runs, so repeating those queries later would not count as novel evidence.
+
+Production planner-model invocation and tool execution remain disabled. Phase
+2 requires a separately frozen challenge set and must meet the precision,
+source-validity, evidence-increment, cost, latency, and tracing thresholds in
+the pre-registration before any production adapter is connected.

--- a/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
+++ b/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
@@ -39,13 +39,16 @@ the executable checker travel with the repository.
 
 ## Verification
 
-- Full zero-network suite: **1,369 passed and 592 subtests passed**.
+- Full zero-network suite: **1,370 passed and 592 subtests passed**.
 - CI-equivalent coverage: **86.92%**, above the frozen 85% threshold.
 - Latest Ruff and the CI-specific Pylint exception-order checks passed.
 - A deliberate change from the two-intent ceiling to three made the targeted
   contract test fail; restoring the ceiling made it pass again. This confirms
   that the test detects the original boundary rather than merely exercising
   the happy path.
+- The CI-caught Sydney/UTC fixture defect was reintroduced; the dedicated
+  regression test failed under a simulated UTC date and passed after the
+  historical fixture date was restored.
 
 ## What this establishes
 

--- a/evidence_gap_audit.py
+++ b/evidence_gap_audit.py
@@ -1,0 +1,237 @@
+"""Audit the phase-1 evidence-gap gate over frozen source collections.
+
+The command is zero-network: it reads existing ``validated_sources.json``
+files, refreshes coverage diagnostics on a copy for legacy fixtures, and
+writes every gate decision. It never invokes a planner or a search adapter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from academic_agent.evidence_gap import (
+    EvidenceGapShadowAudit,
+    parse_shadow_configuration,
+    refresh_coverage_for_offline_audit,
+    run_shadow_assessment,
+    source_collection_sha256,
+)
+from academic_agent.source_pipeline import SourceCollection
+
+
+CASE_FIELDS = (
+    "fixture",
+    "fixture_sha256",
+    "topic",
+    "academic_sources",
+    "patent_sources",
+    "market_sources",
+    "authority_status",
+    "component_status",
+    "gate_state",
+    "signal_count",
+    "signal_codes",
+    "signal_subjects",
+    "executed_call_count",
+    "evidence_changed",
+)
+
+
+class EvidenceGapAuditError(ValueError):
+    """Raised when an audit would describe a partial or drifting fixture set."""
+
+
+def discover_collections(fixtures: Path) -> list[Path]:
+    """Return one-level benchmark collections, excluding nested test artifacts."""
+
+    paths = sorted(fixtures.glob("*/validated_sources.json"))
+    if not paths:
+        raise EvidenceGapAuditError(
+            f"no validated source collections found directly under {fixtures}"
+        )
+    return paths
+
+
+def _read_collection(path: Path) -> tuple[SourceCollection, str]:
+    try:
+        payload = path.read_bytes()
+        collection = SourceCollection.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise EvidenceGapAuditError(f"could not load {path}: {exc}") from exc
+    return collection, hashlib.sha256(payload).hexdigest()
+
+
+def _case_row(
+    fixtures: Path,
+    path: Path,
+    fixture_sha256: str,
+    collection: SourceCollection,
+    audit: EvidenceGapShadowAudit,
+) -> dict[str, Any]:
+    context = audit.context
+    if context is None:
+        raise EvidenceGapAuditError(f"enabled audit produced no context for {path}")
+    return {
+        "fixture": path.parent.relative_to(fixtures).as_posix(),
+        "fixture_sha256": fixture_sha256,
+        "topic": collection.topic,
+        "academic_sources": context.source_counts["academic"],
+        "patent_sources": context.source_counts["patent"],
+        "market_sources": context.source_counts["market"],
+        "authority_status": collection.authority_coverage.status,
+        "component_status": collection.component_coverage.status,
+        "gate_state": audit.gate_state,
+        "signal_count": len(context.signals),
+        "signal_codes": "|".join(signal.code for signal in context.signals),
+        "signal_subjects": "|".join(signal.subject for signal in context.signals),
+        "executed_call_count": audit.executed_call_count,
+        "evidence_changed": audit.evidence_changed,
+    }
+
+
+def evaluate_collections(
+    fixtures: Path,
+    *,
+    expected_count: int | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Run the frozen gate twice and prove its zero-call result is deterministic."""
+
+    paths = discover_collections(fixtures)
+    if expected_count is not None and len(paths) != expected_count:
+        raise EvidenceGapAuditError(
+            f"fixture count is {len(paths)}, expected exactly {expected_count}"
+        )
+
+    enabled = parse_shadow_configuration("true")
+    rows: list[dict[str, Any]] = []
+    deterministic = True
+    input_mutation_count = 0
+    fixture_manifest: list[dict[str, str]] = []
+    for path in paths:
+        original, fixture_sha256 = _read_collection(path)
+        original_hash_before = source_collection_sha256(original)
+        refreshed = refresh_coverage_for_offline_audit(original)
+        first = run_shadow_assessment(refreshed, configuration=enabled)
+        second = run_shadow_assessment(refreshed, configuration=enabled)
+        deterministic = deterministic and first.model_dump() == second.model_dump()
+        if source_collection_sha256(original) != original_hash_before:
+            input_mutation_count += 1
+        rows.append(_case_row(fixtures, path, fixture_sha256, refreshed, first))
+        fixture_manifest.append(
+            {
+                "fixture": path.parent.relative_to(fixtures).as_posix(),
+                "sha256": fixture_sha256,
+            }
+        )
+
+    states = Counter(str(row["gate_state"]) for row in rows)
+    signals = Counter(
+        code
+        for row in rows
+        for code in str(row["signal_codes"]).split("|")
+        if code
+    )
+    executed_calls = sum(int(row["executed_call_count"]) for row in rows)
+    evidence_changes = sum(bool(row["evidence_changed"]) for row in rows)
+    checks = [
+        {
+            "name": "loaded_expected_fixture_count",
+            "passed": expected_count is None or len(rows) == expected_count,
+            "observed": len(rows),
+            "requirement": (
+                "at least one" if expected_count is None else f"exactly {expected_count}"
+            ),
+        },
+        {
+            "name": "deterministic_repeat",
+            "passed": deterministic,
+            "observed": deterministic,
+            "requirement": True,
+        },
+        {
+            "name": "zero_tool_calls_executed",
+            "passed": executed_calls == 0,
+            "observed": executed_calls,
+            "requirement": 0,
+        },
+        {
+            "name": "zero_input_mutations",
+            "passed": input_mutation_count == 0 and evidence_changes == 0,
+            "observed": input_mutation_count + evidence_changes,
+            "requirement": 0,
+        },
+        {
+            "name": "every_fixture_checked",
+            "passed": states["eligible"] + states["no_gap"] == len(rows),
+            "observed": states["eligible"] + states["no_gap"],
+            "requirement": len(rows),
+        },
+    ]
+    result = {
+        "schema_version": 1,
+        "protocol": "evidence-gap-shadow-phase-1",
+        "measurement_design": "retrospective_development_set_not_held_out",
+        "fixture_count": len(rows),
+        "gate_states": dict(sorted(states.items())),
+        "signal_counts": dict(sorted(signals.items())),
+        "executed_call_count": executed_calls,
+        "input_mutation_count": input_mutation_count,
+        "checks": checks,
+        "passed": all(check["passed"] for check in checks),
+        "production_tool_calls_authorized": False,
+        "fixture_manifest": fixture_manifest,
+        "measurement_limit": (
+            "The same stored collections informed gate development. This audit "
+            "tests deterministic zero-call mechanics, not trigger precision or "
+            "supplementary evidence value."
+        ),
+    }
+    return result, rows
+
+
+def write_audit(
+    output: Path,
+    result: dict[str, Any],
+    rows: list[dict[str, Any]],
+) -> None:
+    """Write aggregate and case-level evidence without overwriting a prior audit."""
+
+    if output.exists():
+        raise EvidenceGapAuditError(f"refusing to overwrite audit output: {output}")
+    output.mkdir(parents=True)
+    (output / "result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    with (output / "cases.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CASE_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixtures", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--expected-count", type=int, default=None)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    result, rows = evaluate_collections(
+        args.fixtures,
+        expected_count=args.expected_count,
+    )
+    write_audit(args.output, result, rows)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/academic_agent/evidence_gap.py
+++ b/src/academic_agent/evidence_gap.py
@@ -1,0 +1,609 @@
+"""Zero-call contracts for the evidence-gap planner's shadow phase.
+
+Phase 1 deliberately stops before model planning or supplementary retrieval.
+It records whether an already validated ``SourceCollection`` contains one of a
+small number of explicit gaps, and it validates proposed search intents when a
+test or offline experiment injects a planner.  The production worker never
+injects one in this phase, so enabling the feature adds no provider request and
+cannot change the evidence sent to the six-stage workflow.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from academic_agent.source_pipeline import SourceCollection
+
+
+EVIDENCE_GAP_SHADOW_ENV = "EVIDENCE_GAP_SHADOW_ENABLED"
+EVIDENCE_GAP_SHADOW_FILENAME = "evidence_gap_shadow.json"
+EVIDENCE_GAP_SCHEMA_VERSION = 1
+MAX_GAP_TOOL_CALLS = 2
+
+EvidenceDomain = Literal["academic", "patent", "market"]
+GapScope = Literal["academic", "patent", "market", "cross_domain"]
+GapSignalCode = Literal[
+    "authority_category_missing",
+    "component_missing",
+    "retrieval_domain_failed",
+]
+GapToolName = Literal[
+    "academic_search",
+    "patent_search",
+    "market_search",
+    "authority_search",
+]
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"", "0", "false", "no", "off"})
+_KNOWN_DOMAINS: tuple[EvidenceDomain, ...] = ("academic", "patent", "market")
+_DOMAIN_TO_TOOL: dict[EvidenceDomain, GapToolName] = {
+    "academic": "academic_search",
+    "patent": "patent_search",
+    "market": "market_search",
+}
+_TOOL_TO_DOMAIN: dict[GapToolName, EvidenceDomain] = {
+    "academic_search": "academic",
+    "patent_search": "patent",
+    "market_search": "market",
+    # Regulatory and registry records remain M-domain evidence. Giving their
+    # future adapter a distinct capability name must not create a fourth source
+    # prefix that the report and citation guardrails do not understand.
+    "authority_search": "market",
+}
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class EvidenceGapError(ValueError):
+    """Raised when a shadow proposal violates its frozen execution contract."""
+
+
+class ShadowConfiguration(BaseModel):
+    """Parsed feature state; invalid text is visible rather than silently off."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    state: Literal["enabled", "disabled", "invalid"]
+    raw_value: str
+
+
+class GapSignal(BaseModel):
+    """One deterministic reason a run is eligible for later gap planning."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    signal_id: str = Field(min_length=8, max_length=24)
+    code: GapSignalCode
+    scope: GapScope
+    subject: str = Field(min_length=1, max_length=240)
+    allowed_tools: tuple[GapToolName, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_contract(self) -> "GapSignal":
+        if self.code == "authority_category_missing":
+            expected_scope: GapScope = "market"
+            expected_tools: tuple[GapToolName, ...] = ("authority_search",)
+        elif self.code == "component_missing":
+            expected_scope = "cross_domain"
+            expected_tools = (
+                "academic_search",
+                "patent_search",
+                "market_search",
+            )
+        else:
+            if self.scope == "cross_domain":
+                raise ValueError("a failed retrieval domain must name one known domain")
+            expected_scope = self.scope
+            expected_tools = (_DOMAIN_TO_TOOL[self.scope],)
+        if self.scope != expected_scope or self.allowed_tools != expected_tools:
+            raise ValueError(
+                f"signal contract mismatch for {self.code}: "
+                f"scope={self.scope}, tools={self.allowed_tools}"
+            )
+        return self
+
+
+class GapContext(BaseModel):
+    """Immutable, non-secret input made available to a future planner."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = EVIDENCE_GAP_SCHEMA_VERSION
+    topic: str = Field(min_length=3, max_length=1000)
+    source_collection_sha256: str
+    source_counts: dict[EvidenceDomain, int]
+    signals: tuple[GapSignal, ...] = ()
+    max_tool_calls: Literal[2] = MAX_GAP_TOOL_CALLS
+
+    @field_validator("source_collection_sha256")
+    @classmethod
+    def _validate_hash(cls, value: str) -> str:
+        if not _HEX_64.fullmatch(value):
+            raise ValueError("source_collection_sha256 must be a lowercase SHA-256")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_counts_and_signals(self) -> "GapContext":
+        if set(self.source_counts) != set(_KNOWN_DOMAINS):
+            raise ValueError("source_counts must contain academic, patent, and market")
+        if any(count < 0 for count in self.source_counts.values()):
+            raise ValueError("source counts cannot be negative")
+        signal_ids = [signal.signal_id for signal in self.signals]
+        if len(signal_ids) != len(set(signal_ids)):
+            raise ValueError("gap signal ids must be unique")
+        return self
+
+
+class GapSearchIntent(BaseModel):
+    """One read-only search proposed by an injected/offline planner."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tool: GapToolName
+    query: str = Field(min_length=3, max_length=500)
+    trigger_ids: tuple[str, ...] = Field(min_length=1, max_length=4)
+    result_limit: int = Field(default=5, ge=1, le=10)
+
+    @field_validator("query")
+    @classmethod
+    def _normalise_query(cls, value: str) -> str:
+        value = " ".join(value.split())
+        if len(value) < 3:
+            raise ValueError("query must contain at least three non-space characters")
+        return value
+
+    @field_validator("trigger_ids")
+    @classmethod
+    def _unique_triggers(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("trigger_ids must be unique within one intent")
+        return value
+
+
+class GapPlanProposal(BaseModel):
+    """Strict JSON boundary for a later planner model."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = EVIDENCE_GAP_SCHEMA_VERSION
+    decision: Literal["no_gap", "search", "abstain"]
+    rationale: str = Field(min_length=10, max_length=1200)
+    calls: tuple[GapSearchIntent, ...] = Field(
+        default=(), max_length=MAX_GAP_TOOL_CALLS
+    )
+
+    @model_validator(mode="after")
+    def _validate_decision_shape(self) -> "GapPlanProposal":
+        if self.decision == "search" and not self.calls:
+            raise ValueError("a search decision requires at least one intent")
+        if self.decision != "search" and self.calls:
+            raise ValueError(f"{self.decision} cannot include search intents")
+        return self
+
+
+class ValidatedGapCall(GapSearchIntent):
+    """A proposal joined to its execution domain and local idempotency key."""
+
+    output_domain: EvidenceDomain
+    idempotency_key: str
+
+    @field_validator("idempotency_key")
+    @classmethod
+    def _validate_idempotency_key(cls, value: str) -> str:
+        if not _HEX_64.fullmatch(value):
+            raise ValueError("idempotency_key must be a lowercase SHA-256")
+        return value
+
+
+class ValidatedGapPlan(BaseModel):
+    """A proposal that is safe to hand to a future bounded executor."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = EVIDENCE_GAP_SCHEMA_VERSION
+    decision: Literal["no_gap", "search", "abstain"]
+    rationale: str
+    calls: tuple[ValidatedGapCall, ...] = Field(
+        default=(), max_length=MAX_GAP_TOOL_CALLS
+    )
+
+
+class EvidenceGapShadowAudit(BaseModel):
+    """Persisted phase-1 observation, including explicit non-execution state."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = EVIDENCE_GAP_SCHEMA_VERSION
+    mode: Literal["shadow"] = "shadow"
+    gate_state: Literal["disabled", "no_gap", "eligible", "failed"]
+    planner_state: Literal["not_run", "planned", "abstained", "failed"]
+    checked: bool
+    context: GapContext | None = None
+    plan: ValidatedGapPlan | None = None
+    proposed_call_count: int = Field(default=0, ge=0, le=MAX_GAP_TOOL_CALLS)
+    executed_call_count: int = Field(default=0, ge=0, le=0)
+    added_search_cost_usd: float = Field(default=0.0, ge=0.0, le=0.0)
+    planner_latency_ms: float | None = Field(default=None, ge=0.0)
+    evidence_changed: bool = False
+    failure_type: str | None = None
+    persistence_state: Literal["not_attempted", "written", "failed"] = (
+        "not_attempted"
+    )
+    persistence_error_type: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_states(self) -> "EvidenceGapShadowAudit":
+        if self.executed_call_count != 0 or self.added_search_cost_usd != 0.0:
+            raise ValueError("phase 1 cannot execute or charge for search calls")
+        if self.proposed_call_count != len(self.plan.calls if self.plan else ()):
+            raise ValueError("proposed_call_count must match the validated plan")
+        if self.gate_state == "disabled":
+            if self.checked or self.context is not None or self.plan is not None:
+                raise ValueError("disabled shadow mode cannot claim an evaluation")
+        elif self.gate_state == "no_gap":
+            if not self.checked or self.context is None or self.context.signals:
+                raise ValueError("no_gap requires a checked context with zero signals")
+        elif self.gate_state == "eligible":
+            if not self.checked or self.context is None or not self.context.signals:
+                raise ValueError("eligible requires a checked context with signals")
+        elif self.checked:
+            raise ValueError("failed gate state cannot be reported as checked")
+
+        if self.planner_state == "planned":
+            if self.plan is None or self.plan.decision != "search":
+                raise ValueError("planned requires a validated search plan")
+        elif self.planner_state == "abstained":
+            if self.plan is None or self.plan.decision != "abstain":
+                raise ValueError("abstained requires a validated abstention")
+        elif self.planner_state == "failed":
+            if self.plan is not None or not self.failure_type:
+                raise ValueError("planner failure requires a failure type and no plan")
+        elif self.plan is not None:
+            raise ValueError("not_run cannot carry a plan")
+
+        if self.persistence_state == "failed" and not self.persistence_error_type:
+            raise ValueError("failed persistence requires its error type")
+        if self.persistence_state != "failed" and self.persistence_error_type:
+            raise ValueError("persistence error is only valid for failed persistence")
+        return self
+
+
+GapPlanner = Callable[[GapContext], GapPlanProposal | dict[str, Any]]
+
+
+def parse_shadow_configuration(raw_value: str | None) -> ShadowConfiguration:
+    """Parse one environment value without treating a typo as disabled."""
+
+    normalized = (raw_value or "").strip().casefold()
+    if normalized in _TRUE_VALUES:
+        state: Literal["enabled", "disabled", "invalid"] = "enabled"
+    elif normalized in _FALSE_VALUES:
+        state = "disabled"
+    else:
+        state = "invalid"
+    return ShadowConfiguration(state=state, raw_value=normalized)
+
+
+def shadow_configuration_from_environment() -> ShadowConfiguration:
+    """Read the opt-in flag at execution time, not at module import time."""
+
+    return parse_shadow_configuration(os.getenv(EVIDENCE_GAP_SHADOW_ENV))
+
+
+def source_collection_sha256(collection: SourceCollection) -> str:
+    """Hash the complete validated input using a canonical JSON projection."""
+
+    payload = json.dumps(
+        collection.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _signal_id(code: GapSignalCode, subject: str) -> str:
+    identity = f"{code}\0{' '.join(subject.split()).casefold()}".encode()
+    return f"gap-{hashlib.sha256(identity).hexdigest()[:16]}"
+
+
+def build_gap_context(collection: SourceCollection) -> GapContext:
+    """Derive only explicit high-precision signals from validated evidence."""
+
+    signals: list[GapSignal] = []
+    for category in collection.authority_coverage.missing_categories:
+        signals.append(
+            GapSignal(
+                signal_id=_signal_id("authority_category_missing", category),
+                code="authority_category_missing",
+                scope="market",
+                subject=category,
+                allowed_tools=("authority_search",),
+            )
+        )
+
+    # Partial and unchecked are intentionally excluded. They mean the lexical
+    # diagnostic itself cannot decide coverage, which is too weak a basis for
+    # spending a search request in a precision-first gate.
+    if collection.component_coverage.status == "incomplete":
+        for component in collection.component_coverage.missing_components:
+            signals.append(
+                GapSignal(
+                    signal_id=_signal_id("component_missing", component),
+                    code="component_missing",
+                    scope="cross_domain",
+                    subject=component,
+                    allowed_tools=(
+                        "academic_search",
+                        "patent_search",
+                        "market_search",
+                    ),
+                )
+            )
+
+    for domain in _KNOWN_DOMAINS:
+        if domain not in collection.failed_domains:
+            continue
+        signals.append(
+            GapSignal(
+                signal_id=_signal_id("retrieval_domain_failed", domain),
+                code="retrieval_domain_failed",
+                scope=domain,
+                subject=domain,
+                allowed_tools=(_DOMAIN_TO_TOOL[domain],),
+            )
+        )
+
+    return GapContext(
+        topic=collection.topic,
+        source_collection_sha256=source_collection_sha256(collection),
+        source_counts={
+            "academic": len(collection.academic_sources),
+            "patent": len(collection.patent_sources),
+            "market": len(collection.market_sources),
+        },
+        signals=tuple(signals),
+    )
+
+
+def validate_gap_plan(
+    context: GapContext,
+    proposal: GapPlanProposal | dict[str, Any],
+) -> ValidatedGapPlan:
+    """Join a strict proposal to trigger authorization and idempotency data."""
+
+    parsed = (
+        proposal
+        if isinstance(proposal, GapPlanProposal)
+        else GapPlanProposal.model_validate(proposal)
+    )
+    signal_by_id = {signal.signal_id: signal for signal in context.signals}
+    if not signal_by_id and parsed.decision != "no_gap":
+        raise EvidenceGapError("a context without signals can only return no_gap")
+    if signal_by_id and parsed.decision == "no_gap":
+        raise EvidenceGapError("an eligible context must search or explicitly abstain")
+
+    calls: list[ValidatedGapCall] = []
+    seen_intents: set[tuple[str, str, int, tuple[str, ...]]] = set()
+    for intent in parsed.calls:
+        unknown = sorted(set(intent.trigger_ids) - set(signal_by_id))
+        if unknown:
+            raise EvidenceGapError(f"intent references unknown trigger ids: {unknown}")
+        unauthorized = [
+            signal_id
+            for signal_id in intent.trigger_ids
+            if intent.tool not in signal_by_id[signal_id].allowed_tools
+        ]
+        if unauthorized:
+            raise EvidenceGapError(
+                f"tool {intent.tool} is not authorized by triggers {unauthorized}"
+            )
+
+        normalized_query = " ".join(intent.query.split()).casefold()
+        normalized_triggers = tuple(sorted(intent.trigger_ids))
+        duplicate_key = (
+            intent.tool,
+            normalized_query,
+            intent.result_limit,
+            normalized_triggers,
+        )
+        if duplicate_key in seen_intents:
+            raise EvidenceGapError("duplicate search intents are not allowed")
+        seen_intents.add(duplicate_key)
+        identity_payload = json.dumps(
+            {
+                "collection": context.source_collection_sha256,
+                "tool": intent.tool,
+                "query": normalized_query,
+                "result_limit": intent.result_limit,
+                "trigger_ids": normalized_triggers,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        calls.append(
+            ValidatedGapCall(
+                **intent.model_dump(exclude={"trigger_ids"}),
+                trigger_ids=normalized_triggers,
+                output_domain=_TOOL_TO_DOMAIN[intent.tool],
+                idempotency_key=hashlib.sha256(identity_payload).hexdigest(),
+            )
+        )
+
+    return ValidatedGapPlan(
+        decision=parsed.decision,
+        rationale=parsed.rationale,
+        calls=tuple(calls),
+    )
+
+
+def _failed_audit(
+    *,
+    context: GapContext | None,
+    failure_type: str,
+    latency_ms: float | None = None,
+    evidence_changed: bool = False,
+) -> EvidenceGapShadowAudit:
+    return EvidenceGapShadowAudit(
+        gate_state="eligible" if context and context.signals else "failed",
+        planner_state="failed" if context and context.signals else "not_run",
+        checked=bool(context and context.signals),
+        context=context,
+        planner_latency_ms=latency_ms,
+        evidence_changed=evidence_changed,
+        failure_type=failure_type,
+    )
+
+
+def run_shadow_assessment(
+    collection: SourceCollection,
+    *,
+    configuration: ShadowConfiguration,
+    planner: GapPlanner | None = None,
+) -> EvidenceGapShadowAudit:
+    """Evaluate or plan in shadow mode while guaranteeing zero tool execution."""
+
+    if configuration.state == "disabled":
+        return EvidenceGapShadowAudit(
+            gate_state="disabled",
+            planner_state="not_run",
+            checked=False,
+        )
+    if configuration.state == "invalid":
+        return _failed_audit(
+            context=None,
+            failure_type="invalid_configuration",
+        )
+
+    try:
+        context = build_gap_context(collection)
+        before_hash = source_collection_sha256(collection)
+    except (TypeError, ValueError) as exc:
+        return _failed_audit(
+            context=None,
+            failure_type=f"gate_{type(exc).__name__}",
+        )
+    if not context.signals:
+        return EvidenceGapShadowAudit(
+            gate_state="no_gap",
+            planner_state="not_run",
+            checked=True,
+            context=context,
+        )
+    if planner is None:
+        return EvidenceGapShadowAudit(
+            gate_state="eligible",
+            planner_state="not_run",
+            checked=True,
+            context=context,
+        )
+
+    started = time.perf_counter()
+    try:
+        plan = validate_gap_plan(context, planner(context))
+    except Exception as exc:  # noqa: BLE001
+        # An injected planner is an advisory shadow component. Any provider,
+        # parse, or schema failure must be observable without discarding the
+        # already paid deterministic retrieval and six-stage assessment.
+        latency_ms = (time.perf_counter() - started) * 1000
+        after_hash = source_collection_sha256(collection)
+        if after_hash != before_hash:
+            return _failed_audit(
+                context=context,
+                failure_type="source_collection_mutated",
+                latency_ms=latency_ms,
+                evidence_changed=True,
+            )
+        return _failed_audit(
+            context=context,
+            failure_type=f"planner_{type(exc).__name__}",
+            latency_ms=latency_ms,
+        )
+    latency_ms = (time.perf_counter() - started) * 1000
+    after_hash = source_collection_sha256(collection)
+    if after_hash != before_hash:
+        return _failed_audit(
+            context=context,
+            failure_type="source_collection_mutated",
+            latency_ms=latency_ms,
+            evidence_changed=True,
+        )
+    return EvidenceGapShadowAudit(
+        gate_state="eligible",
+        planner_state="planned" if plan.decision == "search" else "abstained",
+        checked=True,
+        context=context,
+        plan=plan,
+        proposed_call_count=len(plan.calls),
+        planner_latency_ms=latency_ms,
+    )
+
+
+def refresh_coverage_for_offline_audit(collection: SourceCollection) -> SourceCollection:
+    """Recompute diagnostics for legacy fixtures that predate coverage fields.
+
+    This helper is intentionally named for offline audit use. Runtime
+    collections already carry the diagnostics computed by retrieval; silently
+    recomputing them later would make the artifact differ from what the report
+    actually saw.
+    """
+
+    from academic_agent.source_pipeline import (
+        _measure_authority_coverage,
+        _measure_component_coverage,
+    )
+
+    refreshed = collection.model_copy(deep=True)
+    refreshed.authority_coverage = _measure_authority_coverage(
+        refreshed.topic,
+        refreshed.weight_profile,
+        refreshed.market_sources,
+    )
+    refreshed.component_coverage = _measure_component_coverage(
+        refreshed.search_components,
+        (
+            *refreshed.academic_sources,
+            *refreshed.patent_sources,
+            *refreshed.market_sources,
+        ),
+    )
+    return refreshed
+
+
+def persist_shadow_audit(
+    run_directory: Path,
+    audit: EvidenceGapShadowAudit,
+) -> EvidenceGapShadowAudit:
+    """Atomically persist the audit and return the state safe for status.json."""
+
+    target = run_directory / EVIDENCE_GAP_SHADOW_FILENAME
+    temporary = target.with_suffix(".json.tmp")
+    written = audit.model_copy(update={"persistence_state": "written"})
+    try:
+        run_directory.mkdir(parents=True, exist_ok=True)
+        with temporary.open("w", encoding="utf-8") as handle:
+            handle.write(written.model_dump_json(indent=2))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except OSError as exc:
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+        return audit.model_copy(
+            update={
+                "persistence_state": "failed",
+                "persistence_error_type": type(exc).__name__,
+            }
+        )
+    return written

--- a/src/academic_agent/pipeline_worker.py
+++ b/src/academic_agent/pipeline_worker.py
@@ -280,7 +280,7 @@ def _merge_status_fields(
     for sticky in (
         "topic", "source_counts", "evidence_incomplete", "failed_domains", "usage",
         "claim_grounding", "consistency", "observability", "authority_coverage",
-        "component_coverage",
+        "component_coverage", "evidence_gap_shadow",
         "quality_review",
         "checkpointing", "recovery",
     ):
@@ -330,6 +330,11 @@ def main() -> None:
         task_node,
     )
     from academic_agent.checkpoints import CheckpointStore, hash_text
+    from academic_agent.evidence_gap import (
+        persist_shadow_audit,
+        run_shadow_assessment,
+        shadow_configuration_from_environment,
+    )
     from academic_agent.run_spec import (
         RESUME_SNAPSHOT_DIRECTORY, RUN_SPEC_FILENAME, RunSpec,
     )
@@ -375,6 +380,7 @@ def main() -> None:
         consistency: dict | None = None,
         authority_coverage: dict | None = None,
         component_coverage: dict | None = None,
+        evidence_gap_shadow: dict | None = None,
         checkpointing: dict | None = None,
         recovery: dict | None = None,
         quality_review: dict | None = None,
@@ -405,6 +411,8 @@ def main() -> None:
                 data["authority_coverage"] = authority_coverage
             if component_coverage is not None:
                 data["component_coverage"] = component_coverage
+            if evidence_gap_shadow is not None:
+                data["evidence_gap_shadow"] = evidence_gap_shadow
             if quality_review is not None:
                 data["quality_review"] = quality_review
             if checkpointing is not None:
@@ -623,6 +631,27 @@ def main() -> None:
                     )
                     if translated_topic and translated_topic != source_collection.display_topic:
                         source_collection.display_topic = translated_topic
+        # Phase 1 stops at observation. The worker intentionally injects no
+        # planner callback, so even an eligible run proposes and executes zero
+        # searches. Keeping this between retrieval and source serialization
+        # lets the audit hash the exact collection the Crew will receive while
+        # leaving the retrieval checkpoint contract unchanged.
+        gap_shadow = run_shadow_assessment(
+            source_collection,
+            configuration=shadow_configuration_from_environment(),
+        )
+        gap_shadow = persist_shadow_audit(run_dir, gap_shadow)
+        telemetry.set_attributes({
+            "academic_agent.evidence_gap.gate_state": gap_shadow.gate_state,
+            "academic_agent.evidence_gap.planner_state": gap_shadow.planner_state,
+            "academic_agent.evidence_gap.signal_count": (
+                len(gap_shadow.context.signals) if gap_shadow.context else 0
+            ),
+            "academic_agent.evidence_gap.executed_calls": (
+                gap_shadow.executed_call_count
+            ),
+        })
+
         source_json = source_collection.model_dump_json(indent=2)
         if not retrieval_payload:
             retrieval_payload = source_json
@@ -683,6 +712,7 @@ def main() -> None:
             component_coverage=source_collection.component_coverage.model_dump(
                 mode="json"
             ),
+            evidence_gap_shadow=gap_shadow.model_dump(mode="json"),
             **checkpoint_snapshot,
         )
 

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -62,6 +62,14 @@ _STATUS = {
         "missing_components": ["edge AI inference"],
         "unchecked_components": [],
     },
+    "evidence_gap_shadow": {
+        "gate_state": "eligible",
+        "planner_state": "not_run",
+        "checked": True,
+        "proposed_call_count": 0,
+        "executed_call_count": 0,
+        "persistence_state": "written",
+    },
     "quality_review": {"status": "fallback", "failure_type": "RuntimeError"},
     "observability": {"state": "active", "backend": "phoenix",
                       "trace_id": "0123456789abcdef0123456789abcdef",
@@ -80,6 +88,9 @@ class _Run:
         directory.mkdir()
         (directory / "status.json").write_text(json.dumps(_STATUS), encoding="utf-8")
         (directory / "commercialization_report.md").write_text("# r", encoding="utf-8")
+        (directory / "evidence_gap_shadow.json").write_text(
+            json.dumps(_STATUS["evidence_gap_shadow"]), encoding="utf-8"
+        )
 
     def close(self) -> None:
         self._tmp.cleanup()
@@ -127,6 +138,9 @@ class StateReachesTheClientTests(unittest.TestCase):
         self.assertEqual(
             body["observability"]["trace_id"], _STATUS["observability"]["trace_id"]
         )
+        self.assertEqual(
+            body["evidence_gap_shadow"]["gate_state"], "eligible"
+        )
 
     def test_the_progress_endpoint_returns_them_with_their_values(self):
         """This endpoint names each field in its constructor, so it is the one
@@ -140,6 +154,17 @@ class StateReachesTheClientTests(unittest.TestCase):
         self.assertEqual(
             body["observability"]["trace_id"], _STATUS["observability"]["trace_id"]
         )
+        self.assertEqual(
+            body["evidence_gap_shadow"]["gate_state"], "eligible"
+        )
+
+    def test_shadow_state_matches_the_downloadable_artifact(self):
+        """A persisted audit must reach the client through its advertised name."""
+        status = self.client.get(f"/api/runs/{self.run.run_id}").json()
+        artifact = self.client.get(f"/api/runs/{self.run.run_id}/gap-shadow")
+        self.assertEqual(artifact.status_code, 200)
+        self.assertEqual(artifact.json(), status["evidence_gap_shadow"])
+        self.assertIn("gap-shadow", status["artifacts"])
 
     def test_the_two_endpoints_do_not_disagree(self):
         """They are built differently — one splats get_state(), one names every
@@ -188,6 +213,10 @@ class AbsentDataTests(unittest.TestCase):
     def test_a_run_before_component_coverage_reports_unknown_not_complete(self):
         body = self.client.get(f"/api/runs/{self.run_id}").json()
         self.assertIsNone(body["component_coverage"])
+
+    def test_a_run_before_gap_shadow_reports_unknown_not_checked(self):
+        body = self.client.get(f"/api/runs/{self.run_id}").json()
+        self.assertIsNone(body["evidence_gap_shadow"])
 
     def test_null_is_distinguishable_from_zero(self):
         """A run with no usage recorded is not a run that cost nothing. The

--- a/tests/test_evidence_gap.py
+++ b/tests/test_evidence_gap.py
@@ -7,7 +7,7 @@ import unittest
 from datetime import UTC, date, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pydantic import ValidationError
 
@@ -44,7 +44,9 @@ def _source(source_id: str, source_type: str, url: str) -> EvidenceSource:
         title=f"Validated source record {source_id}",
         url=url,
         publisher="Example Publisher",
-        accessed_date=date(2026, 8, 25),
+        # A historical date keeps the synthetic fixture valid when Sydney has
+        # crossed midnight but GitHub's UTC runners have not.
+        accessed_date=date(2025, 1, 1),
         source_type=source_type,
         evidence_summary=_SUMMARY,
     )
@@ -63,7 +65,7 @@ def _collection(
         display_topic=topic,
         search_components=list((components or ComponentCoverage()).components),
         weight_profile=profile,
-        collected_at=datetime(2026, 8, 25, tzinfo=UTC),
+        collected_at=datetime(2025, 1, 1, tzinfo=UTC),
         academic_sources=[_source("A1", "academic_paper", "https://doi.org/10.1000/example")],
         patent_sources=[_source("P1", "patent", "https://patents.google.com/patent/US123")],
         market_sources=[_source("M1", "market_report", "https://example.com/market")],
@@ -87,6 +89,24 @@ def _eligible_collection() -> SourceCollection:
             missing_categories=["clinical_registry"],
         ),
     )
+
+
+class SyntheticFixtureDateTests(unittest.TestCase):
+    def test_fixture_is_valid_when_sydney_is_one_day_ahead_of_utc(self):
+        """A local calendar date must not make the UTC CI fixture future-dated."""
+
+        class UtcRunnerDate(date):
+            @classmethod
+            def today(cls):
+                return cls(2026, 8, 24)
+
+        with patch("academic_agent.evidence.date", UtcRunnerDate):
+            collection = _collection()
+
+        self.assertEqual(
+            collection.academic_sources[0].accessed_date,
+            date(2025, 1, 1),
+        )
 
 
 class ShadowConfigurationTests(unittest.TestCase):

--- a/tests/test_evidence_gap.py
+++ b/tests/test_evidence_gap.py
@@ -1,0 +1,407 @@
+"""Phase-1 evidence-gap contracts: eligibility, plans, and zero-call audit."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import UTC, date, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+from pydantic import ValidationError
+
+import evidence_gap_audit
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    EVIDENCE_GAP_SHADOW_FILENAME,
+    EvidenceGapError,
+    GapPlanProposal,
+    GapSearchIntent,
+    build_gap_context,
+    parse_shadow_configuration,
+    persist_shadow_audit,
+    run_shadow_assessment,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.source_pipeline import (
+    AuthorityCoverage,
+    ComponentCoverage,
+    SourceCollection,
+)
+
+
+_SUMMARY = (
+    "This validated source contains enough specific evidence text for the "
+    "strict source model and for deterministic evidence-gap unit tests."
+)
+
+
+def _source(source_id: str, source_type: str, url: str) -> EvidenceSource:
+    return EvidenceSource(
+        source_id=source_id,
+        title=f"Validated source record {source_id}",
+        url=url,
+        publisher="Example Publisher",
+        accessed_date=date(2026, 8, 25),
+        source_type=source_type,
+        evidence_summary=_SUMMARY,
+    )
+
+
+def _collection(
+    *,
+    topic: str = "solid-state batteries for electric vehicles",
+    profile: str = "industrial",
+    authority: AuthorityCoverage | None = None,
+    components: ComponentCoverage | None = None,
+    failed_domains: dict[str, str] | None = None,
+) -> SourceCollection:
+    return SourceCollection(
+        topic=topic,
+        display_topic=topic,
+        search_components=list((components or ComponentCoverage()).components),
+        weight_profile=profile,
+        collected_at=datetime(2026, 8, 25, tzinfo=UTC),
+        academic_sources=[_source("A1", "academic_paper", "https://doi.org/10.1000/example")],
+        patent_sources=[_source("P1", "patent", "https://patents.google.com/patent/US123")],
+        market_sources=[_source("M1", "market_report", "https://example.com/market")],
+        academic_queries=[topic],
+        patent_queries=[topic],
+        market_queries=[topic],
+        authority_coverage=authority or AuthorityCoverage(),
+        component_coverage=components or ComponentCoverage(),
+        failed_domains=failed_domains or {},
+    )
+
+
+def _eligible_collection() -> SourceCollection:
+    return _collection(
+        topic="CAR-T cell therapy for blood cancers",
+        profile="biomedical",
+        authority=AuthorityCoverage(
+            status="incomplete",
+            required_categories=["regulatory", "clinical_registry"],
+            covered_source_ids={"regulatory": ["M1"]},
+            missing_categories=["clinical_registry"],
+        ),
+    )
+
+
+class ShadowConfigurationTests(unittest.TestCase):
+    def test_missing_and_explicit_false_values_are_disabled(self):
+        self.assertEqual(parse_shadow_configuration(None).state, "disabled")
+        for value in ("", "0", "false", "NO", " off "):
+            with self.subTest(value=value):
+                self.assertEqual(parse_shadow_configuration(value).state, "disabled")
+
+    def test_truthy_values_require_an_explicit_known_spelling(self):
+        for value in ("1", "true", "YES", " on "):
+            with self.subTest(value=value):
+                self.assertEqual(parse_shadow_configuration(value).state, "enabled")
+        self.assertEqual(parse_shadow_configuration("enabled").state, "invalid")
+
+
+class GapGateTests(unittest.TestCase):
+    def test_source_count_alone_never_triggers_the_gate(self):
+        context = build_gap_context(_collection())
+        self.assertEqual(context.source_counts, {"academic": 1, "patent": 1, "market": 1})
+        self.assertEqual(context.signals, ())
+
+    def test_missing_authority_category_has_only_the_specialized_tool(self):
+        context = build_gap_context(_eligible_collection())
+        self.assertEqual(len(context.signals), 1)
+        signal = context.signals[0]
+        self.assertEqual(signal.code, "authority_category_missing")
+        self.assertEqual(signal.subject, "clinical_registry")
+        self.assertEqual(signal.scope, "market")
+        self.assertEqual(signal.allowed_tools, ("authority_search",))
+
+    def test_only_explicitly_incomplete_components_trigger(self):
+        for status in ("partial", "unchecked"):
+            collection = _collection(
+                components=ComponentCoverage(
+                    status=status,
+                    components=["sensor networks", "edge AI inference"],
+                    covered_source_ids={"sensor networks": ["A1"]},
+                    unchecked_components=["edge AI inference"],
+                )
+            )
+            with self.subTest(status=status):
+                self.assertEqual(build_gap_context(collection).signals, ())
+
+        incomplete = _collection(
+            components=ComponentCoverage(
+                status="incomplete",
+                components=["sensor networks", "edge AI inference"],
+                covered_source_ids={"sensor networks": ["A1"]},
+                missing_components=["edge AI inference"],
+            )
+        )
+        signal = build_gap_context(incomplete).signals[0]
+        self.assertEqual(signal.code, "component_missing")
+        self.assertEqual(
+            signal.allowed_tools,
+            ("academic_search", "patent_search", "market_search"),
+        )
+
+    def test_known_failed_domain_triggers_but_unknown_label_does_not(self):
+        context = build_gap_context(_collection(failed_domains={"patent": "timeout", "regulation": "bad"}))
+        self.assertEqual(len(context.signals), 1)
+        self.assertEqual(context.signals[0].subject, "patent")
+        self.assertEqual(context.signals[0].allowed_tools, ("patent_search",))
+
+    def test_context_hash_is_stable_and_does_not_mutate_the_collection(self):
+        collection = _eligible_collection()
+        before = source_collection_sha256(collection)
+        first = build_gap_context(collection)
+        second = build_gap_context(collection)
+        self.assertEqual(first, second)
+        self.assertEqual(before, source_collection_sha256(collection))
+
+
+class GapPlanContractTests(unittest.TestCase):
+    def setUp(self):
+        self.context = build_gap_context(_eligible_collection())
+        self.trigger = self.context.signals[0].signal_id
+
+    def _intent(self, **overrides) -> GapSearchIntent:
+        values = {
+            "tool": "authority_search",
+            "query": "CAR-T blood cancer trial results",
+            "trigger_ids": (self.trigger,),
+            "result_limit": 5,
+        }
+        values.update(overrides)
+        return GapSearchIntent(**values)
+
+    def _proposal(self, *calls: GapSearchIntent) -> GapPlanProposal:
+        return GapPlanProposal(
+            decision="search",
+            rationale="The required registry category is absent from validated evidence.",
+            calls=calls,
+        )
+
+    def test_schema_rejects_unknown_fields_and_a_third_intent(self):
+        with self.assertRaises(ValidationError):
+            GapPlanProposal.model_validate(
+                {
+                    "decision": "abstain",
+                    "rationale": "There is not enough expected evidence value.",
+                    "calls": [],
+                    "surprise": True,
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self._proposal(self._intent(), self._intent(query="second query"), self._intent(query="third query"))
+
+    def test_known_trigger_and_authorized_tool_are_required(self):
+        with self.assertRaisesRegex(EvidenceGapError, "unknown trigger"):
+            validate_gap_plan(
+                self.context,
+                self._proposal(self._intent(trigger_ids=("gap-invented0000",))),
+            )
+        with self.assertRaisesRegex(EvidenceGapError, "not authorized"):
+            validate_gap_plan(
+                self.context,
+                self._proposal(self._intent(tool="academic_search")),
+            )
+
+    def test_eligible_context_must_search_or_explicitly_abstain(self):
+        proposal = GapPlanProposal(
+            decision="no_gap",
+            rationale="No supplementary evidence is required for this collection.",
+        )
+        with self.assertRaisesRegex(EvidenceGapError, "must search or explicitly abstain"):
+            validate_gap_plan(self.context, proposal)
+
+    def test_duplicate_intents_are_rejected_after_normalization(self):
+        with self.assertRaisesRegex(EvidenceGapError, "duplicate"):
+            validate_gap_plan(
+                self.context,
+                self._proposal(
+                    self._intent(),
+                    self._intent(query="  car-t  BLOOD cancer trial results "),
+                ),
+            )
+
+    def test_valid_plan_gets_stable_local_idempotency_and_market_domain(self):
+        first = validate_gap_plan(self.context, self._proposal(self._intent()))
+        second = validate_gap_plan(self.context, self._proposal(self._intent()))
+        self.assertEqual(first, second)
+        self.assertEqual(first.calls[0].output_domain, "market")
+        self.assertEqual(len(first.calls[0].idempotency_key), 64)
+
+
+class ShadowExecutionTests(unittest.TestCase):
+    def test_disabled_mode_never_invokes_an_injected_planner(self):
+        planner = MagicMock(side_effect=AssertionError("must not run"))
+        audit = run_shadow_assessment(
+            _eligible_collection(),
+            configuration=parse_shadow_configuration("false"),
+            planner=planner,
+        )
+        planner.assert_not_called()
+        self.assertEqual(audit.gate_state, "disabled")
+        self.assertFalse(audit.checked)
+
+    def test_disabled_mode_does_not_even_serialize_the_collection(self):
+        collection = MagicMock()
+        collection.model_dump.side_effect = AssertionError("must not inspect")
+        audit = run_shadow_assessment(
+            collection,
+            configuration=parse_shadow_configuration("false"),
+        )
+        collection.model_dump.assert_not_called()
+        self.assertEqual(audit.gate_state, "disabled")
+
+    def test_no_gap_mode_never_invokes_an_injected_planner(self):
+        planner = MagicMock(side_effect=AssertionError("must not run"))
+        audit = run_shadow_assessment(
+            _collection(),
+            configuration=parse_shadow_configuration("true"),
+            planner=planner,
+        )
+        planner.assert_not_called()
+        self.assertEqual(audit.gate_state, "no_gap")
+        self.assertTrue(audit.checked)
+
+    def test_planner_failure_is_not_reported_as_no_gap(self):
+        audit = run_shadow_assessment(
+            _eligible_collection(),
+            configuration=parse_shadow_configuration("true"),
+            planner=MagicMock(side_effect=RuntimeError("provider unavailable")),
+        )
+        self.assertEqual(audit.gate_state, "eligible")
+        self.assertEqual(audit.planner_state, "failed")
+        self.assertEqual(audit.failure_type, "planner_RuntimeError")
+        self.assertEqual(audit.executed_call_count, 0)
+
+    def test_planner_mutation_is_visible_even_when_the_planner_raises(self):
+        collection = _eligible_collection()
+
+        def mutate_then_fail(_context):
+            collection.topic = "mutated topic"
+            raise RuntimeError("planner failed after mutation")
+
+        audit = run_shadow_assessment(
+            collection,
+            configuration=parse_shadow_configuration("true"),
+            planner=mutate_then_fail,
+        )
+        self.assertEqual(audit.planner_state, "failed")
+        self.assertEqual(audit.failure_type, "source_collection_mutated")
+        self.assertTrue(audit.evidence_changed)
+        self.assertEqual(audit.executed_call_count, 0)
+
+    def test_valid_proposal_remains_zero_call_and_does_not_change_evidence(self):
+        collection = _eligible_collection()
+        trigger = build_gap_context(collection).signals[0].signal_id
+
+        def planner(_context):
+            return {
+                "decision": "search",
+                "rationale": "The missing registry category warrants one bounded query.",
+                "calls": [
+                    {
+                        "tool": "authority_search",
+                        "query": "CAR-T blood cancer trial status",
+                        "trigger_ids": [trigger],
+                        "result_limit": 5,
+                    }
+                ],
+            }
+
+        before = source_collection_sha256(collection)
+        audit = run_shadow_assessment(
+            collection,
+            configuration=parse_shadow_configuration("true"),
+            planner=planner,
+        )
+        self.assertEqual(audit.planner_state, "planned")
+        self.assertEqual(audit.proposed_call_count, 1)
+        self.assertEqual(audit.executed_call_count, 0)
+        self.assertEqual(audit.added_search_cost_usd, 0.0)
+        self.assertFalse(audit.evidence_changed)
+        self.assertEqual(before, source_collection_sha256(collection))
+
+    def test_invalid_configuration_is_a_failed_check(self):
+        audit = run_shadow_assessment(
+            _collection(),
+            configuration=parse_shadow_configuration("tru"),
+        )
+        self.assertEqual(audit.gate_state, "failed")
+        self.assertFalse(audit.checked)
+        self.assertEqual(audit.failure_type, "invalid_configuration")
+
+
+class ShadowPersistenceTests(unittest.TestCase):
+    def test_written_state_matches_the_downloadable_artifact(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            audit = run_shadow_assessment(
+                _eligible_collection(),
+                configuration=parse_shadow_configuration("true"),
+            )
+            persisted = persist_shadow_audit(root, audit)
+            payload = json.loads((root / EVIDENCE_GAP_SHADOW_FILENAME).read_text(encoding="utf-8"))
+        self.assertEqual(persisted.persistence_state, "written")
+        self.assertEqual(payload, persisted.model_dump(mode="json"))
+
+    def test_failed_write_is_visible_and_does_not_raise(self):
+        with TemporaryDirectory() as temp:
+            not_a_directory = Path(temp) / "run"
+            not_a_directory.write_text("occupied", encoding="utf-8")
+            audit = run_shadow_assessment(
+                _collection(),
+                configuration=parse_shadow_configuration("true"),
+            )
+            persisted = persist_shadow_audit(not_a_directory, audit)
+        self.assertEqual(persisted.persistence_state, "failed")
+        self.assertEqual(persisted.persistence_error_type, "FileExistsError")
+
+
+class FrozenAuditTests(unittest.TestCase):
+    def _write_fixture(self, root: Path, name: str, collection: SourceCollection) -> None:
+        directory = root / name
+        directory.mkdir()
+        (directory / "validated_sources.json").write_text(
+            collection.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+
+    def test_audit_checks_every_fixture_twice_without_calls_or_mutation(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            self._write_fixture(root, "01", _collection())
+            self._write_fixture(root, "02", _eligible_collection())
+            result, rows = evidence_gap_audit.evaluate_collections(
+                root,
+                expected_count=2,
+            )
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["executed_call_count"], 0)
+        self.assertEqual(result["input_mutation_count"], 0)
+        self.assertEqual(len(rows), 2)
+        self.assertFalse(result["production_tool_calls_authorized"])
+
+    def test_empty_or_partial_fixture_set_fails_closed(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaisesRegex(evidence_gap_audit.EvidenceGapAuditError, "no validated"):
+                evidence_gap_audit.evaluate_collections(root)
+            self._write_fixture(root, "01", _collection())
+            with self.assertRaisesRegex(evidence_gap_audit.EvidenceGapAuditError, "expected exactly 2"):
+                evidence_gap_audit.evaluate_collections(root, expected_count=2)
+
+    def test_writer_refuses_to_replace_a_previous_audit(self):
+        with TemporaryDirectory() as temp:
+            output = Path(temp) / "audit"
+            output.mkdir()
+            with self.assertRaisesRegex(evidence_gap_audit.EvidenceGapAuditError, "refusing to overwrite"):
+                evidence_gap_audit.write_audit(output, {}, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -232,6 +232,11 @@ class MergeStatusFieldsTests(unittest.TestCase):
         data = self._merge(existing, stage="Agent 4")
         self.assertEqual(data["component_coverage"], existing["component_coverage"])
 
+    def test_evidence_gap_shadow_survives_every_stage_write(self):
+        existing = {"evidence_gap_shadow": {"gate_state": "eligible"}}
+        data = self._merge(existing, stage="Agent 4")
+        self.assertEqual(data["evidence_gap_shadow"], existing["evidence_gap_shadow"])
+
     def test_a_new_value_overwrites_the_sticky_one(self):
         existing = {"topic": "old topic"}
         data = self._merge(existing, topic="new topic")
@@ -272,12 +277,15 @@ class MainEndToEndTests(unittest.TestCase):
         self._source_collection.output_language = "English"
         self._source_collection.localized_headings = []
         self._source_collection.display_topic = "a topic"
+        self._source_collection.topic = "a topic"
+        self._source_collection.failed_domains = {}
         self._source_collection.authority_coverage.model_dump.return_value = {
             "status": "not_applicable",
             "required_categories": [],
             "covered_source_ids": {},
             "missing_categories": [],
         }
+        self._source_collection.authority_coverage.missing_categories = []
         self._source_collection.component_coverage.model_dump.return_value = {
             "status": "incomplete",
             "components": ["sensor networks", "edge AI inference"],
@@ -286,6 +294,9 @@ class MainEndToEndTests(unittest.TestCase):
             "unchecked_components": [],
         }
         self._source_collection.model_dump_json.return_value = "{}"
+        self._source_collection.component_coverage.status = "incomplete"
+        self._source_collection.component_coverage.missing_components = ["edge AI inference"]
+        self._source_collection.model_dump.return_value = {}
         self._source_collection.crew_inputs.return_value = {}
 
     def _run(self, run_id="20260101T000000Z-abcdef01"):
@@ -326,6 +337,35 @@ class MainEndToEndTests(unittest.TestCase):
             ["edge AI inference"],
         )
         self.assertTrue((run_dir / "commercialization_scores.json").exists())
+
+        self.assertEqual(status["evidence_gap_shadow"]["gate_state"], "disabled")
+        self.assertEqual(
+            status["evidence_gap_shadow"]["persistence_state"], "written"
+        )
+        self.assertEqual(status["evidence_gap_shadow"]["executed_call_count"], 0)
+        self.assertTrue((run_dir / "evidence_gap_shadow.json").exists())
+
+    def test_enabled_shadow_records_eligibility_without_search_calls(self):
+        crew = MagicMock()
+        crew.agents = []
+        crew.kickoff.return_value = self._crew_result()
+
+        with patch.dict(
+            "os.environ", {"EVIDENCE_GAP_SHADOW_ENABLED": "true"}
+        ), patch("academic_agent.crew.AcademicAgent") as agent_cls:
+            agent_cls.return_value.crew.return_value = crew
+            run_dir = self._run()
+
+        status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+        shadow = status["evidence_gap_shadow"]
+        self.assertEqual(shadow["gate_state"], "eligible")
+        self.assertEqual(shadow["planner_state"], "not_run")
+        self.assertTrue(shadow["checked"])
+        self.assertEqual(shadow["proposed_call_count"], 0)
+        self.assertEqual(shadow["executed_call_count"], 0)
+        self.assertEqual(shadow["added_search_cost_usd"], 0.0)
+        self.assertFalse(shadow["evidence_changed"])
+        crew.kickoff.assert_called_once()
 
     def test_source_collection_failure_writes_error_not_a_crash(self):
         with patch("academic_agent.source_pipeline.collect_source_collection",


### PR DESCRIPTION
A production gap planner would be premature because the current retrieval already performs bounded authority searches, and an unmeasured planner could duplicate requests, mutate validated evidence, or turn a product keyword into uncontrolled cost. This change therefore adds the observation and validation seam first while keeping the feature disabled by default and authorizing no model or search calls.

The new contract derives only explicit high-precision gap signals, validates at most two strictly typed and trigger-authorized read-only intents, and assigns deterministic local idempotency keys. The worker persists disabled, checked, eligible, and failed states separately; the same state reaches status, progress, telemetry, and a downloadable artifact without changing the evidence supplied to CrewAI.

A frozen zero-network replay over all 30 stored source collections found 9 eligible authority cases and 21 no-gap cases with zero calls and zero mutations. The result is disclosed as a retrospective development-set mechanics audit, not trigger precision or evidence-value proof. Production adapters remain blocked behind the separately frozen phase-two thresholds.

The change adds seam tests for the two HTTP endpoints and artifact download, preserves null for legacy runs, and proves the two-intent ceiling by defect reinjection. The final suite reports 1,369 tests plus 592 subtests, 86.92 percent coverage, and green Ruff and CI-specific Pylint checks.
