### PR TITLE
Document the paid regulator title recovery canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,11 +182,17 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   candidate then matched 29/29 disclosed cases while preserving 23/23 clean
   official API titles byte for byte. It may derive only a neutral identifier
   label from an exact FDA 510(k) or ClinicalTrials.gov URL; unsupported broken
-  official titles are rejected. No provider-backed post-integration canary has
-  run yet, so do not present this as title truth, real-world precision/recall,
-  report-quality improvement, or production success evidence. See
+  official titles are rejected. One provider-backed post-integration canary
+  completed for `$0.032665`, but no supported structural defect recurred, so
+  the primary recovery criterion was `not_observed`. The run instead exposed a
+  structurally plausible FDA title that lost its device entity and passed the
+  frozen structural detector. Do not turn either observation into title truth,
+  real-world precision/recall, report-quality improvement, or production
+  recovery success. See
   `docs/prereg-2026-08-25-regulator-title-recovery-candidate.md` and
-  `docs/results-2026-08-25-regulator-title-recovery-candidate.md`.
+  `docs/results-2026-08-25-regulator-title-recovery-candidate.md`, plus
+  `docs/prereg-2026-08-25-regulator-title-recovery-paid-canary.md` and
+  `docs/results-2026-08-25-regulator-title-recovery-paid-canary.md`.
 - The pre-registered offline process audit recovered 30/30 immutable children
   across ten frozen evidence collections and three post-commit boundaries. It
   skipped 90 committed task executions with zero duplicate task executions.

--- a/README.md
+++ b/README.md
@@ -375,11 +375,16 @@ controls, and one attacker-suffix scope control. The deterministic candidate
 matched **29/29** expected actions while preserving **23/23** clean titles byte
 for byte. Production now recovers only a neutral identifier label from an exact
 FDA 510(k) or ClinicalTrials.gov URL and rejects unsupported broken titles; it
-does not guess a document name or repair Unicode semantically. A paid
-post-integration canary remains unrun, so this is not title-truth, production
-precision/recall, or report-quality evidence. See the
+does not guess a document name or repair Unicode semantically. One paid
+post-integration canary completed for `$0.032665`, but no supported structural
+defect recurred, so the primary recovery criterion was `not_observed`. The run
+instead exposed a structurally plausible FDA title that had lost its device
+entity, a different class of defect that the frozen detector intentionally does
+not guess at. This remains neither title-truth, production precision/recall, nor
+report-quality evidence. See the
 [pre-registration](docs/prereg-2026-08-25-regulator-title-recovery-candidate.md)
-and [result](docs/results-2026-08-25-regulator-title-recovery-candidate.md).
+and [development result](docs/results-2026-08-25-regulator-title-recovery-candidate.md),
+plus the [paid canary result](docs/results-2026-08-25-regulator-title-recovery-paid-canary.md).
 
 See the [`examples/`](examples/) folder for three complete real reports across different industries.
 
@@ -1280,10 +1285,14 @@ benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **
 正向控制和 1 条攻击者后缀范围控制。确定性候选匹配 **29/29** 个预期动作，并
 逐字保留 **23/23** 条干净标题。生产路径现在只允许从精确的 FDA 510(k) 或
 ClinicalTrials.gov URL 提取标识符形成中性标签；无法支持的坏标题直接拒绝，
-不会猜测文档名或做语义 Unicode 修复。付费的集成后 canary 尚未运行，因此这些
-数字不代表标题真值、生产 precision/recall 或报告质量改善。详见
+不会猜测文档名或做语义 Unicode 修复。一次付费的集成后 canary 以
+`$0.032665` 完成，但没有再次出现支持范围内的结构性坏标题，因此核心恢复条件为
+`not_observed`。该运行反而发现了一条结构看似正常、却丢失设备实体的 FDA 标题，
+属于冻结检测器刻意不猜测的另一类问题。这些数字仍不代表标题真值、生产
+precision/recall 或报告质量改善。详见
 [预注册](docs/prereg-2026-08-25-regulator-title-recovery-candidate.md)与
-[结果](docs/results-2026-08-25-regulator-title-recovery-candidate.md)。
+[开发结果](docs/results-2026-08-25-regulator-title-recovery-candidate.md)，以及
+[付费 canary 结果](docs/results-2026-08-25-regulator-title-recovery-paid-canary.md)。
 
 完整报告示例见 [`examples/`](examples/) 文件夹（钙钛矿太阳能 / CAR-T 疗法 / 固态电池，三个行业）。
 

