### PR TITLE
Add a production-disconnected Tavily compatibility harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1418 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1444 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -155,7 +155,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  67 test modules plus conftest, organised by subject
+tests/                  70 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering
@@ -165,6 +165,8 @@ regulator_title_recovery_candidate.py
                         frozen title-recovery comparison; never performs retrieval
 evidence_gap_phase2_audit.py
                         frozen zero-network Tool Calling contract replay
+evidence_gap_phase3_audit.py
+                        frozen five-case Tavily harness; dry-run is zero-network
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -183,21 +185,28 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
 ## Things that are known-open
 
 - Blocking on uncited claims (above) — needs the detector tighter first.
-- Evidence-gap Tool Calling has a phase-2 execution kernel, but production is
-  still phase-1 zero-call shadow mode. The frozen 14-case synthetic challenge
-  passed 14/14 exact dispositions and 14/14 deterministic replays outside
-  wall-clock latency. No case exceeded two simulated adapter attempts; six
-  valid rows entered a separate evidence delta and zero unexpected rows did.
-  Query authorization requires both original-topic overlap and the specific
-  component or authority category. URL/domain/relevance/deduplication checks,
-  idempotency, retry accounting, cost inspection states, and input-mutation
-  detection are exercised offline. This is execution-contract evidence only:
-  no live planner, search provider, production evidence gain, report-quality
-  improvement, latency, cost, or reliability result exists. Do not connect the
-  executor to `pipeline_worker.py` until a separately pre-registered live
-  experiment meets the phase-1 trigger-precision, evidence-yield, wrong-source,
-  budget, accounting, and disabled-path regression thresholds. See
-  `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`.
+- Evidence-gap Tool Calling now has a phase-2 execution kernel and a phase-3
+  production-disconnected Tavily adapter; the production workflow is still
+  phase-1 zero-call shadow mode. The phase-2 frozen 14-case synthetic
+  challenge passed 14/14 dispositions and deterministic replays, retained six
+  valid rows in a separate delta, and retained zero unexpected rows.
+  Phase 3 freezes five collection/plan identities and one request per case. Its
+  adapter forces basic search, code-owned domains, no redirects or internal
+  retry, and requires provider request/credit accounting. Candidates, malformed
+  result rows, local quarantine decisions, cost, latency and trace data reach
+  write-once JSON/CSV artifacts. The adapter/audit/executor subset passed 46/46
+  tests; temporary hidden-second-request and provider-row-under-count defects
+  both made their seam tests fail before restoration.
+  No live Tavily request has run, so no provider compatibility, evidence yield,
+  wrong-source rate, real cost, latency, report-quality improvement, reliability
+  or planner-precision result exists. A separately authorized live pilot is
+  required, and every accepted row must then receive complete relevance and
+  novelty review. Even a pilot pass would not authorize production connection:
+  planner trigger precision and disabled-path thresholds remain unsatisfied.
+  Keep `pipeline_worker.py` disconnected from both executor and adapter.
+  See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`
+  and
+  `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -382,6 +382,21 @@ and [result](docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md).
 These are synthetic contract results, not live search value: the production
 worker still instantiates no planner or supplementary adapter.
 
+Phase 3 adds a **production-disconnected, single-request Tavily adapter** and a
+frozen five-case provider-compatibility runner. The adapter forces basic search,
+code-owned domains and provider usage accounting; it performs no hidden retry,
+redirect follow, extraction or result-page fetch. Malformed provider rows and
+local quarantine decisions reach write-once JSON/CSV artifacts separately. The
+default command, `uv run python evidence_gap_phase3_audit.py`, is a zero-network
+identity check; its frozen dry-run validated all 5 collection and plan hashes.
+The adapter/audit/executor subset passed **46/46** tests, including deliberate
+hidden-retry, row-accounting, and non-finite pricing defect re-injection. **No live Tavily pilot has
+run yet**, so this is implementation evidence rather than source quality,
+evidence gain, cost or report improvement. See the
+[phase-3 protocol](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)
+and [implementation result](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md).
+Production remains phase-1 zero-call shadow mode.
+
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
 zero-network census of **95 historical runs** found only **3 in-scope rows over
@@ -1306,6 +1321,17 @@ tests/fixtures/evidence_gap_phase2_challenge.json --output <new-directory>`
 和[结果](docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md)。这些是
 合成执行契约证据，不是线上搜索收益；生产 worker 仍不会实例化 Planner 或
 补充搜索适配器。
+
+第三阶段新增了一个**与生产路径断开、单次请求的 Tavily 适配器**和冻结的五案例
+供应商兼容性 runner。适配器固定使用 basic search、代码自有域名白名单和供应商
+usage 记账，不包含隐藏重试、重定向跟随、正文提取或结果页抓取；格式错误的供应商
+行和本地隔离结果会分别进入 write-once JSON/CSV 产物。默认命令 `uv run python
+evidence_gap_phase3_audit.py` 仍是零网络身份检查，已验证 5/5 集合及计划哈希；
+适配器、审计和执行器子集 **46/46** 通过，并通过临时回注隐藏重试、行数漏记与非有限计费配置
+证明测试会真实变红。**目前尚未运行真实 Tavily pilot**，因此这些结果不代表来源
+质量、证据增量、真实成本或报告改善。详见[第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)
+和[实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)。
+生产环境仍保持第一阶段零补充调用的影子模式。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -65,7 +65,8 @@ source of truth.
 | Blinded utility audit | Five reviewers returned 20/20 eligible judgments; both rounds preferred the full workflow 6:4 for decision usefulness | The pre-registered success rule failed; the monolith led information gain 11:5, so this is not proof of six-stage superiority or adoption |
 | Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
-| Test and CI contract | 1,391 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.01% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
+| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; Phase 3 validated 5/5 collection/plan identities and 46/46 adapter/audit/executor tests | Production remains zero-call shadow mode; no live Tavily quality, evidence-yield, cost, or report-improvement result exists |
+| Test and CI contract | 1,444 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -99,8 +100,9 @@ project's engineering argument: evaluation should be capable of saying no.
 - Run state, quotas, and artifacts are designed for one application replica;
   horizontal scaling requires shared transactional storage and a distributed
   work queue.
-- Evidence-gap planning is shadow-only instrumentation. It records whether a
-  bounded tool call would be justified but does not issue production searches.
+- Evidence-gap production planning remains shadow-only and issues zero
+  supplementary searches. A disconnected phase-2 executor and phase-3
+  single-request adapter exist, but no live Tavily pilot has run.
 - Code-package analysis is not implemented, and patent relevance has no second
   independent reviewer or inter-rater estimate.
 

--- a/docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md
+++ b/docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md
@@ -1,0 +1,183 @@
+# Evidence-gap live provider adapter — phase 3 pre-registration
+
+**Frozen:** 2026-08-25, before the phase-3 provider adapter, manifest, or
+runner was written  
+**Production connection authorized:** no  
+**Live provider requests authorized by this document:** no — execution still
+requires a separate, explicit user authorization with a monetary soft stop
+
+## Question
+
+Can the production-disconnected phase-2 executor call Tavily through an adapter
+that performs exactly one HTTP request, exposes provider credit usage and
+request identity, maps malformed provider rows to inspectable rejections, and
+keeps every result quarantined behind the existing URL, domain, relevance,
+deduplication, and source-registration boundary?
+
+This is a **provider-compatibility pilot**, not a production Tool Calling test.
+The five source collections and their gap intents are frozen fixtures rather
+than newly observed production gaps. The experiment therefore cannot estimate
+planner trigger precision, user value, report-quality improvement, or a
+production success rate.
+
+## Measurement before implementation
+
+The existing data was remeasured before this protocol was written:
+
+- the 30 stored benchmark collections remained 9 `eligible` and 21 `no_gap`;
+- all 18 observed signals remained `authority_category_missing`;
+- the input collections were unchanged and zero supplementary calls ran; and
+- the phase-2 adversarial challenge remained 14/14 exact dispositions, 14/14
+  deterministic replays, and at most two simulated attempts per case.
+
+Those nine eligible collections are a development set, and their original
+retrieval already searched the corresponding authority endpoints. Reusing
+them as evidence of novel search value would therefore be circular.
+
+## Frozen provider contract
+
+The adapter will use Tavily's `POST https://api.tavily.com/search` endpoint.
+The request contract is frozen as follows:
+
+1. `search_depth` is explicitly `basic`; `auto_parameters` is false.
+2. `include_answer`, `include_raw_content`, and `include_images` are false.
+   The adapter retrieves ranked metadata and snippets only; it does not fetch
+   result pages.
+3. `include_usage` is true, and the response must contain both `usage.credits`
+   and `request_id`. A successful response without either field is a failed,
+   uninspectable attempt rather than a free request.
+4. `max_results` equals the already validated call's `result_limit` and may
+   not exceed ten.
+5. `include_domains` is chosen from code-owned allowlists for the capability.
+   User or model text cannot add a domain.
+6. One adapter invocation performs one HTTP request. It has no hidden retry,
+   redirect follow, answer generation, extraction request, or page fetch.
+   Retry ownership remains in the phase-2 executor.
+7. The existing call idempotency key remains the local attempt identity.
+   Tavily does not promise provider-side idempotency, so the study makes no
+   exactly-once claim.
+8. Provider result rows are parsed independently. A malformed row cannot
+   discard a valid sibling row, and every dropped row reaches the audit with a
+   stable rejection code.
+9. The adapter never logs, serializes, hashes into an artifact, or returns the
+   API key.
+
+Tavily's official documentation currently defines basic Search as one credit
+and pay-as-you-go as USD 0.008 per credit. The pilot freezes the conservative
+pay-as-you-go rate of **USD 0.008 per observed credit**, even if the account's
+free allowance makes the actual invoice lower. This prevents a free-tier run
+from being represented as evidence that the operation has no economic cost.
+
+## Frozen five-case pilot manifest
+
+Each case has one synthetic, immutable `SourceCollection`, one deterministic
+gap signal, and one pre-authored `GapSearchIntent`. No planner model runs.
+Every case receives an executor attempt limit of one, so the complete pilot can
+perform at most five provider requests and five basic-search credits.
+
+| ID | Capability | Topic and frozen gap |
+|---|---|---|
+| L01 | `academic_search` | Engineered cutinases for enzymatic PET textile recycling; academic retrieval failed |
+| L02 | `patent_search` | Closed-pore hard-carbon anodes for sodium-ion batteries; patent retrieval failed |
+| L03 | `market_search` | Solid-state transformers for medium-voltage data centres; market retrieval failed |
+| L04 | `authority_search` | AI-enabled retinal screening medical devices; FDA/regulatory evidence missing |
+| L05 | `authority_search` | Personalised neoantigen mRNA vaccines for pancreatic cancer; clinical-registry evidence missing |
+
+The manifest will store the complete collection and plan identities plus their
+SHA-256 values. It is a disclosed compatibility challenge, not a random or
+held-out sample of real user runs.
+
+## Execution authorization and budget
+
+The runner must default to dry-run and open no socket. A live run must require:
+
+- an explicit `--execute-live` switch;
+- `TAVILY_API_KEY` from the process environment, never a command argument;
+- a new output directory that does not already exist;
+- the frozen USD 0.008-per-credit accounting rate; and
+- a separately supplied soft stop of at least USD 0.04 and no more than
+  USD 0.05.
+
+Before each case, the runner must reserve one remaining credit. It stops before
+the request if the projected conservative total would exceed the soft stop.
+Failures are not retried in this pilot. A transport failure with unknown usage
+is `uninspectable`; it is never silently counted as zero cost.
+
+The protocol itself does not authorize those requests. The user must approve
+the live run after reviewing the implementation and exact frozen manifest.
+
+## Artifacts and human review
+
+The live runner writes a new directory once with:
+
+- `manifest.json`: frozen case and identity hashes;
+- `execution.json`: complete executor and provider audit payloads;
+- `candidates.csv`: every returned, adapter-rejected, quarantine-rejected, and
+  accepted row at the public artifact seam; and
+- `review.csv`: accepted candidates with blank `relevant`, `novel`, and
+  `review_note` fields for post-run inspection.
+
+An incomplete review is not a pass. Automated checks may establish request
+budget, schema, and quarantine behavior, but `wrong-source rate` and `novel
+validated evidence yield` remain `not_inspected` until every accepted candidate
+has a completed human label.
+
+## Acceptance criteria for the implementation PR
+
+The code may merge while still production-disconnected only if:
+
+1. the existing zero-network suite, latest Ruff, CI Pylint exception ordering,
+   and the 85% coverage floor remain green;
+2. injected transports prove that one adapter call performs exactly one HTTP
+   request with the frozen body and code-owned domains;
+3. provider usage, request id, provider-row rejection, latency, cost, and trace
+   data reach the final execution artifact;
+4. a one-attempt executor limit prevents retry even for a retryable provider
+   failure;
+5. dry-run, missing-key, malformed-usage, redirect, and budget-stop paths open
+   zero unintended requests and remain observably distinct;
+6. the five-case manifest and all generated artifact schemas reject unknown
+   fields and identity drift;
+7. the production worker still imports neither the phase-2 executor nor the
+   Tavily evidence adapter; and
+8. reintroducing one hidden-retry defect and one provider-row accounting defect
+   makes their targeted tests fail before the defects are removed.
+
+## Criteria for the separately authorized live pilot
+
+The provider-backed pilot is a compatibility pass only if:
+
+- all five manifest identities validate before the first request;
+- no more than five HTTP requests and five credits are observed;
+- conservative incremental cost is no more than USD 0.04;
+- every successful response exposes `request_id` and credit usage;
+- zero policy-rejected or schema-invalid rows enter accepted evidence;
+- all failures, empty results, and uninspectable usage remain distinct; and
+- at least one accepted candidate reaches the human-review packet.
+
+After complete human review, the exploratory value thresholds are:
+
+- wrong-source rate no greater than 5% of accepted candidates; and
+- novel relevant evidence in at least 3 of 5 cases.
+
+Missing either threshold blocks production connection. Passing them still does
+not satisfy the earlier 90% planner-trigger-precision requirement, because this
+pilot injects frozen intents and has no negative planner cases.
+
+## Explicit non-claims
+
+Whether this implementation or pilot passes or fails, it does not establish:
+
+- autonomous Agent tool selection;
+- planner precision or recall;
+- improvement to a commercialization report;
+- production latency, reliability, SLO, or adoption;
+- actual invoice cost below the conservative credit estimate; or
+- permission to merge supplementary evidence into `validated_sources.json`.
+
+Until a later independently labelled study meets every production threshold,
+the accurate description remains:
+
+> A bounded Tool Calling executor has a production-disconnected, single-request
+> Tavily adapter and an auditable live-provider compatibility protocol; the
+> report workflow remains zero-call shadow mode.

