### PR TITLE
Recover structurally broken regulator titles without guessing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1381 tests (602 subtests), CI green on Linux + Windows × Python
+Current state: 1391 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -139,6 +139,8 @@ These are not style preferences; each came from a specific failure.
 src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         evidence models + guardrails, scoring, worker
   source_pipeline.py    ~3,400 lines, retrieval for all three domains
+  source_title_recovery.py
+                        precision-first neutral labels for broken official titles
   evidence.py           models, guardrails, scoring rubric
   pipeline_worker.py    the subprocess one run executes in
   checkpoint_runtime.py
@@ -148,12 +150,14 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  64 test modules plus conftest, organised by subject
+tests/                  65 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering
 regulator_title_audit.py
                         zero-network title census; zero denominator is not a pass
+regulator_title_recovery_candidate.py
+                        frozen title-recovery comparison; never performs retrieval
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -172,6 +176,17 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
 ## Things that are known-open
 
 - Blocking on uncited claims (above) — needs the detector tighter first.
+- Regulator title recovery is integrated from one frozen development challenge,
+  not a production-rate estimate. A zero-network census of 95 historical runs
+  found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The
+  candidate then matched 29/29 disclosed cases while preserving 23/23 clean
+  official API titles byte for byte. It may derive only a neutral identifier
+  label from an exact FDA 510(k) or ClinicalTrials.gov URL; unsupported broken
+  official titles are rejected. No provider-backed post-integration canary has
+  run yet, so do not present this as title truth, real-world precision/recall,
+  report-quality improvement, or production success evidence. See
+  `docs/prereg-2026-08-25-regulator-title-recovery-candidate.md` and
+  `docs/results-2026-08-25-regulator-title-recovery-candidate.md`.
 - The pre-registered offline process audit recovered 30/30 immutable children
   across ten frozen evidence collections and three post-commit boundaries. It
   skipped 90 committed task executions with zero duplicate task executions.

--- a/README.md
+++ b/README.md
@@ -365,18 +365,21 @@ matching source hash for `$0.035442`. This is one repeated-topic observation,
 not phase-2 Tool Calling evidence; see the [phase-1 result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)
 and [post-fix canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md).
 
-The canary's garbled FDA PDF title was measured before any cleanup rule was
-added. A zero-network census found **0 in-scope regulator or registry titles in
-30/30 stored benchmark runs** (and 0 in the ten tracked topic fixtures), so the
-result is explicitly `not_assessable_zero_denominator`, not a clean pass. A
-separate disclosed five-case challenge catches the exact production title while
-leaving plausible FDA and ClinicalTrials.gov controls clean. No production
-normalizer was enabled; reproduce the audit with `uv run python
-regulator_title_audit.py outputs/benchmark outputs/regulator-title-audit
---expected-count 30 --challenge
-evals/regulator_title_quality/challenge-v1.json`. See the
-[protocol](docs/protocol-2026-08-25-regulator-title-quality-audit.md) and
-[result](docs/results-2026-08-25-regulator-title-quality-audit.md).
+The canary's garbled FDA PDF title was measured before any recovery rule was
+written. The original 30-run benchmark had a zero denominator; a wider
+zero-network census of **95 historical runs** found only **3 in-scope rows over
+2 unique ClinicalTrials.gov URLs**, still too small for a prevalence or accuracy
+claim. A pre-registered 29-case development challenge therefore combines 24
+official API records, the observed production failure, three disclosed positive
+controls, and one attacker-suffix scope control. The deterministic candidate
+matched **29/29** expected actions while preserving **23/23** clean titles byte
+for byte. Production now recovers only a neutral identifier label from an exact
+FDA 510(k) or ClinicalTrials.gov URL and rejects unsupported broken titles; it
+does not guess a document name or repair Unicode semantically. A paid
+post-integration canary remains unrun, so this is not title-truth, production
+precision/recall, or report-quality evidence. See the
+[pre-registration](docs/prereg-2026-08-25-regulator-title-recovery-candidate.md)
+and [result](docs/results-2026-08-25-regulator-title-recovery-candidate.md).
 
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
@@ -895,6 +898,7 @@ academic_agent/
 │   ├── main.py              # CLI entry point (--topic "your topic" flag)
 │   ├── evidence.py          # Evidence models, guardrail validators, CommercializationScore
 │   ├── source_pipeline.py   # Structured pre-agent source collection & validation
+│   ├── source_title_recovery.py # Precision-first official-title recovery
 │   ├── source_clients.py    # API clients (OpenAlex, S2, PubMed, arXiv, Lens, Crossref, Serper)
 │   ├── pdf_extractor.py     # Uploaded-paper contribution extraction
 │   ├── language.py          # Language detection, free-form search planning, localization
@@ -920,6 +924,7 @@ academic_agent/
 ├── ablation.py              # Frozen-evidence 1/4/6-node topology experiment
 ├── reviewer_audit.py        # Blinded A/B packet preparation and unblinding
 ├── user_utility_audit.py    # 3–5 reviewer utility packet and strict summarizer
+├── regulator_title_recovery_candidate.py # Frozen title-recovery comparison
 ├── outputs/
 │   ├── <run_id>/            # Per-run output directory
 │   └── benchmark/           # benchmark.py outputs (benchmark_summary.csv, and
@@ -1268,17 +1273,17 @@ canary 已验证影子产物持久化且未改变证据，同时暴露了临床�
 [第一阶段结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)与
 [修复后 canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md)。
 
-针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、未直接增加清洗规则。
-零网络普查发现 30/30 次本地 benchmark 中符合范围的监管/临床注册标题为 **0**
-（仓库内 10 份话题 fixture 同样为 0），因此结果明确记为
-`not_assessable_zero_denominator`，而不是“检查通过”。另用 5 条公开说明的
-challenge 验证：精确的线上错例会被标记，合理的 FDA 与 ClinicalTrials.gov
-标题保持 clean。生产标题规范化仍未启用；可运行 `uv run python
-regulator_title_audit.py outputs/benchmark outputs/regulator-title-audit
---expected-count 30 --challenge
-evals/regulator_title_quality/challenge-v1.json` 复现，详见
-[协议](docs/protocol-2026-08-25-regulator-title-quality-audit.md)与
-[结果](docs/results-2026-08-25-regulator-title-quality-audit.md)。
+针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
+benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、
+2 个唯一 ClinicalTrials.gov URL**，仍不足以估计真实发生率或准确率。因此预注册
+的 29 条开发 challenge 使用 24 条官方 API 记录、1 条线上错例、3 条公开说明的
+正向控制和 1 条攻击者后缀范围控制。确定性候选匹配 **29/29** 个预期动作，并
+逐字保留 **23/23** 条干净标题。生产路径现在只允许从精确的 FDA 510(k) 或
+ClinicalTrials.gov URL 提取标识符形成中性标签；无法支持的坏标题直接拒绝，
+不会猜测文档名或做语义 Unicode 修复。付费的集成后 canary 尚未运行，因此这些
+数字不代表标题真值、生产 precision/recall 或报告质量改善。详见
+[预注册](docs/prereg-2026-08-25-regulator-title-recovery-candidate.md)与
+[结果](docs/results-2026-08-25-regulator-title-recovery-candidate.md)。
 
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 
@@ -1624,6 +1629,7 @@ academic_agent/
 │   ├── main.py              # 命令行入口（支持 --topic 参数）
 │   ├── evidence.py          # 证据模型、guardrail 校验、CommercializationScore 模型
 │   ├── source_pipeline.py   # 六智能体启动前的结构化来源收集与验证
+│   ├── source_title_recovery.py # 精度优先的官方来源标题恢复
 │   ├── source_clients.py    # API 客户端（OpenAlex / S2 / PubMed / arXiv / Lens / Crossref / Serper）
 │   ├── pdf_extractor.py     # 上传论文的核心贡献提取
 │   ├── language.py          # 语言检测、自由描述检索规划、本地化
