### PR TITLE
Audit regulator titles without inventing a denominator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1374 tests (594 subtests), CI green on Linux + Windows × Python
+Current state: 1381 tests (602 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -138,7 +138,7 @@ These are not style preferences; each came from a specific failure.
 ```
 src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         evidence models + guardrails, scoring, worker
-  source_pipeline.py    ~2,900 lines, retrieval for all three domains
+  source_pipeline.py    ~3,400 lines, retrieval for all three domains
   evidence.py           models, guardrails, scoring rubric
   pipeline_worker.py    the subprocess one run executes in
   checkpoint_runtime.py
@@ -148,10 +148,12 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  63 test modules plus conftest, organised by subject
+tests/                  64 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering
+regulator_title_audit.py
+                        zero-network title census; zero denominator is not a pass
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py

--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ matching source hash for `$0.035442`. This is one repeated-topic observation,
 not phase-2 Tool Calling evidence; see the [phase-1 result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)
 and [post-fix canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md).
 
+The canary's garbled FDA PDF title was measured before any cleanup rule was
+added. A zero-network census found **0 in-scope regulator or registry titles in
+30/30 stored benchmark runs** (and 0 in the ten tracked topic fixtures), so the
+result is explicitly `not_assessable_zero_denominator`, not a clean pass. A
+separate disclosed five-case challenge catches the exact production title while
+leaving plausible FDA and ClinicalTrials.gov controls clean. No production
+normalizer was enabled; reproduce the audit with `uv run python
+regulator_title_audit.py outputs/benchmark outputs/regulator-title-audit
+--expected-count 30 --challenge
+evals/regulator_title_quality/challenge-v1.json`. See the
+[protocol](docs/protocol-2026-08-25-regulator-title-quality-audit.md) and
+[result](docs/results-2026-08-25-regulator-title-quality-audit.md).
+
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
 ---
@@ -1254,6 +1267,18 @@ canary 已验证影子产物持久化且未改变证据，同时暴露了临床�
 `$0.035442`。这只是一项重复主题观察，并非第二阶段 Tool Calling 证据；详见
 [第一阶段结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)与
 [修复后 canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md)。
+
+针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、未直接增加清洗规则。
+零网络普查发现 30/30 次本地 benchmark 中符合范围的监管/临床注册标题为 **0**
+（仓库内 10 份话题 fixture 同样为 0），因此结果明确记为
+`not_assessable_zero_denominator`，而不是“检查通过”。另用 5 条公开说明的
+challenge 验证：精确的线上错例会被标记，合理的 FDA 与 ClinicalTrials.gov
+标题保持 clean。生产标题规范化仍未启用；可运行 `uv run python
+regulator_title_audit.py outputs/benchmark outputs/regulator-title-audit
+--expected-count 30 --challenge
+evals/regulator_title_quality/challenge-v1.json` 复现，详见
+[协议](docs/protocol-2026-08-25-regulator-title-quality-audit.md)与
+[结果](docs/results-2026-08-25-regulator-title-quality-audit.md)。
 
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 

--- a/docs/protocol-2026-08-25-regulator-title-quality-audit.md
+++ b/docs/protocol-2026-08-25-regulator-title-quality-audit.md
@@ -1,0 +1,115 @@
+# Regulator-source title quality audit — frozen protocol
+
+**Frozen:** 2026-08-25, after the denominator census and before the detector
+or audit command was implemented.
+
+## Why this is a protocol, not a pre-registration
+
+The post-fix blood-pressure canary had already exposed one garbled FDA title,
+and a read-only census had already established that the 30 stored benchmark
+runs contain zero sources from the regulator and clinical-registry domains in
+scope. Those facts cannot honestly be called unseen predictions. This document
+freezes what will be implemented and how the resulting zero denominator will
+be reported; it does not relabel a retrospective check as a held-out study.
+
+## Question
+
+Can a zero-network audit:
+
+1. enumerate every stored collection and preserve its content hash;
+2. identify sources whose URL belongs to the same narrow regulator or clinical
+   registry domain set used by the production coverage policy;
+3. distinguish a zero denominator from a clean pass;
+4. flag the exact known production title without broadly rejecting plausible
+   regulator titles; and
+5. retain case-level evidence so a later normalization proposal can be judged
+   against observed inputs rather than anecdotes?
+
+The audit does **not** normalize titles and does not change production
+retrieval, source scoring, authority coverage, reports, or the Evidence-gap
+Planner.
+
+## Frozen scope
+
+The authority hosts are the current production sets on 2026-08-25:
+
+- regulator: `fda.gov`, `ema.europa.eu`, `mhra.gov.uk`, `tga.gov.au`,
+  `pmda.go.jp`;
+- clinical registry: `clinicaltrials.gov`, `clinicaltrialsregister.eu`,
+  `euclinicaltrials.eu`, `isrctn.com`, `anzctr.org.au`.
+
+Exact hosts and their subdomains are in scope. A suffix such as
+`fda.gov.attacker.example` is not.
+
+The development census is the 30 direct-child `validated_sources.json` files
+under `outputs/benchmark/`. The tracked ten-topic fixture directory will be
+run as a reproducibility cross-check, but it is not an additional independent
+sample.
+
+## Precision-first title screen
+
+Only explicit structural failures are eligible for `review_required`:
+
+- an empty title;
+- a title that is only its URL or host;
+- a Unicode replacement character, which proves a decoding loss occurred;
+- at least four one-letter alphabetic fragments that make up at least half of
+  the alphabetic tokens **and** an official host printed in the title.
+
+The final rule is deliberately conjunctive. Punctuation density, short titles,
+all-caps words, product codes, and generic PDF suffixes are not enough to flag
+a title because those patterns are common in valid regulator records. A clean
+result means only “none of these structural screens fired,” not that the title
+is semantically correct.
+
+## Frozen challenge
+
+`evals/regulator_title_quality/challenge-v1.json` contains:
+
+- the exact `M7` title and URL observed in the completed production run
+  `20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4`;
+- disclosed synthetic negative controls for normal FDA and registry titles;
+- a host-boundary negative control; and
+- an explicit decoding-loss positive control.
+
+The production case is post-hoc and the controls are synthetic. Passing this
+challenge tests a narrow regression contract, not prevalence, recall, or title
+truth.
+
+## Result states
+
+- `not_assessable_zero_denominator`: every collection loaded, but no in-scope
+  title existed; this must never be rendered as pass.
+- `checked_no_structural_flags`: at least one in-scope title was checked and no
+  frozen screen fired.
+- `review_required`: at least one in-scope title fired a frozen screen.
+- `failed`: a collection, challenge, expected count, or output contract could
+  not be validated.
+
+The command may complete successfully with
+`not_assessable_zero_denominator`. Completion says the census ran; it does not
+invent a quality denominator.
+
+## Acceptance criteria
+
+1. Exactly 30 stored benchmark collections load and appear in the manifest.
+2. The observed benchmark state is
+   `not_assessable_zero_denominator`, not pass or clean.
+3. The exact `M7` case is `review_required` for the frozen fragmented-token
+   reason.
+4. Both plausible-title controls remain clean and the attacker-domain control
+   remains out of scope.
+5. Every challenge expectation matches, all fixture and challenge hashes are
+   persisted, and repeated evaluation is byte-for-byte deterministic after
+   excluding the chosen output directory.
+6. Tests run with networking disabled, the writer refuses to overwrite an
+   existing audit, the original defect is re-injected once, and the complete
+   zero-network suite plus CI lint gates remain green.
+
+## Claims explicitly forbidden
+
+This audit cannot establish regulator-title error rate, title correctness,
+source truth, report correctness, held-out precision/recall, or that a title
+normalizer should ship. With zero benchmark denominator and one known positive
+case, the only valid next-step decision is whether a separately tested,
+authority-specific normalizer is worth investigating.

--- a/docs/results-2026-08-25-regulator-title-quality-audit.md
+++ b/docs/results-2026-08-25-regulator-title-quality-audit.md
@@ -1,0 +1,113 @@
+# Regulator-source title quality audit — result
+
+**Run date:** 2026-08-25
+**Protocol:** [frozen implementation protocol](protocol-2026-08-25-regulator-title-quality-audit.md)
+**Network, LLM, supplementary search, and production mutations:** 0
+
+## Outcome
+
+The audit completed, but the benchmark result is **not assessable**. All 30
+stored benchmark collections loaded and were content-hashed; none contained a
+source from the frozen regulator or clinical-registry host set. The correct
+state is therefore `not_assessable_zero_denominator`, not pass and not
+`checked_no_structural_flags`.
+
+| Dataset | Collections | In-scope titles | Affected collections | State |
+|---|---:|---:|---:|---|
+| Stored 30-run benchmark | 30/30 | 0 | 0/30 | `not_assessable_zero_denominator` |
+| Tracked ten-topic fixtures | 10/10 | 0 | 0/10 | `not_assessable_zero_denominator` |
+
+The ten tracked fixtures are a reproducibility cross-check, not an independent
+sample: they are snapshots of the same benchmark topics. Their agreement only
+shows that a clean clone can reproduce the zero denominator.
+
+## Frozen challenge
+
+The five-case disclosed challenge matched 5/5 expectations. Its SHA-256 is
+`0be6054820be180b749a1925ce66a9ec6a716d4176f5c8fe7308888a7bc4c811`.
+
+| Case | Provenance | Observed state | Reason |
+|---|---|---|---|
+| Production `M7` FDA title | Exact post-fix canary artifact | `review_required` | `fragmented_single_letter_tokens` |
+| Plausible FDA 510(k) title | Synthetic negative control | `clean` | — |
+| Plausible ClinicalTrials.gov title | Synthetic negative control | `clean` | — |
+| `fda.gov.attacker.example` | Synthetic scope control | `out_of_scope` | — |
+| Title containing `�` | Synthetic positive control | `review_required` | `encoding_replacement_character` |
+
+The known production title was:
+
+```text
+'b, , 4 , I 'b, I - accessdata.fda.gov
+```
+
+It came from source `M7` at
+`https://www.accessdata.fda.gov/CDRH510K/K222658.pdf` in run
+`20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4`. The classifier flags it
+only because it combines at least four isolated alphabetic fragments, a
+majority fragment ratio, and the official host printed in the title. It does
+not use general punctuation density, capitalization, title length, PDF
+suffixes, or product codes as failure signals.
+
+This is a post-hoc regression case plus synthetic controls. A 5/5 result does
+not establish prevalence, recall, or held-out precision.
+
+## Determinism and verification
+
+The 30-collection audit was executed twice into separate output directories.
+Both persisted files were byte-identical:
+
+- `result.json`: `4d40f8d1f3d419757058f12d4977bde897f95bf9f8c67f78f34a696a4a0ee778`
+- `cases.csv`: `ffb8ec0843555652701b8fa2b92015b17a36a0a15c64ad75a912ef9293d1e084`
+
+The implementation also records every collection hash and per-collection
+official-source count, retains challenge provenance and expected/observed
+labels at the CSV seam, refuses to overwrite prior output, and fails closed on
+invalid collections or expected-count drift.
+
+The original defect was re-injected by changing the minimum isolated-fragment
+count from four to five. The exact production subtest changed from
+`review_required` to `clean` and failed; restoring four returned the targeted
+suite to green.
+
+Local gates after restoration:
+
+- 1,381 zero-network tests and 602 subtests passed;
+- CI-equivalent coverage remained 86.91%, above the frozen 85% floor;
+- the newest Ruff passed; and
+- the audit itself executed no network or provider path.
+
+Commands:
+
+```bash
+uv run python regulator_title_audit.py outputs/benchmark \
+  outputs/regulator-title-audit-20260825-benchmark \
+  --expected-count 30 \
+  --challenge evals/regulator_title_quality/challenge-v1.json
+
+uv run python regulator_title_audit.py benchmark_fixtures \
+  outputs/regulator-title-audit-20260825-tracked-fixtures \
+  --expected-count 10 \
+  --challenge evals/regulator_title_quality/challenge-v1.json
+```
+
+## Decision
+
+No production title normalizer is added by this change. One observed failure is
+enough for a regression challenge, but zero benchmark denominator is not enough
+to estimate false-positive cost or choose a normalization policy. A broad PDF
+cleaner would violate the project's precision-first rule.
+
+The next defensible step is to retain future official regulator titles in a
+separately versioned challenge set, with manual labels and source identity. A
+future FDA-specific normalizer should be proposed only against that set and
+must preserve the raw title, expose that normalization occurred, and abstain
+when a stable identifier such as a 510(k) number cannot be verified. This audit
+does not authorize that implementation.
+
+## Claim limits
+
+The result establishes that the audit contract represents a zero denominator
+honestly and catches one exact known failure without firing on the disclosed
+controls. It does not establish regulator-title quality, source truth, report
+correctness, production error rate, semantic title correspondence, general
+precision/recall, or business value.

--- a/evals/regulator_title_quality/challenge-v1.json
+++ b/evals/regulator_title_quality/challenge-v1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "measurement_design": "one_observed_production_failure_plus_disclosed_synthetic_controls",
+  "cases": [
+    {
+      "case_id": "production-m7-fragmented-title",
+      "provenance": "observed_production",
+      "run_id": "20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4",
+      "source_id": "M7",
+      "title": "'b, , 4 , I 'b, I - accessdata.fda.gov",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K222658.pdf",
+      "expected_scope": "regulatory",
+      "expected_status": "review_required",
+      "expected_reason_codes": [
+        "fragmented_single_letter_tokens"
+      ]
+    },
+    {
+      "case_id": "control-fda-510k-title",
+      "provenance": "synthetic_negative_control",
+      "run_id": null,
+      "source_id": "M1",
+      "title": "K222658 - Accurate 24 - 510(k) Premarket Notification",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K222658.pdf",
+      "expected_scope": "regulatory",
+      "expected_status": "clean",
+      "expected_reason_codes": []
+    },
+    {
+      "case_id": "control-clinical-registry-title",
+      "provenance": "synthetic_negative_control",
+      "run_id": null,
+      "source_id": "M2",
+      "title": "NCT01234567: Continuous Blood Pressure Monitoring Study",
+      "url": "https://clinicaltrials.gov/study/NCT01234567",
+      "expected_scope": "clinical_registry",
+      "expected_status": "clean",
+      "expected_reason_codes": []
+    },
+    {
+      "case_id": "control-attacker-host",
+      "provenance": "synthetic_scope_control",
+      "run_id": null,
+      "source_id": "M3",
+      "title": "A B C D - fda.gov.attacker.example",
+      "url": "https://fda.gov.attacker.example/fake.pdf",
+      "expected_scope": "out_of_scope",
+      "expected_status": "out_of_scope",
+      "expected_reason_codes": []
+    },
+    {
+      "case_id": "control-decoding-loss",
+      "provenance": "synthetic_positive_control",
+      "run_id": null,
+      "source_id": "M4",
+      "title": "Device Summary � K123456",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K123456.pdf",
+      "expected_scope": "regulatory",
+      "expected_status": "review_required",
+      "expected_reason_codes": [
+        "encoding_replacement_character"
+      ]
+    }
+  ]
+}

