### PR TITLE
Document the post-fix production shadow canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,12 @@ outputs/evidence-gap-shadow-phase1 --expected-count 30`; see the
 [frozen protocol](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md). The
 first paid production canary verified artifact persistence and zero evidence
 mutation, while also exposing a clinical-device authority false negative and a
-journal-title credibility false positive. The narrow correction and its
-remaining post-deployment observation boundary are recorded in the
-[canary result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md).
+journal-title credibility false positive. A separately pre-registered post-fix
+run then observed the biomedical profile, official-regulator coverage, high
+credibility for the legitimate journal, zero supplementary calls, and a
+matching source hash for `$0.035442`. This is one repeated-topic observation,
+not phase-2 Tool Calling evidence; see the [phase-1 result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)
+and [post-fix canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md).
 
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
@@ -1246,8 +1249,11 @@ outputs/evidence-gap-shadow-phase1 --expected-count 30` 复现 30 次零网络�
 设计边界与后续上线阈值见
 [冻结协议](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md)。首次付费生产
 canary 已验证影子产物持久化且未改变证据，同时暴露了临床设备权威来源漏检和
-期刊标题可信度误判；窄范围修正及仍待部署后观察的边界记录在
-[canary 结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)。
+期刊标题可信度误判。随后预注册的 post-fix 运行观察到 biomedical profile、
+官方监管覆盖、正规期刊保持高可信、零补充调用及一致的来源哈希，成本为
+`$0.035442`。这只是一项重复主题观察，并非第二阶段 Tool Calling 证据；详见
+[第一阶段结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)与
+[修复后 canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md)。
 
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 

--- a/docs/prereg-2026-08-25-evidence-gap-shadow-post-fix-canary.md
+++ b/docs/prereg-2026-08-25-evidence-gap-shadow-post-fix-canary.md
@@ -1,0 +1,75 @@
+# Evidence-gap shadow post-fix production canary — pre-registration
+
+**Frozen:** 2026-08-25T02:47:40Z, before the production `POST /api/runs`
+**Authorized production revision:** `8d5ef489391cfa72905a8201d3bb55e76a236e14`
+**Authorized paid scope:** one operator-funded source run, no retry or resume
+**Soft cost stop:** `$0.05`; one already-admitted run may finish above it
+**Planner or supplementary search calls authorized:** no
+
+## Question
+
+Does the narrow correction prompted by the first paid phase-1 canary reach the
+production boundary on the same topic, without enabling a planner, executing a
+supplementary search, or mutating the accepted evidence collection?
+
+This is a post-fix observation of one previously seen topic. It is not a
+held-out trigger-precision study, a phase-2 planner evaluation, or evidence of
+a production success rate.
+
+## Frozen input and preflight
+
+The request topic is exactly:
+
+> Wearable continuous blood pressure monitoring using photoplethysmography for
+> clinical deployment
+
+No language or weight-profile override will be supplied. Before this document
+was frozen:
+
+- GitHub deployment `6075343589` identified the authorized revision and
+  Railway reported it as `success`;
+- `/health/ready` returned HTTP 200 with `llm`, `search`, `outputs`, and
+  `paid_accounting` all `ok`; and
+- the existing operator code reached `/api/access/check` with HTTP 200. The
+  code itself is not recorded in this repository.
+
+## Frozen execution protocol
+
+1. Submit exactly one `POST /api/runs` containing only the topic.
+2. Record the returned run id before any polling.
+3. Poll only that run to a terminal state. Do not retry, resume, or substitute
+   another topic if it fails.
+4. Inspect the public status, source collection, shadow artifact, usage, and
+   checkpoint identity after termination.
+5. Report every criterion as pass, fail, not inspectable, or not observed. A
+   missing field is not a pass.
+
+The `$0.05` threshold is soft because this API exposes aggregate usage only
+after provider work has started. No second run is allowed even if the first
+fails below the threshold.
+
+## Acceptance criteria
+
+1. The observed pipeline revision is the authorized revision.
+2. The single source run reaches `completed` without a child resume.
+3. Automatic profile selection records `biomedical`, not `industrial`.
+4. Authority coverage requires `regulatory` and must not be
+   `not_applicable`. If no validated regulator source is accepted, coverage
+   must be `incomplete`, `regulatory` must be missing, and the shadow gate must
+   expose `authority_category_missing/regulatory`. If a validated official
+   regulator source is accepted, `complete` plus `no_gap` is allowed instead.
+5. The shadow artifact is persisted, records zero executed calls and zero
+   additional search cost, and shows identical source-collection hashes before
+   and after evaluation.
+6. If *American Journal of Preventive Cardiology* is retrieved again, it is
+   not assigned a low/predatory credibility label. Absence of that venue is
+   `not_observed`, not a pass.
+7. Total provider cost is inspectable and no greater than the `$0.05` soft
+   threshold.
+8. No second run, resume, planner request, or supplementary search request is
+   created by this protocol.
+
+Any industrial profile, non-applicable authority result, unauthorized outbound
+call, evidence mutation, terminal failure, or over-threshold inspectable cost
+fails the canary. Passing this canary closes only the exact production defect;
+it does not satisfy the separately frozen phase-2 thresholds.