@@ -1648,6 +1654,7 @@ academic_agent/
 ├── ablation.py              # 冻结证据的 1/4/6 节点拓扑实验
 ├── reviewer_audit.py        # 随机 A/B 盲评包生成与揭盲汇总
 ├── user_utility_audit.py    # 3–5 人用户效用盲评包与严格汇总器
+├── regulator_title_recovery_candidate.py # 冻结标题恢复候选对比
 ├── outputs/
 │   ├── <run_id>/            # 每次正常运行的输出目录
 │   └── benchmark/           # benchmark.py 输出目录（含 benchmark_summary.csv）

--- a/docs/prereg-2026-08-25-regulator-title-recovery-candidate.md
+++ b/docs/prereg-2026-08-25-regulator-title-recovery-candidate.md
@@ -1,0 +1,144 @@
+# Pre-registration: regulator source title recovery candidate
+
+Date registered: 2026-08-25
+
+## Question
+
+Can a deterministic, zero-LLM title recovery rule prevent structurally broken
+titles from reaching validated evidence without rewriting a legitimate title or
+inventing a document name?
+
+This experiment is deliberately narrower than semantic title verification. It
+tests whether an already accepted official regulator or clinical-registry URL
+can retain a usable, traceable display title when the search provider's title
+is structurally corrupt. It does not establish that a clean-looking title is
+semantically correct.
+
+## Evidence already observed before registration
+
+The following are development observations, not prospective validation:
+
+- The original 30-run benchmark and the ten tracked benchmark snapshots contain
+  zero official regulator or clinical-registry titles.
+- A census of 95 top-level historical runs contains three in-scope rows but only
+  two unique ClinicalTrials.gov URLs. All three pass the structural screen.
+- One production FDA 510(k) source carried the title
+  `"'b, , 4 , I 'b, I - accessdata.fda.gov"` for K222658.
+- Running the existing audit directly against `outputs/` failed because its
+  mixed-layout discovery also treated `.paid-operation-ledger.json` as a flat
+  `SourceCollection`. That input-boundary defect will receive its own regression
+  assertion; it is not evidence for or against title recovery.
+
+These observations determined the experiment but cannot be counted as a held-
+out result.
+
+## Frozen clean-control collection
+
+The development challenge will contain 24 official records:
+
+1. The first 12 usable records returned by the ClinicalTrials.gov v2 API for
+   the fixed query `medical device`, preserving API order at collection time.
+   A usable record has an NCT identifier and either `officialTitle` or
+   `briefTitle`; `officialTitle` is preferred.
+### Data-quality amendment recorded before candidate implementation
+
+The fixed openFDA query returned K243224 with two literal `U+0099` C1 control
+characters in `device_name`, rendered as `MitraClip` and `TriClip`. A second
+official API request for that exact K-number confirmed the code points. The row
+cannot honestly remain a clean control, and it will not be removed or replaced
+after selection.
+
+The frozen official sample is therefore classified as **23 clean controls plus
+one observed upstream encoding anomaly**. Criterion 1 below applies to all
+23 genuinely clean rows. K243224 joins the positive controls and must receive a
+neutral identifier label or be rejected; the candidate must not guess that the
+control character was intended to be a trademark symbol. This amendment was
+made after collection but before candidate code or output was inspected.
+
+2. The first 12 usable records returned by the openFDA device 510(k) API for
+   decisions in calendar year 2024, sorted by `decision_date:desc`. A usable
+   record has both `k_number` and `device_name`.
+
+The exact request URLs, retrieval timestamp, selected fields, and SHA-256 of
+each raw API response will be committed with the frozen challenge. If an
+endpoint or query is invalid, the protocol will be amended before inspecting a
+substitute response. Records will not be hand-picked after seeing whether the
+candidate succeeds.
+
+The official API title is a clean-control label. It is not proof that a search
+provider will return the same wording, and it is not a prevalence sample.
+
+## Positive and scope controls
+
+The challenge will also retain, separately from the 24 clean controls:
+
+- the observed K222658 broken title;
+- deterministic synthetic corruptions covering replacement characters,
+  isolated-letter fragments, empty punctuation, and host-only titles;
+- an attacker-suffix host that must remain out of scope.
+
+Synthetic cases test specified behavior only. They must never be included in a
+real-world accuracy denominator.
+
+## Candidate behavior
+
+The candidate may act only after canonical URL validation and only for an
+allowlisted official regulator or clinical-registry host.
+
+1. Preserve every title that does not trigger the high-precision structural
+   screen.
+2. For a structurally broken title, derive a neutral label only when a supported
+   identifier is present in the canonical URL:
+   - `FDA 510(k) record <K-number>` for the known accessdata FDA path;
+   - `ClinicalTrials.gov study <NCT-number>` for the known registry path.
+3. If no supported identifier can be recovered, reject that source row rather
+   than inventing a title.
+4. Never fetch a second page, call an LLM, or infer the exact product/study name
+   in the production path.
+5. Applying the candidate twice must produce the same output.
+
+The neutral label is intentionally less informative than an exact title. It is
+traceable and honest about what the URL proves, while the evidence summary and
+source URL remain available to the report workflow.
+
+## Acceptance criteria registered before collection
+
+The candidate may enter production only if all criteria pass:
+
+1. **Clean preservation:** 23/23 official clean-control titles remain byte-for-
+   byte unchanged and are not sent to review.
+2. **Observed defects:** neither the K222658 production title nor the K243224
+   official API title is retained. Any replacement contains only the URL-
+   derived identifier and a neutral source label, without an inferred device
+   name or guessed Unicode repair.
+3. **Synthetic controls:** every in-scope malformed control is either replaced
+   by a supported neutral label or rejected; none receives an inferred exact
+   title.
+4. **Scope safety:** attacker-suffix and unsupported hosts cannot receive an
+   official fallback.
+5. **Idempotence:** every accepted replacement is stable on a second pass.
+6. **Audit boundary:** a directory containing run artifacts plus unrelated
+   top-level JSON audits the run artifacts without reading the unrelated JSON;
+   a flat-fixture-only directory retains strict validation.
+7. **Seam coverage:** the recovered or rejected decision is asserted at the
+   final `EvidenceSource` construction boundary, not only in a helper test.
+8. **No paid or hidden work:** evaluation performs zero network calls, zero LLM
+   calls, and reports clean, replaced, rejected, and unchecked denominators
+   separately.
+
+Any clean-control rewrite rejects production integration. A partial positive-
+control result also rejects integration rather than relaxing the criterion.
+
+## Defect re-injection
+
+After the tests pass, temporarily bypass the recovery call at the
+`EvidenceSource` construction seam. The known production case must then either
+reach the source unchanged or fail the seam assertion. Restore the production
+call and confirm the targeted suite returns green.
+
+## Claims that remain prohibited
+
+Even a passing result does not support claims of semantic title accuracy,
+real-world precision/recall, source truth, lower LLM cost, higher report quality,
+or better regulatory coverage. A provider-backed canary requires separate paid
+authorization and its own result record.

