### PR TITLE
Add a bounded evidence-gap Tool Calling kernel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1391 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1418 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -142,6 +142,11 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
   source_title_recovery.py
                         precision-first neutral labels for broken official titles
   evidence.py           models, guardrails, scoring rubric
+  evidence_gap.py       phase-1 gap signals and strict plan authorization
+  evidence_gap_execution.py
+                        phase-2 bounded executor; disconnected from production
+  tools/evidence_search.py
+                        one-request read-only adapter response contract
   pipeline_worker.py    the subprocess one run executes in
   checkpoint_runtime.py
                         CrewAI hydration, task identity, and post-guardrail commits
@@ -150,7 +155,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  65 test modules plus conftest, organised by subject
+tests/                  67 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering
@@ -158,6 +163,8 @@ regulator_title_audit.py
                         zero-network title census; zero denominator is not a pass
 regulator_title_recovery_candidate.py
                         frozen title-recovery comparison; never performs retrieval
+evidence_gap_phase2_audit.py
+                        frozen zero-network Tool Calling contract replay
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -176,6 +183,21 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
 ## Things that are known-open
 
 - Blocking on uncited claims (above) — needs the detector tighter first.
+- Evidence-gap Tool Calling has a phase-2 execution kernel, but production is
+  still phase-1 zero-call shadow mode. The frozen 14-case synthetic challenge
+  passed 14/14 exact dispositions and 14/14 deterministic replays outside
+  wall-clock latency. No case exceeded two simulated adapter attempts; six
+  valid rows entered a separate evidence delta and zero unexpected rows did.
+  Query authorization requires both original-topic overlap and the specific
+  component or authority category. URL/domain/relevance/deduplication checks,
+  idempotency, retry accounting, cost inspection states, and input-mutation
+  detection are exercised offline. This is execution-contract evidence only:
+  no live planner, search provider, production evidence gain, report-quality
+  improvement, latency, cost, or reliability result exists. Do not connect the
+  executor to `pipeline_worker.py` until a separately pre-registered live
+  experiment meets the phase-1 trigger-precision, evidence-yield, wrong-source,
+  budget, accounting, and disabled-path regression thresholds. See
+  `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -347,15 +347,16 @@ identity, authorization, failure, and observability contract.
 
 The scorecard (`commercialization_scores.json`) additionally contains: TRL score, patent strength, market accessibility, evidence confidence, overall score, key risks, and key opportunities.
 
-**Evidence-gap planning is currently phase-1 shadow instrumentation, not
-production Tool Calling.** With `EVIDENCE_GAP_SHADOW_ENABLED=true`, retrieval
-records whether explicit authority, compound-component, or failed-domain gaps
-make the run eligible for later planning. It invokes no planner model, executes
-zero supplementary searches, does not change `validated_sources.json`, and
-surfaces disabled / checked / failed states separately. The strict proposal
-schema, two-intent ceiling, trigger authorization and local idempotency keys are
-implemented for offline injection tests only. Reproduce the 30-run zero-network
-mechanics audit with `uv run python evidence_gap_audit.py outputs/benchmark
+**Production evidence-gap planning remains phase-1 shadow
+instrumentation, not enabled Tool Calling.** With
+`EVIDENCE_GAP_SHADOW_ENABLED=true`, retrieval records whether explicit
+authority, compound-component, or failed-domain gaps make the run eligible for
+later planning. It invokes no planner model, executes zero supplementary
+searches, does not change `validated_sources.json`, and surfaces disabled /
+checked / failed states separately. The strict proposal schema, two-intent
+ceiling, trigger authorization and local idempotency keys are implemented for
+offline injection tests. Reproduce the 30-run zero-network mechanics audit with
+`uv run python evidence_gap_audit.py outputs/benchmark
 outputs/evidence-gap-shadow-phase1 --expected-count 30`; see the
 [frozen protocol](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md). The
 first paid production canary verified artifact persistence and zero evidence
@@ -366,6 +367,20 @@ credibility for the legitimate journal, zero supplementary calls, and a
 matching source hash for `$0.035442`. This is one repeated-topic observation,
 not phase-2 Tool Calling evidence; see the [phase-1 result](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)
 and [post-fix canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md).
+
+Phase 2 adds a **production-disconnected bounded execution kernel**: four named
+read-only capabilities, topic-and-gap query authorization, a global two-attempt
+budget, strict adapter responses, URL/domain/relevance/deduplication quarantine,
+idempotency identities, and explicit latency/cost/trace accounting. Its frozen
+14-case zero-network challenge passed **14/14** exact dispositions and **14/14**
+deterministic replays, with at most two simulated attempts, six valid sources
+retained in a separate delta, and zero unexpected sources retained. Reproduce
+it with `uv run python evidence_gap_phase2_audit.py --fixture
+tests/fixtures/evidence_gap_phase2_challenge.json --output <new-directory>`.
+See the [phase-2 protocol](docs/prereg-2026-08-25-evidence-gap-tool-execution-phase2.md)
+and [result](docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md).
+These are synthetic contract results, not live search value: the production
+worker still instantiates no planner or supplementary adapter.
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1264,14 +1279,14 @@ Step 6     Agent 6 — 量化评分（独立于报告；公式自动修正）
 
 评分卡（`commercialization_scores.json`）额外包含：TRL 评分、专利强度、市场可及性、证据置信度、综合评分、关键风险和机遇列表。
 
-**证据缺口规划目前仅为第一阶段影子观测，并非已上线的 Tool Calling。** 设置
-`EVIDENCE_GAP_SHADOW_ENABLED=true` 后，检索层只记录当前证据是否存在明确的
-权威来源、复合组件或失败领域缺口；它不会调用 Planner 模型，不会追加搜索，
-不会改变 `validated_sources.json`，并将“关闭 / 已检查 / 检查失败”分别呈现。
-严格 Proposal Schema、最多两个意图、触发授权和本地幂等键目前只供离线注入
-测试。可用 `uv run python evidence_gap_audit.py outputs/benchmark
-outputs/evidence-gap-shadow-phase1 --expected-count 30` 复现 30 次零网络机制审计；
-设计边界与后续上线阈值见
+**生产环境的证据缺口规划仍停留在第一阶段影子观测，并未启用 Tool
+Calling。** 设置 `EVIDENCE_GAP_SHADOW_ENABLED=true` 后，检索层只记录当前
+证据是否存在明确的权威来源、复合组件或失败领域缺口；它不会调用 Planner
+模型，不会追加搜索，不会改变 `validated_sources.json`，并将“关闭 / 已检查 /
+检查失败”分别呈现。严格 Proposal Schema、最多两个意图、触发授权和本地幂等键
+目前用于离线注入测试。可用 `uv run python evidence_gap_audit.py
+outputs/benchmark outputs/evidence-gap-shadow-phase1 --expected-count 30`
+复现 30 次零网络机制审计；设计边界与后续上线阈值见
 [冻结协议](docs/prereg-2026-08-25-evidence-gap-shadow-planner.md)。首次付费生产
 canary 已验证影子产物持久化且未改变证据，同时暴露了临床设备权威来源漏检和
 期刊标题可信度误判。随后预注册的 post-fix 运行观察到 biomedical profile、
@@ -1279,6 +1294,18 @@ canary 已验证影子产物持久化且未改变证据，同时暴露了临床�
 `$0.035442`。这只是一项重复主题观察，并非第二阶段 Tool Calling 证据；详见
 [第一阶段结果](docs/results-2026-08-25-evidence-gap-shadow-planner-phase1.md)与
 [修复后 canary](docs/results-2026-08-25-evidence-gap-shadow-post-fix-canary.md)。
+
+第二阶段新增了一个**与生产路径断开的受控执行内核**：仅允许四个命名只读
+能力，查询必须同时命中原主题和具体缺口，全局最多两次尝试；适配器返回经过
+严格 Schema、URL/域名/相关性/去重隔离，并记录幂等标识、延迟、成本与 Trace。
+冻结的 14 案例零网络 challenge 得到 **14/14** 精确结果和 **14/14** 确定性
+重放；任一案例最多两次模拟请求，6 条有效来源进入独立 delta，0 条意外来源
+进入。可用 `uv run python evidence_gap_phase2_audit.py --fixture
+tests/fixtures/evidence_gap_phase2_challenge.json --output <new-directory>`
+复现。详见[第二阶段协议](docs/prereg-2026-08-25-evidence-gap-tool-execution-phase2.md)
+和[结果](docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md)。这些是
+合成执行契约证据，不是线上搜索收益；生产 worker 仍不会实例化 Planner 或
+补充搜索适配器。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-25-evidence-gap-tool-execution-phase2.md
+++ b/docs/prereg-2026-08-25-evidence-gap-tool-execution-phase2.md
@@ -1,0 +1,128 @@
+# Evidence-gap bounded tool execution — phase 2 pre-registration
+
+**Frozen:** 2026-08-25, before the phase-2 executor and challenge fixtures were
+written
+**Production evidence changes authorized:** no
+**Network, search-provider, or planner-model calls authorized by this document:**
+no
+
+## Question
+
+Can a validated evidence-gap plan drive a strictly bounded set of read-only
+search adapters while keeping every returned row quarantined until it passes
+the existing evidence rules, and while making request, rejection, latency,
+cost, and trace accounting inspectable?
+
+Phase 2 is an execution-contract experiment.  It does not authorize the
+production worker to inject a planner, execute supplementary search, or change
+the `SourceCollection` supplied to the six-stage workflow.  A later provider-
+backed experiment needs separate authorization because it can spend search and
+LLM quota.
+
+## Measurement already available
+
+The phase-1 replay was rerun from the 30 collections already on disk before any
+phase-2 code was written:
+
+- 30/30 collections loaded and remained byte-identical;
+- 9 were eligible and 21 had no explicit gap;
+- all 18 signals were `authority_category_missing`; and
+- zero component or failed-domain signals occurred.
+
+Those nine cases are a development set and current retrieval already searches
+the relevant authority endpoints.  Repeating their queries would be duplicate
+retrieval, not novel evidence gain, so they cannot establish phase-2 efficacy.
+
+## Frozen execution boundary
+
+1. Input is a phase-1 `GapContext` plus `ValidatedGapPlan`.  The executor never
+   accepts an unvalidated model dictionary.
+2. Only the four named read-only capabilities are addressable:
+   `academic_search`, `patent_search`, `market_search`, and `authority_search`.
+   There is no arbitrary URL, shell, file, mutation, or user-selected tool.
+   Every query must overlap the original research topic; component and
+   authority gaps must additionally name the missing component or authority
+   category. Tool authorization alone cannot widen the user's research scope.
+3. One adapter invocation equals one actual outbound search attempt.  A single
+   run receives a global budget of two attempts.  A retry consumes the same
+   budget; therefore two planned calls leave no retry capacity.
+4. Every adapter response is strict Pydantic data.  Unknown fields, mismatched
+   tool identities, mismatched idempotency keys, and claims of anything other
+   than exactly one outbound attempt are rejected.
+5. Returned candidates remain in a separate evidence delta.  They never enter
+   the original `SourceCollection` in this phase.
+6. Before a candidate can enter that delta it must pass schema validation,
+   public HTTP(S) URL policy, domain/source-type consistency, topical
+   relevance, and URL/DOI/title deduplication against both the original
+   collection and earlier accepted candidates.
+7. Policy rejection, adapter failure, exhaustion, and a clean empty result are
+   different observable states.  No accepted source is reported as a pass when
+   validation did not run.
+8. Audit output records the trigger ids, normalized query hash rather than the
+   full potentially sensitive query, idempotency key, attempt count, raw and
+   accepted counts, rejection reason codes, latency, incremental cost, and
+   trace id.
+9. The executor is deterministic for the same validated inputs and frozen
+   adapter responses.  It does not mutate either input object.
+
+## Frozen zero-network challenge
+
+The executable challenge will contain at least twelve cases spanning all four
+capabilities and the following seams:
+
+- a novel valid source is accepted;
+- an existing URL, DOI, and normalized title are each rejected as duplicates;
+- private, credential-bearing, unsupported-scheme, and non-allowlisted URLs
+  are rejected before registration;
+- a source with the wrong evidence domain is rejected;
+- an off-topic candidate is rejected;
+- one retryable adapter failure consumes a second and final request;
+- two planned calls execute once each and cannot retry;
+- a missing adapter and malformed adapter response are explicit failures;
+- zero validated candidates is `evidence_incomplete`, never a successful
+  evidence gain; and
+- attempted mutation of the original collection is detected at the output
+  seam.
+
+The challenge is a deliberately adversarial contract set, not a random sample
+of production topics and not a held-out estimate of real-world tool value.
+
+## Phase-2 implementation acceptance
+
+The implementation may merge as an experimental, production-disconnected
+kernel only if:
+
+1. the existing zero-network suite, latest Ruff, CI Pylint exception-order
+   check, and 85% coverage floor remain green;
+2. every frozen challenge case produces its exact registered disposition;
+3. no case exceeds two adapter invocations;
+4. zero invalid, duplicate, wrong-domain, or policy-rejected candidates enter
+   the evidence delta;
+5. every triggered success case with a provided valid novel candidate retains
+   at least one candidate, while empty/failed validation remains explicitly
+   incomplete;
+6. all attempt, latency, cost, rejection, and trace fields are present and
+   arithmetically consistent;
+7. the production worker still injects no planner and executes zero
+   supplementary calls; and
+8. reintroducing one request-budget defect and one evidence-quarantine defect
+   makes their targeted tests fail before each defect is removed.
+
+## Criteria before any production connection
+
+This PR cannot satisfy the phase-1 production thresholds with synthetic
+responses alone.  A separately frozen, independently inspected planner and
+live-search run must still report:
+
+- trigger precision of at least 90%;
+- no more than two actual outbound attempts per run;
+- zero invalid, unregistered, or policy-rejected sources entering evidence;
+- wrong-source rate no greater than 5%;
+- novel validated evidence in at least 50% of triggered cases;
+- complete incremental latency, token, search-cost, rejection, and trace
+  accounting; and
+- no output regression when the feature flag is disabled.
+
+Until those criteria pass, the accurate description is **bounded Tool Calling
+execution kernel validated offline**, not production Tool Calling and not an
+improvement in report quality.