--- a/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
+++ b/docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md
@@ -108,7 +108,15 @@ The follow-up correction remains deliberately narrow:
 
 The proposed phrases change zero of the ten topics and zero of the 30 runs in
 the frozen calibration benchmark. No second paid run was used during the code
-fix, so production post-fix behavior remains to be observed after deployment.
+fix.
+
+A [separately pre-registered post-fix canary](results-2026-08-25-evidence-gap-shadow-post-fix-canary.md)
+later observed the deployed correction on the same topic. It selected the
+biomedical profile, required regulator evidence, retained the legitimate
+journal at high credibility, executed zero planner/search calls, and reproduced
+the unchanged source hash. Retrieval accepted an official FDA record, so the
+frozen `complete + no_gap` branch passed; the missing-regulator `eligible`
+branch remains covered by offline seam tests rather than this production run.
 
 Post-fix local gates passed: 1,374 zero-network tests and 594 subtests, Ruff,
 the CI exception-order Pylint checks, and 86.91% measured coverage against the

--- a/docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md
+++ b/docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md
@@ -1,0 +1,70 @@
+# Evidence-gap shadow post-fix production canary — result
+
+**Run:** [20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4](https://academic-commercialization-agent.up.railway.app/run/20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4)
+**Protocol:** [frozen post-fix pre-registration](prereg-2026-08-25-evidence-gap-shadow-post-fix-canary.md)
+**Pre-registration commit:** `0bc5693`
+**Production revision:** `8d5ef489391cfa72905a8201d3bb55e76a236e14`
+**Outcome:** passed the frozen one-run criteria, with disclosed residual limits
+
+## Execution
+
+The operator authorized one paid source run on the same previously observed
+topic. The request was accepted at `2026-08-25T02:49:19Z` and no second run,
+retry, or resume was submitted.
+
+- Terminal state: `completed`, with `resumed_from=null`
+- Elapsed time: 172 seconds
+- Sources: 8 academic + 8 patent + 8 market
+- Provider use: 87,015 tokens over 6 LLM requests
+- Inspectable cost: `$0.035442`, below the `$0.05` soft stop
+- Quality review: passed
+- Consistency screen: 0 blockers and 0 warnings
+- Checkpointing: all seven nodes committed with no errors
+
+## Frozen criteria
+
+| # | Result | Evidence |
+|---|---|---|
+| 1 | Pass at the deployment seam | GitHub deployment `6075343589` identified revision `8d5ef48...`, Railway reported `success`, readiness passed immediately before submission, and no later deployment preceded this run. The public run payload does not export its raw checkpoint identity, so this was not independently recomputed from the Railway volume. |
+| 2 | Pass | The only admitted run reached `completed`; `resumed_from` was null. |
+| 3 | Pass | The persisted source collection recorded `weight_profile=biomedical`. |
+| 4 | Pass under the pre-registered official-source branch | Authority coverage required `regulatory`, accepted official FDA source `M7`, reported `complete`, and therefore correctly produced `no_gap` rather than the alternative missing-category signal. |
+| 5 | Pass | `planner_state=not_run`, `executed_call_count=0`, additional search cost was `$0`, persistence was `written`, and `evidence_changed=false`. Independently loading the final `validated_sources.json` and applying the repository's canonical hash function reproduced `7b2dfae4b4c80b061cd147718fb4f859bdcacc9b2f335f26eaced36f92e78cf9`, exactly matching the pre-evaluation context hash. |
+| 6 | Pass | *American Journal of Preventive Cardiology* recurred as `A5` and retained `credibility_tier=high`; the removed generic title-prefix rule did not label it predatory. |
+| 7 | Pass | `$0.035442` was inspectable and below `$0.05`. |
+| 8 | Pass | Operator history contained exactly one run at or after submission, no child resume, six ordinary workflow LLM requests, and zero planner or supplementary-search executions. |
+
+The accepted regulator record was FDA 510(k) `K222658`. The
+[official Devices@FDA entry](https://www.accessdata.fda.gov/SCRIPTS/cdrh/devicesatfda/index.cfm?db=pmn&id=K222658)
+identifies it as the Accurate 24 non-invasive blood-pressure monitor and records
+a substantially-equivalent decision. This confirms that `M7` is a real,
+topically relevant regulator source rather than a host-only false positive.
+
+## Residual limits and new observation
+
+The result closes the two exact production defects that motivated PR #31:
+automatic classification reached `biomedical`, authority coverage actually
+ran, and the legitimate journal was no longer downgraded. It does not establish
+that the current authority screen understands modality-level claim scope.
+
+`M7` describes pulse-wave-transit-time measurement using piezo and NIRS
+sensors, while the requested topic specifies PPG-based continuous monitoring.
+The report correctly cautioned that `M7` did not confirm the exact PPG modality,
+but the deterministic authority screen currently treats a validated regulator
+category as covered. Accordingly, `no_gap` means only that an official
+regulator source is present; it must not be presented as complete regulatory
+evidence for the exact product concept. A modality-sensitive rule would need a
+separately frozen semantic challenge set and abstention threshold rather than a
+post-hoc keyword patch.
+
+The PDF search title for `M7` was also persisted as garbled extracted text and
+appeared that way in the report reference list. Its URL, FDA identity,
+credibility, and evidence summary were usable, so this did not change the
+frozen pass result. It is nevertheless a presentation-quality defect to assess
+offline before deciding whether a high-precision FDA-specific title normalizer
+is justified.
+
+Finally, this is one repeated-topic observation. It is not a trigger-precision
+rate, evidence-increment result, SLO, or proof that Tool Calling adds value.
+Phase 2 remains disabled and still requires the separately frozen challenge set
+and thresholds in the original phase-1 protocol.


### PR DESCRIPTION
## Why

PR #31 corrected two defects exposed by the first paid shadow canary, but production post-fix behavior remained unobserved. This branch publicly froze the follow-up criteria before sending the one authorized request, then records the result without changing the success rule after the fact.

## Result

- one run only: `20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4`;
- completed in 172 seconds with 8 academic, 8 patent, and 8 market sources;
- 87,015 tokens, 6 ordinary workflow LLM requests, `$0.035442`;
- `weight_profile=biomedical`;
- regulator coverage required and completed by official FDA `M7`;
- legitimate AJPC source retained `credibility_tier=high`;
- planner not run, zero supplementary calls, zero added search cost;
- final source hash independently reproduced the pre-evaluation context hash;
- no retry, resume, or second run.

## Limits retained

The FDA record concerns PWTT with piezo/NIRS sensors rather than the exact PPG modality. The result therefore proves that the regulator category no longer falls through as not applicable; it does not prove modality-complete regulatory evidence. The FDA PDF title was also garbled in the final references and is disclosed as a separate presentation defect. This repeated-topic observation is not phase-two Tool Calling evidence, a success rate, or an SLO.

## Validation

- `1374 passed, 594 subtests passed`
- `uv run --with ruff ruff check .`
- `git diff --check`