--- a/docs/results-2026-08-25-regulator-title-recovery-candidate.md
+++ b/docs/results-2026-08-25-regulator-title-recovery-candidate.md
@@ -1,0 +1,150 @@
+# Results: regulator source title recovery candidate
+
+Date: 2026-08-25
+
+## Outcome
+
+The deterministic candidate passed every pre-registered development control and
+was integrated at the final web-search-result to `EvidenceSource` seam. It is
+accepted for that narrow production integration, not as evidence of semantic
+title accuracy or real-world precision and recall.
+
+The legacy seam matched 25/29 expected actions. The candidate matched 29/29,
+while preserving all 23 genuinely clean official API titles byte for byte.
+
+## Historical denominator measured first
+
+The original benchmark result remained non-assessable: its 30 stored source
+collections and ten tracked snapshots contain no official regulator or clinical
+registry title. A wider zero-network census then inspected 95 top-level
+historical runs:
+
+| Collections | In-scope rows | Unique official URLs | Scope | Structural flags |
+|---:|---:|---:|---|---:|
+| 95 | 3 | 2 | ClinicalTrials.gov only | 0 |
+
+The three rows are two repeated trial-registry records. This is still too small
+to estimate prevalence or semantic correctness. It did, however, replace a zero
+denominator with an explicit small denominator before any production rule was
+written.
+
+Running the audit directly on the mixed `outputs/` root initially failed because
+the discovery function added `.paid-operation-ledger.json` to the run artifacts
+and tried to parse it as `SourceCollection`. The fixed discovery contract treats
+run-directory and flat-fixture layouts as alternatives. The real mixed root now
+loads exactly 95 run artifacts while a flat-only fixture directory remains
+strict.
+
+## Frozen development challenge
+
+The challenge contains 29 cases:
+
+| Provenance | Count |
+|---|---:|
+| Official API clean controls | 23 |
+| Official API observed encoding anomaly | 1 |
+| Observed production failure | 1 |
+| Disclosed synthetic positive controls | 3 |
+| Synthetic attacker-suffix scope control | 1 |
+
+Twelve records came from the ClinicalTrials.gov v2 API and twelve from the
+openFDA device 510(k) API under the selection rules registered before retrieval.
+The openFDA response returned K243224 with literal `U+0099` C1 controls in two
+device names. The row was retained and reclassified as an observed upstream
+anomaly before candidate implementation; it was not removed to make the clean
+preservation result easier.
+
+Frozen challenge SHA-256:
+
+`417f6429cbbc251b2c8923761b1cf1362f5e3d744bbf1170b3d1dc5a98c0cb13`
+
+## Baseline comparison
+
+| Check | Legacy seam | Candidate |
+|---|---:|---:|
+| All expected actions | 25/29 | 29/29 |
+| Official clean titles preserved | 23/23 | 23/23 |
+| Observed defects safely recovered | 0/2 | 2/2 |
+| Synthetic positive controls matched | 1/3 | 3/3 |
+| Attacker-suffix scope control | 1/1 | 1/1 |
+| Idempotent output | Not measured | 29/29 |
+
+The four legacy mismatches were the production K222658 fragmented title, the
+openFDA K243224 control-character title, a replacement-character trial title,
+and an FDA host-only title. The unsupported one-character FDA page was already
+rejected by the old five-character floor; the candidate preserves that fail-
+closed outcome rather than claiming it as a new recovery.
+
+## Production behavior
+
+The candidate acts only after the existing canonical URL and authority allowlist
+checks:
+
+- A structurally clean title is unchanged.
+- A broken `accessdata.fda.gov/CDRH510K/Kxxxxxx.pdf` title becomes
+  `FDA 510(k) record Kxxxxxx`.
+- A broken `clinicaltrials.gov/study/NCTxxxxxxxx` title becomes
+  `ClinicalTrials.gov study NCTxxxxxxxx`.
+- A broken official title without one of those supported URL identifiers is
+  rejected instead of receiving an inferred document name.
+- An attacker-suffix host cannot receive an official fallback even if a caller
+  supplies the wrong category.
+- A recovered source records in `credibility_reason` that the display label came
+  only from the validated official URL identifier.
+
+No second page fetch, LLM call, guessed device name, or guessed Unicode repair is
+performed.
+
+## Defect re-injection
+
+The authority-category handoff at `_web_source` was temporarily replaced with
+`None`, reproducing the pre-candidate path. The final seam test failed because
+the exact fragmented production title reached `EvidenceSource.title`. The
+temporary change was reversed, and the targeted suite returned to green:
+
+`16 passed, 33 subtests passed`
+
+This demonstrates that the new test guards transport to the final source model,
+not merely a helper return value.
+
+## Reproducibility
+
+```bash
+uv run python regulator_title_audit.py outputs \
+  outputs/regulator-title-audit-20260825-all-history-direct-v2 \
+  --expected-count 95 \
+  --challenge evals/regulator_title_quality/challenge-v1.json
+
+uv run python regulator_title_recovery_candidate.py \
+  evals/regulator_title_quality/recovery-challenge-v1.json \
+  outputs/regulator-title-recovery-candidate-20260825-v1
+```
+
+Persisted local artifact hashes:
+
+- `result.json`:
+  `df3d6cececd431f22593098e9267d1c814564502a32a2431fc204988b0cb7f53`
+- `cases.csv`:
+  `ca2686fa6c7da3fa75961d5ad5bf84825568774ff0d7e31367cf347363ce1180`
+
+The candidate evaluation reported zero network calls, zero LLM calls, and zero
+production mutations. The two official API requests used to create the frozen
+development controls are disclosed separately in the challenge metadata.
+
+Post-integration repository validation:
+
+- `uv run --with ruff ruff check .`: pass
+- CI-equivalent narrow pylint control-flow check: pass
+- `uv run pytest -q`: `1391 passed, 627 subtests passed`
+- CI-equivalent coverage run: `87.00%` total, above the `85%` floor
+
+All test runs were zero-network; no provider token was consumed.
+
+## Remaining boundary
+
+This result does not establish title truth, real-world prevalence, report
+quality, production success rate, latency, cost reduction, or regulatory
+coverage. A provider-backed canary remains unrun and requires separate paid
+authorization. Until then, the strongest accurate statement is that the
+candidate passed one frozen development challenge and one defect-reinjection
+test.