--- a/docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md
+++ b/docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md
@@ -1,0 +1,133 @@
+# Evidence-gap bounded Tool Calling execution ¡ª phase 2 result
+
+**Date:** 2026-08-25
+**Status:** **PASS for the offline execution contract; not production-connected
+Tool Calling evidence**
+
+## Frozen question
+
+Can a validated phase-1 evidence-gap plan drive no more than two read-only
+adapter attempts while keeping every returned row outside the original
+`SourceCollection` until it passes URL, domain, relevance, deduplication, and
+source-registration checks?
+
+The protocol was frozen before the executor and challenge fixture were written:
+[phase-2 pre-registration](prereg-2026-08-25-evidence-gap-tool-execution-phase2.md).
+
+## Inputs and method
+
+The audit uses one strict JSON fixture with 14 adversarial cases. It injects
+deterministic local adapters for `academic_search`, `patent_search`,
+`market_search`, and `authority_search`; no adapter opens a socket, calls a
+model, or reads a provider credential.
+
+Each case is executed twice from a fresh `SourceCollection`. The complete
+audit payload must be byte-equivalent across the two replays after excluding
+wall-clock `latency_ms`, which is telemetry rather than identity. The first
+replay is compared with the exact answer frozen in the fixture.
+
+Fixture:
+
+- `tests/fixtures/evidence_gap_phase2_challenge.json`
+- SHA-256:
+  `e75cf412ebdb03528753a5748ca71f6e732e066d332585be0def3879b7e5179a`
+- design:
+  `synthetic_adversarial_contract_not_production`
+
+Reproduction:
+
+```bash
+uv run python evidence_gap_phase2_audit.py \
+  --fixture tests/fixtures/evidence_gap_phase2_challenge.json \
+  --output outputs/evidence-gap-phase2-contract-<new-id>
+```
+
+The output directory must not already exist. The audit writes `summary.json`
+and `cases.csv` once rather than silently replacing an earlier measurement.
+
+## Result
+
+| Measure | Observed |
+|---|---:|
+| Exact frozen dispositions | **14/14** |
+| Deterministic replays outside latency | **14/14** |
+| Canonical-replay simulated adapter attempts | **15** |
+| Maximum attempts in any case | **2** |
+| Valid candidates registered into the separate delta | **6** |
+| Unexpected candidates registered | **0** |
+| Production connection | **false** |
+| Real network/model/provider calls | **0** |
+
+The second deterministic replay repeated the same 15 simulated attempts, so
+the complete local audit exercised 30 adapter invocations. The cost values are
+synthetic accounting fixtures; they are not money spent and are not a
+production cost estimate.
+
+## Covered seams
+
+| Case | Frozen observation |
+|---|---|
+| C01 | A valid academic record becomes quarantined source `A2` |
+| C02 | Existing URL, DOI, and normalized title are each rejected |
+| C03 | Literal-IP, credentialed, file, untrusted, and wrong-domain URLs are rejected |
+| C04 | An allowed-host but off-topic academic record is rejected |
+| C05 | A valid patent is retained while a DOI record returned by the patent tool is rejected as `wrong_evidence_domain` |
+| C06 | A valid reputable-market record reaches the same registration seam |
+| C07 | A requested FDA regulatory record is retained as market-domain evidence |
+| C08 | A clinical-registry record cannot satisfy a regulatory trigger |
+| C09 | One retryable failure consumes the first slot; the second and final attempt succeeds |
+| C10 | A clean zero-result response is `incomplete`, not evidence success |
+| C11 | A malformed response is failed with cost `uninspectable`, not free |
+| C12 | A missing adapter fails before any request and is not reported as a clean empty result |
+| C13 | Two planned calls receive one attempt each; the first cannot consume the second call's slot |
+| C14 | Adapter mutation changes the input hash and invalidates the entire accepted delta |
+
+Plan validation also rejects queries that widen scope: every query must overlap
+the original topic, and component or authority searches must name their
+specific missing component or category.
+
+## Defect re-injection
+
+Two defects were deliberately reintroduced after the tests were written:
+
+1. Raising the global request budget from two to three made
+   `test_two_planned_calls_each_keep_one_slot_and_cannot_retry` fail because
+   the first adapter executed twice instead of once.
+2. Adding `untrusted.example` to the academic host allowlist made
+   `test_untrusted_candidate_urls_never_reach_evidence` fail because an
+   invalid row reached `accepted_sources`.
+
+Both defects were then removed, and the execution/audit subset returned to
+24/24 passing. This checks that the new tests detect the relevant seams rather
+than merely restating current field values.
+
+## Decision
+
+The bounded executor, strict adapter schema, query-scope authorization,
+quarantined evidence delta, and zero-network audit are suitable to merge as an
+**experimental production-disconnected kernel**.
+
+The production worker remains on phase-1 shadow behavior:
+
+- no planner model is injected;
+- no supplementary search adapter is instantiated;
+- `validated_sources.json` is unchanged; and
+- the six-stage report workflow receives no phase-2 evidence delta.
+
+## What this result does not establish
+
+This audit does **not** measure:
+
+- planner trigger precision;
+- live-provider response validity or wrong-source rate;
+- novel evidence yield on real gaps;
+- report-quality improvement;
+- production latency, cost, reliability, or SLO;
+- whether Tool Calling should be enabled by default.
+
+A separately pre-registered provider-backed experiment is still required.
+Until it satisfies the phase-1 production thresholds, the accurate project
+claim is:
+
+> A bounded Tool Calling execution kernel was validated offline; production
+> remains zero-call shadow mode.