--- a/docs/prereg-2026-08-25-regulator-title-recovery-paid-canary.md
+++ b/docs/prereg-2026-08-25-regulator-title-recovery-paid-canary.md
@@ -1,0 +1,83 @@
+# Regulator-title recovery post-integration production canary — pre-registration
+
+**Frozen:** 2026-08-25T06:32:45Z, before the production `POST /api/runs`
+**Authorized production revision:** `8c592fcb35c4e89ce62764d1cd13bfb39f282bb0`
+**Authorized paid scope:** one operator-funded source run, no retry or resume
+**Soft cost stop:** `$0.05`; one already-admitted run may finish above it
+**Planner or supplementary search calls authorized:** no
+
+## Question
+
+Does the precision-first regulator-title recovery reach the deployed
+search-result-to-`EvidenceSource` seam when the previously observed title defect
+recurs, without guessing a semantic title or changing any clean official title?
+
+This is one repeated-topic production observation. It is not a held-out title
+quality study, a real-world precision/recall estimate, or evidence that the
+report itself is more accurate.
+
+## Frozen input and preflight
+
+The request topic is exactly:
+
+> Wearable continuous blood pressure monitoring using photoplethysmography for
+> clinical deployment
+
+No language, weight-profile, paper, BYOK credential, planner option, or recovery
+request will be supplied. Before this document was frozen:
+
+- GitHub deployment `6077280941` identified the authorized revision and
+  Railway reported it as `success`;
+- `/health/ready` returned HTTP 200 with `llm`, `search`, `outputs`, and
+  `paid_accounting` all `ok`;
+- the selected operator code reached `/api/access/check` with HTTP 200; the
+  code itself is not recorded in this repository; and
+- that owner's run history reported `total=4`, with
+  `20260825T024919Z-d8c43b0ba3479dc46227b4bfaa82f0a4` as the latest run.
+
+## Frozen execution protocol
+
+1. Submit exactly one `POST /api/runs` containing only the frozen topic.
+2. Persist the returned run id before any polling or inspection.
+3. Poll only that run to a terminal state. Do not retry, resume, cancel,
+   substitute another topic, or submit a second run.
+4. Inspect the public status, progress, validated source collection, report,
+   usage, checkpoint identity, authority coverage, and evidence-gap artifact.
+5. Re-read the owner history. Exactly one new root run and no child run may
+   exist after the frozen baseline.
+6. Classify each criterion as `pass`, `fail`, `not_inspectable`, or
+   `not_observed`. Silence and absence are never a pass.
+
+The `$0.05` threshold is soft because aggregate provider usage is exposed only
+after work has started. No second run is allowed even if the first fails below
+the threshold or does not retrieve a structurally broken official title.
+
+## Acceptance criteria
+
+1. The observed `pipeline_revision` is the full authorized revision.
+2. The single root run reaches `completed`, creates no recovery child, and
+   commits the ordinary seven-node checkpoint sequence without an error.
+3. Total provider cost is inspectable and no greater than `$0.05`.
+4. The evidence-gap artifact records zero executed planner/tool calls, zero
+   supplementary-search cost, and identical source hashes before and after its
+   evaluation. A disabled or failed check is not a pass.
+5. If K222658 or another supported official URL arrives with a structural title
+   defect, the final `EvidenceSource.title` contains only its neutral URL-derived
+   identifier label, the malformed title is absent, and `credibility_reason`
+   discloses the recovery. If no such defect recurs, this criterion is
+   `not_observed`, not a pass.
+6. Every accepted clean FDA or ClinicalTrials.gov title remains unchanged by
+   the recovery seam. This can pass only for titles observable in the persisted
+   collection; unobserved source classes remain `not_observed`.
+7. Any recovered neutral label that reaches the persisted source collection
+   also reaches the delivered report reference. A source absent from the report
+   is `fail`; an untriggered recovery is `not_observed`.
+8. The owner history increases from four to exactly five root runs, and this
+   protocol creates no second run, resume, planner request, or supplementary
+   search request.
+
+Any unauthorized paid operation, child recovery, evidence mutation, terminal
+failure, semantic title invention, unsupported-host recovery, or inspectable
+over-threshold cost fails the canary. A completed run with no recurrent broken
+official title is a valid production observation but does not pass the primary
+title-recovery criterion.