--- a/evals/regulator_title_quality/recovery-challenge-v1.json
+++ b/evals/regulator_title_quality/recovery-challenge-v1.json
@@ -1,0 +1,314 @@
+{
+  "schema_version": 1,
+  "protocol": "regulator-title-recovery-candidate-v1",
+  "collected_at": "2026-08-25",
+  "measurement_design": "official_api_development_controls_plus_disclosed_positive_and_scope_controls",
+  "collections": [
+    {
+      "source": "clinicaltrials_v2",
+      "request_url": "https://clinicaltrials.gov/api/v2/studies?format=json&pageSize=12&query.term=medical%20device",
+      "raw_response_sha256": "20d71d973a6a08bfcecf3a7f566b712d2a0df46e09c314c69058b38dd3735a88",
+      "selection": "first 12 usable records in API order; officialTitle preferred over briefTitle",
+      "selected_count": 12
+    },
+    {
+      "source": "openfda_510k",
+      "request_url": "https://api.fda.gov/device/510k.json?search=decision_date:%5B20240101+TO+20241231%5D&sort=decision_date:desc&limit=12",
+      "raw_response_sha256": "7ff22718b11cec8fe92246fa994baa762a563fec6629afb6ab7d260678d57404",
+      "selection": "first 12 usable records sorted by decision_date descending",
+      "selected_count": 12
+    }
+  ],
+  "cases": [
+    {
+      "case_id": "ct-clean-01",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT05463081",
+      "url": "https://clinicaltrials.gov/study/NCT05463081",
+      "input_title": "Clinical Trial of the Safety and Efficacy of Medical Device \"Laser Medical Device \"Magic Gyno\"\"",
+      "expected_action": "preserve",
+      "expected_title": "Clinical Trial of the Safety and Efficacy of Medical Device \"Laser Medical Device \"Magic Gyno\"\"",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-02",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT02705781",
+      "url": "https://clinicaltrials.gov/study/NCT02705781",
+      "input_title": "Functionality and Accuracy of the smARTrack System in Real-Life ICU Settings",
+      "expected_action": "preserve",
+      "expected_title": "Functionality and Accuracy of the smARTrack System in Real-Life ICU Settings",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-03",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT06811519",
+      "url": "https://clinicaltrials.gov/study/NCT06811519",
+      "input_title": "AI-based Prediction of Cardiac Function Using Echocardiography and Body Composition Data (ECHO-FIT Study)",
+      "expected_action": "preserve",
+      "expected_title": "AI-based Prediction of Cardiac Function Using Echocardiography and Body Composition Data (ECHO-FIT Study)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-04",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT06793930",
+      "url": "https://clinicaltrials.gov/study/NCT06793930",
+      "input_title": "The Effects of a Tailored, Optimised, and Person-centred Critical Pathway to Promote Lifestyle Modification in People With Metabolic Syndrome: A Mixed-methods Study",
+      "expected_action": "preserve",
+      "expected_title": "The Effects of a Tailored, Optimised, and Person-centred Critical Pathway to Promote Lifestyle Modification in People With Metabolic Syndrome: A Mixed-methods Study",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-05",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT05005000",
+      "url": "https://clinicaltrials.gov/study/NCT05005000",
+      "input_title": "Autologous Intra-Articular Micro-Fragmented Adipose Transfer for the Treatment of Thumb Carpometacarpal Joint Arthritis",
+      "expected_action": "preserve",
+      "expected_title": "Autologous Intra-Articular Micro-Fragmented Adipose Transfer for the Treatment of Thumb Carpometacarpal Joint Arthritis",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-06",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT03455400",
+      "url": "https://clinicaltrials.gov/study/NCT03455400",
+      "input_title": "Ventilation Distribution Observed With Electrical Impedance Tomography (EIT) During Spontaneous Breathing in Healthy Newborn Infants",
+      "expected_action": "preserve",
+      "expected_title": "Ventilation Distribution Observed With Electrical Impedance Tomography (EIT) During Spontaneous Breathing in Healthy Newborn Infants",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-07",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT06560307",
+      "url": "https://clinicaltrials.gov/study/NCT06560307",
+      "input_title": "Examination of Programming with the Enterra® Therapy System in a Double-Blinded, Randomized, Prospective Study in the Treatment of Nausea and Vomiting Symptoms Using Gastric Electrical Stimulation",
+      "expected_action": "preserve",
+      "expected_title": "Examination of Programming with the Enterra® Therapy System in a Double-Blinded, Randomized, Prospective Study in the Treatment of Nausea and Vomiting Symptoms Using Gastric Electrical Stimulation",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-08",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT03339492",
+      "url": "https://clinicaltrials.gov/study/NCT03339492",
+      "input_title": "Prospective, Randomized, Double-Blind, Placebo Controlled Study to Evaluate the Safety and Efficacy of Pulsed Electromagnetic Field (PEMF) Therapy as an Adjunctive Treatment to Surgical Repair of Full Thickness Rotator Cuff Tears",
+      "expected_action": "preserve",
+      "expected_title": "Prospective, Randomized, Double-Blind, Placebo Controlled Study to Evaluate the Safety and Efficacy of Pulsed Electromagnetic Field (PEMF) Therapy as an Adjunctive Treatment to Surgical Repair of Full Thickness Rotator Cuff Tears",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-09",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT07742592",
+      "url": "https://clinicaltrials.gov/study/NCT07742592",
+      "input_title": "Retrospective Real-World Data Collection of the Conformable GORE® TAG® Thoracic Endoprosthesis When Used in Frozen Elephant Trunk Procedures for Treatment of Aortic Aneurysms and Dissections",
+      "expected_action": "preserve",
+      "expected_title": "Retrospective Real-World Data Collection of the Conformable GORE® TAG® Thoracic Endoprosthesis When Used in Frozen Elephant Trunk Procedures for Treatment of Aortic Aneurysms and Dissections",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-10",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT06655636",
+      "url": "https://clinicaltrials.gov/study/NCT06655636",
+      "input_title": "Assisting Stroke Survivors With Engineering Technology (ASSET): Design Project D3: Exoskeletal Networks for Forearm Supination",
+      "expected_action": "preserve",
+      "expected_title": "Assisting Stroke Survivors With Engineering Technology (ASSET): Design Project D3: Exoskeletal Networks for Forearm Supination",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-11",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT05459636",
+      "url": "https://clinicaltrials.gov/study/NCT05459636",
+      "input_title": "Time-Efficient Inspiratory Muscle Strength Training as a New Approach to Lower Blood Pressure, Improve Respiratory Function, and Reduce Exertional Dyspnea in Adults With Obesity",
+      "expected_action": "preserve",
+      "expected_title": "Time-Efficient Inspiratory Muscle Strength Training as a New Approach to Lower Blood Pressure, Improve Respiratory Function, and Reduce Exertional Dyspnea in Adults With Obesity",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "ct-clean-12",
+      "source": "clinicaltrials_v2",
+      "record_id": "NCT06351436",
+      "url": "https://clinicaltrials.gov/study/NCT06351436",
+      "input_title": "Using Mindfulness With Immersive Virtual Reality Cave Experience in Promoting Mental Well-Being: A Feasibility Study",
+      "expected_action": "preserve",
+      "expected_title": "Using Mindfulness With Immersive Virtual Reality Cave Experience in Promoting Mental Well-Being: A Feasibility Study",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-01",
+      "source": "openfda_510k",
+      "record_id": "K241852",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K241852.pdf",
+      "input_title": "Nasal Aspirator (NS 13)",
+      "expected_action": "preserve",
+      "expected_title": "Nasal Aspirator (NS 13)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-02",
+      "source": "openfda_510k",
+      "record_id": "K242468",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K242468.pdf",
+      "input_title": "Power Wheelchair (D10, D12, D15, D17, D20, D37)",
+      "expected_action": "preserve",
+      "expected_title": "Power Wheelchair (D10, D12, D15, D17, D20, D37)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-03",
+      "source": "openfda_510k",
+      "record_id": "K243225",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K243225.pdf",
+      "input_title": "Nasal Pillow Mask - Small (NNPM-01/ Nefes S); Nasal Pillow Mask - Medium (NNPM-02/ Nefes M); Nasal Pillow Mask - Large (NNPM-03/ Nefes L)",
+      "expected_action": "preserve",
+      "expected_title": "Nasal Pillow Mask - Small (NNPM-01/ Nefes S); Nasal Pillow Mask - Medium (NNPM-02/ Nefes M); Nasal Pillow Mask - Large (NNPM-03/ Nefes L)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-observed-encoding-01",
+      "source": "openfda_510k",
+      "record_id": "K243224",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K243224.pdf",
+      "input_title": "MitraClip\u0099 G5 Steerable Guide Catheter (SGC0801); TriClip\u0099 G5 Steerable Guide Catheter (TSGC0801)",
+      "expected_action": "recover",
+      "expected_title": "FDA 510(k) record K243224",
+      "label_provenance": "official_api_observed_encoding_anomaly"
+    },
+    {
+      "case_id": "fda-clean-04",
+      "source": "openfda_510k",
+      "record_id": "K241338",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K241338.pdf",
+      "input_title": "Peak Flow Meter",
+      "expected_action": "preserve",
+      "expected_title": "Peak Flow Meter",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-05",
+      "source": "openfda_510k",
+      "record_id": "K242989",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K242989.pdf",
+      "input_title": "Electric Wheelchair (MODEL H)",
+      "expected_action": "preserve",
+      "expected_title": "Electric Wheelchair (MODEL H)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-06",
+      "source": "openfda_510k",
+      "record_id": "K243670",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K243670.pdf",
+      "input_title": "Idys® LIF",
+      "expected_action": "preserve",
+      "expected_title": "Idys® LIF",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-07",
+      "source": "openfda_510k",
+      "record_id": "K243445",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K243445.pdf",
+      "input_title": "Splendor X (Alex, Alex2, Nd:YAG, Alex+Nd:YAG)",
+      "expected_action": "preserve",
+      "expected_title": "Splendor X (Alex, Alex2, Nd:YAG, Alex+Nd:YAG)",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-08",
+      "source": "openfda_510k",
+      "record_id": "K242376",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K242376.pdf",
+      "input_title": "Next Generation Access Platform",
+      "expected_action": "preserve",
+      "expected_title": "Next Generation Access Platform",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-09",
+      "source": "openfda_510k",
+      "record_id": "K243394",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K243394.pdf",
+      "input_title": "AF531 Oro-Nasal SE Face Mask",
+      "expected_action": "preserve",
+      "expected_title": "AF531 Oro-Nasal SE Face Mask",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-10",
+      "source": "openfda_510k",
+      "record_id": "K242804",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K242804.pdf",
+      "input_title": "PAL Aspiration System",
+      "expected_action": "preserve",
+      "expected_title": "PAL Aspiration System",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "fda-clean-11",
+      "source": "openfda_510k",
+      "record_id": "K233119",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K233119.pdf",
+      "input_title": "8MP Color LCD Displays C811W, C811WT, PA27 and PA27T",
+      "expected_action": "preserve",
+      "expected_title": "8MP Color LCD Displays C811W, C811WT, PA27 and PA27T",
+      "label_provenance": "official_api_clean_control"
+    },
+    {
+      "case_id": "production-fda-fragmented-k222658",
+      "source": "production_observation",
+      "record_id": "K222658",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K222658.pdf",
+      "input_title": "'b, , 4 , I 'b, I - accessdata.fda.gov",
+      "expected_action": "recover",
+      "expected_title": "FDA 510(k) record K222658",
+      "label_provenance": "observed_production_failure"
+    },
+    {
+      "case_id": "synthetic-ct-replacement-character",
+      "source": "synthetic_control",
+      "record_id": "NCT02705781",
+      "url": "https://clinicaltrials.gov/study/NCT02705781",
+      "input_title": "Functionality � Accuracy",
+      "expected_action": "recover",
+      "expected_title": "ClinicalTrials.gov study NCT02705781",
+      "label_provenance": "synthetic_positive_control"
+    },
+    {
+      "case_id": "synthetic-fda-host-only",
+      "source": "synthetic_control",
+      "record_id": "K241852",
+      "url": "https://www.accessdata.fda.gov/CDRH510K/K241852.pdf",
+      "input_title": "accessdata.fda.gov",
+      "expected_action": "recover",
+      "expected_title": "FDA 510(k) record K241852",
+      "label_provenance": "synthetic_positive_control"
+    },
+    {
+      "case_id": "synthetic-official-unsupported-path",
+      "source": "synthetic_control",
+      "record_id": "",
+      "url": "https://www.fda.gov/medical-devices/example",
+      "input_title": "�",
+      "expected_action": "reject",
+      "expected_title": null,
+      "label_provenance": "synthetic_positive_control"
+    },
+    {
+      "case_id": "synthetic-attacker-suffix",
+      "source": "synthetic_control",
+      "record_id": "K241852",
+      "url": "https://accessdata.fda.gov.attacker.example/CDRH510K/K241852.pdf",
+      "input_title": "�",
+      "expected_action": "out_of_scope",
+      "expected_title": null,
+      "label_provenance": "synthetic_scope_control"
+    }
+  ]
+}