--- a/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
+++ b/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
@@ -1,0 +1,138 @@
+# Evidence-gap live-provider adapter — phase 3 implementation result
+
+**Date:** 2026-08-25
+**Status:** **PASS for the production-disconnected adapter and audit contract;
+live provider pilot not run**
+
+## Frozen question
+
+Can the phase-2 executor call Tavily through an adapter that performs exactly
+one HTTP request, exposes provider request and credit accounting, preserves
+malformed result rows as inspectable rejections, and keeps all surviving rows
+behind the existing evidence quarantine?
+
+The protocol was committed before the adapter, manifest, or runner was written:
+[phase-3 pre-registration](prereg-2026-08-25-evidence-gap-live-adapter-phase3.md).
+That protocol does not authorize live requests. No Tavily request was made for
+this implementation result.
+
+## Frozen inputs
+
+The disclosed five-case compatibility manifest is:
+
+- `tests/fixtures/evidence_gap_phase3_manifest.json`
+- fixture SHA-256:
+  `4ee79ec8295c5e51a14fcef78180788be09aaa5102e8e0c6096e0944528339b2`
+- maximum provider requests: **5**
+- request limit per case: **1**
+- conservative accounting rate: **USD 0.008 per observed credit**
+
+| Case | Capability | Collection SHA-256 | Validated plan SHA-256 |
+|---|---|---|---|
+| L01 | `academic_search` | `29c5f4d7950a1b922181b80d5a030d4f6195fe3e36914eba98516477b8b60e0e` | `edf5fa01ef2602e4784a1c142280a7b1cfb89b8eaba6d7e4d0aa6095bcce2fdc` |
+| L02 | `patent_search` | `eb89323dce3f4cd26eeba6c65ca6615192c2d77e5770a01f84292ce34c52e602` | `ebe2eafb2d4edb15bfab92a5ce410682438e29383505f5bf637fc239f6b0af02` |
+| L03 | `market_search` | `5d43335e8573f5339b6dcb9082338404cb48b5cc39427864233f4ecbb83269fc` | `77f1799658dfd8eb38ca7e7bbe7b6e07f5cfc4f2092a616014fd79cd7f53e0df` |
+| L04 | `authority_search` | `b2602e731706f72a391868c59cf52e10fa90c8d24213f57f39edca111a192412` | `24f47b475c9c2ceea18933c5db5e0d9dd7bcc630f2de56877a9cf524edaf4d09` |
+| L05 | `authority_search` | `bf90f23ee209a5047877c6ac613c202fc383e5b29462211dc50cf8d8b9ec1f88` | `6eeb08af683cf1b2a18c312fee0eb7e30c40db88c747299315dd724ac57f3dde` |
+
+Reproduce the zero-network identity check with:
+
+```bash
+uv run python evidence_gap_phase3_audit.py
+```
+
+Dry-run is the command default. It constructs no provider adapter, reads no API
+key, and opens no socket.
+
+## Implemented boundary
+
+The new adapter and runner establish the following implementation facts:
+
+- one adapter invocation calls its injected transport exactly once;
+- the default transport follows no redirects and contains no retry loop;
+- request bodies force Tavily `basic` search, disable generated answers, raw
+  content and images, request usage accounting, and use code-owned domains;
+- the API key is read only from an explicit constructor value or
+  `TAVILY_API_KEY`; it does not enter request bodies or artifacts;
+- a successful response requires both `request_id` and `usage.credits`;
+- provider rows are parsed independently, including malformed URL rows;
+- candidates plus adapter-rejected rows must exactly cover every provider row;
+- provider identity, credits, row rejections, local quarantine decisions,
+  latency, cost, trace ID and the one-attempt limit reach `execution.json`;
+- accepted rows remain a separate evidence delta and never enter
+  `validated_sources.json`; and
+- a live execution, if separately authorized, writes `manifest.json`,
+  `execution.json`, `candidates.csv` and an initially blank `review.csv` once.
+
+The injected five-case artifact test observed five simulated requests, five
+credits, a conservative USD 0.04 total, one adapter-rejected row, five locally
+accepted quarantined rows, and zero production connections. These are fixture
+values, not provider performance or money spent.
+
+## Failure states
+
+The runner keeps these states distinct:
+
+- missing key, invalid soft stop, existing output path, or identity drift fail
+  before any adapter request;
+- redirect and non-retryable HTTP failures are not retried;
+- a retryable transport failure still receives only one pilot attempt;
+- missing usage or request identity makes cost/credits `uninspectable` rather
+  than zero;
+- observed cost can stop the pilot before the next reserved request; and
+- human relevance and novelty remain `not_inspected` until every accepted row
+  in `review.csv` is labelled.
+
+## Defect re-injection
+
+Three implementation defects were temporarily reintroduced after the tests were
+written:
+
+1. A second call to the injected transport made
+   `test_adapter_performs_one_basic_search_and_keeps_secret_out_of_artifacts`
+   fail with two observed calls instead of one.
+2. Counting only parsed candidates instead of every provider result made
+   `test_malformed_provider_rows_are_accounted_without_dropping_valid_siblings`
+   fail at the strict response boundary because three rejected rows vanished
+   from the provider total.
+3. Removing the finite accounting-rate check made the `NaN` and infinity cases
+   in `test_invalid_accounting_rate_fails_before_transport` fail before the
+   defect was removed.
+
+
+All three defects were removed. The adapter, phase-3 audit, and phase-2 executor
+subset then returned to **46/46 passing**. The complete zero-network suite
+passed **1444 tests plus 627 subtests**. CI-equivalent coverage measured
+**87.07%**, above the frozen 85% floor. Latest Ruff and the narrow CI Pylint
+checks for exception order, unreachable code and undefined names also returned
+clean.
+
+## Decision and next gate
+
+The single-request adapter and five-case runner are suitable to merge as a
+**production-disconnected compatibility harness**. The production worker still
+imports neither the phase-2 executor nor this Tavily adapter. Shadow mode still
+performs zero supplementary calls.
+
+The next operation is optional and separately paid: execute the exact five
+cases with `--execute-live`, `TAVILY_API_KEY`, a new output directory, and a
+USD 0.04–0.05 soft stop after explicit user authorization. The resulting
+accepted rows then require complete human review before wrong-source rate or
+novel evidence yield can be calculated.
+
+## Explicit non-claims
+
+This implementation result does **not** establish:
+
+- live-provider compatibility or response quality;
+- planner trigger precision or autonomous tool selection;
+- novel evidence yield or wrong-source rate;
+- improvement to any commercialization report;
+- production latency, reliability, cost, SLO or adoption; or
+- permission to connect supplementary evidence to the report workflow.
+
+The accurate claim at this point is:
+
+> A production-disconnected bounded Tool Calling kernel now has a strict
+> single-request Tavily adapter and a frozen, auditable five-case live-pilot
+> protocol; production remains zero-call shadow mode.

