### PR TITLE
Prepare a measured v2 portfolio release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 [![Live demo](https://img.shields.io/badge/live%20demo-try%20it-brightgreen.svg)](https://academic-commercialization-agent.up.railway.app)
 
+[Portfolio case study](docs/portfolio-case-study.md) | [90-second demo guide](docs/demo-script-90s.md) | [v2.0.0 release notes](docs/release-v2.0.0.md)
+
 [English](#english) | [中文](#chinese)
 
 ---

--- a/api/main.py
+++ b/api/main.py
@@ -100,7 +100,7 @@ app = FastAPI(
         "Submit a research topic, poll for progress, retrieve the report and "
         "scorecard. The web client and CLI execute the same six-agent pipeline."
     ),
-    version="1.0.0",
+    version="2.0.0",
     lifespan=_lifespan,
 )
 

--- a/docs/demo-script-90s.md
+++ b/docs/demo-script-90s.md
@@ -1,0 +1,98 @@
+# 90-Second Portfolio Demo Guide
+
+## Recording goal
+
+Show one complete decision-support journey without waiting for or paying for a
+new run during recording. The video should demonstrate the product, the
+evidence boundary, and one measured reliability result. It should not try to
+enumerate every feature.
+
+Use a previously completed run. Open it before recording and confirm that the
+report, scorecard, source tabs, reliability panel, and downloadable artifacts
+all load. Do not expose an access code, API key, owner code, private run list,
+Phoenix credential, browser bookmarks, or terminal environment variables.
+
+## Shot list and Chinese narration
+
+### 0–10 seconds — problem and input
+
+**Screen:** Open the live home page. Place a commercialization topic in the
+composer, but do not submit it.
+
+**Narration:**
+
+> 科研商业化判断不能只看论文，还要同时核对专利、市场和监管证据。这个系统把研究主题或论文转换成一份可追溯、可评分的商业化评估报告。
+
+### 10–24 seconds — constrained architecture
+
+**Screen:** Switch to a prepared diagram or the README execution-flow section,
+then briefly show the in-progress screenshot.
+
+**Narration:**
+
+> 我没有让大模型自由搜索。Python 检索层先验证来源、去重并冻结证据，再由三个领域节点并行分析，Writer、Reviewer 和 Scorer 只在这份证据边界内工作。
+
+### 24–45 seconds — report and citations
+
+**Screen:** Open the completed run. Scroll from the executive summary to one
+claim with an [A], [P], or [M] citation, then open the matching source in
+the Sources tab.
+
+**Narration:**
+
+> 报告中的每个来源编号都必须回到已注册的论文、专利或市场记录。Pydantic 和 Guardrail 会阻止虚构来源、引用断链、结构错误和评分公式漂移，而不是只依赖 Prompt 提醒模型。
+
+### 45–62 seconds — decision surface
+
+**Screen:** Show the scorecard, risks/opportunities, reliability panel, token
+usage, and cost status. Pause long enough for labels to be readable.
+
+**Narration:**
+
+> 前端同时展示五维评分、证据支撑、风险机会、检查是否真正执行，以及 Token 和成本。没有运行的检查会显示未检查，不会被包装成通过。
+
+### 62–77 seconds — production resilience
+
+**Screen:** Show the checkpoint/recovery section in the README or the recovery
+result document, then return to the live result.
+
+**Narration:**
+
+> 长任务按输入、证据、配置和流水线哈希保存节点级 Checkpoint。故障恢复会创建不可变子运行，只复用重新验证过的连续前缀；线上一次同版本恢复复用了四个节点，并以零次新增证据节点调用完成后续流程。
+
+### 77–90 seconds — measured outcome and honest boundary
+
+**Screen:** Show the measured-results table in the README, then finish on the
+GitHub repository and live-demo links.
+
+**Narration:**
+
+> 项目目前有一千三百九十一项测试和六百二十七个子测试，并完成九十单元消融和五人盲评。盲评没有证明六阶段一定优于单模型，所以我保留失败结论。这个项目的重点不是堆 Agent，而是让 Agent 结果可验证、可恢复、可审计。
+
+## Recording checklist
+
+- Record at 1920×1080, 30 fps, with browser zoom at 100% or 110%.
+- Use a clean browser profile or hide bookmarks, extensions, notifications,
+  account avatars, and unrelated tabs.
+- Preload the live home page, one completed run, the measured-results section,
+  and the checkpoint result before recording.
+- Use a completed run rather than clicking **Run Analysis**. This keeps the take
+  deterministic, avoids a three-minute pause, and incurs no new provider cost.
+- Keep one citation-to-source interaction in the final cut; it is the clearest
+  evidence that this is more than a report-generation UI.
+- Keep one explicit non-success state (not_run, not_observed, or
+  not_inspectable) visible if the chosen run has one.
+- Add Chinese captions and short English overlays for: Validated evidence,
+  Guardrails, Checkpoint recovery, and Measured evaluation.
+- Do not claim autonomous Tool Calling, classic vector RAG, six-stage
+  superiority, production SLOs, exactly-once execution, adoption, or ROI.
+- End with both links on screen for at least two seconds:
+  [live application](https://academic-commercialization-agent.up.railway.app)
+  and [GitHub repository](https://github.com/shuxiachai/academic-commercialization-agent).
+
+## Before publishing
+
+Watch the exported video once without sound and once audio-only. The silent pass
+checks whether the product story is visually understandable; the audio-only
+pass catches narration that depends on unreadable UI text. Verify every number
+against [the case study](portfolio-case-study.md) immediately before upload.

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -1,0 +1,119 @@
+# Portfolio Case Study: Evidence-Constrained Commercialization Assessment
+
+## The problem
+
+Commercialization decisions require evidence from several domains at once:
+technical maturity, patents, market signals, competitors, and regulatory or
+clinical milestones where applicable. A general-purpose chat response can be
+fast, but it is difficult to audit when a claim, score, or recommendation is
+not tied to a source.
+
+This project turns a research topic or paper into a structured, scored
+commercialization report. It is designed as a reliability-first decision-support
+workflow for technology-transfer, investment, and industry-research scenarios.
+It does not replace technical, legal, regulatory, or investment due diligence.
+
+## What I built
+
+The production path is an **evidence-constrained, six-stage LLM workflow**, not
+an unrestricted autonomous agent:
+
+Before those stages, deterministic Python retrieval plans the query, collects
+academic, patent, market, and applicable authority evidence, validates
+identifiers and URLs, assigns provenance tiers, deduplicates records, and
+persists a frozen source registry. The LLM workflow then runs:
+
+1. An Academic specialist analyses the frozen literature collection.
+2. A Patent specialist analyses the frozen patent collection.
+3. A Market specialist analyses the frozen market and authority collection.
+4. A Writer produces a report whose inline source IDs must resolve to the
+   validated registry.
+5. A Reviewer emits a bounded correction plan; code applies exact edits rather
+   than allowing an unconstrained rewrite.
+6. A Scorer produces a traceable scorecard, while deterministic code validates
+   source IDs and recalculates the weighted total.
+
+FastAPI serves the same run artifacts to a build-free HTML/CSS/ES-module client
+and the CLI. Each run executes in a subprocess and writes auditable state under
+outputs/<run_id>/, so the API, browser, CLI, and recovery path observe the same
+source of truth.
+
+## Reliability and production engineering
+
+- Pydantic schemas and task guardrails reject malformed evidence, invented
+  source IDs, broken citation registries, invalid report structure, and score
+  formula drift.
+- Node-level, content-addressed checkpoints bind reuse to input, evidence,
+  configuration, task, and pipeline identity. Recovery creates an immutable
+  child and revalidates the longest contiguous committed prefix.
+- Access-code and BYOK paths isolate credentials, share bounded paid-operation
+  admission, and enforce concurrency and daily operator-funded limits before a
+  provider call.
+- Rate limiting, ownership checks, upload bounds, SSRF-oriented URL validation,
+  strict security headers, and retention controls protect the public surface.
+- OpenTelemetry and OpenInference connect retrieval, CrewAI tasks, provider
+  requests, and post-run checks in one privacy-reduced trace. Local artifacts
+  remain authoritative if the collector is unavailable.
+- Docker runs as a non-root user with tini; Railway hosts the public demo.
+
+## What I measured
+
+| Evaluation | Result | What it does **not** prove |
+|---|---|---|
+| Frozen live baseline | 30/30 completed; 26/30 within milestone-anchored TRL ranges; 30/30 formula and structure checks; 0 unsupported numeric lines | Not a blinded held-out accuracy score, and not complete hallucination elimination |
+| Topology ablation | 90 paid cells across 1-, 4-, and 6-node workflows; the 4-node arm used 54.89% fewer median tokens and 47.03% lower median cost than the 6-node arm | Supports domain decomposition, but does not prove every production stage is necessary |
+| Blinded utility audit | Five reviewers returned 20/20 eligible judgments; both rounds preferred the full workflow 6:4 for decision usefulness | The pre-registered success rule failed; the monolith led information gain 11:5, so this is not proof of six-stage superiority or adoption |
+| Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
+| Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
+| Test and CI contract | 1,391 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.01% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
+
+The negative results are retained deliberately. For example, the first patent
+relevance candidate raised auto-kept precision to 94.6% but falsely removed six
+relevant patents, so it was rejected rather than tuned after seeing the labels.
+The user-utility study also failed its registered success criterion even though
+the full workflow won a simple majority. This distinction is part of the
+project's engineering argument: evaluation should be capable of saying no.
+
+## Key decisions and lessons
+
+- **Retrieval before reasoning:** freezing and validating evidence before CrewAI
+  reduces tool autonomy, but makes citations, retries, replay, and fault recovery
+  auditable.
+- **Assertions at system seams:** tests cover whether computed values reach both
+  API endpoints and the browser contract, not only whether an internal field is
+  correct.
+- **Silence is not success:** checks distinguish pass, fail, not_run,
+  not_observed, and not_inspectable where a zero denominator could otherwise
+  look healthy.
+- **Precision before blocking:** heuristic screens report conservatively. The
+  uncited-claim detector remains non-blocking because the stored baseline shows
+  that its false-positive burden is still too high.
+- **Recovery is at-least-once at provider boundaries:** committed local nodes can
+  be reused safely, but an interrupted external request cannot be claimed as
+  exactly once without provider-supported idempotency.
+
+## Current limitations
+
+- The small utility panel contains only one target-domain user and does not
+  establish adoption, ROI, or improved real-world decisions.
+- Run state, quotas, and artifacts are designed for one application replica;
+  horizontal scaling requires shared transactional storage and a distributed
+  work queue.
+- Evidence-gap planning is shadow-only instrumentation. It records whether a
+  bounded tool call would be justified but does not issue production searches.
+- Code-package analysis is not implemented, and patent relevance has no second
+  independent reviewer or inter-rater estimate.
+
+## Reproduce or inspect
+
+- [Live application](https://academic-commercialization-agent.up.railway.app)
+- [Architecture and full documentation](../README.md)
+- [Topology ablation protocol and result](prereg-2026-08-21-agent-topology-ablation.md)
+- [User-utility result](results-2026-08-23-user-utility-audit.md)
+- [Checkpoint recovery design](checkpoint-recovery.md)
+- [Production recovery canary](results-2026-08-24-paid-same-revision-recovery-post-fix.md)
+
+    uv sync
+    uv run pytest -q
+    uv run --with ruff ruff check .
+    uv run uvicorn api.main:app --reload

--- a/docs/release-v2.0.0.md
+++ b/docs/release-v2.0.0.md
@@ -1,0 +1,114 @@
+# Academic Commercialization Assessment Agent v2.0.0
+
+## Reliability-first production workflow
+
+Version 2.0.0 turns the original Gradio demonstration into a deployable,
+evidence-constrained decision-support system. A FastAPI service, build-free web
+client, CLI, and recovery path now observe the same persisted run artifacts.
+The release also adds measured evaluation, paid-operation controls,
+privacy-reduced tracing, and node-level crash recovery.
+
+This remains decision support rather than legal, regulatory, technical, or
+investment advice.
+
+## Highlights
+
+### Evidence before generation
+
+- Deterministic retrieval plans free-form topics and collects academic, patent,
+  market, and applicable regulator or trial-registry records before CrewAI runs.
+- DOI/URL checks, allowlists, provenance tiers, relevance screening,
+  deduplication, and a rejection audit produce a frozen source registry.
+- The six-stage workflow analyses that registry, writes a cited report, applies
+  a bounded review plan, and generates a source-traceable scorecard.
+- Evidence-gap planning is available as zero-call shadow instrumentation. It
+  records whether bounded supplemental search would be justified but performs
+  no production Tool Calling in this release.
+
+### Public application and paid boundaries
+
+- Gradio has been replaced by FastAPI plus a vanilla HTML/CSS/ES-module client.
+- Runs execute in cancellable subprocesses and expose live progress, sources,
+  scorecards, reliability states, usage, cost, and downloadable reports.
+- Access-code and BYOK modes isolate credentials and run history.
+- Complete runs and PDF extraction share concurrency and daily paid-operation
+  admission; failed startup rolls back reserved quota.
+- Rate limiting, ownership checks, bounded uploads, retention, URL validation,
+  and strict response headers harden the public surface.
+
+### Auditable recovery and observability
+
+- Content-addressed checkpoints bind reusable outputs to input, evidence,
+  configuration, task, and pipeline identity.
+- Recovery creates an immutable child, requires fresh credentials, validates
+  the longest contiguous prefix, and exposes reuse separately from persistence.
+- OpenTelemetry and OpenInference connect retrieval, CrewAI tasks, provider
+  calls, and quality checks in one privacy-reduced trace. Local artifacts remain
+  authoritative when the collector is unavailable.
+
+## Measured evidence
+
+- **Baseline:** 30/30 end-to-end completions, 26/30 milestone-anchored TRL
+  matches, 30/30 formula checks, 30/30 report-structure checks, and 0 unsupported
+  numeric lines. This is a revised calibration baseline, not a held-out score.
+- **Topology ablation:** 90 paid cells across 1-, 4-, and 6-node workflows. The
+  4-node arm used 54.89% fewer median tokens and 47.03% lower median cost than
+  the 6-node arm. This supports domain decomposition, not every production node.
+- **User utility:** five reviewers completed 20/20 eligible blinded judgments.
+  The full workflow won decision usefulness 6:4 in each round but failed the
+  pre-registered success rule; the monolith led information gain 11:5.
+- **Fault injection:** 30/30 zero-network recovery children completed, skipped
+  90 committed task executions, and duplicated 0 task executions.
+- **Production recovery:** one post-fix same-revision child reused a four-node
+  prefix, made 0 new evidence-agent requests, and completed the suffix. The
+  interrupted source's usage was unavailable, so total cost and general savings
+  remain uninspectable.
+- **Verification:** 1,391 tests plus 627 subtests, Linux/Windows × Python
+  3.11/3.12 CI, and 87.01% measured coverage above an 85% floor.
+
+The protocols, row-level artifacts, failed candidates, and caveats are linked
+from the [README](../README.md) and summarized in the
+[portfolio case study](portfolio-case-study.md).
+
+## Breaking changes from v1.0.0
+
+- The Gradio UI and python app.py development path are retired. Start the web
+  application with uv run uvicorn api.main:app --reload.
+- The HTTP API and persisted run contract are now the supported integration
+  surfaces. Consumers of the original UI callbacks must migrate to the FastAPI
+  endpoints documented at /docs.
+- Public deployment configuration now separates operator-funded access codes,
+  BYOK credentials, paid-operation limits, retention, and optional telemetry.
+  Review .env.example rather than carrying forward a v1 environment blindly.
+
+## Run locally
+
+    uv sync
+    uv run pytest -q
+    uv run --with ruff ruff check .
+    uv run uvicorn api.main:app --reload
+
+Then open http://127.0.0.1:8000. Real analysis requires one supported LLM key
+and one search-provider key; the test suite is zero-network.
+
+## Known limits
+
+- The user-utility panel is small and mostly proxy users; it does not establish
+  adoption, ROI, or better real-world investment decisions.
+- File-backed run state and paid-operation accounting target one application
+  replica. Horizontal scale requires a transactional shared store and queue.
+- External provider requests remain at-least-once at interruption boundaries.
+- Production supplemental Tool Calling is intentionally disabled until the
+  shadow planner demonstrates useful evidence gain at acceptable error, cost,
+  and latency.
+- Code-package analysis is not implemented. Patent relevance has one human
+  label set but no second independent reviewer or inter-rater agreement.
+- Precision-first regulator-title recovery covers only exact FDA 510(k) and
+  ClinicalTrials.gov URL shapes and is not evidence of title truth.
+
+## Portfolio material
+
+- [Live application](https://academic-commercialization-agent.up.railway.app)
+- [One-page case study](portfolio-case-study.md)
+- [90-second demo recording guide](demo-script-90s.md)
+- [Full README](../README.md)

--- a/docs/release-v2.0.0.md
+++ b/docs/release-v2.0.0.md
@@ -67,8 +67,9 @@ investment advice.
   3.11/3.12 CI, and 87.01% measured coverage above an 85% floor.
 
 The protocols, row-level artifacts, failed candidates, and caveats are linked
-from the [README](../README.md) and summarized in the
-[portfolio case study](portfolio-case-study.md).
+from the [README](https://github.com/shuxiachai/academic-commercialization-agent/blob/v2.0.0/README.md)
+and summarized in the
+[portfolio case study](https://github.com/shuxiachai/academic-commercialization-agent/blob/v2.0.0/docs/portfolio-case-study.md).
 
 ## Breaking changes from v1.0.0
 
@@ -109,6 +110,6 @@ and one search-provider key; the test suite is zero-network.
 ## Portfolio material
 
 - [Live application](https://academic-commercialization-agent.up.railway.app)
-- [One-page case study](portfolio-case-study.md)
-- [90-second demo recording guide](demo-script-90s.md)
-- [Full README](../README.md)
+- [One-page case study](https://github.com/shuxiachai/academic-commercialization-agent/blob/v2.0.0/docs/portfolio-case-study.md)
+- [90-second demo recording guide](https://github.com/shuxiachai/academic-commercialization-agent/blob/v2.0.0/docs/demo-script-90s.md)
+- [Full README](https://github.com/shuxiachai/academic-commercialization-agent/blob/v2.0.0/README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "academic_agent"
-version = "1.0.0"
+version = "2.0.0"
 description = "Academic research commercialization assessment agent built with CrewAI"
 authors = [{ name = "Jason Chai", email = "shuxiachai@163.com" }]
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "academic-agent"
-version = "1.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "arize-phoenix-otel" },


### PR DESCRIPTION
The existing v1.0.0 release still described the retired Gradio demonstration, while the supported product now exposes a FastAPI API, a build-free web client, paid-operation controls, observability, measured evaluation, and checkpoint recovery. Treating those changes as a small documentation refresh would hide a real integration break, so the package, lockfile, and OpenAPI metadata now move together to v2.0.0.

Add a recruiter-facing case study that explains the deterministic evidence boundary, six-stage workflow, production seams, and the evidence behind each reliability claim. It deliberately retains the failed utility criterion, the one-observation recovery limit, and the single-replica constraint so the portfolio cannot turn non-results into adoption, savings, or SLO claims.

Add release notes and a 90-second recording guide that uses a completed run instead of spending provider budget during a take. The storyboard makes citation traceability and explicit not-run states visible, and names the claims that must not appear in narration. Link all three artifacts from the README so a reviewer can move from the product page to measured evidence without searching the repository.

Validated with uv lock --check, matching package and FastAPI version reads, 1391 tests plus 627 subtests, 87.01% measured coverage against the 85% CI floor, Ruff, and git diff --check.