--- a/regulator_title_audit.py
+++ b/regulator_title_audit.py
@@ -197,20 +197,26 @@ def discover_collections(fixtures: Path) -> list[Path]:
     A clean clone retains ten equivalent SourceCollection snapshots as direct
     JSON files. Supporting both layouts lets the 30-run census use the original
     artifacts while CI can exercise the same parser over tracked evidence.
+
+    The layouts are alternatives, not additive. A live ``outputs/`` root also
+    contains JSON ledgers and operational state. Once run artifacts are present,
+    treating every top-level JSON file as another collection both changes the
+    denominator and fails on valid non-collection state.
     """
 
     run_artifacts = sorted(fixtures.glob("*/validated_sources.json"))
+    if run_artifacts:
+        return run_artifacts
     flat_fixtures = sorted(
         path
         for path in fixtures.glob("*.json")
         if path.name != "manifest.json"
     )
-    paths = run_artifacts + flat_fixtures
-    if not paths:
+    if not flat_fixtures:
         raise RegulatorTitleAuditError(
             f"no source collections found directly under {fixtures}"
         )
-    return paths
+    return flat_fixtures
 
 
 def _fixture_name(fixtures: Path, path: Path) -> str:

--- a/regulator_title_recovery_candidate.py
+++ b/regulator_title_recovery_candidate.py
@@ -1,0 +1,322 @@
+"""Evaluate a zero-network official-source title recovery candidate."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, HttpUrl, model_validator
+
+from academic_agent.source_title_recovery import recover_official_source_title
+from regulator_title_audit import authority_scope_for_url
+
+
+ExpectedAction = Literal["preserve", "recover", "reject", "out_of_scope"]
+LabelProvenance = Literal[
+    "official_api_clean_control",
+    "official_api_observed_encoding_anomaly",
+    "observed_production_failure",
+    "synthetic_positive_control",
+    "synthetic_scope_control",
+]
+
+CASE_FIELDS = (
+    "case_id",
+    "source",
+    "record_id",
+    "url",
+    "input_title",
+    "label_provenance",
+    "expected_action",
+    "baseline_action",
+    "candidate_action",
+    "expected_title",
+    "baseline_title",
+    "candidate_title",
+    "reason_codes",
+    "baseline_matches_expectation",
+    "candidate_matches_expectation",
+    "idempotent_output",
+)
+
+
+class RecoveryCandidateError(ValueError):
+    """Raised when the candidate evaluation would be partial or mutable."""
+
+
+class FrozenCollection(BaseModel):
+    """Provenance for one official API response used during case selection."""
+
+    source: str = Field(min_length=3)
+    request_url: HttpUrl
+    raw_response_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    selection: str = Field(min_length=20)
+    selected_count: int = Field(gt=0)
+
+
+class RecoveryCase(BaseModel):
+    """One immutable input and expected action at the recovery seam."""
+
+    case_id: str = Field(min_length=5)
+    source: str = Field(min_length=3)
+    record_id: str
+    url: HttpUrl
+    input_title: str
+    expected_action: ExpectedAction
+    expected_title: str | None
+    label_provenance: LabelProvenance
+
+    @model_validator(mode="after")
+    def expected_title_matches_action(self) -> "RecoveryCase":
+        if self.expected_action in {"preserve", "recover"}:
+            if self.expected_title is None:
+                raise ValueError("accepted actions require expected_title")
+        elif self.expected_title is not None:
+            raise ValueError("rejected or out-of-scope cases cannot expect a title")
+        return self
+
+
+class RecoveryChallenge(BaseModel):
+    """Frozen development controls, not a real-world prevalence sample."""
+
+    schema_version: Literal[1]
+    protocol: Literal["regulator-title-recovery-candidate-v1"]
+    collected_at: str = Field(min_length=10)
+    measurement_design: str = Field(min_length=20)
+    collections: list[FrozenCollection] = Field(min_length=2)
+    cases: list[RecoveryCase] = Field(min_length=1)
+
+
+def _read_challenge(path: Path) -> tuple[RecoveryChallenge, str]:
+    try:
+        payload = path.read_bytes()
+        challenge = RecoveryChallenge.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise RecoveryCandidateError(f"could not load frozen challenge: {exc}") from exc
+    case_ids = [case.case_id for case in challenge.cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise RecoveryCandidateError("frozen challenge contains duplicate case_id values")
+    return challenge, hashlib.sha256(payload).hexdigest()
+
+
+def _authority_category(url: str) -> Literal["regulatory", "clinical_registry"] | None:
+    scope = authority_scope_for_url(url)
+    if scope in {"regulatory", "clinical_registry"}:
+        return scope
+    return None
+
+
+def _legacy_baseline(case: RecoveryCase) -> tuple[ExpectedAction, str | None]:
+    """Reproduce the pre-candidate title seam without calling production code.
+
+    Previously any market title of five or more characters survived unchanged;
+    shorter titles were rejected before URL-specific handling. Out-of-scope
+    hosts were rejected elsewhere by the market allowlist, so they remain a
+    distinct scope outcome here rather than being counted as title successes.
+    """
+
+    if _authority_category(str(case.url)) is None:
+        return "out_of_scope", None
+    if len(case.input_title.strip()) < 5:
+        return "reject", None
+    return "preserve", case.input_title
+
+
+def _matches(
+    case: RecoveryCase,
+    action: str,
+    title: str | None,
+) -> bool:
+    return action == case.expected_action and title == case.expected_title
+
+
+def evaluate_candidate(
+    challenge_path: Path,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    """Evaluate baseline and candidate deterministically over frozen cases."""
+
+    challenge, challenge_sha256 = _read_challenge(challenge_path)
+    rows: list[dict[str, object]] = []
+    for case in challenge.cases:
+        url = str(case.url)
+        category = _authority_category(url)
+        baseline_action, baseline_title = _legacy_baseline(case)
+        decision = recover_official_source_title(
+            case.input_title,
+            url,
+            authority_category=category,
+        )
+        candidate_title = decision.title
+        idempotent = True
+        if candidate_title is not None and decision.action in {"preserve", "recover"}:
+            second = recover_official_source_title(
+                candidate_title,
+                url,
+                authority_category=category,
+            )
+            idempotent = second.title == candidate_title
+        rows.append(
+            {
+                "case_id": case.case_id,
+                "source": case.source,
+                "record_id": case.record_id,
+                "url": url,
+                "input_title": case.input_title,
+                "label_provenance": case.label_provenance,
+                "expected_action": case.expected_action,
+                "baseline_action": baseline_action,
+                "candidate_action": decision.action,
+                "expected_title": case.expected_title or "",
+                "baseline_title": baseline_title or "",
+                "candidate_title": candidate_title or "",
+                "reason_codes": "|".join(decision.reason_codes),
+                "baseline_matches_expectation": _matches(
+                    case,
+                    baseline_action,
+                    baseline_title,
+                ),
+                "candidate_matches_expectation": _matches(
+                    case,
+                    decision.action,
+                    candidate_title,
+                ),
+                "idempotent_output": idempotent,
+            }
+        )
+
+    provenance_counts = Counter(str(row["label_provenance"]) for row in rows)
+    baseline_matches = sum(bool(row["baseline_matches_expectation"]) for row in rows)
+    candidate_matches = sum(bool(row["candidate_matches_expectation"]) for row in rows)
+
+    def matched(provenance: str) -> int:
+        return sum(
+            bool(row["candidate_matches_expectation"])
+            for row in rows
+            if row["label_provenance"] == provenance
+        )
+
+    official_selected = sum(item.selected_count for item in challenge.collections)
+    checks = [
+        {
+            "name": "official_api_selection_is_frozen",
+            "passed": official_selected == 24,
+            "observed": official_selected,
+            "requirement": 24,
+        },
+        {
+            "name": "clean_controls_are_preserved",
+            "passed": matched("official_api_clean_control") == 23,
+            "observed": matched("official_api_clean_control"),
+            "requirement": 23,
+        },
+        {
+            "name": "observed_defects_are_recovered",
+            "passed": (
+                matched("official_api_observed_encoding_anomaly") == 1
+                and matched("observed_production_failure") == 1
+            ),
+            "observed": (
+                matched("official_api_observed_encoding_anomaly")
+                + matched("observed_production_failure")
+            ),
+            "requirement": 2,
+        },
+        {
+            "name": "synthetic_positive_controls_match",
+            "passed": matched("synthetic_positive_control") == 3,
+            "observed": matched("synthetic_positive_control"),
+            "requirement": 3,
+        },
+        {
+            "name": "scope_control_matches",
+            "passed": matched("synthetic_scope_control") == 1,
+            "observed": matched("synthetic_scope_control"),
+            "requirement": 1,
+        },
+        {
+            "name": "all_outputs_are_idempotent",
+            "passed": all(bool(row["idempotent_output"]) for row in rows),
+            "observed": sum(bool(row["idempotent_output"]) for row in rows),
+            "requirement": len(rows),
+        },
+        {
+            "name": "all_candidate_expectations_match",
+            "passed": candidate_matches == len(rows),
+            "observed": candidate_matches,
+            "requirement": len(rows),
+        },
+    ]
+    result: dict[str, object] = {
+        "schema_version": 1,
+        "protocol": challenge.protocol,
+        "challenge_sha256": challenge_sha256,
+        "measurement_design": challenge.measurement_design,
+        "case_count": len(rows),
+        "provenance_counts": dict(sorted(provenance_counts.items())),
+        "baseline": {
+            "matched_expectation_count": baseline_matches,
+            "mismatched_expectation_count": len(rows) - baseline_matches,
+        },
+        "candidate": {
+            "state": (
+                "accepted_for_production_integration"
+                if all(bool(check["passed"]) for check in checks)
+                else "rejected"
+            ),
+            "matched_expectation_count": candidate_matches,
+            "mismatched_expectation_count": len(rows) - candidate_matches,
+        },
+        "checks": checks,
+        "contract_checks_passed": all(bool(check["passed"]) for check in checks),
+        "network_calls": 0,
+        "llm_calls": 0,
+        "production_mutations": 0,
+        "measurement_limit": (
+            "This development challenge does not estimate real-world prevalence, "
+            "semantic title accuracy, precision, recall, or report-quality impact."
+        ),
+    }
+    return result, rows
+
+
+def write_candidate(
+    output: Path,
+    result: dict[str, object],
+    rows: list[dict[str, object]],
+) -> None:
+    """Persist the result once so reruns cannot silently replace evidence."""
+
+    if output.exists():
+        raise RecoveryCandidateError(f"refusing to overwrite existing output: {output}")
+    output.mkdir(parents=True)
+    (output / "result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    with (output / "cases.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CASE_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("challenge", type=Path)
+    parser.add_argument("output", type=Path)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    result, rows = evaluate_candidate(args.challenge)
+    write_candidate(args.output, result, rows)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/academic_agent/source_pipeline.py
+++ b/src/academic_agent/source_pipeline.py
@@ -17,6 +17,7 @@ from urllib.request import Request, urlopen
 from pydantic import BaseModel, Field, ValidationError
 
 from academic_agent.evidence import EvidenceSource, _WEIGHT_PROFILES, check_public_url
+from academic_agent.source_title_recovery import recover_official_source_title
 
 from academic_agent.source_clients import (  # noqa: F401  (re-exported below)
     SourceCollectionError,
@@ -1919,7 +1920,7 @@ def _web_source(
     title = _clean_text(str(result.get("title", "")))
     link = str(result.get("link", "")).strip()
     snippet = str(result.get("snippet", ""))
-    if len(title) < 5 or not link:
+    if not link:
         return None, "search result lacks a usable title or URL"
     try:
         canonical = _canonical_url(link)
@@ -1928,6 +1929,8 @@ def _web_source(
         return None, f"invalid URL: {exc}"
 
     if domain == "patent":
+        if len(title) < 5:
+            return None, "search result lacks a usable title or URL"
         if host not in _PATENT_HOSTS:
             return None, f"non-primary patent host: {host}"
         source_type = "patent"
@@ -1952,6 +1955,32 @@ def _web_source(
         if profile is None:
             return None, f"market host is blocked or not approved: {host}"
         source_type, credibility_tier, credibility_reason = profile
+        authority_category = _authority_category_for_url(canonical)
+        title_decision = recover_official_source_title(
+            title,
+            canonical,
+            authority_category=authority_category,
+        )
+        if title_decision.action == "reject":
+            reasons = ", ".join(title_decision.reason_codes)
+            return None, (
+                "official source title is structurally unusable "
+                f"({reasons}) and its URL has no supported identifier"
+            )
+        if title_decision.action == "recover":
+            # The helper can recover only when it has an identifier-derived
+            # neutral label.  Keeping the defensive fallback makes this seam
+            # fail closed if that contract is weakened in a future refactor.
+            if title_decision.title is None:
+                return None, "official source title recovery returned no label"
+            title = title_decision.title
+            credibility_reason += (
+                " Search-result title was structurally unusable "
+                f"({', '.join(title_decision.reason_codes)}); the display label "
+                "contains only the identifier from the validated official URL."
+            )
+        if len(title) < 5:
+            return None, "search result lacks a usable title or URL"
 
     # Search-result patent hosts are allowlisted before this point. Avoiding a
     # second request keeps collection predictable, but this transport shortcut

--- a/src/academic_agent/source_title_recovery.py
+++ b/src/academic_agent/source_title_recovery.py
@@ -1,0 +1,147 @@
+"""Precision-first recovery for structurally broken official-source titles.
+
+Search providers occasionally return a valid regulator URL with a title that
+is only encoding debris.  This module never tries to reconstruct the exact
+document name: doing so would turn a display-quality repair into an unsupported
+claim.  It either preserves the original bytes, derives a neutral label from a
+validated URL identifier, or asks the caller to reject the source.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlsplit
+
+
+AuthorityCategory = Literal["regulatory", "clinical_registry"]
+RecoveryAction = Literal["preserve", "recover", "reject", "out_of_scope"]
+TitleDefectReason = Literal[
+    "empty_title",
+    "host_or_url_only",
+    "encoding_replacement_character",
+    "unicode_control_character",
+    "fragmented_single_letter_tokens",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TitleRecoveryDecision:
+    """One auditable decision at the title-to-EvidenceSource seam."""
+
+    action: RecoveryAction
+    title: str | None
+    reason_codes: tuple[TitleDefectReason, ...] = ()
+
+
+def _is_host_or_url_only(title: str, url: str, host: str) -> bool:
+    """Detect exact source identities without flagging short product names."""
+
+    normalized_title = title.strip().lower().rstrip("/")
+    normalized_url = url.strip().lower().rstrip("/")
+    bare_url = re.sub(r"^https?://", "", normalized_url)
+    bare_host = host.removeprefix("www.")
+    return normalized_title in {
+        normalized_url,
+        bare_url,
+        host,
+        bare_host,
+        f"www.{bare_host}",
+    }
+
+
+def structural_title_defects(
+    title: str,
+    url: str,
+) -> tuple[TitleDefectReason, ...]:
+    """Return only high-precision structural defects, never semantic guesses.
+
+    C0/C1 controls are intentionally separate from U+FFFD.  The frozen openFDA
+    sample contains literal U+0099 bytes, so checking only the usual replacement
+    character would describe an upstream decoding failure as a clean title.
+    """
+
+    stripped = title.strip()
+    host = (urlsplit(url).hostname or "").lower()
+    reasons: list[TitleDefectReason] = []
+    if not stripped:
+        reasons.append("empty_title")
+    elif _is_host_or_url_only(stripped, url, host):
+        reasons.append("host_or_url_only")
+
+    if "\ufffd" in title:
+        reasons.append("encoding_replacement_character")
+    if any(unicodedata.category(character) == "Cc" for character in title):
+        reasons.append("unicode_control_character")
+
+    # The observed FDA failure has four isolated b/I fragments followed by the
+    # source host.  All three conditions are required because model numbers,
+    # initials and single-letter trial arms are legitimate title content.
+    alpha_tokens = re.findall(r"[A-Za-z]+", title)
+    single_letter_tokens = sum(len(token) == 1 for token in alpha_tokens)
+    visible_host = host.removeprefix("www.")
+    if (
+        single_letter_tokens >= 4
+        and single_letter_tokens * 2 >= len(alpha_tokens)
+        and bool(visible_host)
+        and visible_host in title.lower()
+    ):
+        reasons.append("fragmented_single_letter_tokens")
+
+    return tuple(reasons)
+
+
+def _neutral_identifier_label(
+    url: str,
+    authority_category: AuthorityCategory,
+) -> str | None:
+    """Derive only identifiers whose syntax and host jointly establish scope."""
+
+    parsed = urlsplit(url)
+    host = (parsed.hostname or "").lower().removeprefix("www.")
+    if authority_category == "regulatory" and host == "accessdata.fda.gov":
+        match = re.fullmatch(r"/CDRH510K/(K\d{6})\.pdf", parsed.path, re.IGNORECASE)
+        if match:
+            return f"FDA 510(k) record {match.group(1).upper()}"
+    if authority_category == "clinical_registry" and host == "clinicaltrials.gov":
+        match = re.fullmatch(r"/study/(NCT\d{8})/?", parsed.path, re.IGNORECASE)
+        if match:
+            return f"ClinicalTrials.gov study {match.group(1).upper()}"
+    return None
+
+
+def recover_official_source_title(
+    title: str,
+    url: str,
+    *,
+    authority_category: AuthorityCategory | None,
+) -> TitleRecoveryDecision:
+    """Preserve, safely relabel, or reject one official search-result title.
+
+    The authority category comes from the caller's already established URL
+    allowlist.  Host checks are repeated when extracting an identifier so a
+    future caller cannot accidentally grant an attacker-suffix URL a regulator
+    label merely by passing the wrong category.
+    """
+
+    if authority_category is None:
+        return TitleRecoveryDecision(action="out_of_scope", title=None)
+
+    reasons = structural_title_defects(title, url)
+    if not reasons:
+        return TitleRecoveryDecision(action="preserve", title=title)
+
+    neutral_title = _neutral_identifier_label(url, authority_category)
+    if neutral_title is None:
+        return TitleRecoveryDecision(
+            action="reject",
+            title=None,
+            reason_codes=reasons,
+        )
+    return TitleRecoveryDecision(
+        action="recover",
+        title=neutral_title,
+        reason_codes=reasons,
+    )

--- a/tests/test_regulator_title_recovery.py
+++ b/tests/test_regulator_title_recovery.py
@@ -1,0 +1,281 @@
+"""Contracts for precision-first official-source title recovery.
+
+The important assertions sit at two seams: the frozen challenge must persist
+every baseline/candidate decision, and `_web_source` must place the recovered
+label on the final EvidenceSource rather than merely calculating it in a helper.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import socket
+from datetime import UTC, date, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pytest
+
+import regulator_title_audit
+import regulator_title_recovery_candidate
+from academic_agent.evidence import EvidenceSource
+from academic_agent.source_pipeline import SourceCollection, _web_source
+from academic_agent.source_title_recovery import recover_official_source_title
+
+
+_ROOT = Path(__file__).resolve().parent.parent
+_CHALLENGE = (
+    _ROOT
+    / "evals"
+    / "regulator_title_quality"
+    / "recovery-challenge-v1.json"
+)
+_CHALLENGE_SHA256 = "417f6429cbbc251b2c8923761b1cf1362f5e3d744bbf1170b3d1dc5a98c0cb13"
+_FDA_URL = "https://www.accessdata.fda.gov/CDRH510K/K222658.pdf"
+_FDA_BAD_TITLE = "'b, , 4 , I 'b, I - accessdata.fda.gov"
+
+
+def _result(title: str, url: str) -> dict[str, str]:
+    return {
+        "title": title,
+        "link": url,
+        "snippet": (
+            "The official record describes a regulated product or registered "
+            "study and provides enough context for the evidence model."
+        ),
+    }
+
+
+def _source_collection() -> SourceCollection:
+    source = EvidenceSource(
+        source_id="A1",
+        title="Deterministic academic control title",
+        url="https://doi.org/10.1000/recovery-control",
+        publisher="Control Publisher",
+        accessed_date=date(2026, 8, 25),
+        source_type="academic_paper",
+        credibility_tier="high",
+        credibility_reason="Deterministic local fixture for discovery testing.",
+        evidence_summary=(
+            "This local evidence summary is deliberately long enough to meet "
+            "the production model contract without any network access."
+        ),
+        summary_source="abstract",
+        doi="10.1000/recovery-control",
+    )
+    return SourceCollection(
+        topic="official source title recovery",
+        display_topic="official source title recovery",
+        collected_at=datetime(2026, 8, 25, tzinfo=UTC),
+        academic_sources=[source],
+        patent_sources=[],
+        market_sources=[],
+        academic_queries=["control query"],
+        patent_queries=["control query"],
+        market_queries=["control query"],
+    )
+
+
+def test_frozen_candidate_improves_only_disclosed_development_controls() -> None:
+    with mock.patch.object(
+        socket,
+        "create_connection",
+        side_effect=AssertionError("candidate attempted network access"),
+    ):
+        first, first_rows = regulator_title_recovery_candidate.evaluate_candidate(
+            _CHALLENGE
+        )
+        second, second_rows = regulator_title_recovery_candidate.evaluate_candidate(
+            _CHALLENGE
+        )
+
+    assert first == second
+    assert first_rows == second_rows
+    assert first["challenge_sha256"] == _CHALLENGE_SHA256
+    assert first["case_count"] == 29
+    assert first["baseline"] == {
+        "matched_expectation_count": 25,
+        "mismatched_expectation_count": 4,
+    }
+    assert first["candidate"] == {
+        "state": "accepted_for_production_integration",
+        "matched_expectation_count": 29,
+        "mismatched_expectation_count": 0,
+    }
+    assert first["contract_checks_passed"] is True
+    assert first["network_calls"] == 0
+    assert first["llm_calls"] == 0
+    assert first["production_mutations"] == 0
+
+
+def test_every_frozen_clean_control_is_byte_preserved(subtests) -> None:
+    payload = json.loads(_CHALLENGE.read_text(encoding="utf-8"))
+    clean_cases = [
+        case
+        for case in payload["cases"]
+        if case["label_provenance"] == "official_api_clean_control"
+    ]
+    assert len(clean_cases) == 23
+    for case in clean_cases:
+        with subtests.test(case_id=case["case_id"]):
+            scope = regulator_title_audit.authority_scope_for_url(case["url"])
+            decision = recover_official_source_title(
+                case["input_title"],
+                case["url"],
+                authority_category=scope,
+            )
+            assert decision.action == "preserve"
+            assert decision.title == case["input_title"]
+            assert decision.reason_codes == ()
+
+
+def test_observed_encoding_failures_receive_only_identifier_labels(subtests) -> None:
+    cases = (
+        (
+            "MitraClip\u0099 G5 Steerable Guide Catheter; TriClip\u0099 G5",
+            "https://www.accessdata.fda.gov/CDRH510K/K243224.pdf",
+            "FDA 510(k) record K243224",
+            "unicode_control_character",
+        ),
+        (
+            _FDA_BAD_TITLE,
+            _FDA_URL,
+            "FDA 510(k) record K222658",
+            "fragmented_single_letter_tokens",
+        ),
+    )
+    for title, url, expected, reason in cases:
+        with subtests.test(url=url):
+            decision = recover_official_source_title(
+                title,
+                url,
+                authority_category="regulatory",
+            )
+            assert decision.action == "recover"
+            assert decision.title == expected
+            assert reason in decision.reason_codes
+
+
+def test_unsupported_and_attacker_urls_fail_closed() -> None:
+    unsupported = recover_official_source_title(
+        "�",
+        "https://www.fda.gov/medical-devices/example",
+        authority_category="regulatory",
+    )
+    attacker = recover_official_source_title(
+        "�",
+        "https://accessdata.fda.gov.attacker.example/CDRH510K/K241852.pdf",
+        authority_category=None,
+    )
+    assert unsupported.action == "reject"
+    assert unsupported.title is None
+    assert attacker.action == "out_of_scope"
+    assert attacker.title is None
+
+
+def test_recovered_title_reaches_final_evidence_source_seam() -> None:
+    source, reason = _web_source(
+        _result(_FDA_BAD_TITLE, _FDA_URL),
+        "M7",
+        "market",
+        date(2026, 8, 25),
+        lambda _url: (True, ""),
+    )
+    assert reason == ""
+    assert source is not None
+    assert source.title == "FDA 510(k) record K222658"
+    assert "identifier from the validated official URL" in source.credibility_reason
+    assert _FDA_BAD_TITLE not in source.model_dump_json()
+
+
+def test_empty_title_recovers_only_from_a_supported_official_identifier() -> None:
+    """Guard the early-title-check move at the final source-model seam.
+
+    Empty search titles used to be rejected before authority validation.  The
+    recovery path intentionally delays that rejection, but only a validated
+    official URL with a supported identifier may turn the absence into a
+    neutral label.  Asserting the final ``EvidenceSource`` prevents a helper-
+    only test from missing a future transport regression.
+    """
+
+    source, reason = _web_source(
+        _result("", _FDA_URL),
+        "M8",
+        "market",
+        date(2026, 8, 25),
+        lambda _url: (True, ""),
+    )
+    assert reason == ""
+    assert source is not None
+    assert source.title == "FDA 510(k) record K222658"
+    assert "empty_title" in source.credibility_reason
+
+
+def test_unsupported_broken_official_title_is_rejected_at_source_seam() -> None:
+    source, reason = _web_source(
+        _result("�", "https://www.fda.gov/medical-devices/example"),
+        "M1",
+        "market",
+        date(2026, 8, 25),
+        lambda _url: (True, ""),
+    )
+    assert source is None
+    assert "structurally unusable" in reason
+    assert "no supported identifier" in reason
+
+
+def test_mixed_audit_root_prefers_run_artifacts_over_unrelated_json() -> None:
+    with TemporaryDirectory() as temp:
+        root = Path(temp)
+        run = root / "20260825T000000Z-control"
+        run.mkdir()
+        (run / "validated_sources.json").write_text(
+            _source_collection().model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        (root / ".paid-operation-ledger.json").write_text(
+            '{"schema_version": 1, "counts": {}}\n',
+            encoding="utf-8",
+        )
+
+        discovered = regulator_title_audit.discover_collections(root)
+        result, _ = regulator_title_audit.evaluate_audit(root, expected_count=1)
+
+    assert discovered == [run / "validated_sources.json"]
+    assert result["collection_count"] == 1
+
+
+def test_flat_only_audit_input_remains_strict() -> None:
+    with TemporaryDirectory() as temp:
+        root = Path(temp)
+        (root / "not-a-source-collection.json").write_text("{}\n", encoding="utf-8")
+        with pytest.raises(
+            regulator_title_audit.RegulatorTitleAuditError,
+            match="could not load",
+        ):
+            regulator_title_audit.evaluate_audit(root, expected_count=1)
+
+
+def test_candidate_writer_persists_every_decision_and_refuses_overwrite() -> None:
+    result, rows = regulator_title_recovery_candidate.evaluate_candidate(_CHALLENGE)
+    with TemporaryDirectory() as temp:
+        output = Path(temp) / "candidate"
+        regulator_title_recovery_candidate.write_candidate(output, result, rows)
+        persisted = json.loads((output / "result.json").read_text(encoding="utf-8"))
+        with (output / "cases.csv").open(encoding="utf-8", newline="") as handle:
+            case_rows = list(csv.DictReader(handle))
+        with pytest.raises(
+            regulator_title_recovery_candidate.RecoveryCandidateError,
+            match="refusing to overwrite",
+        ):
+            regulator_title_recovery_candidate.write_candidate(output, result, rows)
+
+    assert persisted["candidate"]["state"] == "accepted_for_production_integration"
+    assert len(case_rows) == 29
+    known = next(
+        row for row in case_rows if row["case_id"] == "production-fda-fragmented-k222658"
+    )
+    assert known["baseline_matches_expectation"] == "False"
+    assert known["candidate_matches_expectation"] == "True"
+    assert known["candidate_title"] == "FDA 510(k) record K222658"


### PR DESCRIPTION
## Why

A paid shadow-planner canary exposed a valid FDA source whose search title was encoding debris. The 30-run benchmark had no regulator-title denominator, and a wider zero-network census of 95 historical runs found only 3 in-scope rows over 2 unique URLs, so this PR freezes a development challenge instead of claiming population accuracy.

## What changed

- freezes a pre-registered 29-case challenge from official APIs, the production failure, disclosed synthetic controls, and an attacker-suffix control
- adds a deterministic, fail-closed recovery seam that preserves clean titles and derives only neutral FDA 510(k) or ClinicalTrials.gov identifier labels
- rejects structurally broken official titles when the validated URL has no supported identifier
- fixes mixed outputs-root audit discovery so operational ledgers cannot alter the source-collection denominator
- adds final EvidenceSource seam tests, idempotence and scope controls, immutable candidate artifacts, and defect-reinjection evidence
- updates English/Chinese README and AGENTS boundaries without claiming title truth or production precision

## Measured result

- legacy behavior: 25/29 expected actions
- candidate: 29/29 expected actions
- clean official titles preserved byte-for-byte: 23/23
- historical census: 95 runs, 3 in-scope rows, 2 unique URLs

## Validation

- uv run --with ruff ruff check .
- narrow CI pylint control-flow check
- uv run pytest -q: 1391 passed, 627 subtests passed
- CI-equivalent coverage: 87.00% (floor 85%)

A provider-backed post-integration canary is intentionally not part of this PR and remains separately budget-gated.