### PR TITLE
Fix clinical authority gaps exposed by the shadow canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1370 tests (592 subtests), CI green on Linux + Windows × Python
+Current state: 1374 tests (594 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -355,7 +355,12 @@ schema, two-intent ceiling, trigger authorization and local idempotency keys are
 implemented for offline injection tests only. Reproduce the 30-run zero-network
 mechanics audit with `uv run python evidence_gap_audit.py outputs/benchmark
 outputs/evidence-gap-shadow-phase1 --expected-count 30`; see the
-[frozen protocol](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md).
+[frozen protocol](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md). The
+first paid production canary verified artifact persistence and zero evidence
+mutation, while also exposing a clinical-device authority false negative and a
+journal-title credibility false positive. The narrow correction and its
+remaining post-deployment observation boundary are recorded in the
+[canary result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md).
 
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
@@ -1239,7 +1244,10 @@ Step 6     Agent 6 — 量化评分（独立于报告；公式自动修正）
 测试。可用 `uv run python evidence_gap_audit.py outputs/benchmark
 outputs/evidence-gap-shadow-phase1 --expected-count 30` 复现 30 次零网络机制审计；
 设计边界与后续上线阈值见
-[冻结协议](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md)。
+[冻结协议](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md)。首次付费生产
+canary 已验证影子产物持久化且未改变证据，同时暴露了临床设备权威来源漏检和
+期刊标题可信度误判；窄范围修正及仍待部署后观察的边界记录在
+[canary 结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)。
 
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 

--- a/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
+++ b/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
@@ -72,3 +72,44 @@ Production planner-model invocation and tool execution remain disabled. Phase
 2 requires a separately frozen challenge set and must meet the precision,
 source-validity, evidence-increment, cost, latency, and tracing thresholds in
 the pre-registration before any production adapter is connected.
+
+## Production canary and follow-up correction
+
+An operator-selected production canary ran on 2026-08-25 after the shadow flag
+was enabled. It was a runtime check, not a held-out trigger-accuracy study:
+
+- Run: [20260825T014903Z-07c05a15f0afebb64471a7433121a4e1](https://academic-commercialization-agent.up.railway.app/run/20260825T014903Z-07c05a15f0afebb64471a7433121a4e1)
+- Topic: wearable continuous blood-pressure monitoring via photoplethysmography
+- Completion: 162 seconds, 8 academic + 8 patent + 7 market sources
+- Provider use: 6 requests, 78,254 tokens, `$0.032152`
+- Shadow artifact: `checked=true`, `persistence_state=written`, zero executed
+  calls, zero added search cost, and no evidence mutation
+
+The runtime and public artifact seams passed. The `no_gap` decision did not:
+the run exposed a deterministic false negative and a separate credibility
+false positive.
+
+1. The normalized clinical-monitoring topic fell through to the `industrial`
+   weight profile.
+2. Authority coverage consequently reported `not_applicable`, despite the
+   finished report acknowledging that its regulatory pathway was not mapped.
+3. The generic `American Journal of` publisher fragment downgraded the official
+   ASPC/Elsevier *American Journal of Preventive Cardiology* as predatory,
+   contrary to the [NLM Catalog record](https://www.ncbi.nlm.nih.gov/nlmcatalog/101769122).
+
+The follow-up correction remains deliberately narrow:
+
+- `blood pressure` selects the biomedical profile;
+- `blood pressure monitor` requires regulator evidence, but does not invent
+  a universal clinical-trial-registry requirement for medical devices;
+- a generic journal-title prefix no longer establishes publisher identity;
+- classification, regulator-query, authority-coverage, shadow-gate, and
+  production-journal regressions assert the full seams.
+
+The proposed phrases change zero of the ten topics and zero of the 30 runs in
+the frozen calibration benchmark. No second paid run was used during the code
+fix, so production post-fix behavior remains to be observed after deployment.
+
+Post-fix local gates passed: 1,374 zero-network tests and 594 subtests, Ruff,
+the CI exception-order Pylint checks, and 86.91% measured coverage against the
+85% floor.

--- a/src/academic_agent/source_pipeline.py
+++ b/src/academic_agent/source_pipeline.py
@@ -42,7 +42,7 @@ _BIOMEDICAL_MARKERS: tuple[str, ...] = (
     "drug ", "therapy", "vaccine", "clinical trial", "pharmaceutical",
     "diagnostic", "implant", "surgical", "gene editing", "cell therapy",
     "gene therapy", "medical device", "antibody", "in vitro", "in vivo",
-    "oncology", "cancer treatment", "immunotherapy",
+    "oncology", "cancer treatment", "immunotherapy", "blood pressure",
     # Bioprocess / cellular agriculture — manufacturing maturity is the key gate
     "cultivated meat", "cultured meat", "cell-based meat", "cellular agriculture",
     "tissue engineering", "stem cell", "bioprocessing", "bioreactor scale",
@@ -59,6 +59,11 @@ _REGULATED_BIOMEDICAL_MARKERS: tuple[str, ...] = (
     "surgical", "cell therapy", "gene therapy", "medical device",
     "cancer treatment", "immunotherapy", "genetic disease",
     "drug candidate", "drug treatment", "patient treatment",
+    # The phrase is intentionally narrower than "clinical" or "monitoring".
+    # A production canary showed that a cuffless blood-pressure product reached
+    # an industrial score profile and skipped regulator retrieval, while either
+    # generic term would also catch non-product workflow and factory topics.
+    "blood pressure monitor",
 )
 _CLINICAL_REGISTRY_MARKERS: tuple[str, ...] = (
     "therapy", "vaccine", "clinical trial", "cell therapy", "gene therapy",
@@ -212,7 +217,13 @@ _OFFICIAL_PATENT_HOSTS = frozenset({
 })
 # Publishers/journal-name fragments known to appear on Beall's predatory list or
 # widely flagged by the academic community.  Matched case-insensitively as
-# substrings of the publisher field returned by search APIs.
+# substrings of the publisher field returned by search APIs.  A generic
+# "American Journal of" title prefix is deliberately absent: APIs sometimes put
+# the venue title in this field, and the prefix alone says nothing about the
+# publisher.  It misclassified the official ASPC/Elsevier American Journal of
+# Preventive Cardiology in a paid production canary.  Unknown titles now remain
+# unclassified instead of receiving a low-confidence label, preserving the
+# project's precision-first policy.
 _PREDATORY_PUBLISHER_FRAGMENTS: frozenset[str] = frozenset({
     "fringe global",
     "omics publishing",
@@ -221,7 +232,6 @@ _PREDATORY_PUBLISHER_FRAGMENTS: frozenset[str] = frozenset({
     "scirp",
     "hindawi",                     # acquired many low-quality journals post-2021
     "science publishing group",
-    "american journal of",         # many predatory clones use this prefix
     "international journal of innovation",
     "global journal of",
     "world journal of",
@@ -245,33 +255,6 @@ _PREDATORY_PUBLISHER_FRAGMENTS: frozenset[str] = frozenset({
     "innovationinfo",
 })
 
-# Legitimate journals whose names contain a predatory fragment — checked first
-# to prevent false positives (e.g. "american journal of medicine" starts with
-# the "american journal of" predatory-clone prefix).
-_PREDATORY_PUBLISHER_WHITELIST: frozenset[str] = frozenset({
-    "american journal of medicine",
-    "american journal of epidemiology",
-    "american journal of public health",
-    "american journal of respiratory",
-    "american journal of clinical",
-    "american journal of obstetrics",
-    "american journal of surgery",
-    "american journal of cardiology",
-    "american journal of psychiatry",
-    "american journal of roentgenology",
-    "american journal of gastroenterology",
-    "american journal of kidney",
-    "american journal of hematology",
-    "american journal of sports medicine",
-    "american journal of neuroradiology",
-    "american journal of human genetics",
-    "american journal of botany",
-    "american journal of physics",
-    "american journal of mathematics",
-    "american journal of nursing",
-    "american journal of law",
-})
-
 # Borderline publishers: flagged for volume/speed issues but operate many
 # legitimate peer-reviewed journals — downgrade to "medium" rather than "low".
 _BORDERLINE_PUBLISHER_FRAGMENTS: frozenset[str] = frozenset({
@@ -282,8 +265,6 @@ _BORDERLINE_PUBLISHER_FRAGMENTS: frozenset[str] = frozenset({
 def _is_predatory_publisher(publisher: str) -> bool:
     """Return True if the publisher name is definitively predatory (→ low tier)."""
     lowered = publisher.lower()
-    if any(safe in lowered for safe in _PREDATORY_PUBLISHER_WHITELIST):
-        return False
     return any(frag in lowered for frag in _PREDATORY_PUBLISHER_FRAGMENTS)
 
 

--- a/tests/test_evidence_gap.py
+++ b/tests/test_evidence_gap.py
@@ -29,6 +29,8 @@ from academic_agent.source_pipeline import (
     AuthorityCoverage,
     ComponentCoverage,
     SourceCollection,
+    _detect_weight_profile,
+    _measure_authority_coverage,
 )
 
 
@@ -137,6 +139,35 @@ class GapGateTests(unittest.TestCase):
         self.assertEqual(signal.subject, "clinical_registry")
         self.assertEqual(signal.scope, "market")
         self.assertEqual(signal.allowed_tools, ("authority_search",))
+
+    def test_clinical_monitoring_topic_reaches_enabled_shadow_boundary(self):
+        """The live false negative must be caught across classification and gate seams."""
+        topic = "Wearable continuous blood pressure monitoring via photoplethysmography"
+        profile = _detect_weight_profile(topic)
+        collection = _collection(topic=topic, profile=profile)
+        collection.authority_coverage = _measure_authority_coverage(
+            topic,
+            profile,
+            [
+                *collection.academic_sources,
+                *collection.patent_sources,
+                *collection.market_sources,
+            ],
+        )
+
+        audit = run_shadow_assessment(
+            collection,
+            configuration=parse_shadow_configuration("true"),
+        )
+
+        self.assertEqual(profile, "biomedical")
+        self.assertEqual(audit.gate_state, "eligible")
+        self.assertTrue(audit.checked)
+        self.assertEqual(
+            [(signal.code, signal.subject) for signal in audit.context.signals],
+            [("authority_category_missing", "regulatory")],
+        )
+        self.assertEqual(audit.executed_call_count, 0)
 
     def test_only_explicitly_incomplete_components_trigger(self):
         for status in ("partial", "unchecked"):

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -182,19 +182,25 @@ class PredatoryPublisherTests(TestCase):
                     f"Expected '{publisher}' NOT to be flagged as predatory",
                 )
 
-    def test_whitelist_prevents_false_positive(self) -> None:
-        """Legitimate 'American Journal of X' titles must not be flagged."""
+    def test_ambiguous_journal_title_prefix_is_not_publisher_identity(self) -> None:
+        """A generic venue prefix must never be enough for a low-confidence label."""
         cases = [
+            # This exact production source is the official ASPC journal,
+            # published by Elsevier; the old finite whitelist omitted it.
+            "American Journal of Preventive Cardiology",
             "American Journal of Medicine",
             "American Journal of Epidemiology",
             "American Journal of Public Health",
             "American Journal of Cardiology",
+            # Precision is preferable to inventing a publisher classification
+            # for a title the detector does not know.
+            "American Journal of Unclassified Research",
         ]
         for publisher in cases:
             with self.subTest(publisher=publisher):
                 self.assertFalse(
                     _is_predatory_publisher(publisher),
-                    f"Whitelist should prevent '{publisher}' from being flagged",
+                    f"A title prefix alone must not flag '{publisher}'",
                 )
 
     def test_borderline_publishers_detected(self) -> None:

--- a/tests/test_source_pipeline.py
+++ b/tests/test_source_pipeline.py
@@ -961,6 +961,21 @@ class WeightProfileDetectionTests(TestCase):
         self.assertEqual(_detect_weight_profile("CAR-T cell therapy manufacturing"), "biomedical")
         self.assertEqual(_detect_weight_profile("antibody drug conjugate"), "biomedical")
 
+    def test_blood_pressure_monitoring_is_biomedical(self):
+        """The production canary's exact class must not fall through to industrial."""
+        self.assertEqual(
+            _detect_weight_profile(
+                "Wearable continuous blood pressure monitoring via photoplethysmography"
+            ),
+            "biomedical",
+        )
+        # The fix is the biomedical measurement, not the generic word
+        # "pressure"; industrial pressure monitoring must retain its profile.
+        self.assertEqual(
+            _detect_weight_profile("pipeline pressure monitoring for chemical plants"),
+            "industrial",
+        )
+
     def test_biomedical_bioprocess(self):
         # Food biotech / cellular agriculture markers added for cultivated-meat topics
         self.assertEqual(_detect_weight_profile("cultivated meat bioreactor scale-up"), "biomedical")
@@ -1066,6 +1081,16 @@ class AuthorityQueryPlanningTests(TestCase):
         self.assertIn("site:fda.gov", market[0])
         self.assertIn("site:ema.europa.eu", market[1])
         self.assertIn("site:clinicaltrials.gov", market[2])
+
+    def test_blood_pressure_monitor_queries_regulators_but_not_trial_registry(self):
+        """A marketed monitor needs regulator evidence, not an invented trial duty."""
+        from academic_agent.source_pipeline import _queries
+
+        topic = "Wearable continuous blood pressure monitoring via photoplethysmography"
+        market = _queries(topic, weight_profile=_detect_weight_profile(topic))["market"]
+        self.assertIn("site:fda.gov", market[0])
+        self.assertIn("site:ema.europa.eu", market[1])
+        self.assertFalse(any("clinicaltrials.gov" in query for query in market))
 
     def test_nonclinical_biomedical_methods_do_not_require_clinical_authorities(self):
         from academic_agent.source_pipeline import _queries
@@ -1200,6 +1225,20 @@ class AuthorityCoverageTests(TestCase):
         )
         self.assertEqual(coverage.status, "incomplete")
         self.assertEqual(coverage.missing_categories, ["clinical_registry"])
+
+    def test_blood_pressure_monitor_without_official_record_is_incomplete(self):
+        """Market-page clearance claims do not satisfy official regulator coverage."""
+        from academic_agent.source_pipeline import _measure_authority_coverage
+
+        topic = "Wearable continuous blood pressure monitoring via photoplethysmography"
+        coverage = _measure_authority_coverage(
+            topic,
+            _detect_weight_profile(topic),
+            [],
+        )
+        self.assertEqual(coverage.status, "incomplete")
+        self.assertEqual(coverage.required_categories, ["regulatory"])
+        self.assertEqual(coverage.missing_categories, ["regulatory"])
 
     def test_nonclinical_topics_are_explicitly_not_applicable(self):
         from academic_agent.source_pipeline import _measure_authority_coverage


### PR DESCRIPTION
## Why

The first paid phase-one shadow canary verified artifact persistence and zero evidence mutation, but its `no_gap` decision was a false negative. The wearable blood-pressure topic was classified as industrial, which made official regulator coverage look not applicable. The same run also revealed that a generic `American Journal of` title prefix falsely downgraded an official ASPC/Elsevier journal.

## What changed

- classify blood-pressure topics as biomedical;
- require regulator evidence for blood-pressure monitors without imposing a universal trial-registry requirement;
- remove the ambiguous journal-title prefix and its inevitably incomplete allowlist;
- assert classification, query planning, authority coverage, shadow-gate delivery, and source-credibility seams;
- document the paid observation, frozen-baseline impact, and the fact that post-fix production behavior remains unobserved.

The new markers change 0/10 frozen benchmark topics and 0/30 frozen runs.

## Validation

- `1374 passed, 594 subtests passed`
- coverage `86.91%` against the `85%` CI floor
- `uv run --with ruff ruff check .`
- CI-scope Pylint checks
- original classification and publisher defects re-injected separately; each made its new regression test fail before restoration