--- a/evidence_gap_phase2_audit.py
+++ b/evidence_gap_phase2_audit.py
@@ -1,0 +1,583 @@
+"""Replay the frozen Phase-2 bounded Tool Calling contract without networking.
+
+This audit intentionally exercises injected deterministic adapters rather than
+real providers. It answers whether the execution, budget, quarantine, and
+observability seams behave as pre-registered; it cannot estimate production
+trigger precision or evidence value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import deque
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    GapSignalCode,
+    GapToolName,
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    build_gap_context,
+    validate_gap_plan,
+)
+from academic_agent.evidence_gap_execution import (
+    EvidenceGapExecutionAudit,
+    execute_gap_plan,
+)
+from academic_agent.source_pipeline import (
+    AuthorityCoverage,
+    ComponentCoverage,
+    SourceCollection,
+)
+from academic_agent.tools.evidence_search import (
+    ReadOnlySearchAdapter,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+
+
+DEFAULT_FIXTURE = Path("tests/fixtures/evidence_gap_phase2_challenge.json")
+_TRACE_PREFIX = "phase2-contract"
+_SUMMARY = (
+    "This source provides sufficiently detailed and topic-specific evidence "
+    "for the bounded Tool Calling execution and quarantine audit contract."
+)
+
+
+class Phase2AuditError(ValueError):
+    """Raised when the frozen challenge or an observed result drifts."""
+
+
+class ChallengeCall(BaseModel):
+    """One planner-approved intent represented without unstable signal ids."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tool: GapToolName
+    trigger_code: GapSignalCode
+    trigger_subject: str = Field(min_length=1, max_length=240)
+    query: str | None = Field(default=None, min_length=3, max_length=500)
+    result_limit: int = Field(default=5, ge=1, le=10)
+
+
+class AdapterEvent(BaseModel):
+    """One deterministic adapter outcome consumed by one executor attempt."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    type: Literal["response", "failure", "malformed", "mutation"]
+    retryable: bool = False
+    failure_type: str | None = Field(default=None, max_length=200)
+    search_cost_usd: float | None = Field(default=0.0, ge=0.0)
+    candidates: tuple[ToolEvidenceCandidate, ...] = Field(default=(), max_length=10)
+
+    @model_validator(mode="after")
+    def _validate_event_shape(self) -> "AdapterEvent":
+        if self.type == "failure":
+            if not self.failure_type:
+                raise ValueError("failure events require failure_type")
+            if self.candidates:
+                raise ValueError("failure events cannot contain candidates")
+        elif self.failure_type is not None or self.retryable:
+            raise ValueError("only failure events may declare failure metadata")
+
+        if self.type in {"response", "mutation"}:
+            if self.search_cost_usd is None:
+                raise ValueError("response events require inspectable numeric cost")
+        elif self.type == "malformed" and self.candidates:
+            raise ValueError("malformed events cannot contain parsed candidates")
+        return self
+
+
+class ExpectedCaseResult(BaseModel):
+    """Exact frozen disposition at the public execution-audit seam."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    evidence_delta_state: Literal["unchanged", "augmented", "incomplete", "failed"]
+    outbound_attempt_count: int = Field(ge=0, le=2)
+    accepted_count: int = Field(ge=0, le=20)
+    call_states: tuple[str, ...]
+    rejection_codes: tuple[str, ...]
+    cost_state: Literal["known", "uninspectable"]
+    incremental_search_cost_usd: float | None = Field(default=None, ge=0.0)
+    failure_type: str | None = None
+    call_failure_types: tuple[str | None, ...]
+
+    @model_validator(mode="after")
+    def _validate_cost_shape(self) -> "ExpectedCaseResult":
+        if self.cost_state == "known" and self.incremental_search_cost_usd is None:
+            raise ValueError("known cost requires a numeric expected value")
+        if (
+            self.cost_state == "uninspectable"
+            and self.incremental_search_cost_usd is not None
+        ):
+            raise ValueError("uninspectable cost must use null")
+        return self
+
+
+class ChallengeCase(BaseModel):
+    """One adversarial input, injected adapter sequence, and frozen answer."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^C\d{2}-[a-z0-9-]+$")
+    calls: tuple[ChallengeCall, ...] = Field(min_length=1, max_length=2)
+    adapters: dict[GapToolName, tuple[AdapterEvent, ...]]
+    expected: ExpectedCaseResult
+
+    @model_validator(mode="after")
+    def _validate_case_shape(self) -> "ChallengeCase":
+        planned_tools = {call.tool for call in self.calls}
+        unexpected = set(self.adapters) - planned_tools
+        if unexpected:
+            raise ValueError(f"adapters without planned calls: {sorted(unexpected)}")
+        if any(not events for events in self.adapters.values()):
+            raise ValueError("configured adapters require at least one event")
+        if len(self.expected.call_states) != len(self.calls):
+            raise ValueError("expected call_states must cover every planned call")
+        if len(self.expected.call_failure_types) != len(self.calls):
+            raise ValueError(
+                "expected call_failure_types must cover every planned call"
+            )
+        return self
+
+
+class Phase2Challenge(BaseModel):
+    """Strict top-level frozen challenge contract."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1]
+    challenge_id: Literal["evidence-gap-tool-execution-phase2"]
+    measurement_design: Literal["synthetic_adversarial_contract_not_production"]
+    topic: str = Field(min_length=20, max_length=500)
+    cases: tuple[ChallengeCase, ...] = Field(min_length=12)
+
+    @model_validator(mode="after")
+    def _validate_unique_case_ids(self) -> "Phase2Challenge":
+        case_ids = [case.case_id for case in self.cases]
+        if len(case_ids) != len(set(case_ids)):
+            raise ValueError("challenge case ids must be unique")
+        return self
+
+
+def _source(
+    source_id: str,
+    *,
+    title: str,
+    url: str,
+    source_type: str,
+    doi: str | None = None,
+) -> EvidenceSource:
+    return EvidenceSource(
+        source_id=source_id,
+        title=title,
+        url=url,
+        doi=doi,
+        publisher="Fixture Publisher",
+        accessed_date=date(2025, 1, 1),
+        source_type=source_type,
+        evidence_summary=_SUMMARY,
+        summary_source="search_snippet",
+    )
+
+
+def _collection(topic: str) -> SourceCollection:
+    """Build the one frozen evidence identity used by every challenge case."""
+
+    return SourceCollection(
+        topic=topic,
+        display_topic=topic,
+        search_aliases=["self-powered wearable glucose sensor monitoring"],
+        search_components=["battery-free telemetry", "glucose biosensor"],
+        output_language="English",
+        weight_profile="biomedical",
+        collected_at=datetime(2025, 1, 1, tzinfo=UTC),
+        academic_sources=[
+            _source(
+                "A1",
+                title="Battery-free wearable glucose biosensor baseline study",
+                url="https://doi.org/10.1000/existing",
+                doi="10.1000/existing",
+                source_type="academic_paper",
+            )
+        ],
+        patent_sources=[
+            _source(
+                "P1",
+                title="Battery-free wearable glucose biosensor telemetry patent",
+                url="https://patents.google.com/patent/US1234567A1",
+                source_type="patent",
+            )
+        ],
+        market_sources=[
+            _source(
+                "M1",
+                title="Battery-free wearable glucose monitoring market deployment",
+                url="https://www.reuters.com/technology/wearable-glucose-monitoring/",
+                source_type="reputable_news",
+            )
+        ],
+        academic_queries=[topic],
+        patent_queries=[topic],
+        market_queries=[topic],
+        authority_coverage=AuthorityCoverage(
+            status="incomplete",
+            required_categories=["regulatory", "clinical_registry"],
+            missing_categories=["regulatory", "clinical_registry"],
+        ),
+        component_coverage=ComponentCoverage(
+            status="incomplete",
+            components=["battery-free telemetry", "glucose biosensor"],
+            covered_source_ids={"glucose biosensor": ["A1"]},
+            missing_components=["battery-free telemetry"],
+        ),
+        failed_domains={
+            "academic": "fixture timeout",
+            "patent": "fixture timeout",
+            "market": "fixture timeout",
+        },
+    )
+
+
+def _trigger_id(
+    context: GapContext,
+    *,
+    code: GapSignalCode,
+    subject: str,
+) -> str:
+    matches = [
+        signal.signal_id
+        for signal in context.signals
+        if signal.code == code and signal.subject == subject
+    ]
+    if len(matches) != 1:
+        raise Phase2AuditError(
+            f"expected one trigger for code={code}, subject={subject}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _plan_for_case(
+    context: GapContext,
+    case: ChallengeCase,
+) -> ValidatedGapPlan:
+    calls = tuple(
+        GapSearchIntent(
+            tool=call.tool,
+            query=call.query or context.topic,
+            trigger_ids=(
+                _trigger_id(
+                    context,
+                    code=call.trigger_code,
+                    subject=call.trigger_subject,
+                ),
+            ),
+            result_limit=call.result_limit,
+        )
+        for call in case.calls
+    )
+    return validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen synthetic challenge contains a specific evidence "
+                "gap and permits only this bounded read-only search."
+            ),
+            calls=calls,
+        ),
+    )
+
+
+class _FixtureAdapter:
+    """Consume declared events without opening a socket or hiding a retry."""
+
+    def __init__(
+        self,
+        events: tuple[AdapterEvent, ...],
+        *,
+        collection: SourceCollection,
+        case_id: str,
+    ) -> None:
+        self._events = deque(events)
+        self._collection = collection
+        self._case_id = case_id
+        self._attempt = 0
+
+    def __call__(
+        self,
+        call: ValidatedGapCall,
+    ) -> ToolAdapterResponse | dict[str, object]:
+        self._attempt += 1
+        if not self._events:
+            raise RuntimeError("fixture adapter received an unregistered attempt")
+        event = self._events.popleft()
+        if event.type == "failure":
+            raise ToolAdapterFailure(
+                "frozen fixture failure",
+                retryable=event.retryable,
+                failure_type=event.failure_type or "fixture_failure",
+                search_cost_usd=event.search_cost_usd,
+            )
+        if event.type == "malformed":
+            # The unknown key proves the strict response schema, while the
+            # missing provider cost must remain visibly uninspectable.
+            return {
+                "tool": call.tool,
+                "idempotency_key": call.idempotency_key,
+                "outbound_request_count": 1,
+                "candidates": [],
+                "unexpected": True,
+            }
+        if event.type == "mutation":
+            # This simulates a badly behaved injected adapter. The returned row
+            # is otherwise valid so only the final hash seam can catch it.
+            self._collection.display_topic = "mutated fixture display topic"
+
+        return ToolAdapterResponse(
+            tool=call.tool,
+            idempotency_key=call.idempotency_key,
+            candidates=event.candidates,
+            search_cost_usd=event.search_cost_usd or 0.0,
+            provider_request_id=(
+                f"{self._case_id}-{call.tool}-{self._attempt}"
+            ),
+        )
+
+
+def _adapters_for_case(
+    case: ChallengeCase,
+    collection: SourceCollection,
+) -> dict[GapToolName, ReadOnlySearchAdapter]:
+    return {
+        tool: _FixtureAdapter(
+            events,
+            collection=collection,
+            case_id=case.case_id,
+        )
+        for tool, events in case.adapters.items()
+    }
+
+
+def _expected_projection(audit: EvidenceGapExecutionAudit) -> dict[str, object]:
+    cost = audit.incremental_search_cost_usd
+    return {
+        "evidence_delta_state": audit.evidence_delta_state,
+        "outbound_attempt_count": audit.outbound_attempt_count,
+        "accepted_count": len(audit.accepted_sources),
+        "call_states": [call.state for call in audit.call_audits],
+        "rejection_codes": [
+            rejection.code
+            for call in audit.call_audits
+            for rejection in call.rejections
+        ],
+        "cost_state": audit.cost_state,
+        "incremental_search_cost_usd": (
+            round(cost, 9) if cost is not None else None
+        ),
+        "failure_type": audit.failure_type,
+        "call_failure_types": [
+            call.failure_type for call in audit.call_audits
+        ],
+    }
+
+
+def _deterministic_projection(
+    audit: EvidenceGapExecutionAudit,
+) -> dict[str, object]:
+    payload = audit.model_dump(mode="json")
+    for call in payload["call_audits"]:
+        # Wall-clock duration is required telemetry, but it is not an identity
+        # field and cannot be byte-identical across two local replays.
+        call.pop("latency_ms", None)
+    return payload
+
+
+def _execute_case(
+    challenge: Phase2Challenge,
+    case: ChallengeCase,
+) -> EvidenceGapExecutionAudit:
+    collection = _collection(challenge.topic)
+    context = build_gap_context(collection)
+    plan = _plan_for_case(context, case)
+    return execute_gap_plan(
+        collection,
+        context=context,
+        plan=plan,
+        adapters=_adapters_for_case(case, collection),
+        trace_id=f"{_TRACE_PREFIX}-{case.case_id}",
+    )
+
+
+def _case_result(
+    challenge: Phase2Challenge,
+    case: ChallengeCase,
+) -> dict[str, object]:
+    first = _execute_case(challenge, case)
+    second = _execute_case(challenge, case)
+    if _deterministic_projection(first) != _deterministic_projection(second):
+        raise Phase2AuditError(
+            f"{case.case_id}: deterministic replay drifted outside latency"
+        )
+
+    observed = _expected_projection(first)
+    frozen = case.expected.model_dump(mode="json")
+    if observed != frozen:
+        raise Phase2AuditError(
+            f"{case.case_id}: observed disposition differs from frozen answer\n"
+            f"expected={json.dumps(frozen, sort_keys=True)}\n"
+            f"observed={json.dumps(observed, sort_keys=True)}"
+        )
+    return {
+        "case_id": case.case_id,
+        "status": "passed",
+        "observed": observed,
+        "audit": first.model_dump(mode="json"),
+        "deterministic_replay": "passed",
+    }
+
+
+def run_challenge(fixture_path: Path = DEFAULT_FIXTURE) -> dict[str, object]:
+    """Validate and replay the complete frozen challenge twice per case."""
+
+    fixture_bytes = fixture_path.read_bytes()
+    challenge = Phase2Challenge.model_validate_json(fixture_bytes)
+    case_results = [
+        _case_result(challenge, case)
+        for case in challenge.cases
+    ]
+    attempts = [
+        int(result["observed"]["outbound_attempt_count"])
+        for result in case_results
+    ]
+    accepted = [
+        int(result["observed"]["accepted_count"])
+        for result in case_results
+    ]
+    return {
+        "schema_version": 1,
+        "challenge_id": challenge.challenge_id,
+        "measurement_design": challenge.measurement_design,
+        "fixture_sha256": hashlib.sha256(fixture_bytes).hexdigest(),
+        "production_connected": False,
+        "real_network_calls_performed": False,
+        "case_count": len(case_results),
+        "passed_case_count": len(case_results),
+        "deterministic_replay_passed_count": len(case_results),
+        "simulated_adapter_attempt_count": sum(attempts),
+        "maximum_case_attempt_count": max(attempts, default=0),
+        "accepted_source_count": sum(accepted),
+        "unexpected_accepted_source_count": 0,
+        "status": "passed",
+        "cases": case_results,
+    }
+
+
+def write_audit_artifacts(
+    result: dict[str, object],
+    output_directory: Path,
+) -> None:
+    """Write once so a later replay cannot overwrite its measured result."""
+
+    output_directory.mkdir(parents=True, exist_ok=False)
+    summary_path = output_directory / "summary.json"
+    summary_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    cases = result.get("cases")
+    if not isinstance(cases, list):
+        raise Phase2AuditError("result cases are not a list")
+    with (output_directory / "cases.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=(
+                "case_id",
+                "status",
+                "evidence_delta_state",
+                "outbound_attempt_count",
+                "accepted_count",
+                "cost_state",
+                "incremental_search_cost_usd",
+                "deterministic_replay",
+            ),
+        )
+        writer.writeheader()
+        for item in cases:
+            if not isinstance(item, dict) or not isinstance(
+                item.get("observed"), dict
+            ):
+                raise Phase2AuditError("case result has an invalid shape")
+            observed = item["observed"]
+            writer.writerow(
+                {
+                    "case_id": item["case_id"],
+                    "status": item["status"],
+                    "evidence_delta_state": observed["evidence_delta_state"],
+                    "outbound_attempt_count": observed[
+                        "outbound_attempt_count"
+                    ],
+                    "accepted_count": observed["accepted_count"],
+                    "cost_state": observed["cost_state"],
+                    "incremental_search_cost_usd": observed[
+                        "incremental_search_cost_usd"
+                    ],
+                    "deterministic_replay": item["deterministic_replay"],
+                }
+            )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Replay the frozen zero-network Phase-2 Tool Calling audit."
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help="Strict frozen challenge JSON.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="New output directory; existing paths are refused.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = run_challenge(args.fixture)
+    write_audit_artifacts(result, args.output)
+    print(
+        "Phase-2 audit passed: "
+        f"{result['passed_case_count']}/{result['case_count']} cases; "
+        f"max attempts={result['maximum_case_attempt_count']}; "
+        "real network calls=0."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/evidence_gap.py
+++ b/src/academic_agent/evidence_gap.py
@@ -62,6 +62,30 @@ _TOOL_TO_DOMAIN: dict[GapToolName, EvidenceDomain] = {
     "authority_search": "market",
 }
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+_SCOPE_TOKEN = re.compile(r"[^\W_]+", re.UNICODE)
+_SCOPE_STOP_WORDS = frozenset(
+    {
+        "and",
+        "for",
+        "from",
+        "into",
+        "of",
+        "on",
+        "the",
+        "to",
+        "using",
+        "via",
+        "with",
+    }
+)
+_AUTHORITY_SCOPE_TERMS = {
+    "regulatory": frozenset(
+        {"approval", "authorization", "ema", "fda", "regulatory"}
+    ),
+    "clinical_registry": frozenset(
+        {"clinical", "clinicaltrials", "registry", "trial"}
+    ),
+}
 
 
 class EvidenceGapError(ValueError):
@@ -376,6 +400,47 @@ def build_gap_context(collection: SourceCollection) -> GapContext:
     )
 
 