--- a/docs/results-2026-08-25-regulator-title-recovery-candidate.md
+++ b/docs/results-2026-08-25-regulator-title-recovery-candidate.md
@@ -144,7 +144,11 @@ All test runs were zero-network; no provider token was consumed.
 
 This result does not establish title truth, real-world prevalence, report
 quality, production success rate, latency, cost reduction, or regulatory
-coverage. A provider-backed canary remains unrun and requires separate paid
-authorization. Until then, the strongest accurate statement is that the
-candidate passed one frozen development challenge and one defect-reinjection
-test.
+coverage. A later provider-backed canary completed within budget, but the
+primary malformed-title trigger did not recur and therefore remained
+`not_observed`. That run also exposed a different, structurally plausible title
+that had lost its device entity; it was outside this detector's frozen contract.
+The strongest accurate statement remains that the candidate passed one frozen
+development challenge and one defect-reinjection test. See the
+[paid canary result](results-2026-08-25-regulator-title-recovery-paid-canary.md)
+for the production boundary and the new observation.

--- a/docs/results-2026-08-25-regulator-title-recovery-paid-canary.md
+++ b/docs/results-2026-08-25-regulator-title-recovery-paid-canary.md
@@ -1,0 +1,89 @@
+# Regulator-title recovery post-integration production canary — result
+
+**Run:** [20260825T063703Z-efb379b66c5c46133bf50b7d5397a41f](https://academic-commercialization-agent.up.railway.app/run/20260825T063703Z-efb379b66c5c46133bf50b7d5397a41f)
+**Protocol:** [frozen pre-registration](prereg-2026-08-25-regulator-title-recovery-paid-canary.md)
+**Pre-registration commit:** `b9303a1`
+**Authorized production revision:** `8c592fcb35c4e89ce62764d1cd13bfb39f282bb0`
+**Outcome:** valid production observation, but not a pass because the primary
+recovery trigger was not observed
+
+## Execution
+
+The operator authorized one paid root run on the repeated blood-pressure topic.
+One initial local `curl` invocation failed shell parsing before it formed an
+HTTP request. The owner history still contained exactly four entries after that
+client-side failure. The request was then submitted once from a persisted JSON
+payload, and the returned run id was written to the ignored audit directory
+before polling began. No retry, resume, cancellation, topic substitution, or
+second paid operation followed.
+
+- Terminal state: `completed`, with no error and `resumed_from=null`
+- Elapsed time: 161 seconds
+- Sources: 3 academic + 8 patent + 8 market; no failed domain
+- Provider use: 77,724 tokens over 6 ordinary workflow requests
+- Inspectable cost: `$0.032665`, below the `$0.05` soft stop
+- Quality review: passed
+- Consistency screen: 0 blockers and 0 warnings
+- Checkpointing: `retrieval`, all three evidence nodes, `writer`, `reviewer`,
+  and `scorer` committed without an error
+- Recovery: `not_requested`; no child run or reused node
+- Operator history: exactly 4 before and 5 after, with this run as the only new
+  entry
+
+## Frozen criteria
+
+| # | Result | Evidence |
+|---|---|---|
+| 1 | `not_inspectable` at the public run boundary | GitHub deployment `6077280941` and Railway deployment state identified the authorized revision before submission. The public status, steps, sources, and report endpoints do not export checkpoint `identity.pipeline_revision`, so the exact field cannot be observed independently and is not inferred into a pass. |
+| 2 | `pass` | The one root run completed, created no recovery child, and exposed the ordinary seven committed checkpoint nodes with no checkpoint error. |
+| 3 | `pass` | Cost was complete and inspectable at `$0.032665`, below `$0.05`. |
+| 4 | `pass` | The shadow check ran with `gate_state=no_gap`, `planner_state=not_run`, zero proposed or executed calls, `$0` additional search cost, `evidence_changed=false`, and `persistence_state=written`. Pydantic-loading the delivered source collection and applying the repository's canonical hash function independently reproduced `07ffcda8db8375e9070c887393405c3819a57b46114983bad33045e14dcafd75`, exactly matching the artifact. |
+| 5 | `not_observed` | K222658 did not recur, and no supported FDA 510(k) or ClinicalTrials.gov URL arrived with a defect recognized by the frozen structural detector. Absence is not a recovery pass. |
+| 6 | `pass` only for the recovery transformation seam | FDA source `M5` was observable. Its persisted title produced zero frozen structural-defect codes, carried no recovery disclosure, and therefore followed the byte-preserving branch. This says nothing about whether the upstream title was semantically true; the separate finding below shows that it was not. |
+| 7 | `not_observed` | No neutral identifier label was recovered, so report delivery of a recovered label could not be tested. |
+| 8 | `pass` | Owner history increased from four to exactly five root runs. There was one effective production POST, no resume, and no Planner or supplementary-search request. |
+
+The canary therefore did not pass its primary question. It did establish that
+the integrated workflow completed under the frozen budget and that the recovery
+seam did not rewrite the one structurally clean title it observed. Those are
+supporting observations, not evidence that malformed supported titles recover
+in production.
+
+## New finding: structurally plausible but semantically damaged title
+
+The accepted regulator source was `M5`:
+
+> `TM Clinical Platform with ClearSightm Finger Cuffs 510(k)`
+
+Its URL is the official FDA record
+[`K140312`](https://www.accessdata.fda.gov/cdrh_docs/pdf14/K140312.pdf). The
+first page of that document identifies the device as the **EV1000 Clinical
+Platform with ClearSight Finger Cuffs**. The persisted search-result title lost
+the `EV1000` entity and converted trademark notation into the literal fragments
+`TM` and `m`. The same damaged title reached the delivered report reference
+exactly once.
+
+This is not a U+FFFD decoding failure: the delivered report contains zero
+replacement characters. It also does not match any frozen structural defect,
+so the detector correctly followed its current precision-first contract rather
+than guessing that a grammatically plausible title was wrong. The report body
+still named EV1000 because the evidence summary retained that entity, but the
+reference title remained inaccurate.
+
+This finding must not be converted into a one-example production patch. The URL
+uses `/cdrh_docs/pdf14/K140312.pdf`, outside the two exact identifier paths in
+the frozen recovery rule, and the defect requires title-truth comparison rather
+than debris detection. A defensible follow-up needs a separately frozen set of
+clean and entity-damaged official titles, a precision-first semantic or
+metadata comparison, and an abstention path. Until that exists, the honest
+status is: structural recovery passed its development challenge, its production
+trigger remains unobserved, and one different class of title-quality defect is
+now measured.
+
+## Boundary of the result
+
+This is one repeated-topic provider-backed observation. It is not a title error
+rate, production precision/recall, report-quality improvement, SLO, or proof
+that the recovery rule handles malformed titles in production. It also does not
+establish independent source truth beyond the one FDA record opened for this
+audit.


### PR DESCRIPTION
## Why

The integrated regulator-title recovery had only a frozen development
challenge. This branch pre-registered one provider-backed production canary
before submission, then records the result without turning a completed workflow
into proof that the recovery branch executed.

## Result

- one effective root run, no retry, resume, Planner, or supplementary search;
- completed in 161 seconds with 77,724 tokens over 6 requests;
- inspectable cost `$0.032665`, below the `$0.05` soft stop;
- seven checkpoints committed and owner history increased exactly 4 to 5;
- Shadow ran with zero calls, zero added cost, unchanged evidence, and an
  independently reproduced source hash;
- primary malformed-title recovery: `not_observed`;
- exact public `pipeline_revision`: `not_inspectable`.

The run also surfaced a different defect. FDA source M5 kept a grammatically
plausible title that omitted the EV1000 entity and corrupted trademark notation.
The official PDF confirms the mismatch, while the frozen structural detector
correctly returns no defect. The result therefore documents the finding and
requires a separate measured semantic-title challenge instead of widening the
production rule from one post-hoc example.

## Verification

- `uv run --with ruff ruff check .`
- `uv run pytest -q --basetemp outputs/.pytest-regulator-title-canary`
  (`1391 passed, 627 subtests passed`)

The first local test attempt used the system pytest temp root and encountered
Windows `WinError 5` during `tmp_path` setup. No assertion failed; relocating
only pytest's temporary directory produced the complete green run above.