--- a/regulator_title_audit.py
+++ b/regulator_title_audit.py
@@ -1,0 +1,498 @@
+"""Audit regulator-source title structure over frozen source collections.
+
+This command never retrieves a page and never normalizes production evidence.
+It measures only a deliberately narrow set of structural title failures, then
+keeps a zero official-source denominator distinct from a clean result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, Field, HttpUrl
+
+from academic_agent.source_pipeline import SourceCollection
+
+
+AuthorityScope = Literal["regulatory", "clinical_registry", "out_of_scope"]
+TitleStatus = Literal["clean", "review_required", "out_of_scope"]
+ReasonCode = Literal[
+    "empty_title",
+    "host_or_url_only",
+    "encoding_replacement_character",
+    "fragmented_single_letter_tokens",
+]
+
+# This is an audit protocol, not a live policy object. Freezing the exact host
+# set makes a result reproducible even if production later adds another
+# regulator. The protocol records that these values matched production on
+# 2026-08-25; changing them requires a new schema version, not a silent rerun.
+REGULATORY_DOMAINS = frozenset(
+    {
+        "fda.gov",
+        "ema.europa.eu",
+        "mhra.gov.uk",
+        "tga.gov.au",
+        "pmda.go.jp",
+    }
+)
+CLINICAL_REGISTRY_DOMAINS = frozenset(
+    {
+        "clinicaltrials.gov",
+        "clinicaltrialsregister.eu",
+        "euclinicaltrials.eu",
+        "isrctn.com",
+        "anzctr.org.au",
+    }
+)
+
+CASE_FIELDS = (
+    "dataset",
+    "fixture",
+    "fixture_sha256",
+    "source_domain",
+    "source_id",
+    "authority_scope",
+    "host",
+    "title",
+    "url",
+    "status",
+    "reason_codes",
+    "provenance",
+    "expected_scope",
+    "expected_status",
+    "expected_reason_codes",
+    "matches_expectation",
+)
+
+
+class RegulatorTitleAuditError(ValueError):
+    """Raised when an audit would accept partial or ambiguous input."""
+
+
+class FrozenChallengeCase(BaseModel):
+    """One disclosed post-hoc or synthetic title-quality regression case."""
+
+    case_id: str = Field(min_length=3)
+    provenance: Literal[
+        "observed_production",
+        "synthetic_negative_control",
+        "synthetic_positive_control",
+        "synthetic_scope_control",
+    ]
+    run_id: str | None = None
+    source_id: str = Field(min_length=2)
+    # Empty is allowed here because the challenge contract must be able to
+    # prove that the screen catches an empty title. Valid SourceCollection
+    # records already reject it earlier through EvidenceSource.
+    title: str
+    url: HttpUrl
+    expected_scope: AuthorityScope
+    expected_status: TitleStatus
+    expected_reason_codes: list[ReasonCode] = Field(default_factory=list)
+
+
+class FrozenChallenge(BaseModel):
+    """Versioned challenge whose labels are evaluated without network access."""
+
+    schema_version: Literal[1]
+    measurement_design: str = Field(min_length=10)
+    cases: list[FrozenChallengeCase] = Field(min_length=1)
+
+
+def _host_matches(host: str, domains: frozenset[str]) -> bool:
+    """Match exact hosts or subdomains without trusting attacker suffixes."""
+
+    normalized = host.removeprefix("www.").lower()
+    return any(
+        normalized == domain or normalized.endswith(f".{domain}")
+        for domain in domains
+    )
+
+
+def authority_scope_for_url(url: str) -> AuthorityScope:
+    """Return the frozen authority scope for a URL."""
+
+    try:
+        host = (urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return "out_of_scope"
+    if _host_matches(host, REGULATORY_DOMAINS):
+        return "regulatory"
+    if _host_matches(host, CLINICAL_REGISTRY_DOMAINS):
+        return "clinical_registry"
+    return "out_of_scope"
+
+
+def _is_host_or_url_only(title: str, url: str, host: str) -> bool:
+    """Detect only identities, not merely short or generic regulator titles."""
+
+    normalized_title = title.strip().lower().rstrip("/")
+    normalized_url = url.strip().lower().rstrip("/")
+    bare_url = re.sub(r"^https?://", "", normalized_url)
+    bare_host = host.removeprefix("www.")
+    return normalized_title in {
+        normalized_url,
+        bare_url,
+        host,
+        bare_host,
+        f"www.{bare_host}",
+    }
+
+
+def assess_title(title: str, url: str) -> tuple[TitleStatus, list[ReasonCode]]:
+    """Apply the frozen precision-first structural title screen.
+
+    A clean result is intentionally modest: it means that none of four
+    structural failure signatures fired. It does not establish semantic title
+    correctness or correspondence to the linked record.
+    """
+
+    scope = authority_scope_for_url(url)
+    if scope == "out_of_scope":
+        return "out_of_scope", []
+
+    stripped = title.strip()
+    reasons: list[ReasonCode] = []
+    host = (urlsplit(url).hostname or "").lower()
+    if not stripped:
+        reasons.append("empty_title")
+    elif _is_host_or_url_only(stripped, url, host):
+        reasons.append("host_or_url_only")
+
+    if "\ufffd" in title:
+        reasons.append("encoding_replacement_character")
+
+    # The known FDA failure contains four isolated b/I fragments followed by
+    # the source host. Requiring all three signals avoids treating product
+    # codes, 510(k), initials, punctuation, or one-letter trial arms as enough
+    # evidence of corruption.
+    alpha_tokens = re.findall(r"[A-Za-z]+", title)
+    single_letter_tokens = sum(len(token) == 1 for token in alpha_tokens)
+    title_lower = title.lower()
+    visible_host = host.removeprefix("www.")
+    if (
+        single_letter_tokens >= 4
+        and single_letter_tokens * 2 >= len(alpha_tokens)
+        and bool(visible_host)
+        and visible_host in title_lower
+    ):
+        reasons.append("fragmented_single_letter_tokens")
+
+    return ("review_required" if reasons else "clean"), reasons
+
+
+def discover_collections(fixtures: Path) -> list[Path]:
+    """Find either run artifacts or tracked flat benchmark fixtures.
+
+    The live benchmark stores one ``validated_sources.json`` per direct child.
+    A clean clone retains ten equivalent SourceCollection snapshots as direct
+    JSON files. Supporting both layouts lets the 30-run census use the original
+    artifacts while CI can exercise the same parser over tracked evidence.
+    """
+
+    run_artifacts = sorted(fixtures.glob("*/validated_sources.json"))
+    flat_fixtures = sorted(
+        path
+        for path in fixtures.glob("*.json")
+        if path.name != "manifest.json"
+    )
+    paths = run_artifacts + flat_fixtures
+    if not paths:
+        raise RegulatorTitleAuditError(
+            f"no source collections found directly under {fixtures}"
+        )
+    return paths
+
+
+def _fixture_name(fixtures: Path, path: Path) -> str:
+    relative = path.relative_to(fixtures)
+    if path.name == "validated_sources.json":
+        return relative.parent.as_posix()
+    return relative.as_posix()
+
+
+def _read_collection(path: Path) -> tuple[SourceCollection, str]:
+    try:
+        payload = path.read_bytes()
+        collection = SourceCollection.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise RegulatorTitleAuditError(f"could not load {path}: {exc}") from exc
+    return collection, hashlib.sha256(payload).hexdigest()
+
+
+def _all_sources(collection: SourceCollection):
+    yield from (("academic", source) for source in collection.academic_sources)
+    yield from (("patent", source) for source in collection.patent_sources)
+    yield from (("market", source) for source in collection.market_sources)
+
+
+def _benchmark_rows(
+    fixtures: Path,
+    path: Path,
+    fixture_sha256: str,
+    collection: SourceCollection,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for source_domain, source in _all_sources(collection):
+        if source.url is None:
+            continue
+        url = str(source.url)
+        scope = authority_scope_for_url(url)
+        if scope == "out_of_scope":
+            continue
+        status, reasons = assess_title(source.title, url)
+        rows.append(
+            {
+                "dataset": "benchmark",
+                "fixture": _fixture_name(fixtures, path),
+                "fixture_sha256": fixture_sha256,
+                "source_domain": source_domain,
+                "source_id": source.source_id,
+                "authority_scope": scope,
+                "host": (urlsplit(url).hostname or "").lower(),
+                "title": source.title,
+                "url": url,
+                "status": status,
+                "reason_codes": "|".join(reasons),
+                "provenance": "stored_source_collection",
+                "expected_scope": "",
+                "expected_status": "",
+                "expected_reason_codes": "",
+                "matches_expectation": "",
+            }
+        )
+    return rows
+
+
+def _read_challenge(path: Path) -> tuple[FrozenChallenge, str]:
+    try:
+        payload = path.read_bytes()
+        challenge = FrozenChallenge.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise RegulatorTitleAuditError(f"could not load challenge {path}: {exc}") from exc
+    return challenge, hashlib.sha256(payload).hexdigest()
+
+
+def _challenge_rows(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    challenge, challenge_sha256 = _read_challenge(path)
+    rows: list[dict[str, Any]] = []
+    for case in challenge.cases:
+        url = str(case.url)
+        scope = authority_scope_for_url(url)
+        status, reasons = assess_title(case.title, url)
+        expected_reasons = list(case.expected_reason_codes)
+        matches = (
+            scope == case.expected_scope
+            and status == case.expected_status
+            and reasons == expected_reasons
+        )
+        rows.append(
+            {
+                "dataset": "challenge",
+                "fixture": case.case_id,
+                "fixture_sha256": challenge_sha256,
+                "source_domain": "challenge",
+                "source_id": case.source_id,
+                "authority_scope": scope,
+                "host": (urlsplit(url).hostname or "").lower(),
+                "title": case.title,
+                "url": url,
+                "status": status,
+                "reason_codes": "|".join(reasons),
+                "provenance": case.provenance,
+                "expected_scope": case.expected_scope,
+                "expected_status": case.expected_status,
+                "expected_reason_codes": "|".join(expected_reasons),
+                "matches_expectation": matches,
+            }
+        )
+
+    matched = sum(bool(row["matches_expectation"]) for row in rows)
+    result = {
+        "state": "matched" if matched == len(rows) else "failed",
+        "case_count": len(rows),
+        "matched_expectation_count": matched,
+        "sha256": challenge_sha256,
+        "measurement_design": challenge.measurement_design,
+    }
+    return result, rows
+
+
+def evaluate_audit(
+    fixtures: Path,
+    *,
+    expected_count: int | None = None,
+    challenge_path: Path | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Census frozen titles and optionally run the disclosed challenge."""
+
+    paths = discover_collections(fixtures)
+    if expected_count is not None and len(paths) != expected_count:
+        raise RegulatorTitleAuditError(
+            f"fixture count is {len(paths)}, expected exactly {expected_count}"
+        )
+
+    rows: list[dict[str, Any]] = []
+    fixture_manifest: list[dict[str, Any]] = []
+    affected_fixtures: set[str] = set()
+    for path in paths:
+        collection, fixture_sha256 = _read_collection(path)
+        fixture = _fixture_name(fixtures, path)
+        fixture_rows = _benchmark_rows(
+            fixtures,
+            path,
+            fixture_sha256,
+            collection,
+        )
+        rows.extend(fixture_rows)
+        if fixture_rows:
+            affected_fixtures.add(fixture)
+        fixture_manifest.append(
+            {
+                "fixture": fixture,
+                "sha256": fixture_sha256,
+                "official_source_count": len(fixture_rows),
+            }
+        )
+
+    benchmark_rows = list(rows)
+    flagged = sum(row["status"] == "review_required" for row in benchmark_rows)
+    if not benchmark_rows:
+        benchmark_state = "not_assessable_zero_denominator"
+    elif flagged:
+        benchmark_state = "review_required"
+    else:
+        benchmark_state = "checked_no_structural_flags"
+
+    challenge_result: dict[str, Any] = {
+        "state": "not_run",
+        "case_count": 0,
+        "matched_expectation_count": 0,
+        "sha256": None,
+        "measurement_design": None,
+    }
+    if challenge_path is not None:
+        challenge_result, challenge_rows = _challenge_rows(challenge_path)
+        rows.extend(challenge_rows)
+
+    scope_counts = Counter(row["authority_scope"] for row in benchmark_rows)
+    reason_counts = Counter(
+        reason
+        for row in benchmark_rows
+        for reason in str(row["reason_codes"]).split("|")
+        if reason
+    )
+    unique_urls = {str(row["url"]) for row in benchmark_rows}
+    checks = [
+        {
+            "name": "loaded_expected_fixture_count",
+            "passed": expected_count is None or len(paths) == expected_count,
+            "observed": len(paths),
+            "requirement": (
+                "at least one"
+                if expected_count is None
+                else f"exactly {expected_count}"
+            ),
+        },
+        {
+            "name": "every_fixture_manifested",
+            "passed": len(fixture_manifest) == len(paths),
+            "observed": len(fixture_manifest),
+            "requirement": len(paths),
+        },
+        {
+            "name": "challenge_expectations_match",
+            "passed": challenge_result["state"] in {"not_run", "matched"},
+            "observed": challenge_result["state"],
+            "requirement": "not_run or matched",
+        },
+    ]
+    contract_checks_passed = all(bool(check["passed"]) for check in checks)
+    result = {
+        "schema_version": 1,
+        "protocol": "regulator-source-title-quality-v1",
+        "measurement_design": (
+            "retrospective_development_census_plus_disclosed_challenge"
+        ),
+        "collection_count": len(paths),
+        "fixture_manifest": fixture_manifest,
+        "benchmark": {
+            "state": benchmark_state,
+            "official_source_count": len(benchmark_rows),
+            "unique_official_url_count": len(unique_urls),
+            "affected_collection_count": len(affected_fixtures),
+            "clean_source_count": len(benchmark_rows) - flagged,
+            "review_required_source_count": flagged,
+            "scope_counts": dict(sorted(scope_counts.items())),
+            "reason_counts": dict(sorted(reason_counts.items())),
+        },
+        "challenge": challenge_result,
+        "checks": checks,
+        "contract_checks_passed": contract_checks_passed,
+        "network_calls": 0,
+        "production_mutations": 0,
+        "normalization_applied": False,
+        "measurement_limit": (
+            "A zero denominator is not a clean pass. Structural screens do not "
+            "establish semantic title correctness, source truth, prevalence, "
+            "or held-out precision and recall."
+        ),
+    }
+    return result, rows
+
+
+def write_audit(
+    output: Path,
+    result: dict[str, Any],
+    rows: list[dict[str, Any]],
+) -> None:
+    """Persist aggregate and case evidence without replacing a prior audit."""
+
+    if output.exists():
+        raise RegulatorTitleAuditError(
+            f"refusing to overwrite audit output: {output}"
+        )
+    output.mkdir(parents=True)
+    (output / "result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    with (output / "cases.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CASE_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixtures", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--expected-count", type=int, default=None)
+    parser.add_argument("--challenge", type=Path, default=None)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    result, rows = evaluate_audit(
+        args.fixtures,
+        expected_count=args.expected_count,
+        challenge_path=args.challenge,
+    )
+    write_audit(args.output, result, rows)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    if not result["contract_checks_passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_regulator_title_audit.py
+++ b/tests/test_regulator_title_audit.py
@@ -1,0 +1,274 @@
+"""Contracts for the zero-network regulator-source title audit.
+
+The important seam is the persisted result, not only the classifier return:
+a dataset with no official titles must reach the output as not assessable, and
+the known production failure must survive into the case CSV with its provenance.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import socket
+import unittest
+from datetime import UTC, date, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import regulator_title_audit
+from academic_agent.evidence import EvidenceSource
+from academic_agent.source_pipeline import SourceCollection
+
+
+_CHALLENGE = (
+    Path(__file__).resolve().parent.parent
+    / "evals"
+    / "regulator_title_quality"
+    / "challenge-v1.json"
+)
+_KNOWN_BAD_TITLE = "'b, , 4 , I 'b, I - accessdata.fda.gov"
+_KNOWN_BAD_URL = "https://www.accessdata.fda.gov/CDRH510K/K222658.pdf"
+
+
+def _source(
+    source_id: str,
+    title: str,
+    url: str,
+    *,
+    source_type: str = "government",
+) -> EvidenceSource:
+    return EvidenceSource(
+        source_id=source_id,
+        title=title,
+        url=url,
+        publisher="Example Authority",
+        accessed_date=date(2026, 8, 25),
+        source_type=source_type,
+        credibility_tier="high",
+        credibility_reason="Authority identity supplied for a deterministic test.",
+        evidence_summary=(
+            "This deterministic test summary is intentionally long enough to "
+            "satisfy the production evidence contract without external data."
+        ),
+        summary_source="search_snippet",
+    )
+
+
+def _collection(*market_sources: EvidenceSource) -> SourceCollection:
+    academic = _source(
+        "A1",
+        "A complete academic control title",
+        "https://doi.org/10.1000/example",
+        source_type="academic_paper",
+    )
+    return SourceCollection(
+        topic="deterministic title audit topic",
+        display_topic="deterministic title audit topic",
+        collected_at=datetime(2026, 8, 25, tzinfo=UTC),
+        academic_sources=[academic],
+        patent_sources=[],
+        market_sources=list(market_sources),
+        academic_queries=["academic query"],
+        patent_queries=["patent query"],
+        market_queries=["market query"],
+    )
+
+
+def _write_run(root: Path, name: str, collection: SourceCollection) -> None:
+    run = root / name
+    run.mkdir()
+    (run / "validated_sources.json").write_text(
+        collection.model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+
+
+class TitleScreenTests(unittest.TestCase):
+    def test_frozen_challenge_signatures_are_precision_first(self):
+        cases = [
+            (
+                _KNOWN_BAD_TITLE,
+                _KNOWN_BAD_URL,
+                "review_required",
+                ["fragmented_single_letter_tokens"],
+            ),
+            (
+                "K222658 - Accurate 24 - 510(k) Premarket Notification",
+                _KNOWN_BAD_URL,
+                "clean",
+                [],
+            ),
+            (
+                "NCT01234567: Continuous Blood Pressure Monitoring Study",
+                "https://clinicaltrials.gov/study/NCT01234567",
+                "clean",
+                [],
+            ),
+            (
+                "Device Summary � K123456",
+                "https://www.accessdata.fda.gov/CDRH510K/K123456.pdf",
+                "review_required",
+                ["encoding_replacement_character"],
+            ),
+        ]
+        for title, url, expected_status, expected_reasons in cases:
+            with self.subTest(title=title):
+                status, reasons = regulator_title_audit.assess_title(title, url)
+                self.assertEqual(status, expected_status)
+                self.assertEqual(reasons, expected_reasons)
+
+    def test_authority_scope_rejects_attacker_suffixes(self):
+        cases = {
+            "https://www.accessdata.fda.gov/file.pdf": "regulatory",
+            "https://clinicaltrials.gov/study/NCT1": "clinical_registry",
+            "https://fda.gov.attacker.example/file.pdf": "out_of_scope",
+            "https://example.com/?next=fda.gov": "out_of_scope",
+        }
+        for url, expected in cases.items():
+            with self.subTest(url=url):
+                self.assertEqual(
+                    regulator_title_audit.authority_scope_for_url(url),
+                    expected,
+                )
+
+
+class FrozenCollectionAuditTests(unittest.TestCase):
+    def test_zero_denominator_is_not_rendered_as_a_clean_pass(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_run(root, "01", _collection())
+            _write_run(root, "02", _collection())
+            # The implementation imports no networking client. The patch makes
+            # that an executable contract rather than an inference from imports.
+            with mock.patch.object(
+                socket,
+                "create_connection",
+                side_effect=AssertionError("audit attempted network access"),
+            ):
+                first, first_rows = regulator_title_audit.evaluate_audit(
+                    root,
+                    expected_count=2,
+                    challenge_path=_CHALLENGE,
+                )
+                second, second_rows = regulator_title_audit.evaluate_audit(
+                    root,
+                    expected_count=2,
+                    challenge_path=_CHALLENGE,
+                )
+
+        self.assertEqual(first, second)
+        self.assertEqual(first_rows, second_rows)
+        self.assertEqual(
+            first["benchmark"]["state"],
+            "not_assessable_zero_denominator",
+        )
+        self.assertEqual(first["benchmark"]["official_source_count"], 0)
+        self.assertNotIn("passed", first["benchmark"])
+        self.assertEqual(first["challenge"]["state"], "matched")
+        self.assertTrue(first["contract_checks_passed"])
+        self.assertTrue(
+            all(item["official_source_count"] == 0 for item in first["fixture_manifest"])
+        )
+
+    def test_official_titles_reach_case_rows_and_aggregate_state(self):
+        clean = _source(
+            "M1",
+            "K222658 - Accurate 24 - 510(k) Premarket Notification",
+            _KNOWN_BAD_URL,
+        )
+        broken = _source("M2", _KNOWN_BAD_TITLE, _KNOWN_BAD_URL)
+        attacker = _source(
+            "M3",
+            "A B C D - fda.gov.attacker.example",
+            "https://fda.gov.attacker.example/fake.pdf",
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_run(root, "01", _collection(clean, broken, attacker))
+            result, rows = regulator_title_audit.evaluate_audit(
+                root,
+                expected_count=1,
+            )
+
+        benchmark_rows = [row for row in rows if row["dataset"] == "benchmark"]
+        self.assertEqual(result["benchmark"]["state"], "review_required")
+        self.assertEqual(result["benchmark"]["official_source_count"], 2)
+        self.assertEqual(result["benchmark"]["review_required_source_count"], 1)
+        self.assertEqual({row["source_id"] for row in benchmark_rows}, {"M1", "M2"})
+        broken_row = next(row for row in benchmark_rows if row["source_id"] == "M2")
+        self.assertEqual(broken_row["title"], _KNOWN_BAD_TITLE)
+        self.assertEqual(
+            broken_row["reason_codes"],
+            "fragmented_single_letter_tokens",
+        )
+
+    def test_flat_tracked_fixture_layout_excludes_manifest(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "01-topic.json").write_text(
+                _collection().model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+            (root / "manifest.json").write_text("{}\n", encoding="utf-8")
+            result, _ = regulator_title_audit.evaluate_audit(
+                root,
+                expected_count=1,
+            )
+        self.assertEqual(result["collection_count"], 1)
+        self.assertEqual(result["fixture_manifest"][0]["fixture"], "01-topic.json")
+
+    def test_partial_or_invalid_fixture_sets_fail_closed(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaisesRegex(
+                regulator_title_audit.RegulatorTitleAuditError,
+                "no source collections",
+            ):
+                regulator_title_audit.evaluate_audit(root)
+            _write_run(root, "01", _collection())
+            with self.assertRaisesRegex(
+                regulator_title_audit.RegulatorTitleAuditError,
+                "expected exactly 2",
+            ):
+                regulator_title_audit.evaluate_audit(root, expected_count=2)
+            (root / "01" / "validated_sources.json").write_text(
+                "{\"truncated\": true}",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                regulator_title_audit.RegulatorTitleAuditError,
+                "could not load",
+            ):
+                regulator_title_audit.evaluate_audit(root)
+
+    def test_writer_persists_case_seam_and_refuses_overwrite(self):
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            fixtures = root / "fixtures"
+            fixtures.mkdir()
+            _write_run(fixtures, "01", _collection())
+            result, rows = regulator_title_audit.evaluate_audit(
+                fixtures,
+                expected_count=1,
+                challenge_path=_CHALLENGE,
+            )
+            output = root / "audit"
+            regulator_title_audit.write_audit(output, result, rows)
+            persisted = json.loads((output / "result.json").read_text(encoding="utf-8"))
+            with (output / "cases.csv").open(encoding="utf-8", newline="") as handle:
+                case_rows = list(csv.DictReader(handle))
+            with self.assertRaisesRegex(
+                regulator_title_audit.RegulatorTitleAuditError,
+                "refusing to overwrite",
+            ):
+                regulator_title_audit.write_audit(output, result, rows)
+
+        self.assertEqual(persisted["benchmark"]["state"], "not_assessable_zero_denominator")
+        known = next(row for row in case_rows if row["fixture"] == "production-m7-fragmented-title")
+        self.assertEqual(known["title"], _KNOWN_BAD_TITLE)
+        self.assertEqual(known["matches_expectation"], "True")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The post-fix blood-pressure canary exposed one garbled FDA PDF title. That observation justified a regression case, but not a broad production cleanup rule: the project had not measured how many comparable regulator titles existed in its stored evidence or what false-positive cost a heuristic would create.

## What changed

- add a zero-network regulator and clinical-registry title census
- preserve every source-collection hash and case-level result
- represent an empty official-title set as not_assessable_zero_denominator
- freeze the exact production M7 title plus disclosed synthetic controls
- test exact/subdomain authority matching, attacker suffixes, persistence, overwrite refusal, deterministic output, and fail-closed input validation
- publish the protocol, result, commands, and explicit claim limits

No production retrieval, authority-coverage, report, planner, or title-normalization path changed.

## Measured result

- 30/30 stored benchmark collections loaded; 0 in-scope titles
- 10/10 tracked fixtures loaded; 0 in-scope titles
- benchmark state: not_assessable_zero_denominator
- challenge: 5/5 expectations matched
- repeated 30-run result.json and cases.csv were byte-identical
- defect re-injection changed the known production case to clean and made its test fail

## Validation

- 1381 tests passed
- 602 subtests passed
- 86.91% CI-equivalent coverage
- latest Ruff passed
- narrow CI Pylint checks passed

The result intentionally rejects adding a production normalizer until a real labelled denominator exists.