+def _scope_tokens(value: str) -> frozenset[str]:
+    return frozenset(
+        token
+        for token in _SCOPE_TOKEN.findall(value.casefold())
+        if token not in _SCOPE_STOP_WORDS
+    )
+
+
+def _validate_query_scope(
+    context: GapContext,
+    intent: GapSearchIntent,
+    signal_by_id: dict[str, GapSignal],
+) -> None:
+    """Keep a valid tool name from becoming an arbitrary-search capability."""
+
+    query_tokens = _scope_tokens(intent.query)
+    topic_tokens = _scope_tokens(context.topic)
+    required_topic_overlap = min(2, len(topic_tokens))
+    if (
+        required_topic_overlap
+        and len(query_tokens & topic_tokens) < required_topic_overlap
+    ):
+        raise EvidenceGapError(
+            "search query is outside the authorized topic scope"
+        )
+
+    for trigger_id in intent.trigger_ids:
+        signal = signal_by_id[trigger_id]
+        if signal.code == "component_missing":
+            if not query_tokens & _scope_tokens(signal.subject):
+                raise EvidenceGapError(
+                    "component search query does not name its missing component"
+                )
+        elif signal.code == "authority_category_missing":
+            category_terms = _AUTHORITY_SCOPE_TERMS[signal.subject]
+            if not query_tokens & category_terms:
+                raise EvidenceGapError(
+                    "authority search query does not name its missing category"
+                )
+
+
 def validate_gap_plan(
     context: GapContext,
     proposal: GapPlanProposal | dict[str, Any],
@@ -408,6 +473,8 @@ def validate_gap_plan(
             raise EvidenceGapError(
                 f"tool {intent.tool} is not authorized by triggers {unauthorized}"
             )
+
+        _validate_query_scope(context, intent, signal_by_id)
 
         normalized_query = " ".join(intent.query.split()).casefold()
         normalized_triggers = tuple(sorted(intent.trigger_ids))

--- a/src/academic_agent/evidence_gap_execution.py
+++ b/src/academic_agent/evidence_gap_execution.py
@@ -1,0 +1,851 @@
+"""Production-disconnected execution kernel for evidence-gap Tool Calling.
+
+The module deliberately accepts only a ValidatedGapPlan. Model output, network
+clients, and report mutation stay outside this boundary: phase 2 is measuring
+whether a plan can be executed and quarantined safely before any production
+worker is allowed to connect it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import re
+import time
+from collections.abc import Mapping
+from typing import Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence import EvidenceSource, normalize_doi
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapToolName,
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    source_collection_sha256,
+)
+from academic_agent.source_pipeline import (
+    SourceCollection,
+    _OFFICIAL_PATENT_HOSTS,
+    _PATENT_HOSTS,
+    _authority_category_for_url,
+    _canonical_url,
+    _market_source_profile,
+    _relevance_score,
+    _topic_bigrams,
+    _topic_domain_keywords,
+    _topic_keywords,
+)
+from academic_agent.tools.evidence_search import (
+    ReadOnlySearchAdapter,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+
+
+MAX_OUTBOUND_SEARCH_ATTEMPTS = 2
+_PREFIX_BY_DOMAIN = {"academic": "A", "patent": "P", "market": "M"}
+_MIN_RELEVANCE_BY_DOMAIN = {"academic": 3, "patent": 1, "market": 2}
+_ACADEMIC_RECORD_HOSTS = frozenset(
+    {
+        "arxiv.org",
+        "doi.org",
+        "ncbi.nlm.nih.gov",
+        "openalex.org",
+        "pubmed.ncbi.nlm.nih.gov",
+        "semanticscholar.org",
+    }
+)
+_BLOCKED_HOST_SUFFIXES = (
+    ".internal",
+    ".invalid",
+    ".local",
+    ".localhost",
+    ".test",
+)
+_TITLE_WORDS = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+
+CallState = Literal[
+    "accepted",
+    "empty",
+    "rejected",
+    "failed",
+    "budget_exhausted",
+]
+EvidenceDeltaState = Literal["augmented", "incomplete", "unchanged", "failed"]
+RejectionCode = Literal[
+    "credentialed_url",
+    "duplicate_doi",
+    "duplicate_title",
+    "duplicate_url",
+    "host_not_allowlisted",
+    "non_public_literal_host",
+    "off_topic",
+    "source_schema_invalid",
+    "unsupported_url",
+    "wrong_authority_category",
+    "wrong_evidence_domain",
+]
+
+
+class EvidenceGapExecutionError(ValueError):
+    """Raised before execution when trusted phase-1 identities do not join."""
+
+
+class CandidateRejection(BaseModel):
+    """One quarantined row and why it did not enter the evidence delta."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_index: int = Field(ge=0)
+    code: RejectionCode
+    detail: str = Field(min_length=1, max_length=500)
+
+
+class GapToolCallAudit(BaseModel):
+    """Observable result of one validated logical call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    call_index: int = Field(ge=0, le=1)
+    tool: GapToolName
+    trigger_ids: tuple[str, ...] = Field(min_length=1, max_length=4)
+    query_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    state: CallState
+    outbound_attempt_count: int = Field(
+        ge=0,
+        le=MAX_OUTBOUND_SEARCH_ATTEMPTS,
+    )
+    raw_candidate_count: int = Field(default=0, ge=0, le=10)
+    accepted_source_ids: tuple[str, ...] = ()
+    rejections: tuple[CandidateRejection, ...] = ()
+    latency_ms: float = Field(ge=0.0)
+    search_cost_usd: float | None = Field(default=0.0, ge=0.0)
+    cost_state: Literal["known", "uninspectable"] = "known"
+    failure_type: str | None = Field(default=None, max_length=200)
+    trace_id: str = Field(min_length=8, max_length=128)
+
+    @model_validator(mode="after")
+    def _validate_state(self) -> "GapToolCallAudit":
+        if self.cost_state == "uninspectable" and self.search_cost_usd is not None:
+            raise ValueError("uninspectable cost must be represented by null")
+        if self.cost_state == "known" and self.search_cost_usd is None:
+            raise ValueError("known cost requires a numeric value")
+        if self.state == "accepted" and not self.accepted_source_ids:
+            raise ValueError("accepted state requires at least one registered source")
+        if self.state != "accepted" and self.accepted_source_ids:
+            raise ValueError(f"{self.state} cannot carry accepted sources")
+        if self.state in {"failed", "budget_exhausted"} and not self.failure_type:
+            raise ValueError(f"{self.state} requires a failure type")
+        if self.state not in {"failed", "budget_exhausted"} and self.failure_type:
+            raise ValueError("only failed calls may carry a failure type")
+        return self
+
+
+class EvidenceGapExecutionAudit(BaseModel):
+    """Complete phase-2 result; accepted candidates remain quarantined."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["phase2_experiment"] = "phase2_experiment"
+    production_connected: Literal[False] = False
+    decision: Literal["no_gap", "search", "abstain"]
+    evidence_delta_state: EvidenceDeltaState
+    source_collection_sha256_before: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_collection_sha256_after: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    outbound_attempt_count: int = Field(
+        ge=0,
+        le=MAX_OUTBOUND_SEARCH_ATTEMPTS,
+    )
+    call_audits: tuple[GapToolCallAudit, ...] = Field(default=(), max_length=2)
+    accepted_sources: tuple[EvidenceSource, ...] = ()
+    incremental_search_cost_usd: float | None = Field(default=0.0, ge=0.0)
+    cost_state: Literal["known", "uninspectable"] = "known"
+    trace_id: str = Field(min_length=8, max_length=128)
+    failure_type: str | None = Field(default=None, max_length=200)
+
+    @model_validator(mode="after")
+    def _validate_totals(self) -> "EvidenceGapExecutionAudit":
+        attempts = sum(call.outbound_attempt_count for call in self.call_audits)
+        if attempts != self.outbound_attempt_count:
+            raise ValueError("outbound_attempt_count must equal the call-audit total")
+        accepted_ids = tuple(
+            source_id
+            for call in self.call_audits
+            for source_id in call.accepted_source_ids
+        )
+        if accepted_ids != tuple(
+            source.source_id for source in self.accepted_sources
+        ):
+            raise ValueError(
+                "accepted sources must match call-audit registration order"
+            )
+        if (
+            self.cost_state == "uninspectable"
+            and self.incremental_search_cost_usd is not None
+        ):
+            raise ValueError("uninspectable total cost must be represented by null")
+        if (
+            self.cost_state == "known"
+            and self.incremental_search_cost_usd is None
+        ):
+            raise ValueError("known total cost requires a numeric value")
+        if self.evidence_delta_state == "augmented" and not self.accepted_sources:
+            raise ValueError("augmented state requires accepted sources")
+        if self.evidence_delta_state != "augmented" and self.accepted_sources:
+            raise ValueError(
+                f"{self.evidence_delta_state} cannot carry accepted sources"
+            )
+        if self.evidence_delta_state == "failed" and not self.failure_type:
+            raise ValueError("failed execution requires a failure type")
+        if self.evidence_delta_state != "failed" and self.failure_type:
+            raise ValueError("only failed execution may carry a failure type")
+        return self
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_text(plan.model_dump_json(exclude_none=False))
+
+
+def _host_matches(host: str, allowed: frozenset[str] | set[str]) -> bool:
+    normalized = host.removeprefix("www.").lower()
+    return any(
+        normalized == domain or normalized.endswith(f".{domain}")
+        for domain in allowed
+    )
+
+
+def _title_key(value: str) -> str:
+    return " ".join(_TITLE_WORDS.findall(value.casefold()))
+
+
+def _next_source_numbers(collection: SourceCollection) -> dict[str, int]:
+    next_numbers: dict[str, int] = {}
+    for domain, prefix in _PREFIX_BY_DOMAIN.items():
+        numbers = [
+            int(source.source_id[1:])
+            for source in collection.sources_for_prefix(prefix)
+            if (
+                source.source_id.startswith(prefix)
+                and source.source_id[1:].isdigit()
+            )
+        ]
+        next_numbers[domain] = max(numbers, default=0) + 1
+    return next_numbers
+
+
+def _static_url_policy(
+    value: str,
+    *,
+    call: ValidatedGapCall,
+    context: GapContext,
+) -> tuple[bool, RejectionCode | None, str, str | None]:
+    """Validate a returned record without following its untrusted URL.
+
+    The only outbound operation belongs to the fixed search-provider adapter.
+    Fetching each result page here would silently multiply a two-request budget.
+    Host policy therefore fails closed before a later production design can add
+    separately accounted reachability requests.
+    """
+
+    try:
+        parsed = urlsplit(value)
+        canonical = _canonical_url(value)
+    except (TypeError, ValueError) as exc:
+        return (
+            False,
+            "unsupported_url",
+            f"URL parsing failed: {type(exc).__name__}",
+            None,
+        )
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return (
+            False,
+            "unsupported_url",
+            "only absolute HTTP(S) URLs are accepted",
+            None,
+        )
+    if parsed.username or parsed.password:
+        return (
+            False,
+            "credentialed_url",
+            "URLs containing credentials are forbidden",
+            None,
+        )
+    if " " in value:
+        return (
+            False,
+            "unsupported_url",
+            "URLs containing spaces are forbidden",
+            None,
+        )
+    try:
+        value.encode("ascii")
+    except UnicodeError:
+        return (
+            False,
+            "unsupported_url",
+            "URLs must be ASCII before registration",
+            None,
+        )
+
+    host = parsed.hostname.rstrip(".").casefold()
+    if host == "localhost" or host.endswith(_BLOCKED_HOST_SUFFIXES):
+        return (
+            False,
+            "non_public_literal_host",
+            f"blocked host: {host}",
+            None,
+        )
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        # Even a currently global literal address has no stable publisher
+        # identity and can later be reassigned; evidence links require names.
+        return (
+            False,
+            "non_public_literal_host",
+            "literal IP hosts are forbidden",
+            None,
+        )
+
+    if call.tool == "academic_search":
+        if not _host_matches(host, _ACADEMIC_RECORD_HOSTS):
+            return (
+                False,
+                "host_not_allowlisted",
+                f"academic record host is not approved: {host}",
+                None,
+            )
+    elif call.tool == "patent_search":
+        if host not in _PATENT_HOSTS:
+            return (
+                False,
+                "wrong_evidence_domain",
+                f"non-patent host returned by patent tool: {host}",
+                None,
+            )
+    else:
+        profile = _market_source_profile(canonical, host)
+        if profile is None or profile[2].startswith(
+            "First-party company page"
+        ):
+            return (
+                False,
+                "host_not_allowlisted",
+                f"market record host is not approved: {host}",
+                None,
+            )
+        if call.tool == "authority_search":
+            category = _authority_category_for_url(canonical)
+            if category is None:
+                return (
+                    False,
+                    "wrong_evidence_domain",
+                    "authority tool returned a non-authority URL",
+                    None,
+                )
+            signal_by_id = {
+                signal.signal_id: signal for signal in context.signals
+            }
+            expected = {
+                signal_by_id[trigger].subject
+                for trigger in call.trigger_ids
+                if trigger in signal_by_id
+            }
+            if category not in expected:
+                return (
+                    False,
+                    "wrong_authority_category",
+                    (
+                        f"authority category {category!r} was not requested "
+                        f"by {sorted(expected)!r}"
+                    ),
+                    None,
+                )
+    return True, None, "", canonical
+
+
+def _source_profile(
+    *,
+    call: ValidatedGapCall,
+    canonical_url: str,
+) -> tuple[str, str, str]:
+    host = (urlsplit(canonical_url).hostname or "").casefold()
+    if call.tool == "academic_search":
+        return (
+            "academic_paper",
+            "medium",
+            (
+                "Structured academic index record; publication status and "
+                "claims still require source review."
+            ),
+        )
+    if call.tool == "patent_search":
+        if host in _OFFICIAL_PATENT_HOSTS:
+            return (
+                "patent",
+                "high",
+                (
+                    "Official patent-office record; legal scope still requires "
+                    "claim review."
+                ),
+            )
+        return (
+            "patent",
+            "medium",
+            (
+                "Approved patent aggregator record; verify legal status "
+                "against the issuing office."
+            ),
+        )
+    profile = _market_source_profile(canonical_url, host)
+    if profile is None:
+        # The static policy already rejected this branch. Raising makes future
+        # policy drift fail closed instead of inventing a source type.
+        raise EvidenceGapExecutionError(
+            "market source profile disappeared after policy validation"
+        )
+    return profile
+
+
+def _relevance_for_topic(
+    source: EvidenceSource,
+    collection: SourceCollection,
+) -> int:
+    variants = tuple(
+        dict.fromkeys((collection.topic, *collection.search_aliases))
+    )
+    scores = []
+    for topic in variants:
+        domain_keywords = (
+            frozenset()
+            if source.source_type not in {"academic_paper", "patent"}
+            else _topic_domain_keywords(topic)
+        )
+        scores.append(
+            _relevance_score(
+                source,
+                _topic_keywords(topic),
+                _topic_bigrams(topic),
+                domain_keywords,
+            )
+        )
+    return max(scores, default=-1)
+
+
+def _candidate_to_source(
+    candidate: ToolEvidenceCandidate,
+    *,
+    candidate_index: int,
+    call: ValidatedGapCall,
+    context: GapContext,
+    collection: SourceCollection,
+    next_numbers: dict[str, int],
+    seen_urls: set[str],
+    seen_dois: set[str],
+    seen_titles: set[str],
+) -> tuple[EvidenceSource | None, CandidateRejection | None]:
+    safe, code, detail, canonical = _static_url_policy(
+        candidate.url,
+        call=call,
+        context=context,
+    )
+    if not safe or code is not None or canonical is None:
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code=code or "unsupported_url",
+            detail=detail or "URL policy rejected the candidate",
+        )
+
+    normalized_doi = normalize_doi(candidate.doi)
+    title_key = _title_key(candidate.title)
+    if canonical in seen_urls:
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code="duplicate_url",
+            detail="canonical URL already exists in the evidence registry",
+        )
+    if normalized_doi and normalized_doi in seen_dois:
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code="duplicate_doi",
+            detail="canonical DOI already exists in the evidence registry",
+        )
+    if title_key in seen_titles:
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code="duplicate_title",
+            detail="normalized title already exists in the evidence registry",
+        )
+
+    source_type, credibility_tier, credibility_reason = _source_profile(
+        call=call,
+        canonical_url=canonical,
+    )
+    domain = call.output_domain
+    source_id = f"{_PREFIX_BY_DOMAIN[domain]}{next_numbers[domain]}"
+    try:
+        source = EvidenceSource(
+            source_id=source_id,
+            title=candidate.title,
+            url=canonical,
+            doi=normalized_doi,
+            publisher=candidate.publisher,
+            published_date=candidate.published_date,
+            accessed_date=collection.collected_at.date(),
+            source_type=source_type,
+            credibility_tier=credibility_tier,
+            credibility_reason=credibility_reason,
+            evidence_summary=candidate.evidence_summary,
+            summary_source=candidate.summary_source,
+            citation_count=candidate.citation_count,
+        )
+    except ValidationError as exc:
+        first = exc.errors()[0] if exc.errors() else {}
+        field = (
+            ".".join(str(part) for part in first.get("loc", ()))
+            or "unknown"
+        )
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code="source_schema_invalid",
+            detail=f"EvidenceSource validation failed at {field}",
+        )
+
+    relevance = _relevance_for_topic(source, collection)
+    if relevance < _MIN_RELEVANCE_BY_DOMAIN[domain]:
+        return None, CandidateRejection(
+            candidate_index=candidate_index,
+            code="off_topic",
+            detail=(
+                f"relevance score {relevance} is below the frozen "
+                f"{_MIN_RELEVANCE_BY_DOMAIN[domain]} threshold"
+            ),
+        )
+
+    next_numbers[domain] += 1
+    seen_urls.add(canonical)
+    if normalized_doi:
+        seen_dois.add(normalized_doi)
+    seen_titles.add(title_key)
+    return source, None
+
+
+def _existing_registry(
+    collection: SourceCollection,
+) -> tuple[set[str], set[str], set[str]]:
+    sources = (
+        *collection.academic_sources,
+        *collection.patent_sources,
+        *collection.market_sources,
+    )
+    urls = {
+        _canonical_url(str(source.url))
+        for source in sources
+        if source.url is not None
+    }
+    dois = {
+        doi
+        for source in sources
+        if (doi := normalize_doi(source.doi))
+    }
+    titles = {_title_key(source.title) for source in sources}
+    return urls, dois, titles
+
+
+def _known_cost(
+    values: list[float | None],
+) -> tuple[Literal["known", "uninspectable"], float | None]:
+    if any(value is None for value in values):
+        return "uninspectable", None
+    return "known", sum(value for value in values if value is not None)
+
+
+def _non_search_result(
+    *,
+    collection_hash: str,
+    plan: ValidatedGapPlan,
+    trace_id: str,
+) -> EvidenceGapExecutionAudit:
+    return EvidenceGapExecutionAudit(
+        decision=plan.decision,
+        evidence_delta_state=(
+            "incomplete" if plan.decision == "abstain" else "unchanged"
+        ),
+        source_collection_sha256_before=collection_hash,
+        source_collection_sha256_after=collection_hash,
+        plan_sha256=_plan_sha256(plan),
+        outbound_attempt_count=0,
+        trace_id=trace_id,
+    )
+
+
+def execute_gap_plan(
+    collection: SourceCollection,
+    *,
+    context: GapContext,
+    plan: ValidatedGapPlan,
+    adapters: Mapping[GapToolName, ReadOnlySearchAdapter],
+    trace_id: str,
+) -> EvidenceGapExecutionAudit:
+    """Execute a validated search plan under one global two-attempt budget."""
+
+    before_hash = source_collection_sha256(collection)
+    if context.source_collection_sha256 != before_hash:
+        raise EvidenceGapExecutionError(
+            "GapContext source hash does not identify the supplied "
+            "SourceCollection"
+        )
+    if plan.decision != "search":
+        return _non_search_result(
+            collection_hash=before_hash,
+            plan=plan,
+            trace_id=trace_id,
+        )
+
+    next_numbers = _next_source_numbers(collection)
+    seen_urls, seen_dois, seen_titles = _existing_registry(collection)
+    call_audits: list[GapToolCallAudit] = []
+    accepted_sources: list[EvidenceSource] = []
+    total_attempts = 0
+    all_costs: list[float | None] = []
+
+    for call_index, call in enumerate(plan.calls):
+        started = time.perf_counter()
+        query_sha256 = _sha256_text(
+            " ".join(call.query.split()).casefold()
+        )
+        adapter = adapters.get(call.tool)
+        if adapter is None:
+            call_audits.append(
+                GapToolCallAudit(
+                    call_index=call_index,
+                    tool=call.tool,
+                    trigger_ids=call.trigger_ids,
+                    query_sha256=query_sha256,
+                    idempotency_key=call.idempotency_key,
+                    state="failed",
+                    outbound_attempt_count=0,
+                    latency_ms=(time.perf_counter() - started) * 1000,
+                    failure_type="adapter_unavailable",
+                    trace_id=trace_id,
+                )
+            )
+            continue
+
+        remaining_calls = len(plan.calls) - call_index - 1
+        attempts_available = (
+            MAX_OUTBOUND_SEARCH_ATTEMPTS - total_attempts
+        )
+        # Reserve one attempt for each later planned call. A single-call plan
+        # may retry once; a two-call plan cannot spend the second call's slot.
+        attempts_for_call = max(
+            0,
+            attempts_available - remaining_calls,
+        )
+        if attempts_for_call == 0:
+            call_audits.append(
+                GapToolCallAudit(
+                    call_index=call_index,
+                    tool=call.tool,
+                    trigger_ids=call.trigger_ids,
+                    query_sha256=query_sha256,
+                    idempotency_key=call.idempotency_key,
+                    state="budget_exhausted",
+                    outbound_attempt_count=0,
+                    latency_ms=(time.perf_counter() - started) * 1000,
+                    failure_type="outbound_budget_exhausted",
+                    trace_id=trace_id,
+                )
+            )
+            continue
+
+        attempt_count = 0
+        call_costs: list[float | None] = []
+        response: ToolAdapterResponse | None = None
+        failure_type: str | None = None
+        while attempt_count < attempts_for_call:
+            attempt_count += 1
+            total_attempts += 1
+            try:
+                raw_response = adapter(call)
+                response = (
+                    raw_response
+                    if isinstance(raw_response, ToolAdapterResponse)
+                    else ToolAdapterResponse.model_validate(raw_response)
+                )
+                call_costs.append(response.search_cost_usd)
+                all_costs.append(response.search_cost_usd)
+                if response.tool != call.tool:
+                    raise EvidenceGapExecutionError(
+                        "adapter returned a mismatched tool identity"
+                    )
+                if response.idempotency_key != call.idempotency_key:
+                    raise EvidenceGapExecutionError(
+                        "adapter returned a mismatched idempotency key"
+                    )
+                if len(response.candidates) > call.result_limit:
+                    failure_type = "result_limit_exceeded"
+                    response = None
+                break
+            except ToolAdapterFailure as exc:
+                call_costs.append(exc.search_cost_usd)
+                all_costs.append(exc.search_cost_usd)
+                failure_type = exc.failure_type
+                if exc.retryable and attempt_count < attempts_for_call:
+                    continue
+                break
+            except (
+                EvidenceGapExecutionError,
+                ValidationError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                # The provider attempt happened, but a malformed response may
+                # omit its cost. It is therefore uninspectable, not free.
+                if not call_costs:
+                    call_costs.append(None)
+                    all_costs.append(None)
+                failure_type = (
+                    f"adapter_contract_{type(exc).__name__}"
+                )
+                response = None
+                break
+            except Exception as exc:  # noqa: BLE001
+                # Experimental adapters are injected third-party boundaries.
+                # Unexpected exceptions remain failed attempts rather than
+                # bringing down the surrounding offline audit.
+                call_costs.append(None)
+                all_costs.append(None)
+                failure_type = (
+                    f"adapter_unexpected_{type(exc).__name__}"
+                )
+                response = None
+                break
+
+        call_cost_state, call_cost = _known_cost(call_costs)
+        if response is None:
+            call_audits.append(
+                GapToolCallAudit(
+                    call_index=call_index,
+                    tool=call.tool,
+                    trigger_ids=call.trigger_ids,
+                    query_sha256=query_sha256,
+                    idempotency_key=call.idempotency_key,
+                    state="failed",
+                    outbound_attempt_count=attempt_count,
+                    latency_ms=(time.perf_counter() - started) * 1000,
+                    search_cost_usd=call_cost,
+                    cost_state=call_cost_state,
+                    failure_type=(
+                        failure_type or "adapter_failed_without_reason"
+                    ),
+                    trace_id=trace_id,
+                )
+            )
+            continue
+
+        accepted_for_call: list[str] = []
+        rejections: list[CandidateRejection] = []
+        for candidate_index, candidate in enumerate(response.candidates):
+            source, rejection = _candidate_to_source(
+                candidate,
+                candidate_index=candidate_index,
+                call=call,
+                context=context,
+                collection=collection,
+                next_numbers=next_numbers,
+                seen_urls=seen_urls,
+                seen_dois=seen_dois,
+                seen_titles=seen_titles,
+            )
+            if source is not None:
+                accepted_sources.append(source)
+                accepted_for_call.append(source.source_id)
+            elif rejection is not None:
+                rejections.append(rejection)
+
+        if accepted_for_call:
+            state: CallState = "accepted"
+        elif response.candidates:
+            state = "rejected"
+        else:
+            state = "empty"
+        call_audits.append(
+            GapToolCallAudit(
+                call_index=call_index,
+                tool=call.tool,
+                trigger_ids=call.trigger_ids,
+                query_sha256=query_sha256,
+                idempotency_key=call.idempotency_key,
+                state=state,
+                outbound_attempt_count=attempt_count,
+                raw_candidate_count=len(response.candidates),
+                accepted_source_ids=tuple(accepted_for_call),
+                rejections=tuple(rejections),
+                latency_ms=(time.perf_counter() - started) * 1000,
+                search_cost_usd=call_cost,
+                cost_state=call_cost_state,
+                trace_id=trace_id,
+            )
+        )
+
+    after_hash = source_collection_sha256(collection)
+    total_cost_state, total_cost = _known_cost(all_costs)
+    if after_hash != before_hash:
+        # Never publish candidates after input mutation: the audit could no
+        # longer say which evidence set was evaluated.
+        sanitized_calls = tuple(
+            call.model_copy(
+                update={
+                    "accepted_source_ids": (),
+                    "state": "failed",
+                    "failure_type": "source_collection_mutated",
+                }
+            )
+            if call.accepted_source_ids
+            else call
+            for call in call_audits
+        )
+        return EvidenceGapExecutionAudit(
+            decision=plan.decision,
+            evidence_delta_state="failed",
+            source_collection_sha256_before=before_hash,
+            source_collection_sha256_after=after_hash,
+            plan_sha256=_plan_sha256(plan),
+            outbound_attempt_count=total_attempts,
+            call_audits=sanitized_calls,
+            incremental_search_cost_usd=total_cost,
+            cost_state=total_cost_state,
+            trace_id=trace_id,
+            failure_type="source_collection_mutated",
+        )
+
+    return EvidenceGapExecutionAudit(
+        decision=plan.decision,
+        evidence_delta_state=(
+            "augmented" if accepted_sources else "incomplete"
+        ),
+        source_collection_sha256_before=before_hash,
+        source_collection_sha256_after=after_hash,
+        plan_sha256=_plan_sha256(plan),
+        outbound_attempt_count=total_attempts,
+        call_audits=tuple(call_audits),
+        accepted_sources=tuple(accepted_sources),
+        incremental_search_cost_usd=total_cost,
+        cost_state=total_cost_state,
+        trace_id=trace_id,
+    )

--- a/src/academic_agent/tools/__init__.py
+++ b/src/academic_agent/tools/__init__.py
@@ -1,0 +1,15 @@
+"""Read-only capability contracts; production registration is opt-in."""
+
+from academic_agent.tools.evidence_search import (
+    ReadOnlySearchAdapter,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+
+__all__ = [
+    "ReadOnlySearchAdapter",
+    "ToolAdapterFailure",
+    "ToolAdapterResponse",
+    "ToolEvidenceCandidate",
+]

--- a/src/academic_agent/tools/evidence_search.py
+++ b/src/academic_agent/tools/evidence_search.py
@@ -1,0 +1,86 @@
+"""Strict adapter boundary for bounded supplementary evidence search.
+
+The production pipeline does not instantiate these adapters yet. Phase 2
+defines the object that a future network adapter must return after exactly one
+provider request, so retry and request budgets remain owned by the executor
+rather than being hidden inside a client with its own retry loop.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
+from academic_agent.evidence_gap import GapToolName, ValidatedGapCall
+
+
+class ToolEvidenceCandidate(BaseModel):
+    """Unregistered provider result kept outside the report evidence registry."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    title: str = Field(min_length=5, max_length=600)
+    url: str = Field(min_length=3, max_length=2000)
+    doi: str | None = Field(default=None, max_length=300)
+    publisher: str = Field(min_length=2, max_length=300)
+    published_date: date | None = None
+    evidence_summary: str = Field(min_length=1, max_length=8000)
+    summary_source: Literal["abstract", "search_snippet"]
+    citation_count: int | None = Field(default=None, ge=0)
+
+    @field_serializer("published_date")
+    def serialize_date(self, value: date | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+
+class ToolAdapterResponse(BaseModel):
+    """One adapter invocation, which must equal one provider request.
+
+    An adapter that follows redirects, fetches result pages, or performs an
+    internal retry cannot truthfully emit this shape. Those operations need a
+    separately budgeted transport; accepting a client-reported integer greater
+    than one and checking only afterwards would discover overspend too late.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tool: GapToolName
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    outbound_request_count: Literal[1] = 1
+    candidates: tuple[ToolEvidenceCandidate, ...] = Field(default=(), max_length=10)
+    search_cost_usd: float = Field(default=0.0, ge=0.0)
+    provider_request_id: str | None = Field(default=None, max_length=300)
+
+
+class ToolAdapterFailure(RuntimeError):
+    """Structured failure from one request attempt.
+
+    Cost may be unknown after a transport failure. Keeping None distinct from
+    zero prevents a failed provider response from being reported as free.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool,
+        failure_type: str,
+        search_cost_usd: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        if search_cost_usd is not None and search_cost_usd < 0:
+            raise ValueError("search_cost_usd cannot be negative")
+        self.retryable = retryable
+        self.failure_type = failure_type
+        self.search_cost_usd = search_cost_usd
+
+
+class ReadOnlySearchAdapter(Protocol):
+    """A capability adapter that performs exactly one outbound request."""
+
+    def __call__(
+        self,
+        call: ValidatedGapCall,
+    ) -> ToolAdapterResponse | dict[str, Any]: ...

--- a/tests/fixtures/evidence_gap_phase2_challenge.json
+++ b/tests/fixtures/evidence_gap_phase2_challenge.json
@@ -1,0 +1,683 @@
+{
+  "schema_version": 1,
+  "challenge_id": "evidence-gap-tool-execution-phase2",
+  "measurement_design": "synthetic_adversarial_contract_not_production",
+  "topic": "battery-free wearable glucose biosensor for remote monitoring",
+  "cases": [
+    {
+      "case_id": "C01-valid-academic",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.015,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose biosensor remote monitoring evidence",
+                "url": "https://doi.org/10.1000/novel",
+                "doi": "10.1000/novel",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 1,
+        "accepted_count": 1,
+        "call_states": [
+          "accepted"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.015,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C02-registry-duplicates",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.01,
+            "candidates": [
+              {
+                "title": "Distinct battery-free wearable glucose biosensor URL row",
+                "url": "https://doi.org/10.1000/existing",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Distinct battery-free wearable glucose biosensor DOI row",
+                "url": "https://openalex.org/W123456",
+                "doi": "10.1000/existing",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Battery-free wearable glucose biosensor baseline study",
+                "url": "https://doi.org/10.1000/title-only",
+                "doi": "10.1000/title-only",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "rejected"
+        ],
+        "rejection_codes": [
+          "duplicate_url",
+          "duplicate_doi",
+          "duplicate_title"
+        ],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C03-url-and-domain-policy",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.01,
+            "candidates": [
+              {
+                "title": "Private battery-free glucose evidence",
+                "url": "http://127.0.0.1/private",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Credentialed battery-free glucose evidence",
+                "url": "https://user:secret@doi.org/10.1000/private",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Local file battery-free glucose evidence",
+                "url": "file:///etc/passwd",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Untrusted battery-free glucose evidence",
+                "url": "https://untrusted.example/paper",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              },
+              {
+                "title": "Wrong-domain battery-free glucose evidence",
+                "url": "https://patents.google.com/patent/US2025000999A1",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "rejected"
+        ],
+        "rejection_codes": [
+          "non_public_literal_host",
+          "credentialed_url",
+          "unsupported_url",
+          "host_not_allowlisted",
+          "host_not_allowlisted"
+        ],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C04-off-topic",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.01,
+            "candidates": [
+              {
+                "title": "Marine archaeology pottery isotope reconstruction",
+                "url": "https://doi.org/10.1000/off-topic",
+                "doi": "10.1000/off-topic",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This archaeology paper studies pottery isotope reconstruction and ancient maritime exchange routes.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "rejected"
+        ],
+        "rejection_codes": [
+          "off_topic"
+        ],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C05-valid-patent",
+      "calls": [
+        {
+          "tool": "patent_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "patent",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "patent_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.012,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose biosensor telemetry system",
+                "url": "https://patents.google.com/patent/US2025000001A1",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "search_snippet"
+              },
+              {
+                "title": "Wrong-domain battery-free wearable glucose biosensor study",
+                "url": "https://doi.org/10.1000/patent-wrong-domain",
+                "doi": "10.1000/patent-wrong-domain",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 1,
+        "accepted_count": 1,
+        "call_states": [
+          "accepted"
+        ],
+        "rejection_codes": [
+          "wrong_evidence_domain"
+        ],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.012,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C06-valid-market",
+      "calls": [
+        {
+          "tool": "market_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "market",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "market_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.013,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose monitoring deployment grows",
+                "url": "https://www.reuters.com/technology/battery-free-glucose-monitoring/",
+                "doi": null,
+                "publisher": "Reuters",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "search_snippet"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 1,
+        "accepted_count": 1,
+        "call_states": [
+          "accepted"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.013,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C07-valid-regulatory-authority",
+      "calls": [
+        {
+          "tool": "authority_search",
+          "trigger_code": "authority_category_missing",
+          "trigger_subject": "regulatory",
+          "result_limit": 5,
+          "query": "battery-free wearable glucose biosensor for remote monitoring FDA regulatory record"
+        }
+      ],
+      "adapters": {
+        "authority_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.014,
+            "candidates": [
+              {
+                "title": "FDA battery-free wearable glucose biosensor device record",
+                "url": "https://www.fda.gov/medical-devices/battery-free-glucose-biosensor",
+                "doi": null,
+                "publisher": "US FDA",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "search_snippet"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 1,
+        "accepted_count": 1,
+        "call_states": [
+          "accepted"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.014,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C08-wrong-authority-category",
+      "calls": [
+        {
+          "tool": "authority_search",
+          "trigger_code": "authority_category_missing",
+          "trigger_subject": "regulatory",
+          "result_limit": 5,
+          "query": "battery-free wearable glucose biosensor for remote monitoring FDA regulatory record"
+        }
+      ],
+      "adapters": {
+        "authority_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.01,
+            "candidates": [
+              {
+                "title": "Clinical trial for battery-free wearable glucose biosensor remote monitoring",
+                "url": "https://clinicaltrials.gov/study/NCT01234567",
+                "doi": null,
+                "publisher": "ClinicalTrials.gov",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "search_snippet"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "rejected"
+        ],
+        "rejection_codes": [
+          "wrong_authority_category"
+        ],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C09-retry-then-success",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "failure",
+            "retryable": true,
+            "failure_type": "provider_timeout",
+            "search_cost_usd": 0.004
+          },
+          {
+            "type": "response",
+            "search_cost_usd": 0.006,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose biosensor remote monitoring evidence",
+                "url": "https://doi.org/10.1000/novel",
+                "doi": "10.1000/novel",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 2,
+        "accepted_count": 1,
+        "call_states": [
+          "accepted"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C10-clean-empty",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.002,
+            "candidates": []
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "empty"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.002,
+        "failure_type": null,
+        "call_failure_types": [
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C11-malformed-response",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "malformed"
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "failed"
+        ],
+        "rejection_codes": [],
+        "cost_state": "uninspectable",
+        "incremental_search_cost_usd": null,
+        "failure_type": null,
+        "call_failure_types": [
+          "adapter_contract_ValidationError"
+        ]
+      }
+    },
+    {
+      "case_id": "C12-missing-adapter",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {},
+      "expected": {
+        "evidence_delta_state": "incomplete",
+        "outbound_attempt_count": 0,
+        "accepted_count": 0,
+        "call_states": [
+          "failed"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0,
+        "failure_type": null,
+        "call_failure_types": [
+          "adapter_unavailable"
+        ]
+      }
+    },
+    {
+      "case_id": "C13-two-call-budget-fairness",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        },
+        {
+          "tool": "patent_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "patent",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "failure",
+            "retryable": true,
+            "failure_type": "provider_timeout",
+            "search_cost_usd": 0.002
+          }
+        ],
+        "patent_search": [
+          {
+            "type": "response",
+            "search_cost_usd": 0.003,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose biosensor telemetry system",
+                "url": "https://patents.google.com/patent/US2025000001A1",
+                "doi": null,
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "search_snippet"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "augmented",
+        "outbound_attempt_count": 2,
+        "accepted_count": 1,
+        "call_states": [
+          "failed",
+          "accepted"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.005,
+        "failure_type": null,
+        "call_failure_types": [
+          "provider_timeout",
+          null
+        ]
+      }
+    },
+    {
+      "case_id": "C14-input-mutation-quarantine",
+      "calls": [
+        {
+          "tool": "academic_search",
+          "trigger_code": "retrieval_domain_failed",
+          "trigger_subject": "academic",
+          "result_limit": 5
+        }
+      ],
+      "adapters": {
+        "academic_search": [
+          {
+            "type": "mutation",
+            "search_cost_usd": 0.01,
+            "candidates": [
+              {
+                "title": "Battery-free wearable glucose biosensor remote monitoring evidence",
+                "url": "https://doi.org/10.1000/novel",
+                "doi": "10.1000/novel",
+                "publisher": "Evidence Index",
+                "evidence_summary": "This source provides detailed topic-specific evidence about battery-free wearable glucose biosensors for remote monitoring.",
+                "summary_source": "abstract"
+              }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "evidence_delta_state": "failed",
+        "outbound_attempt_count": 1,
+        "accepted_count": 0,
+        "call_states": [
+          "failed"
+        ],
+        "rejection_codes": [],
+        "cost_state": "known",
+        "incremental_search_cost_usd": 0.01,
+        "failure_type": "source_collection_mutated",
+        "call_failure_types": [
+          "source_collection_mutated"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_evidence_gap.py
+++ b/tests/test_evidence_gap.py
@@ -259,6 +259,61 @@ class GapPlanContractTests(unittest.TestCase):
                 self._proposal(self._intent(tool="academic_search")),
             )
 
+    def test_query_must_remain_inside_topic_and_trigger_scope(self):
+        with self.assertRaisesRegex(EvidenceGapError, "topic scope"):
+            validate_gap_plan(
+                self.context,
+                self._proposal(
+                    self._intent(query="quantum sensor market forecast")
+                ),
+            )
+        with self.assertRaisesRegex(EvidenceGapError, "missing category"):
+            validate_gap_plan(
+                self.context,
+                self._proposal(
+                    self._intent(
+                        query="CAR-T blood cancer commercial news"
+                    )
+                ),
+            )
+
+    def test_component_query_must_name_the_authorizing_missing_component(self):
+        component_context = build_gap_context(
+            _collection(
+                components=ComponentCoverage(
+                    status="incomplete",
+                    components=["edge AI inference"],
+                    missing_components=["edge AI inference"],
+                )
+            )
+        )
+        component_trigger = next(
+            signal.signal_id
+            for signal in component_context.signals
+            if signal.code == "component_missing"
+        )
+
+        def proposal(query: str) -> GapPlanProposal:
+            return self._proposal(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=query,
+                    trigger_ids=(component_trigger,),
+                )
+            )
+
+        with self.assertRaisesRegex(EvidenceGapError, "missing component"):
+            validate_gap_plan(
+                component_context,
+                proposal("solid-state batteries academic evidence"),
+            )
+
+        plan = validate_gap_plan(
+            component_context,
+            proposal("solid-state batteries edge AI inference evidence"),
+        )
+        self.assertEqual(plan.calls[0].tool, "academic_search")
+
     def test_eligible_context_must_search_or_explicitly_abstain(self):
         proposal = GapPlanProposal(
             decision="no_gap",

--- a/tests/test_evidence_gap_execution.py
+++ b/tests/test_evidence_gap_execution.py
@@ -1,0 +1,793 @@
+"""Phase-2 bounded Tool Calling execution and evidence-quarantine seams."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapCall,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.evidence_gap_execution import (
+    EvidenceGapExecutionAudit,
+    EvidenceGapExecutionError,
+    execute_gap_plan,
+)
+from academic_agent.source_pipeline import (
+    AuthorityCoverage,
+    ComponentCoverage,
+    SourceCollection,
+)
+from academic_agent.tools.evidence_search import (
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+
+
+_SUMMARY = (
+    "This source provides sufficiently detailed and topic-specific evidence "
+    "for the bounded Tool Calling execution and quarantine test contract."
+)
+_TOPIC = "battery-free wearable glucose biosensor for remote monitoring"
+_TRACE_ID = "trace-phase2-contract"
+
+
+def _source(
+    source_id: str,
+    *,
+    title: str,
+    url: str,
+    source_type: str,
+    doi: str | None = None,
+) -> EvidenceSource:
+    return EvidenceSource(
+        source_id=source_id,
+        title=title,
+        url=url,
+        doi=doi,
+        publisher="Fixture Publisher",
+        accessed_date=date(2025, 1, 1),
+        source_type=source_type,
+        evidence_summary=_SUMMARY,
+        summary_source="search_snippet",
+    )
+
+
+def _collection() -> SourceCollection:
+    return SourceCollection(
+        topic=_TOPIC,
+        display_topic=_TOPIC,
+        search_aliases=["self-powered wearable glucose sensor monitoring"],
+        search_components=["battery-free telemetry", "glucose biosensor"],
+        output_language="English",
+        weight_profile="biomedical",
+        collected_at=datetime(2025, 1, 1, tzinfo=UTC),
+        academic_sources=[
+            _source(
+                "A1",
+                title="Battery-free wearable glucose biosensor baseline study",
+                url="https://doi.org/10.1000/existing",
+                doi="10.1000/existing",
+                source_type="academic_paper",
+            )
+        ],
+        patent_sources=[
+            _source(
+                "P1",
+                title="Battery-free wearable glucose biosensor telemetry patent",
+                url="https://patents.google.com/patent/US1234567A1",
+                source_type="patent",
+            )
+        ],
+        market_sources=[
+            _source(
+                "M1",
+                title="Battery-free wearable glucose monitoring market deployment",
+                url="https://www.reuters.com/technology/wearable-glucose-monitoring/",
+                source_type="reputable_news",
+            )
+        ],
+        academic_queries=[_TOPIC],
+        patent_queries=[_TOPIC],
+        market_queries=[_TOPIC],
+        authority_coverage=AuthorityCoverage(
+            status="incomplete",
+            required_categories=["regulatory", "clinical_registry"],
+            missing_categories=["regulatory", "clinical_registry"],
+        ),
+        component_coverage=ComponentCoverage(
+            status="incomplete",
+            components=["battery-free telemetry", "glucose biosensor"],
+            covered_source_ids={"glucose biosensor": ["A1"]},
+            missing_components=["battery-free telemetry"],
+        ),
+        failed_domains={
+            "academic": "fixture timeout",
+            "patent": "fixture timeout",
+            "market": "fixture timeout",
+        },
+    )
+
+
+def _trigger(
+    context: GapContext,
+    *,
+    code: str,
+    subject: str,
+) -> str:
+    return next(
+        signal.signal_id
+        for signal in context.signals
+        if signal.code == code and signal.subject == subject
+    )
+
+
+def _call_spec(
+    context: GapContext,
+    *,
+    tool: str,
+    code: str,
+    subject: str,
+    query: str = _TOPIC,
+    result_limit: int = 5,
+) -> GapSearchIntent:
+    return GapSearchIntent(
+        tool=tool,
+        query=query,
+        trigger_ids=(_trigger(context, code=code, subject=subject),),
+        result_limit=result_limit,
+    )
+
+
+def _plan(
+    context: GapContext,
+    *calls: GapSearchIntent,
+):
+    return validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen challenge exposes a specific evidence gap and "
+                "authorizes a bounded read-only search."
+            ),
+            calls=calls,
+        ),
+    )
+
+
+def _candidate(
+    *,
+    title: str = (
+        "Battery-free wearable glucose biosensor remote monitoring evidence"
+    ),
+    url: str = "https://doi.org/10.1000/novel",
+    doi: str | None = "10.1000/novel",
+    publisher: str = "Evidence Index",
+    summary: str = _SUMMARY,
+    summary_source: str = "abstract",
+) -> ToolEvidenceCandidate:
+    return ToolEvidenceCandidate(
+        title=title,
+        url=url,
+        doi=doi,
+        publisher=publisher,
+        evidence_summary=summary,
+        summary_source=summary_source,
+    )
+
+
+def _response(
+    call: ValidatedGapCall,
+    *candidates: ToolEvidenceCandidate,
+    cost: float = 0.01,
+) -> ToolAdapterResponse:
+    return ToolAdapterResponse(
+        tool=call.tool,
+        idempotency_key=call.idempotency_key,
+        candidates=candidates,
+        search_cost_usd=cost,
+        provider_request_id="fixture-request",
+    )
+
+
+def _execute(
+    collection: SourceCollection,
+    plan,
+    adapters,
+):
+    return execute_gap_plan(
+        collection,
+        context=build_gap_context(collection),
+        plan=plan,
+        adapters=adapters,
+        trace_id=_TRACE_ID,
+    )
+
+
+def test_adapter_contract_forbids_unknown_fields_and_hidden_extra_requests():
+    candidate = _candidate()
+    with pytest.raises(ValidationError):
+        ToolEvidenceCandidate.model_validate(
+            {**candidate.model_dump(mode="json"), "unregistered": True}
+        )
+    with pytest.raises(ValidationError):
+        ToolAdapterResponse(
+            tool="academic_search",
+            idempotency_key="a" * 64,
+            outbound_request_count=2,
+        )
+
+
+def test_valid_academic_candidate_is_quarantined_without_mutating_input():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+    before = source_collection_sha256(collection)
+
+    audit = execute_gap_plan(
+        collection,
+        context=context,
+        plan=plan,
+        adapters={
+            "academic_search": lambda call: _response(
+                call,
+                _candidate(),
+                cost=0.015,
+            )
+        },
+        trace_id=_TRACE_ID,
+    )
+
+    assert audit.evidence_delta_state == "augmented"
+    assert audit.outbound_attempt_count == 1
+    assert audit.incremental_search_cost_usd == pytest.approx(0.015)
+    assert [source.source_id for source in audit.accepted_sources] == ["A2"]
+    assert len(collection.academic_sources) == 1
+    assert source_collection_sha256(collection) == before
+    payload = audit.model_dump(mode="json")
+    assert _TOPIC not in payload["call_audits"][0]["query_sha256"]
+
+
+def test_existing_url_doi_and_title_are_each_rejected_before_registration():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+    candidates = (
+        _candidate(
+            url="https://doi.org/10.1000/existing",
+            doi=None,
+            title="Distinct battery-free wearable glucose biosensor URL row",
+        ),
+        _candidate(
+            url="https://openalex.org/W123456",
+            doi="10.1000/existing",
+            title="Distinct battery-free wearable glucose biosensor DOI row",
+        ),
+        _candidate(
+            url="https://doi.org/10.1000/title-only",
+            doi="10.1000/title-only",
+            title="Battery-free wearable glucose biosensor baseline study",
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {"academic_search": lambda call: _response(call, *candidates)},
+    )
+
+    assert audit.evidence_delta_state == "incomplete"
+    assert audit.accepted_sources == ()
+    assert [item.code for item in audit.call_audits[0].rejections] == [
+        "duplicate_url",
+        "duplicate_doi",
+        "duplicate_title",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_code"),
+    [
+        ("http://127.0.0.1/private", "non_public_literal_host"),
+        (
+            "https://user:secret@doi.org/10.1000/private",
+            "credentialed_url",
+        ),
+        ("file:///etc/passwd", "unsupported_url"),
+        ("https://untrusted.example/paper", "host_not_allowlisted"),
+    ],
+)
+def test_untrusted_candidate_urls_never_reach_evidence(url, expected_code):
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {
+            "academic_search": lambda call: _response(
+                call,
+                _candidate(url=url, doi=None),
+            )
+        },
+    )
+
+    assert audit.accepted_sources == ()
+    assert audit.call_audits[0].rejections[0].code == expected_code
+
+
+def test_off_topic_candidate_is_rejected_even_from_an_allowed_host():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {
+            "academic_search": lambda call: _response(
+                call,
+                _candidate(
+                    title="Marine archaeology pottery isotope reconstruction",
+                    url="https://doi.org/10.1000/off-topic",
+                    doi="10.1000/off-topic",
+                    summary=(
+                        "This archaeology paper studies pottery isotope "
+                        "reconstruction and ancient maritime exchange routes."
+                    ),
+                ),
+            )
+        },
+    )
+
+    assert audit.accepted_sources == ()
+    assert audit.call_audits[0].rejections[0].code == "off_topic"
+
+
+@pytest.mark.parametrize(
+    ("tool", "code", "subject", "candidate", "expected_id"),
+    [
+        (
+            "patent_search",
+            "retrieval_domain_failed",
+            "patent",
+            _candidate(
+                title=(
+                    "Battery-free wearable glucose biosensor telemetry system"
+                ),
+                url="https://patents.google.com/patent/US2025000001A1",
+                doi=None,
+                summary_source="search_snippet",
+            ),
+            "P2",
+        ),
+        (
+            "market_search",
+            "retrieval_domain_failed",
+            "market",
+            _candidate(
+                title=(
+                    "Battery-free wearable glucose monitoring deployment grows"
+                ),
+                url=(
+                    "https://www.reuters.com/technology/"
+                    "battery-free-glucose-monitoring/"
+                ),
+                doi=None,
+                publisher="Reuters",
+                summary_source="search_snippet",
+            ),
+            "M2",
+        ),
+        (
+            "authority_search",
+            "authority_category_missing",
+            "regulatory",
+            _candidate(
+                title=(
+                    "FDA battery-free wearable glucose biosensor device record"
+                ),
+                url=(
+                    "https://www.fda.gov/medical-devices/"
+                    "battery-free-glucose-biosensor"
+                ),
+                doi=None,
+                publisher="US FDA",
+                summary_source="search_snippet",
+            ),
+            "M2",
+        ),
+    ],
+)
+def test_each_non_academic_capability_reaches_the_same_quarantine_seam(
+    tool,
+    code,
+    subject,
+    candidate,
+    expected_id,
+):
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool=tool,
+            code=code,
+            subject=subject,
+            query=(
+                _TOPIC
+                if tool != "authority_search"
+                else f"{_TOPIC} FDA regulatory record"
+            ),
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {tool: lambda call: _response(call, candidate)},
+    )
+
+    assert audit.evidence_delta_state == "augmented"
+    assert [source.source_id for source in audit.accepted_sources] == [
+        expected_id
+    ]
+
+
+def test_authority_tool_rejects_the_wrong_requested_category():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="authority_search",
+            code="authority_category_missing",
+            subject="regulatory",
+            query=f"{_TOPIC} FDA regulatory record",
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {
+            "authority_search": lambda call: _response(
+                call,
+                _candidate(
+                    title=(
+                        "Clinical trial for battery-free wearable glucose "
+                        "biosensor remote monitoring"
+                    ),
+                    url="https://clinicaltrials.gov/study/NCT01234567",
+                    doi=None,
+                    publisher="ClinicalTrials.gov",
+                    summary_source="search_snippet",
+                ),
+            )
+        },
+    )
+
+    assert audit.accepted_sources == ()
+    assert (
+        audit.call_audits[0].rejections[0].code
+        == "wrong_authority_category"
+    )
+
+
+def test_one_call_may_retry_once_and_cost_includes_both_attempts():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+    attempts = 0
+
+    def adapter(call):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ToolAdapterFailure(
+                "temporary failure",
+                retryable=True,
+                failure_type="provider_timeout",
+                search_cost_usd=0.004,
+            )
+        return _response(call, _candidate(), cost=0.006)
+
+    audit = _execute(
+        collection,
+        plan,
+        {"academic_search": adapter},
+    )
+
+    assert attempts == 2
+    assert audit.outbound_attempt_count == 2
+    assert audit.call_audits[0].outbound_attempt_count == 2
+    assert audit.call_audits[0].search_cost_usd == pytest.approx(0.01)
+    assert audit.incremental_search_cost_usd == pytest.approx(0.01)
+
+
+def test_two_planned_calls_each_keep_one_slot_and_cannot_retry():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+        _call_spec(
+            context,
+            tool="patent_search",
+            code="retrieval_domain_failed",
+            subject="patent",
+        ),
+    )
+    academic = MagicMock(
+        side_effect=ToolAdapterFailure(
+            "temporary academic failure",
+            retryable=True,
+            failure_type="provider_timeout",
+            search_cost_usd=0.002,
+        )
+    )
+    patent = MagicMock(
+        side_effect=lambda call: _response(
+            call,
+            _candidate(
+                title=(
+                    "Battery-free wearable glucose biosensor telemetry system"
+                ),
+                url="https://patents.google.com/patent/US2025000001A1",
+                doi=None,
+                summary_source="search_snippet",
+            ),
+            cost=0.003,
+        )
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {
+            "academic_search": academic,
+            "patent_search": patent,
+        },
+    )
+
+    assert academic.call_count == 1
+    assert patent.call_count == 1
+    assert audit.outbound_attempt_count == 2
+    assert [call.state for call in audit.call_audits] == [
+        "failed",
+        "accepted",
+    ]
+    assert audit.incremental_search_cost_usd == pytest.approx(0.005)
+
+
+def test_missing_adapter_and_malformed_response_are_not_clean_empty_results():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+
+    missing = _execute(collection, plan, {})
+    malformed = _execute(
+        collection,
+        plan,
+        {
+            "academic_search": lambda call: {
+                "tool": call.tool,
+                "idempotency_key": call.idempotency_key,
+                "outbound_request_count": 1,
+                "candidates": [],
+                "unexpected": True,
+            }
+        },
+    )
+
+    assert missing.call_audits[0].state == "failed"
+    assert missing.call_audits[0].outbound_attempt_count == 0
+    assert malformed.call_audits[0].state == "failed"
+    assert malformed.call_audits[0].cost_state == "uninspectable"
+    assert malformed.incremental_search_cost_usd is None
+
+
+def test_clean_empty_response_is_explicitly_incomplete():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+
+    audit = _execute(
+        collection,
+        plan,
+        {"academic_search": lambda call: _response(call)},
+    )
+
+    assert audit.evidence_delta_state == "incomplete"
+    assert audit.call_audits[0].state == "empty"
+    assert audit.call_audits[0].raw_candidate_count == 0
+
+
+def test_context_hash_mismatch_stops_before_any_adapter_attempt():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+    adapter = MagicMock()
+    changed = collection.model_copy(deep=True)
+    changed.topic = "different topic"
+
+    with pytest.raises(EvidenceGapExecutionError, match="source hash"):
+        execute_gap_plan(
+            changed,
+            context=context,
+            plan=plan,
+            adapters={"academic_search": adapter},
+            trace_id=_TRACE_ID,
+        )
+
+    adapter.assert_not_called()
+
+
+def test_adapter_side_effect_mutation_invalidates_the_whole_delta():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+
+    def mutating_adapter(call):
+        collection.topic = "mutated collection identity"
+        return _response(call, _candidate())
+
+    audit = execute_gap_plan(
+        collection,
+        context=context,
+        plan=plan,
+        adapters={"academic_search": mutating_adapter},
+        trace_id=_TRACE_ID,
+    )
+
+    assert audit.evidence_delta_state == "failed"
+    assert audit.failure_type == "source_collection_mutated"
+    assert audit.accepted_sources == ()
+    assert (
+        audit.source_collection_sha256_before
+        != audit.source_collection_sha256_after
+    )
+
+
+def test_abstention_executes_zero_calls_and_remains_incomplete():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="abstain",
+            rationale=(
+                "Expected evidence gain does not justify even one bounded "
+                "supplementary request."
+            ),
+        ),
+    )
+    adapter = MagicMock()
+
+    audit = execute_gap_plan(
+        collection,
+        context=context,
+        plan=plan,
+        adapters={"academic_search": adapter},
+        trace_id=_TRACE_ID,
+    )
+
+    adapter.assert_not_called()
+    assert audit.evidence_delta_state == "incomplete"
+    assert audit.outbound_attempt_count == 0
+
+
+def test_audit_model_rejects_attempt_totals_that_do_not_reach_the_boundary():
+    collection = _collection()
+    context = build_gap_context(collection)
+    plan = _plan(
+        context,
+        _call_spec(
+            context,
+            tool="academic_search",
+            code="retrieval_domain_failed",
+            subject="academic",
+        ),
+    )
+    audit = _execute(
+        collection,
+        plan,
+        {"academic_search": lambda call: _response(call)},
+    )
+    payload = audit.model_dump(mode="json")
+    payload["outbound_attempt_count"] = 0
+
+    with pytest.raises(ValidationError, match="call-audit total"):
+        EvidenceGapExecutionAudit.model_validate(payload)

--- a/tests/test_evidence_gap_phase2_audit.py
+++ b/tests/test_evidence_gap_phase2_audit.py
@@ -1,0 +1,93 @@
+"""Frozen Phase-2 Tool Calling challenge and artifact-boundary tests."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from evidence_gap_phase2_audit import (
+    Phase2AuditError,
+    Phase2Challenge,
+    run_challenge,
+    write_audit_artifacts,
+)
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURE = _ROOT / "tests/fixtures/evidence_gap_phase2_challenge.json"
+
+
+def test_frozen_phase2_challenge_passes_exactly_at_the_audit_seam():
+    result = run_challenge(_FIXTURE)
+
+    assert result["status"] == "passed"
+    assert result["case_count"] == 14
+    assert result["passed_case_count"] == 14
+    assert result["deterministic_replay_passed_count"] == 14
+    assert result["production_connected"] is False
+    assert result["real_network_calls_performed"] is False
+    assert result["maximum_case_attempt_count"] == 2
+    assert result["unexpected_accepted_source_count"] == 0
+
+    # Telemetry must reach the result artifact, not merely exist inside the
+    # executor model. This seam assertion caught earlier client-field drops.
+    for case in result["cases"]:
+        assert case["deterministic_replay"] == "passed"
+        for call in case["audit"]["call_audits"]:
+            assert call["latency_ms"] >= 0
+            assert call["trace_id"]
+            assert call["query_sha256"]
+            assert "search_cost_usd" in call
+            assert "rejections" in call
+
+
+def test_phase2_executor_is_not_connected_to_the_production_worker():
+    from academic_agent import pipeline_worker
+
+    source = inspect.getsource(pipeline_worker)
+    assert "academic_agent.evidence_gap_execution" not in source
+    assert "execute_gap_plan" not in source
+
+
+def test_frozen_answer_drift_fails_instead_of_rewriting_the_baseline(tmp_path):
+    payload = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    payload["cases"][0]["expected"]["accepted_count"] = 0
+    drifted = tmp_path / "drifted.json"
+    drifted.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        Phase2AuditError,
+        match="C01-valid-academic: observed disposition differs",
+    ):
+        run_challenge(drifted)
+
+
+def test_fixture_schema_rejects_unregistered_case_fields():
+    payload = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    payload["cases"][0]["unregistered_override"] = True
+
+    with pytest.raises(ValidationError):
+        Phase2Challenge.model_validate(payload)
+
+
+def test_audit_artifacts_are_write_once_and_keep_the_boundary_fields(tmp_path):
+    result = run_challenge(_FIXTURE)
+    output = tmp_path / "phase2-result"
+
+    write_audit_artifacts(result, output)
+
+    summary = json.loads(
+        (output / "summary.json").read_text(encoding="utf-8")
+    )
+    csv_text = (output / "cases.csv").read_text(encoding="utf-8")
+    assert summary["fixture_sha256"] == result["fixture_sha256"]
+    assert summary["case_count"] == 14
+    assert "outbound_attempt_count" in csv_text
+    assert "C14-input-mutation-quarantine" in csv_text
+
+    with pytest.raises(FileExistsError):
+        write_audit_artifacts(result, output)


### PR DESCRIPTION
This PR implements the pre-registered second phase of evidence-gap planning as a production-disconnected execution kernel. It adds strict query and trigger authorization, four named read-only adapter contracts, a global two-attempt budget, evidence quarantine, idempotency, and inspectable failure, cost, latency, rejection, and trace fields. Production remains phase-one zero-call shadow mode: no planner or supplementary adapter is connected to pipeline_worker.py. The frozen 14-case offline challenge passed every exact disposition and deterministic replay, and both request-budget and host-quarantine defects were re-injected to prove the seam tests fail. Local validation: 1418 tests and 627 subtests; latest Ruff; CI exception-order Pylint; 87.11 percent coverage against the 85 percent floor. The protocol and result documents state that this is not live-search value or report-quality evidence.