--- a/evidence_gap_phase3_audit.py
+++ b/evidence_gap_phase3_audit.py
@@ -1,0 +1,668 @@
+"""Frozen five-case live-provider compatibility audit for evidence-gap search.
+
+Dry-run is the default and validates every collection and plan identity without
+constructing a provider adapter. Live execution remains production-disconnected
+and requires a separate command switch, environment credential, bounded soft
+stop, and write-once output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.evidence_gap_execution import (
+    EvidenceGapExecutionAudit,
+    execute_gap_plan,
+)
+from academic_agent.source_pipeline import AuthorityCoverage, SourceCollection
+from academic_agent.tools.evidence_search import ReadOnlySearchAdapter
+from academic_agent.tools.tavily_evidence_search import (
+    TAVILY_BASIC_USD_PER_CREDIT,
+    TavilyEvidenceSearchAdapter,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_MANIFEST_PATH = _ROOT / "tests/fixtures/evidence_gap_phase3_manifest.json"
+_COLLECTED_AT = datetime(2026, 8, 25, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 8, 25)
+_EXPECTED_CASE_TOOLS = {
+    "L01": "academic_search",
+    "L02": "patent_search",
+    "L03": "market_search",
+    "L04": "authority_search",
+    "L05": "authority_search",
+}
+_CSV_COLUMNS = (
+    "case_id",
+    "tool",
+    "provider_request_id",
+    "provider_result_index",
+    "adapter_disposition",
+    "local_disposition",
+    "accepted_source_id",
+    "title",
+    "url",
+    "provider_rejection_code",
+    "local_rejection_code",
+    "rejection_detail",
+    "trace_id",
+)
+_REVIEW_COLUMNS = (
+    "case_id",
+    "accepted_source_id",
+    "title",
+    "url",
+    "relevant",
+    "novel",
+    "review_note",
+)
+
+
+class Phase3AuditError(ValueError):
+    """Raised before a provider request when a frozen contract does not join."""
+
+
+class Phase3CaseSpec(BaseModel):
+    """Small deterministic recipe whose expanded identities are frozen."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^L0[1-5]$")
+    tool: Literal[
+        "academic_search",
+        "patent_search",
+        "market_search",
+        "authority_search",
+    ]
+    topic: str = Field(min_length=20, max_length=300)
+    gap_code: Literal["retrieval_domain_failed", "authority_category_missing"]
+    gap_subject: Literal[
+        "academic",
+        "patent",
+        "market",
+        "regulatory",
+        "clinical_registry",
+    ]
+    query: str = Field(min_length=20, max_length=500)
+    result_limit: Literal[5] = 5
+    expected_collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    expected_plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def _validate_gap_shape(self) -> "Phase3CaseSpec":
+        if self.gap_code == "retrieval_domain_failed":
+            if self.gap_subject not in {"academic", "patent", "market"}:
+                raise ValueError("retrieval failure must name an evidence domain")
+        elif self.gap_subject not in {"regulatory", "clinical_registry"}:
+            raise ValueError("authority gap must name a supported authority category")
+        return self
+
+
+class Phase3Manifest(BaseModel):
+    """Frozen pilot fixture with no credential or mutable runtime settings."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    provider: Literal["tavily"] = "tavily"
+    usd_per_credit: Literal[0.008] = TAVILY_BASIC_USD_PER_CREDIT
+    maximum_requests: Literal[5] = 5
+    cases: tuple[Phase3CaseSpec, ...] = Field(min_length=5, max_length=5)
+
+    @model_validator(mode="after")
+    def _validate_frozen_case_set(self) -> "Phase3Manifest":
+        case_ids = [case.case_id for case in self.cases]
+        if case_ids != list(_EXPECTED_CASE_TOOLS):
+            raise ValueError("phase-3 cases must remain ordered L01 through L05")
+        if any(
+            case.tool != _EXPECTED_CASE_TOOLS[case.case_id]
+            for case in self.cases
+        ):
+            raise ValueError("phase-3 capability assignment drifted")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedPhase3Case:
+    spec: Phase3CaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+
+
+class Phase3FrozenCaseArtifact(BaseModel):
+    """Expanded frozen case persisted for independent identity inspection."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: Phase3CaseSpec
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_collection: SourceCollection
+    validated_plan: ValidatedGapPlan
+
+    @model_validator(mode="after")
+    def _validate_expanded_identities(self) -> "Phase3FrozenCaseArtifact":
+        if (
+            source_collection_sha256(self.source_collection)
+            != self.collection_sha256
+        ):
+            raise ValueError("expanded source collection hash does not match")
+        if _plan_sha256(self.validated_plan) != self.plan_sha256:
+            raise ValueError("expanded validated plan hash does not match")
+        return self
+
+
+class Phase3ManifestArtifact(BaseModel):
+    """Write-once expansion of the small fixture into complete frozen inputs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["phase3_frozen_provider_compatibility"] = (
+        "phase3_frozen_provider_compatibility"
+    )
+    production_connected: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    cases: tuple[Phase3FrozenCaseArtifact, ...] = Field(
+        min_length=5,
+        max_length=5,
+    )
+
+
+class Phase3CaseExecution(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^L0[1-5]$")
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    audit: EvidenceGapExecutionAudit
+
+
+class Phase3ExecutionArtifact(BaseModel):
+    """Public live result; unknown and uninspectable are never clean passes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["phase3_live_provider_compatibility"] = (
+        "phase3_live_provider_compatibility"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    provider: Literal["tavily"] = "tavily"
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    soft_stop_usd: float = Field(ge=0.04, le=0.05)
+    usd_per_credit: Literal[0.008] = TAVILY_BASIC_USD_PER_CREDIT
+    request_count: int = Field(ge=0, le=5)
+    credit_state: Literal["known", "uninspectable"]
+    credit_count: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    cost_state: Literal["known", "uninspectable"]
+    conservative_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    completed_case_count: int = Field(ge=0, le=5)
+    stopped_reason: Literal["completed", "soft_stop", "cost_uninspectable"]
+    review_state: Literal["not_inspected"] = "not_inspected"
+    cases: tuple[Phase3CaseExecution, ...] = Field(max_length=5)
+
+    @model_validator(mode="after")
+    def _validate_totals(self) -> "Phase3ExecutionArtifact":
+        requests = sum(case.audit.outbound_attempt_count for case in self.cases)
+        if requests != self.request_count:
+            raise ValueError("request count must equal the executor audit total")
+        if len(self.cases) != self.completed_case_count:
+            raise ValueError("completed case count must equal persisted case audits")
+        if self.credit_state == "known" and self.credit_count is None:
+            raise ValueError("known credits require a numeric total")
+        if self.credit_state == "uninspectable" and self.credit_count is not None:
+            raise ValueError("uninspectable credits must be null")
+        if self.cost_state == "known" and self.conservative_cost_usd is None:
+            raise ValueError("known cost requires a numeric total")
+        if self.cost_state == "uninspectable" and self.conservative_cost_usd is not None:
+            raise ValueError("uninspectable cost must be null")
+        return self
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _seed_source(spec: Phase3CaseSpec) -> EvidenceSource:
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen baseline evidence source",
+        url=f"https://doi.org/10.5555/phase3.{spec.case_id.casefold()}",
+        publisher="Frozen Phase 3 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This frozen baseline source represents prior evidence for {spec.topic}. "
+            "It exists only to make the synthetic collection schema-valid and "
+            "does not answer the separately declared evidence gap."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(spec: Phase3CaseSpec) -> PreparedPhase3Case:
+    """Expand one frozen recipe without clocks, network, models, or randomness."""
+
+    authority_coverage = AuthorityCoverage()
+    failed_domains: dict[str, str] = {}
+    if spec.gap_code == "retrieval_domain_failed":
+        failed_domains[spec.gap_subject] = (
+            "frozen provider-compatibility retrieval failure"
+        )
+    else:
+        authority_coverage = AuthorityCoverage(
+            status="incomplete",
+            required_categories=[spec.gap_subject],
+            missing_categories=[spec.gap_subject],
+        )
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile=(
+            "biomedical" if spec.tool == "authority_search" else "industrial"
+        ),
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        authority_coverage=authority_coverage,
+        failed_domains=failed_domains,
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == spec.gap_code and signal.subject == spec.gap_subject
+        ),
+        None,
+    )
+    if trigger is None:
+        raise Phase3AuditError(f"{spec.case_id}: frozen gap signal was not produced")
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen compatibility case authorizes one read-only provider "
+                "request for its explicit evidence gap."
+            ),
+            calls=(
+                GapSearchIntent(
+                    tool=spec.tool,
+                    query=spec.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=spec.result_limit,
+                ),
+            ),
+        ),
+    )
+    return PreparedPhase3Case(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+    )
+
+
+def load_frozen_cases(
+    manifest_path: Path = DEFAULT_MANIFEST_PATH,
+    *,
+    enforce_hashes: bool = True,
+) -> tuple[str, tuple[PreparedPhase3Case, ...]]:
+    raw = manifest_path.read_bytes()
+    manifest = Phase3Manifest.model_validate_json(raw)
+    prepared = tuple(build_case(spec) for spec in manifest.cases)
+    if enforce_hashes:
+        for case in prepared:
+            if case.collection_sha256 != case.spec.expected_collection_sha256:
+                raise Phase3AuditError(
+                    f"{case.spec.case_id}: source collection identity drifted"
+                )
+            if case.plan_sha256 != case.spec.expected_plan_sha256:
+                raise Phase3AuditError(
+                    f"{case.spec.case_id}: validated plan identity drifted"
+                )
+    return _sha256_bytes(raw), prepared
+
+
+def dry_run(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> dict:
+    """Validate the complete frozen expansion while opening zero sockets."""
+
+    fixture_sha256, cases = load_frozen_cases(manifest_path)
+    return {
+        "mode": "phase3_dry_run",
+        "production_connected": False,
+        "real_network_calls_performed": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_request_count": 5,
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "tool": case.spec.tool,
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _credit_total(
+    executions: list[Phase3CaseExecution],
+) -> tuple[Literal["known", "uninspectable"], float | None]:
+    credits: list[float] = []
+    for execution in executions:
+        for call in execution.audit.call_audits:
+            if call.outbound_attempt_count == 0:
+                continue
+            if call.provider_usage is None:
+                return "uninspectable", None
+            credits.append(call.provider_usage.credit_count)
+    return "known", sum(credits)
+
+
+def _cost_total(
+    executions: list[Phase3CaseExecution],
+) -> tuple[Literal["known", "uninspectable"], float | None]:
+    costs = [item.audit.incremental_search_cost_usd for item in executions]
+    if any(cost is None for cost in costs):
+        return "uninspectable", None
+    return "known", sum(cost for cost in costs if cost is not None)
+
+
+def execute_live_pilot(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    manifest_path: Path = DEFAULT_MANIFEST_PATH,
+    adapter: ReadOnlySearchAdapter | None = None,
+) -> Phase3ExecutionArtifact:
+    """Execute at most one provider request per frozen case, never production."""
+
+    if not 0.04 <= soft_stop_usd <= 0.05:
+        raise Phase3AuditError("soft stop must be between USD 0.04 and USD 0.05")
+    if output_dir.exists():
+        raise FileExistsError(f"phase-3 output already exists: {output_dir}")
+    fixture_sha256, prepared = load_frozen_cases(manifest_path)
+    live_adapter = (
+        adapter if adapter is not None else TavilyEvidenceSearchAdapter()
+    )
+
+    # Reserve the path only after every non-network prerequisite has passed.
+    # A duplicate path therefore fails before adapter construction or billing.
+    output_dir.mkdir(parents=True, exist_ok=False)
+    executions: list[Phase3CaseExecution] = []
+    known_cost = 0.0
+    stopped_reason: Literal["completed", "soft_stop", "cost_uninspectable"] = (
+        "completed"
+    )
+    for case in prepared:
+        projected_cost = known_cost + TAVILY_BASIC_USD_PER_CREDIT
+        if projected_cost > soft_stop_usd + 1e-12:
+            stopped_reason = "soft_stop"
+            break
+        audit = execute_gap_plan(
+            case.collection,
+            context=case.context,
+            plan=case.plan,
+            adapters={case.spec.tool: live_adapter},
+            trace_id=f"phase3-{case.spec.case_id.casefold()}-compatibility",
+            outbound_attempt_limit=1,
+        )
+        executions.append(
+            Phase3CaseExecution(
+                case_id=case.spec.case_id,
+                collection_sha256=case.collection_sha256,
+                plan_sha256=case.plan_sha256,
+                audit=audit,
+            )
+        )
+        if audit.incremental_search_cost_usd is None:
+            stopped_reason = "cost_uninspectable"
+            break
+        known_cost += audit.incremental_search_cost_usd
+
+    credit_state, credit_count = _credit_total(executions)
+    cost_state, conservative_cost = _cost_total(executions)
+    artifact = Phase3ExecutionArtifact(
+        fixture_sha256=fixture_sha256,
+        soft_stop_usd=soft_stop_usd,
+        request_count=sum(
+            item.audit.outbound_attempt_count for item in executions
+        ),
+        credit_state=credit_state,
+        credit_count=credit_count,
+        cost_state=cost_state,
+        conservative_cost_usd=conservative_cost,
+        completed_case_count=len(executions),
+        stopped_reason=stopped_reason,
+        cases=tuple(executions),
+    )
+    write_artifacts(prepared, artifact, output_dir)
+    return artifact
+
+
+def _manifest_artifact(
+    prepared: tuple[PreparedPhase3Case, ...],
+    fixture_sha256: str,
+) -> Phase3ManifestArtifact:
+    return Phase3ManifestArtifact(
+        fixture_sha256=fixture_sha256,
+        cases=tuple(
+            Phase3FrozenCaseArtifact(
+                spec=case.spec,
+                collection_sha256=case.collection_sha256,
+                plan_sha256=case.plan_sha256,
+                source_collection=case.collection,
+                validated_plan=case.plan,
+            )
+            for case in prepared
+        ),
+    )
+
+
+def _candidate_rows(
+    artifact: Phase3ExecutionArtifact,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    rows: list[dict[str, str]] = []
+    reviews: list[dict[str, str]] = []
+    for execution in artifact.cases:
+        for call in execution.audit.call_audits:
+            local_rejections = {
+                item.candidate_index: item for item in call.rejections
+            }
+            accepted_ids = iter(call.accepted_source_ids)
+            for candidate_index, candidate in enumerate(call.candidate_records):
+                local_rejection = local_rejections.get(candidate_index)
+                if local_rejection is not None:
+                    accepted_source_id = ""
+                    local_disposition = "quarantine_rejected"
+                elif call.state == "accepted":
+                    accepted_source_id = next(accepted_ids)
+                    local_disposition = "quarantined_accepted"
+                else:
+                    # A call-level failure invalidates its entire delta. Keep
+                    # the row inspectable without pretending it was accepted.
+                    accepted_source_id = ""
+                    local_disposition = "call_failed_before_registration"
+                row = {
+                    "case_id": execution.case_id,
+                    "tool": call.tool,
+                    "provider_request_id": (
+                        call.provider_usage.request_id if call.provider_usage else ""
+                    ),
+                    "provider_result_index": str(
+                        candidate.provider_result_index
+                        if candidate.provider_result_index is not None
+                        else candidate_index
+                    ),
+                    "adapter_disposition": "candidate",
+                    "local_disposition": local_disposition,
+                    "accepted_source_id": accepted_source_id,
+                    "title": candidate.title,
+                    "url": candidate.url,
+                    "provider_rejection_code": "",
+                    "local_rejection_code": (
+                        local_rejection.code if local_rejection else ""
+                    ),
+                    "rejection_detail": (
+                        local_rejection.detail if local_rejection else ""
+                    ),
+                    "trace_id": call.trace_id,
+                }
+                rows.append(row)
+                if accepted_source_id:
+                    reviews.append(
+                        {
+                            "case_id": execution.case_id,
+                            "accepted_source_id": accepted_source_id,
+                            "title": candidate.title,
+                            "url": candidate.url,
+                            "relevant": "",
+                            "novel": "",
+                            "review_note": "",
+                        }
+                    )
+            for rejection in call.provider_rejections:
+                rows.append(
+                    {
+                        "case_id": execution.case_id,
+                        "tool": call.tool,
+                        "provider_request_id": (
+                            call.provider_usage.request_id
+                            if call.provider_usage
+                            else ""
+                        ),
+                        "provider_result_index": str(
+                            rejection.provider_result_index
+                        ),
+                        "adapter_disposition": "provider_rejected",
+                        "local_disposition": "not_checked",
+                        "accepted_source_id": "",
+                        "title": rejection.title or "",
+                        "url": rejection.url or "",
+                        "provider_rejection_code": rejection.code,
+                        "local_rejection_code": "",
+                        "rejection_detail": rejection.detail,
+                        "trace_id": call.trace_id,
+                    }
+                )
+    rows.sort(key=lambda row: (row["case_id"], int(row["provider_result_index"])))
+    return rows, reviews
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _write_new(path: Path, value: str) -> None:
+    with path.open("x", encoding="utf-8", newline="") as handle:
+        handle.write(value)
+
+
+def write_artifacts(
+    prepared: tuple[PreparedPhase3Case, ...],
+    artifact: Phase3ExecutionArtifact,
+    output_dir: Path,
+) -> None:
+    """Write all public artifacts once; reruns need a new directory."""
+
+    if not output_dir.is_dir():
+        raise FileNotFoundError("phase-3 output directory must already be reserved")
+    manifest = _manifest_artifact(prepared, artifact.fixture_sha256)
+    rows, reviews = _candidate_rows(artifact)
+    _write_new(
+        output_dir / "manifest.json",
+        json.dumps(
+            manifest.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    _write_new(
+        output_dir / "execution.json",
+        artifact.model_dump_json(indent=2) + "\n",
+    )
+    _write_new(output_dir / "candidates.csv", _csv_text(_CSV_COLUMNS, rows))
+    _write_new(output_dir / "review.csv", _csv_text(_REVIEW_COLUMNS, reviews))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST_PATH)
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(json.dumps(dry_run(args.manifest), indent=2, sort_keys=True))
+        return 0
+    if args.output_dir is None or args.soft_stop_usd is None:
+        raise SystemExit(
+            "--execute-live requires --output-dir and --soft-stop-usd"
+        )
+    artifact = execute_live_pilot(
+        output_dir=args.output_dir,
+        soft_stop_usd=args.soft_stop_usd,
+        manifest_path=args.manifest,
+    )
+    print(artifact.model_dump_json(indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/evidence_gap_execution.py
+++ b/src/academic_agent/evidence_gap_execution.py
@@ -39,10 +39,12 @@ from academic_agent.source_pipeline import (
     _topic_keywords,
 )
 from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
     ReadOnlySearchAdapter,
     ToolAdapterFailure,
     ToolAdapterResponse,
     ToolEvidenceCandidate,
+    ToolProviderUsage,
 )
 
 
@@ -121,6 +123,15 @@ class GapToolCallAudit(BaseModel):
         le=MAX_OUTBOUND_SEARCH_ATTEMPTS,
     )
     raw_candidate_count: int = Field(default=0, ge=0, le=10)
+    candidate_records: tuple[ToolEvidenceCandidate, ...] = Field(
+        default=(),
+        max_length=10,
+    )
+    provider_usage: ToolProviderUsage | None = None
+    provider_rejections: tuple[ProviderResultRejection, ...] = Field(
+        default=(),
+        max_length=10,
+    )
     accepted_source_ids: tuple[str, ...] = ()
     rejections: tuple[CandidateRejection, ...] = ()
     latency_ms: float = Field(ge=0.0)
@@ -143,6 +154,29 @@ class GapToolCallAudit(BaseModel):
             raise ValueError(f"{self.state} requires a failure type")
         if self.state not in {"failed", "budget_exhausted"} and self.failure_type:
             raise ValueError("only failed calls may carry a failure type")
+        if self.raw_candidate_count != len(self.candidate_records) + len(
+            self.provider_rejections
+        ):
+            raise ValueError(
+                "raw candidate count must cover provider candidates and rejections"
+            )
+        if self.provider_usage is None:
+            if self.provider_rejections:
+                raise ValueError("provider rejections require provider usage")
+        elif self.provider_usage.result_count != self.raw_candidate_count:
+            raise ValueError("provider usage result count must reach the call audit")
+        if self.state not in {"failed", "budget_exhausted"}:
+            if len(self.accepted_source_ids) + len(self.rejections) != len(
+                self.candidate_records
+            ):
+                raise ValueError(
+                    "every candidate must reach acceptance or local quarantine"
+                )
+            rejection_indices = [item.candidate_index for item in self.rejections]
+            if len(rejection_indices) != len(set(rejection_indices)) or any(
+                index >= len(self.candidate_records) for index in rejection_indices
+            ):
+                raise ValueError("candidate rejection indices must be unique and valid")
         return self
 
 
@@ -159,6 +193,11 @@ class EvidenceGapExecutionAudit(BaseModel):
     source_collection_sha256_before: str = Field(pattern=r"^[0-9a-f]{64}$")
     source_collection_sha256_after: str = Field(pattern=r"^[0-9a-f]{64}$")
     plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    outbound_attempt_limit: int = Field(
+        default=MAX_OUTBOUND_SEARCH_ATTEMPTS,
+        ge=1,
+        le=MAX_OUTBOUND_SEARCH_ATTEMPTS,
+    )
     outbound_attempt_count: int = Field(
         ge=0,
         le=MAX_OUTBOUND_SEARCH_ATTEMPTS,
@@ -175,6 +214,8 @@ class EvidenceGapExecutionAudit(BaseModel):
         attempts = sum(call.outbound_attempt_count for call in self.call_audits)
         if attempts != self.outbound_attempt_count:
             raise ValueError("outbound_attempt_count must equal the call-audit total")
+        if attempts > self.outbound_attempt_limit:
+            raise ValueError("outbound attempts exceed the declared execution limit")
         accepted_ids = tuple(
             source_id
             for call in self.call_audits
@@ -579,6 +620,7 @@ def _non_search_result(
     collection_hash: str,
     plan: ValidatedGapPlan,
     trace_id: str,
+    outbound_attempt_limit: int,
 ) -> EvidenceGapExecutionAudit:
     return EvidenceGapExecutionAudit(
         decision=plan.decision,
@@ -588,6 +630,7 @@ def _non_search_result(
         source_collection_sha256_before=collection_hash,
         source_collection_sha256_after=collection_hash,
         plan_sha256=_plan_sha256(plan),
+        outbound_attempt_limit=outbound_attempt_limit,
         outbound_attempt_count=0,
         trace_id=trace_id,
     )
@@ -600,8 +643,14 @@ def execute_gap_plan(
     plan: ValidatedGapPlan,
     adapters: Mapping[GapToolName, ReadOnlySearchAdapter],
     trace_id: str,
+    outbound_attempt_limit: int = MAX_OUTBOUND_SEARCH_ATTEMPTS,
 ) -> EvidenceGapExecutionAudit:
-    """Execute a validated search plan under one global two-attempt budget."""
+    """Execute a validated search plan under one explicit global attempt budget."""
+
+    if not 1 <= outbound_attempt_limit <= MAX_OUTBOUND_SEARCH_ATTEMPTS:
+        raise EvidenceGapExecutionError(
+            "outbound_attempt_limit must be between one and two"
+        )
 
     before_hash = source_collection_sha256(collection)
     if context.source_collection_sha256 != before_hash:
@@ -614,6 +663,7 @@ def execute_gap_plan(
             collection_hash=before_hash,
             plan=plan,
             trace_id=trace_id,
+            outbound_attempt_limit=outbound_attempt_limit,
         )
 
     next_numbers = _next_source_numbers(collection)
@@ -647,9 +697,7 @@ def execute_gap_plan(
             continue
 
         remaining_calls = len(plan.calls) - call_index - 1
-        attempts_available = (
-            MAX_OUTBOUND_SEARCH_ATTEMPTS - total_attempts
-        )
+        attempts_available = outbound_attempt_limit - total_attempts
         # Reserve one attempt for each later planned call. A single-call plan
         # may retry once; a two-call plan cannot spend the second call's slot.
         attempts_for_call = max(
@@ -697,7 +745,12 @@ def execute_gap_plan(
                     raise EvidenceGapExecutionError(
                         "adapter returned a mismatched idempotency key"
                     )
-                if len(response.candidates) > call.result_limit:
+                raw_result_count = (
+                    response.provider_usage.result_count
+                    if response.provider_usage is not None
+                    else len(response.candidates)
+                )
+                if raw_result_count > call.result_limit:
                     failure_type = "result_limit_exceeded"
                     response = None
                 break
@@ -778,9 +831,14 @@ def execute_gap_plan(
             elif rejection is not None:
                 rejections.append(rejection)
 
+        raw_result_count = (
+            response.provider_usage.result_count
+            if response.provider_usage is not None
+            else len(response.candidates)
+        )
         if accepted_for_call:
             state: CallState = "accepted"
-        elif response.candidates:
+        elif raw_result_count:
             state = "rejected"
         else:
             state = "empty"
@@ -793,7 +851,10 @@ def execute_gap_plan(
                 idempotency_key=call.idempotency_key,
                 state=state,
                 outbound_attempt_count=attempt_count,
-                raw_candidate_count=len(response.candidates),
+                raw_candidate_count=raw_result_count,
+                candidate_records=response.candidates,
+                provider_usage=response.provider_usage,
+                provider_rejections=response.provider_rejections,
                 accepted_source_ids=tuple(accepted_for_call),
                 rejections=tuple(rejections),
                 latency_ms=(time.perf_counter() - started) * 1000,
@@ -826,6 +887,7 @@ def execute_gap_plan(
             source_collection_sha256_before=before_hash,
             source_collection_sha256_after=after_hash,
             plan_sha256=_plan_sha256(plan),
+            outbound_attempt_limit=outbound_attempt_limit,
             outbound_attempt_count=total_attempts,
             call_audits=sanitized_calls,
             incremental_search_cost_usd=total_cost,
@@ -842,6 +904,7 @@ def execute_gap_plan(
         source_collection_sha256_before=before_hash,
         source_collection_sha256_after=after_hash,
         plan_sha256=_plan_sha256(plan),
+        outbound_attempt_limit=outbound_attempt_limit,
         outbound_attempt_count=total_attempts,
         call_audits=tuple(call_audits),
         accepted_sources=tuple(accepted_sources),

--- a/src/academic_agent/tools/evidence_search.py
+++ b/src/academic_agent/tools/evidence_search.py
@@ -8,10 +8,17 @@ rather than being hidden inside a client with its own retry loop.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 from typing import Any, Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    model_validator,
+)
 
 from academic_agent.evidence_gap import GapToolName, ValidatedGapCall
 
@@ -29,10 +36,44 @@ class ToolEvidenceCandidate(BaseModel):
     evidence_summary: str = Field(min_length=1, max_length=8000)
     summary_source: Literal["abstract", "search_snippet"]
     citation_count: int | None = Field(default=None, ge=0)
+    # A provider index is evidence-lineage metadata, not a source identifier.
+    # Keeping it optional preserves the phase-2 fixture contract while letting
+    # a live adapter prove which provider row survived schema validation.
+    provider_result_index: int | None = Field(default=None, ge=0)
 
     @field_serializer("published_date")
     def serialize_date(self, value: date | None) -> str | None:
         return value.isoformat() if value is not None else None
+
+
+ProviderResultRejectionCode = Literal[
+    "provider_result_not_object",
+    "provider_result_schema_invalid",
+]
+
+
+class ProviderResultRejection(BaseModel):
+    """A provider row rejected before it could become a tool candidate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider_result_index: int = Field(ge=0)
+    code: ProviderResultRejectionCode
+    detail: str = Field(min_length=1, max_length=500)
+    title: str | None = Field(default=None, max_length=600)
+    url: str | None = Field(default=None, max_length=2000)
+
+
+class ToolProviderUsage(BaseModel):
+    """Provider-owned request identity and conservative credit accounting."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["tavily"]
+    request_id: str = Field(min_length=3, max_length=300)
+    result_count: int = Field(ge=0, le=20)
+    credit_count: float = Field(ge=0.0, allow_inf_nan=False)
+    usd_per_credit: float = Field(ge=0.0, allow_inf_nan=False)
 
 
 class ToolAdapterResponse(BaseModel):
@@ -50,8 +91,62 @@ class ToolAdapterResponse(BaseModel):
     idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
     outbound_request_count: Literal[1] = 1
     candidates: tuple[ToolEvidenceCandidate, ...] = Field(default=(), max_length=10)
-    search_cost_usd: float = Field(default=0.0, ge=0.0)
+    search_cost_usd: float = Field(default=0.0, ge=0.0, allow_inf_nan=False)
     provider_request_id: str | None = Field(default=None, max_length=300)
+    provider_usage: ToolProviderUsage | None = None
+    provider_rejections: tuple[ProviderResultRejection, ...] = Field(
+        default=(),
+        max_length=20,
+    )
+
+    @model_validator(mode="after")
+    def _validate_provider_accounting(self) -> "ToolAdapterResponse":
+        if self.provider_usage is None:
+            if self.provider_rejections:
+                raise ValueError(
+                    "provider rejections require provider usage accounting"
+                )
+            return self
+
+        usage = self.provider_usage
+        if self.provider_request_id != usage.request_id:
+            raise ValueError(
+                "provider_request_id must match provider usage identity"
+            )
+        if usage.result_count != len(self.candidates) + len(
+            self.provider_rejections
+        ):
+            raise ValueError(
+                "provider result count must cover candidates and rejections"
+            )
+        candidate_indices = [
+            candidate.provider_result_index for candidate in self.candidates
+        ]
+        if any(index is None for index in candidate_indices):
+            raise ValueError(
+                "provider-accounted candidates require provider result indices"
+            )
+        all_indices = [
+            int(index) for index in candidate_indices if index is not None
+        ] + [
+            rejection.provider_result_index
+            for rejection in self.provider_rejections
+        ]
+        if sorted(all_indices) != list(range(usage.result_count)):
+            raise ValueError(
+                "provider result indices must cover every returned row once"
+            )
+        expected_cost = usage.credit_count * usage.usd_per_credit
+        if not math.isclose(
+            self.search_cost_usd,
+            expected_cost,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError(
+                "search cost must equal provider credits times unit cost"
+            )
+        return self
 
 
 class ToolAdapterFailure(RuntimeError):
@@ -70,8 +165,10 @@ class ToolAdapterFailure(RuntimeError):
         search_cost_usd: float | None = None,
     ) -> None:
         super().__init__(message)
-        if search_cost_usd is not None and search_cost_usd < 0:
-            raise ValueError("search_cost_usd cannot be negative")
+        if search_cost_usd is not None and (
+            not math.isfinite(search_cost_usd) or search_cost_usd < 0
+        ):
+            raise ValueError("search_cost_usd must be finite and non-negative")
         self.retryable = retryable
         self.failure_type = failure_type
         self.search_cost_usd = search_cost_usd

--- a/src/academic_agent/tools/tavily_evidence_search.py
+++ b/src/academic_agent/tools/tavily_evidence_search.py
@@ -1,0 +1,333 @@
+"""One-request Tavily adapter for the production-disconnected gap experiment.
+
+The adapter deliberately owns no retry loop, redirect following, result-page
+fetch, or evidence registration. The phase-2 executor owns retry budgets and
+the existing deterministic quarantine owns trust decisions; hiding either
+inside this provider client would make request and evidence accounting false.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from academic_agent.evidence import normalize_doi
+from academic_agent.evidence_gap import GapToolName, ValidatedGapCall
+from academic_agent.source_pipeline import (
+    _AUTHORITATIVE_RESEARCH_DOMAINS,
+    _CLINICAL_REGISTRY_DOMAINS,
+    _CONSULTING_RESEARCH_DOMAINS,
+    _INDUSTRY_NEWS_DOMAINS,
+    _MARKET_RESEARCH_DOMAINS,
+    _NONPROFIT_RESEARCH_DOMAINS,
+    _PATENT_HOSTS,
+    _PRESS_RELEASE_DOMAINS,
+    _REGULATORY_AUTHORITY_DOMAINS,
+    _REPUTABLE_NEWS_DOMAINS,
+    _STANDARDS_BODY_DOMAINS,
+    _THINK_TANK_DOMAINS,
+)
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+
+
+TAVILY_SEARCH_ENDPOINT = "https://api.tavily.com/search"
+TAVILY_BASIC_USD_PER_CREDIT = 0.008
+_ACADEMIC_RECORD_DOMAINS = frozenset(
+    {
+        "arxiv.org",
+        "doi.org",
+        "ncbi.nlm.nih.gov",
+        "openalex.org",
+        "pubmed.ncbi.nlm.nih.gov",
+        "semanticscholar.org",
+    }
+)
+_MARKET_DOMAINS = frozenset().union(
+    _AUTHORITATIVE_RESEARCH_DOMAINS,
+    _CONSULTING_RESEARCH_DOMAINS,
+    _INDUSTRY_NEWS_DOMAINS,
+    _MARKET_RESEARCH_DOMAINS,
+    _NONPROFIT_RESEARCH_DOMAINS,
+    _PRESS_RELEASE_DOMAINS,
+    _REPUTABLE_NEWS_DOMAINS,
+    _STANDARDS_BODY_DOMAINS,
+    _THINK_TANK_DOMAINS,
+)
+_INCLUDE_DOMAINS: Mapping[GapToolName, tuple[str, ...]] = {
+    "academic_search": tuple(sorted(_ACADEMIC_RECORD_DOMAINS)),
+    "patent_search": tuple(sorted(_PATENT_HOSTS)),
+    "market_search": tuple(sorted(_MARKET_DOMAINS)),
+    "authority_search": tuple(
+        sorted(_REGULATORY_AUTHORITY_DOMAINS | _CLINICAL_REGISTRY_DOMAINS)
+    ),
+}
+
+
+class TavilyOneRequestTransport(Protocol):
+    """Injected transport whose one invocation equals one outbound request."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes: ...
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Turn every redirect into HTTPError instead of an uncounted request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _UrllibOneRequestTransport:
+    """Default transport with no redirect or retry behavior."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method="POST",
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read()
+
+
+class _TavilyUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    credits: float = Field(ge=0.0, allow_inf_nan=False)
+
+
+class _TavilyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    request_id: str = Field(min_length=3, max_length=300)
+    results: tuple[Any, ...] = Field(max_length=20)
+    usage: _TavilyUsage
+
+
+class _TavilyResult(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    title: str = Field(min_length=5, max_length=600)
+    url: str = Field(min_length=3, max_length=2000)
+    content: str = Field(min_length=1)
+    published_date: str | None = None
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    """Describe schema failures without copying untrusted provider content."""
+
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "row"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "provider row failed schema validation"
+
+
+def _optional_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        # Date is optional provider metadata. Rejecting an otherwise auditable
+        # record over a malformed date would reduce evidence without improving
+        # URL, source, or topic precision.
+        return None
+
+
+def _doi_from_url(value: str) -> str | None:
+    parsed = urlsplit(value)
+    if (parsed.hostname or "").removeprefix("www.").casefold() != "doi.org":
+        return None
+    return normalize_doi(parsed.path.lstrip("/"))
+
+
+class TavilyEvidenceSearchAdapter:
+    """Convert one Tavily response into unregistered evidence candidates."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 20.0,
+        usd_per_credit: float = TAVILY_BASIC_USD_PER_CREDIT,
+        transport: TavilyOneRequestTransport | None = None,
+    ) -> None:
+        resolved_key = (api_key or os.getenv("TAVILY_API_KEY") or "").strip()
+        if not resolved_key:
+            raise ValueError("TAVILY_API_KEY is required for the live adapter")
+        if not 0 < timeout <= 60:
+            raise ValueError("timeout must be greater than zero and at most 60 seconds")
+        # Validate the accounting rate before constructing any paid request.
+        # Letting NaN or infinity reach the response boundary would turn a
+        # configuration error into an uninspectable cost only after billing.
+        if not math.isfinite(usd_per_credit) or usd_per_credit < 0:
+            raise ValueError("usd_per_credit must be finite and non-negative")
+        self._api_key = resolved_key
+        self._timeout = timeout
+        self._usd_per_credit = usd_per_credit
+        self._transport = transport or _UrllibOneRequestTransport()
+
+    def __call__(self, call: ValidatedGapCall) -> ToolAdapterResponse:
+        """Perform exactly one provider request and preserve every result row."""
+
+        body = json.dumps(
+            {
+                "query": call.query,
+                "search_depth": "basic",
+                "auto_parameters": False,
+                "include_answer": False,
+                "include_raw_content": False,
+                "include_images": False,
+                "include_usage": True,
+                "max_results": call.result_limit,
+                "include_domains": list(_INCLUDE_DOMAINS[call.tool]),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            raw_payload = self._transport(
+                endpoint=TAVILY_SEARCH_ENDPOINT,
+                body=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "AcademicAgentEvidenceGap/1.0",
+                },
+                timeout=self._timeout,
+            )
+        except HTTPError as exc:
+            is_redirect = 300 <= exc.code < 400
+            raise ToolAdapterFailure(
+                f"Tavily HTTP {exc.code}",
+                retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
+                failure_type=("provider_redirect" if is_redirect else "provider_http"),
+                search_cost_usd=None,
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise ToolAdapterFailure(
+                f"Tavily transport failed: {type(exc).__name__}",
+                retryable=True,
+                failure_type="provider_transport",
+                search_cost_usd=None,
+            ) from exc
+
+        try:
+            decoded = json.loads(raw_payload.decode("utf-8"))
+            envelope = _TavilyEnvelope.model_validate(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            raise ToolAdapterFailure(
+                f"Tavily response failed schema validation: {type(exc).__name__}",
+                retryable=False,
+                failure_type="provider_response_invalid",
+                search_cost_usd=None,
+            ) from exc
+
+        cost = envelope.usage.credits * self._usd_per_credit
+        if len(envelope.results) > call.result_limit:
+            raise ToolAdapterFailure(
+                "Tavily returned more rows than the authorized result limit",
+                retryable=False,
+                failure_type="provider_result_limit_exceeded",
+                search_cost_usd=cost,
+            )
+
+        candidates: list[ToolEvidenceCandidate] = []
+        rejections: list[ProviderResultRejection] = []
+        for index, raw_result in enumerate(envelope.results):
+            if not isinstance(raw_result, dict):
+                rejections.append(
+                    ProviderResultRejection(
+                        provider_result_index=index,
+                        code="provider_result_not_object",
+                        detail="provider result must be a JSON object",
+                    )
+                )
+                continue
+            try:
+                result = _TavilyResult.model_validate(raw_result)
+                host = (urlsplit(result.url).hostname or "").removeprefix("www.")
+                candidates.append(
+                    ToolEvidenceCandidate(
+                        title=result.title,
+                        url=result.url,
+                        doi=_doi_from_url(result.url),
+                        publisher=host,
+                        published_date=_optional_date(result.published_date),
+                        evidence_summary=result.content[:8000],
+                        summary_source="search_snippet",
+                        provider_result_index=index,
+                    )
+                )
+            except (ValidationError, ValueError) as exc:
+                detail = (
+                    _validation_detail(exc)
+                    if isinstance(exc, ValidationError)
+                    else f"provider row URL parsing failed: {type(exc).__name__}"
+                )
+                rejections.append(
+                    ProviderResultRejection(
+                        provider_result_index=index,
+                        code="provider_result_schema_invalid",
+                        detail=detail,
+                        title=(
+                            raw_result.get("title")[:600]
+                            if isinstance(raw_result.get("title"), str)
+                            else None
+                        ),
+                        url=(
+                            raw_result.get("url")[:2000]
+                            if isinstance(raw_result.get("url"), str)
+                            else None
+                        ),
+                    )
+                )
+
+        usage = ToolProviderUsage(
+            provider="tavily",
+            request_id=envelope.request_id,
+            result_count=len(envelope.results),
+            credit_count=envelope.usage.credits,
+            usd_per_credit=self._usd_per_credit,
+        )
+        return ToolAdapterResponse(
+            tool=call.tool,
+            idempotency_key=call.idempotency_key,
+            candidates=tuple(candidates),
+            search_cost_usd=cost,
+            provider_request_id=envelope.request_id,
+            provider_usage=usage,
+            provider_rejections=tuple(rejections),
+        )

--- a/tests/fixtures/evidence_gap_phase3_manifest.json
+++ b/tests/fixtures/evidence_gap_phase3_manifest.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "provider": "tavily",
+  "usd_per_credit": 0.008,
+  "maximum_requests": 5,
+  "cases": [
+    {
+      "case_id": "L01",
+      "tool": "academic_search",
+      "topic": "Engineered cutinases for enzymatic PET textile recycling",
+      "gap_code": "retrieval_domain_failed",
+      "gap_subject": "academic",
+      "query": "engineered cutinases enzymatic PET textile recycling academic performance study",
+      "result_limit": 5,
+      "expected_collection_sha256": "29c5f4d7950a1b922181b80d5a030d4f6195fe3e36914eba98516477b8b60e0e",
+      "expected_plan_sha256": "edf5fa01ef2602e4784a1c142280a7b1cfb89b8eaba6d7e4d0aa6095bcce2fdc"
+    },
+    {
+      "case_id": "L02",
+      "tool": "patent_search",
+      "topic": "Closed-pore hard-carbon anodes for sodium-ion batteries",
+      "gap_code": "retrieval_domain_failed",
+      "gap_subject": "patent",
+      "query": "closed-pore hard-carbon anodes sodium-ion battery patent claims",
+      "result_limit": 5,
+      "expected_collection_sha256": "eb89323dce3f4cd26eeba6c65ca6615192c2d77e5770a01f84292ce34c52e602",
+      "expected_plan_sha256": "ebe2eafb2d4edb15bfab92a5ce410682438e29383505f5bf637fc239f6b0af02"
+    },
+    {
+      "case_id": "L03",
+      "tool": "market_search",
+      "topic": "Solid-state transformers for medium-voltage data centres",
+      "gap_code": "retrieval_domain_failed",
+      "gap_subject": "market",
+      "query": "solid-state transformers medium-voltage data centres market deployment adoption",
+      "result_limit": 5,
+      "expected_collection_sha256": "5d43335e8573f5339b6dcb9082338404cb48b5cc39427864233f4ecbb83269fc",
+      "expected_plan_sha256": "77f1799658dfd8eb38ca7e7bbe7b6e07f5cfc4f2092a616014fd79cd7f53e0df"
+    },
+    {
+      "case_id": "L04",
+      "tool": "authority_search",
+      "topic": "AI-enabled retinal screening medical devices",
+      "gap_code": "authority_category_missing",
+      "gap_subject": "regulatory",
+      "query": "AI-enabled retinal screening medical devices FDA regulatory clearance",
+      "result_limit": 5,
+      "expected_collection_sha256": "b2602e731706f72a391868c59cf52e10fa90c8d24213f57f39edca111a192412",
+      "expected_plan_sha256": "24f47b475c9c2ceea18933c5db5e0d9dd7bcc630f2de56877a9cf524edaf4d09"
+    },
+    {
+      "case_id": "L05",
+      "tool": "authority_search",
+      "topic": "Personalised neoantigen mRNA vaccines for pancreatic cancer",
+      "gap_code": "authority_category_missing",
+      "gap_subject": "clinical_registry",
+      "query": "personalised neoantigen mRNA vaccines pancreatic cancer clinical trial registry",
+      "result_limit": 5,
+      "expected_collection_sha256": "bf90f23ee209a5047877c6ac613c202fc383e5b29462211dc50cf8d8b9ec1f88",
+      "expected_plan_sha256": "6eeb08af683cf1b2a18c312fee0eb7e30c40db88c747299315dd724ac57f3dde"
+    }
+  ]
+}

--- a/tests/test_evidence_gap_phase3_audit.py
+++ b/tests/test_evidence_gap_phase3_audit.py
@@ -1,0 +1,318 @@
+"""Frozen Phase-3 provider pilot and public artifact seam tests."""
+
+from __future__ import annotations
+
+import csv
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import evidence_gap_phase3_audit as phase3
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from evidence_gap_phase3_audit import (
+    DEFAULT_MANIFEST_PATH,
+    Phase3AuditError,
+    Phase3ExecutionArtifact,
+    Phase3Manifest,
+    Phase3ManifestArtifact,
+    dry_run,
+    execute_live_pilot,
+    load_frozen_cases,
+    write_artifacts,
+)
+
+
+class FixtureAdapter:
+    """Offline adapter that returns one policy-valid row for every capability."""
+
+    def __init__(self, *, credits: float = 1.0, reject_one_row: bool = False):
+        self.calls = []
+        self.credits = credits
+        self.reject_one_row = reject_one_row
+
+    def __call__(self, call):
+        self.calls.append(call)
+        request_number = len(self.calls)
+        if call.tool == "academic_search":
+            url = f"https://openalex.org/W900000{request_number}"
+        elif call.tool == "patent_search":
+            url = (
+                "https://patents.google.com/patent/"
+                f"US202600000{request_number}A1"
+            )
+        elif call.tool == "market_search":
+            url = (
+                "https://www.reuters.com/technology/"
+                f"phase3-market-{request_number}/"
+            )
+        elif "clinical" in call.query.casefold():
+            url = f"https://clinicaltrials.gov/study/NCT9000000{request_number}"
+        else:
+            url = (
+                "https://www.fda.gov/medical-devices/"
+                f"phase3-regulatory-{request_number}"
+            )
+        candidate = ToolEvidenceCandidate(
+            title=f"{call.query} validated evidence record",
+            url=url,
+            publisher="Frozen Provider Fixture",
+            evidence_summary=(
+                f"{call.query} is documented in this frozen provider response "
+                "with enough topic detail for deterministic relevance checking."
+            ),
+            summary_source="search_snippet",
+            provider_result_index=0,
+        )
+        rejections = ()
+        result_count = 1
+        if self.reject_one_row and request_number == 1:
+            rejections = (
+                ProviderResultRejection(
+                    provider_result_index=1,
+                    code="provider_result_not_object",
+                    detail="provider result must be a JSON object",
+                ),
+            )
+            result_count = 2
+        request_id = f"tavily-fixture-{request_number}"
+        return ToolAdapterResponse(
+            tool=call.tool,
+            idempotency_key=call.idempotency_key,
+            candidates=(candidate,),
+            search_cost_usd=self.credits * 0.008,
+            provider_request_id=request_id,
+            provider_usage=ToolProviderUsage(
+                provider="tavily",
+                request_id=request_id,
+                result_count=result_count,
+                credit_count=self.credits,
+                usd_per_credit=0.008,
+            ),
+            provider_rejections=rejections,
+        )
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_dry_run_validates_five_frozen_identities_without_constructing_adapter(
+    monkeypatch,
+):
+    def forbidden_adapter():
+        raise AssertionError("dry-run must not construct a network adapter")
+
+    monkeypatch.setattr(phase3, "TavilyEvidenceSearchAdapter", forbidden_adapter)
+
+    result = dry_run()
+
+    assert result["mode"] == "phase3_dry_run"
+    assert result["case_count"] == 5
+    assert result["maximum_request_count"] == 5
+    assert result["production_connected"] is False
+    assert result["real_network_calls_performed"] is False
+    assert [case["case_id"] for case in result["cases"]] == [
+        "L01",
+        "L02",
+        "L03",
+        "L04",
+        "L05",
+    ]
+
+
+def test_manifest_identity_drift_fails_before_any_adapter_is_needed(tmp_path):
+    payload = json.loads(DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["cases"][0]["topic"] += " changed"
+    changed = tmp_path / "changed.json"
+    changed.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(Phase3AuditError, match="source collection identity drifted"):
+        load_frozen_cases(changed)
+
+
+def test_manifest_and_execution_schemas_reject_unknown_fields():
+    payload = json.loads(DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["unregistered_override"] = True
+    with pytest.raises(ValidationError):
+        Phase3Manifest.model_validate(payload)
+
+    artifact = {
+        "fixture_sha256": "a" * 64,
+        "soft_stop_usd": 0.04,
+        "request_count": 0,
+        "credit_state": "known",
+        "credit_count": 0,
+        "cost_state": "known",
+        "conservative_cost_usd": 0,
+        "completed_case_count": 0,
+        "stopped_reason": "completed",
+        "cases": [],
+        "unregistered_override": True,
+    }
+    with pytest.raises(ValidationError):
+        Phase3ExecutionArtifact.model_validate(artifact)
+
+    with pytest.raises(ValidationError):
+        Phase3ManifestArtifact.model_validate(
+            {
+                "fixture_sha256": "a" * 64,
+                "cases": [],
+                "unregistered_override": True,
+            }
+        )
+
+
+def test_live_fixture_reaches_all_artifact_seams_without_production_connection(
+    tmp_path,
+):
+    adapter = FixtureAdapter(reject_one_row=True)
+    output = tmp_path / "phase3-live-fixture"
+
+    artifact = execute_live_pilot(
+        output_dir=output,
+        soft_stop_usd=0.04,
+        adapter=adapter,
+    )
+
+    assert len(adapter.calls) == 5
+    assert artifact.request_count == 5
+    assert artifact.credit_state == "known"
+    assert artifact.credit_count == 5
+    assert artifact.cost_state == "known"
+    assert artifact.conservative_cost_usd == pytest.approx(0.04)
+    assert artifact.stopped_reason == "completed"
+    assert artifact.review_state == "not_inspected"
+    assert artifact.production_connected is False
+    assert artifact.report_workflow_connected is False
+    assert {path.name for path in output.iterdir()} == {
+        "manifest.json",
+        "execution.json",
+        "candidates.csv",
+        "review.csv",
+    }
+
+    execution = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    first_call = execution["cases"][0]["audit"]["call_audits"][0]
+    assert first_call["outbound_attempt_count"] == 1
+    assert first_call["provider_usage"]["request_id"] == "tavily-fixture-1"
+    assert first_call["raw_candidate_count"] == 2
+    assert first_call["candidate_records"][0]["provider_result_index"] == 0
+    assert first_call["provider_rejections"][0]["provider_result_index"] == 1
+    assert first_call["latency_ms"] >= 0
+    assert first_call["trace_id"]
+
+    candidate_rows = _read_csv(output / "candidates.csv")
+    assert len(candidate_rows) == 6
+    assert {row["adapter_disposition"] for row in candidate_rows} == {
+        "candidate",
+        "provider_rejected",
+    }
+    assert all(
+        row["local_disposition"] != "quarantined_accepted"
+        or row["accepted_source_id"]
+        for row in candidate_rows
+    )
+    review_rows = _read_csv(output / "review.csv")
+    assert len(review_rows) == 5
+    assert all(row["relevant"] == row["novel"] == "" for row in review_rows)
+
+    _, prepared = load_frozen_cases()
+    with pytest.raises(FileExistsError):
+        write_artifacts(prepared, artifact, output)
+
+
+def test_retryable_failure_stops_after_one_uninspectable_attempt(tmp_path):
+    attempts = 0
+
+    def failing_adapter(call):
+        nonlocal attempts
+        attempts += 1
+        raise ToolAdapterFailure(
+            f"temporary failure for {call.tool}",
+            retryable=True,
+            failure_type="provider_timeout",
+            search_cost_usd=None,
+        )
+
+    artifact = execute_live_pilot(
+        output_dir=tmp_path / "uninspectable",
+        soft_stop_usd=0.04,
+        adapter=failing_adapter,
+    )
+
+    assert attempts == 1
+    assert artifact.request_count == 1
+    assert artifact.cases[0].audit.outbound_attempt_limit == 1
+    assert artifact.credit_state == "uninspectable"
+    assert artifact.credit_count is None
+    assert artifact.cost_state == "uninspectable"
+    assert artifact.conservative_cost_usd is None
+    assert artifact.stopped_reason == "cost_uninspectable"
+
+
+def test_observed_cost_stops_before_a_second_request(tmp_path):
+    adapter = FixtureAdapter(credits=5)
+
+    artifact = execute_live_pilot(
+        output_dir=tmp_path / "soft-stop",
+        soft_stop_usd=0.04,
+        adapter=adapter,
+    )
+
+    assert len(adapter.calls) == 1
+    assert artifact.request_count == 1
+    assert artifact.credit_count == 5
+    assert artifact.conservative_cost_usd == pytest.approx(0.04)
+    assert artifact.stopped_reason == "soft_stop"
+
+
+def test_invalid_budget_existing_output_and_missing_key_fail_before_request(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = FixtureAdapter()
+    with pytest.raises(Phase3AuditError, match="soft stop"):
+        execute_live_pilot(
+            output_dir=tmp_path / "invalid-budget",
+            soft_stop_usd=0.039,
+            adapter=adapter,
+        )
+    assert adapter.calls == []
+
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    with pytest.raises(FileExistsError):
+        execute_live_pilot(
+            output_dir=existing,
+            soft_stop_usd=0.04,
+            adapter=adapter,
+        )
+    assert adapter.calls == []
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    missing_key_output = tmp_path / "missing-key"
+    with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+        execute_live_pilot(
+            output_dir=missing_key_output,
+            soft_stop_usd=0.04,
+        )
+    assert not missing_key_output.exists()
+
+
+def test_phase3_executor_and_adapter_remain_disconnected_from_worker():
+    from academic_agent import pipeline_worker
+
+    source = inspect.getsource(pipeline_worker)
+    assert "academic_agent.evidence_gap_execution" not in source
+    assert "tavily_evidence_search" not in source
+    assert "execute_gap_plan" not in source

--- a/tests/test_tavily_evidence_search.py
+++ b/tests/test_tavily_evidence_search.py
@@ -1,0 +1,255 @@
+"""One-request Tavily adapter contract tests; every transport is offline."""
+
+from __future__ import annotations
+
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.tools.evidence_search import ToolAdapterFailure
+from academic_agent.tools.tavily_evidence_search import (
+    TAVILY_BASIC_USD_PER_CREDIT,
+    TAVILY_SEARCH_ENDPOINT,
+    TavilyEvidenceSearchAdapter,
+)
+
+
+_OUTPUT_DOMAINS = {
+    "academic_search": "academic",
+    "patent_search": "patent",
+    "market_search": "market",
+    "authority_search": "market",
+}
+
+
+def _call(tool: str = "academic_search", *, result_limit: int = 5):
+    return ValidatedGapCall(
+        tool=tool,
+        query="PET cutinase plastic recycling commercial deployment",
+        trigger_ids=("gap-fixture",),
+        result_limit=result_limit,
+        output_domain=_OUTPUT_DOMAINS[tool],
+        idempotency_key="a" * 64,
+    )
+
+
+def _payload(*results, credits: float = 1.0):
+    return {
+        "request_id": "tavily-request-123",
+        "results": list(results),
+        "usage": {"credits": credits},
+    }
+
+
+def _result(
+    *,
+    title: str = "PET cutinase improves enzymatic plastic recycling",
+    url: str = "https://doi.org/10.1000/pet-cutinase",
+    content: str = (
+        "The study reports PET cutinase performance for enzymatic plastic "
+        "recycling under commercially relevant process conditions."
+    ),
+):
+    return {
+        "title": title,
+        "url": url,
+        "content": content,
+        "published_date": "2025-04-03",
+    }
+
+
+class RecordingTransport:
+    def __init__(self, payload: dict):
+        self.payload = payload
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_adapter_performs_one_basic_search_and_keeps_secret_out_of_artifacts():
+    transport = RecordingTransport(_payload(_result()))
+    adapter = TavilyEvidenceSearchAdapter(
+        api_key="tvly-test-secret",
+        transport=transport,
+    )
+
+    response = adapter(_call())
+
+    assert len(transport.calls) == 1
+    request = transport.calls[0]
+    body = json.loads(request["body"])
+    assert request["endpoint"] == TAVILY_SEARCH_ENDPOINT
+    assert request["headers"]["Authorization"] == "Bearer tvly-test-secret"
+    assert body["search_depth"] == "basic"
+    assert body["auto_parameters"] is False
+    assert body["include_answer"] is False
+    assert body["include_raw_content"] is False
+    assert body["include_images"] is False
+    assert body["include_usage"] is True
+    assert body["max_results"] == 5
+    assert body["include_domains"] == sorted(body["include_domains"])
+    assert "doi.org" in body["include_domains"]
+    assert "tvly-test-secret" not in request["body"].decode("utf-8")
+
+    assert response.outbound_request_count == 1
+    assert response.provider_request_id == "tavily-request-123"
+    assert response.provider_usage is not None
+    assert response.provider_usage.result_count == 1
+    assert response.search_cost_usd == pytest.approx(
+        TAVILY_BASIC_USD_PER_CREDIT
+    )
+    assert response.candidates[0].provider_result_index == 0
+    assert response.candidates[0].doi == "10.1000/pet-cutinase"
+    assert response.candidates[0].publisher == "doi.org"
+    serialized = response.model_dump_json()
+    assert "tvly-test-secret" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("tool", "required_domain"),
+    [
+        ("academic_search", "openalex.org"),
+        ("patent_search", "patents.google.com"),
+        ("market_search", "reuters.com"),
+        ("authority_search", "fda.gov"),
+    ],
+)
+def test_each_tool_receives_a_code_owned_sorted_domain_scope(
+    tool,
+    required_domain,
+):
+    transport = RecordingTransport(_payload())
+    adapter = TavilyEvidenceSearchAdapter(api_key="key", transport=transport)
+
+    adapter(_call(tool))
+
+    body = json.loads(transport.calls[0]["body"])
+    assert required_domain in body["include_domains"]
+    assert len(body["include_domains"]) == len(set(body["include_domains"]))
+    assert body["include_domains"] == sorted(body["include_domains"])
+
+
+def test_malformed_provider_rows_are_accounted_without_dropping_valid_siblings():
+    transport = RecordingTransport(
+        _payload(
+            _result(),
+            "not-an-object",
+            {"title": "bad", "url": "https://doi.org/10.1000/bad"},
+            _result(
+                title="Malformed URL should reject only this provider row",
+                url="https://[invalid",
+            ),
+            _result(
+                title="Second PET cutinase plastic recycling evidence record",
+                url="https://openalex.org/W123456",
+            ),
+        )
+    )
+    adapter = TavilyEvidenceSearchAdapter(api_key="key", transport=transport)
+
+    response = adapter(_call())
+
+    assert [item.provider_result_index for item in response.candidates] == [0, 4]
+    assert [item.provider_result_index for item in response.provider_rejections] == [
+        1,
+        2,
+        3,
+    ]
+    assert [item.code for item in response.provider_rejections] == [
+        "provider_result_not_object",
+        "provider_result_schema_invalid",
+        "provider_result_schema_invalid",
+    ]
+    assert response.provider_usage is not None
+    assert response.provider_usage.result_count == 5
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"request_id": "request", "results": []},
+        {"request_id": "request", "results": [], "usage": {}},
+        {"request_id": "x", "results": [], "usage": {"credits": 1}},
+    ],
+)
+def test_missing_or_invalid_provider_accounting_is_not_reported_as_free(payload):
+    transport = RecordingTransport(payload)
+    adapter = TavilyEvidenceSearchAdapter(api_key="key", transport=transport)
+
+    with pytest.raises(ToolAdapterFailure) as caught:
+        adapter(_call())
+
+    assert len(transport.calls) == 1
+    assert caught.value.failure_type == "provider_response_invalid"
+    assert caught.value.search_cost_usd is None
+    assert caught.value.retryable is False
+
+
+@pytest.mark.parametrize(
+    ("status", "retryable", "failure_type"),
+    [
+        (302, False, "provider_redirect"),
+        (401, False, "provider_http"),
+        (408, True, "provider_http"),
+        (429, True, "provider_http"),
+        (503, True, "provider_http"),
+    ],
+)
+def test_http_failures_are_classified_without_a_hidden_retry(
+    status,
+    retryable,
+    failure_type,
+):
+    attempts = 0
+
+    def failing_transport(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise HTTPError(kwargs["endpoint"], status, "fixture", None, None)
+
+    adapter = TavilyEvidenceSearchAdapter(
+        api_key="key",
+        transport=failing_transport,
+    )
+
+    with pytest.raises(ToolAdapterFailure) as caught:
+        adapter(_call())
+
+    assert attempts == 1
+    assert caught.value.retryable is retryable
+    assert caught.value.failure_type == failure_type
+    assert caught.value.search_cost_usd is None
+
+
+def test_provider_result_limit_violation_preserves_known_credit_cost():
+    transport = RecordingTransport(
+        _payload(_result(), _result(title="Another valid PET cutinase result"))
+    )
+    adapter = TavilyEvidenceSearchAdapter(api_key="key", transport=transport)
+
+    with pytest.raises(ToolAdapterFailure) as caught:
+        adapter(_call(result_limit=1))
+
+    assert len(transport.calls) == 1
+    assert caught.value.failure_type == "provider_result_limit_exceeded"
+    assert caught.value.search_cost_usd == pytest.approx(
+        TAVILY_BASIC_USD_PER_CREDIT
+    )
+
+
+@pytest.mark.parametrize("invalid_rate", [float("nan"), float("inf"), -0.001])
+def test_invalid_accounting_rate_fails_before_transport(invalid_rate):
+    transport = RecordingTransport(_payload(_result()))
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        TavilyEvidenceSearchAdapter(
+            api_key="key",
+            usd_per_credit=invalid_rate,
+            transport=transport,
+        )
+
+    assert transport.calls == []


### PR DESCRIPTION
## Why

Phase 2 established deterministic planning and quarantine behavior with injected adapters, but it did not prove that a real provider boundary could preserve request identity, credit cost, and malformed-row lineage. Connecting that unmeasured boundary directly to the report workflow would make paid production behavior unauditable.

## What changed

- add a strict single-request Tavily adapter with code-owned domain scopes, no hidden retry or redirect following, and no result-page fetch;
- require provider request ID and finite credit accounting, while preserving malformed provider rows separately from local quarantine rejections;
- expose an explicit one-attempt executor limit and carry candidates, provider usage, rejections, latency, cost, and trace identity to the final audit seam;
- freeze five collection/plan identities in a dry-run-first Phase 3 runner with write-once JSON/CSV artifacts and blank human-review fields; and
- synchronize the public case study, README, implementation result, and AGENTS index.

## Safety boundary

The production worker, API, and browser remain disconnected from the new adapter. Shadow mode still performs zero supplementary searches. No live Tavily request or paid pilot was run in this PR; live execution still requires separate user authorization, an environment-only key, a new output directory, one attempt per case, and a USD 0.04-0.05 soft stop.

## Verification

- `uv run pytest -q`: 1,444 passed plus 627 subtests;
- CI-equivalent coverage: 87.07%, above the frozen 85% floor;
- `uv run --with ruff ruff check .`: clean;
- narrow CI Pylint checks: clean;
- zero-network Phase 3 dry-run: 5/5 frozen collection and plan hashes reproduced; and
- hidden retry, provider-row undercounting, and non-finite pricing defects were each re-injected and made their seam tests fail before restoration.

The pre-registration and implementation result remain separate artifacts so the eventual paid pilot cannot silently rewrite its acceptance criteria.
