### PR TITLE
Fail closed on the committed Phase 3 fixture identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1444 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1445 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -194,9 +194,14 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   adapter forces basic search, code-owned domains, no redirects or internal
   retry, and requires provider request/credit accounting. Candidates, malformed
   result rows, local quarantine decisions, cost, latency and trace data reach
-  write-once JSON/CSV artifacts. The adapter/audit/executor subset passed 46/46
-  tests; temporary hidden-second-request and provider-row-under-count defects
-  both made their seam tests fail before restoration.
+  write-once JSON/CSV artifacts. The first authorized post-merge preflight
+  found that the implementation result had recorded a pre-commit draft's raw
+  fixture hash rather than the first committed artifact. It stopped before
+  adapter construction with zero requests and zero cost. The runner now checks
+  the canonical committed bytes before JSON parsing or case expansion. The
+  adapter/audit/executor subset passed 52/52 tests; temporary fixture-identity,
+  hidden-second-request and provider-row-under-count defects made their seam
+  tests fail before restoration.
   No live Tavily request has run, so no provider compatibility, evidence yield,
   wrong-source rate, real cost, latency, report-quality improvement, reliability
   or planner-precision result exists. A separately authorized live pilot is
@@ -206,7 +211,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   Keep `pipeline_worker.py` disconnected from both executor and adapter.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`
   and
-  `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`.
+  `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,
+  plus
+  `docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -389,12 +389,18 @@ redirect follow, extraction or result-page fetch. Malformed provider rows and
 local quarantine decisions reach write-once JSON/CSV artifacts separately. The
 default command, `uv run python evidence_gap_phase3_audit.py`, is a zero-network
 identity check; its frozen dry-run validated all 5 collection and plan hashes.
-The adapter/audit/executor subset passed **46/46** tests, including deliberate
-hidden-retry, row-accounting, and non-finite pricing defect re-injection. **No live Tavily pilot has
-run yet**, so this is implementation evidence rather than source quality,
-evidence gain, cost or report improvement. See the
-[phase-3 protocol](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)
-and [implementation result](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md).
+The first authorized post-merge preflight then found that the implementation
+result had recorded a pre-commit draft's fixture SHA instead of the first
+committed artifact; it stopped before adapter construction with zero provider
+requests and zero cost. The runner now checks the canonical raw-byte identity
+before parsing or case expansion. The adapter/audit/executor subset passed
+**52/52** tests, including deliberate fixture-identity, hidden-retry,
+row-accounting, and non-finite pricing defect re-injection. **No live Tavily
+pilot has run yet**, so this is implementation evidence rather than source
+quality, evidence gain, cost or report improvement. See the
+[phase-3 protocol](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md),
+the [implementation result](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md),
+and the [fixture-identity erratum](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md).
 Production remains phase-1 zero-call shadow mode.
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
@@ -1327,10 +1333,14 @@ tests/fixtures/evidence_gap_phase2_challenge.json --output <new-directory>`
 usage 记账，不包含隐藏重试、重定向跟随、正文提取或结果页抓取；格式错误的供应商
 行和本地隔离结果会分别进入 write-once JSON/CSV 产物。默认命令 `uv run python
 evidence_gap_phase3_audit.py` 仍是零网络身份检查，已验证 5/5 集合及计划哈希；
-适配器、审计和执行器子集 **46/46** 通过，并通过临时回注隐藏重试、行数漏记与非有限计费配置
+首次获授权的合并后预检发现，实现结果误记了提交前草稿的夹具 SHA，而不是首个
+已提交产物；系统在构造适配器前停止，供应商请求和成本均为 0。runner 现在会在
+解析 JSON 或展开案例前校验规范的原始字节身份。适配器、审计和执行器子集
+**52/52** 通过，并通过临时回注夹具身份、隐藏重试、行数漏记与非有限计费配置
 证明测试会真实变红。**目前尚未运行真实 Tavily pilot**，因此这些结果不代表来源
-质量、证据增量、真实成本或报告改善。详见[第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)
-和[实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)。
+质量、证据增量、真实成本或报告改善。详见[第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)、
+[实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)
+和[夹具身份勘误](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md)。
 生产环境仍保持第一阶段零补充调用的影子模式。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次

--- a/docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md
+++ b/docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md
@@ -1,0 +1,62 @@
+# Phase 3 fixture identity — preflight erratum
+
+**Date discovered:** 2026-08-25
+**Live provider requests before discovery:** **0**
+**Cost before discovery:** **USD 0.00**
+
+## What the preflight found
+
+After PR #38 merged, the study owner authorized the separately gated Tavily
+compatibility pilot. The mandatory dry-run reproduced all five frozen
+collection hashes and all five validated-plan hashes, but reported the raw
+manifest SHA-256 as:
+
+`4f216d5a7ad0f44db0b973a10087fc6075ac1a2dddddde0430faf62595ca377f`
+
+The Phase 3 implementation result had instead recorded:
+
+`4ee79ec8295c5e51a14fcef78180788be09aaa5102e8e0c6096e0944528339b2`
+
+The pilot stopped at that discrepancy. No live adapter was constructed, no
+output directory was reserved, and no provider request was made.
+
+## Cause
+
+The incorrect value came from a pre-commit working-tree draft. The raw bytes in
+Git's first public blob for the manifest have the `4f216d...` SHA-256 above.
+Recomputing common line-ending variants did
+not reproduce `4ee79e...`: the committed LF bytes hash to `4f216d...`, while a
+CRLF conversion hashes to `eb476b...`. The earlier value therefore does not
+identify a reproducible repository artifact.
+
+This is an artifact-provenance defect, not evidence that a topic, query,
+collection, or validated plan changed. The ten semantic identities remained
+byte-for-byte equal to their disclosed values.
+
+## Correction
+
+The first committed manifest blob is now the canonical Phase 3 fixture:
+
+`4f216d5a7ad0f44db0b973a10087fc6075ac1a2dddddde0430faf62595ca377f`
+
+The runner now freezes that value in code and validates it before JSON parsing
+or case expansion. Whitespace-only edits therefore fail before adapter
+construction or billing. The original implementation-result commit remains in
+Git history; this erratum supplements it instead of pretending the incorrect
+value was never published.
+
+## Experiment status
+
+The live-provider pilot remains **not run**. The earlier authorization applied
+to revision `5be937e`, whose preflight exposed this defect, and is not silently
+carried to a corrected revision. After the correction merges and CI/deployment
+checks pass, live execution requires a new explicit authorization with the same
+five-request maximum and USD 0.04 soft stop.
+
+No other acceptance threshold changes:
+
+- at most five requests and five observed credits;
+- conservative cost no greater than USD 0.04;
+- complete request, usage, row, quarantine, latency, and trace accounting;
+- zero policy-invalid rows entering the evidence delta; and
+- human review before any wrong-source or novel-evidence claim.

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -65,8 +65,8 @@ source of truth.
 | Blinded utility audit | Five reviewers returned 20/20 eligible judgments; both rounds preferred the full workflow 6:4 for decision usefulness | The pre-registered success rule failed; the monolith led information gain 11:5, so this is not proof of six-stage superiority or adoption |
 | Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
-| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; Phase 3 validated 5/5 collection/plan identities and 46/46 adapter/audit/executor tests | Production remains zero-call shadow mode; no live Tavily quality, evidence-yield, cost, or report-improvement result exists |
-| Test and CI contract | 1,444 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
+| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; Phase 3 validated 5/5 collection/plan identities and 52/52 adapter/audit/executor tests; its first authorized preflight stopped on a raw fixture-identity discrepancy before any provider request | Production remains zero-call shadow mode; no live Tavily quality, evidence-yield, cost, or report-improvement result exists |
+| Test and CI contract | 1,445 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -102,7 +102,9 @@ project's engineering argument: evaluation should be capable of saying no.
   work queue.
 - Evidence-gap production planning remains shadow-only and issues zero
   supplementary searches. A disconnected phase-2 executor and phase-3
-  single-request adapter exist, but no live Tavily pilot has run.
+  single-request adapter exist. The first authorized Phase 3 preflight exposed
+  and fail-closed on an artifact-provenance defect at zero cost; no live Tavily
+  pilot has run.
 - Code-package analysis is not implemented, and patent relevance has no second
   independent reviewer or inter-rater estimate.
 

--- a/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
+++ b/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
@@ -4,6 +4,13 @@
 **Status:** **PASS for the production-disconnected adapter and audit contract;
 live provider pilot not run**
 
+> **Post-publication correction (2026-08-25):** the first authorized live
+> preflight found that this result had recorded a pre-commit draft's manifest
+> SHA-256 instead of the first committed Git artifact. It stopped before
+> adapter construction and made zero provider requests. The canonical value
+> and fail-closed correction are documented in the
+> [fixture-identity erratum](errata-2026-08-25-evidence-gap-phase3-fixture-identity.md).
+
 ## Frozen question
 
 Can the phase-2 executor call Tavily through an adapter that performs exactly
@@ -22,7 +29,9 @@ The disclosed five-case compatibility manifest is:
 
 - `tests/fixtures/evidence_gap_phase3_manifest.json`
 - fixture SHA-256:
-  `4ee79ec8295c5e51a14fcef78180788be09aaa5102e8e0c6096e0944528339b2`
+  `4f216d5a7ad0f44db0b973a10087fc6075ac1a2dddddde0430faf62595ca377f`
+  (the previously published `4ee79e...` value identified an uncommitted draft
+  and is retracted; see the erratum above)
 - maximum provider requests: **5**
 - request limit per case: **1**
 - conservative accounting rate: **USD 0.008 per observed credit**
@@ -85,7 +94,7 @@ The runner keeps these states distinct:
 
 ## Defect re-injection
 
-Three implementation defects were temporarily reintroduced after the tests were
+Four implementation defects were temporarily reintroduced after the tests were
 written:
 
 1. A second call to the injected transport made
@@ -98,11 +107,15 @@ written:
 3. Removing the finite accounting-rate check made the `NaN` and infinity cases
    in `test_invalid_accounting_rate_fails_before_transport` fail before the
    defect was removed.
+4. Removing the raw fixture-identity gate made
+   `test_manifest_raw_identity_drift_fails_before_case_expansion` enter case
+   expansion and fail on L01 instead of rejecting the changed bytes.
 
 
-All three defects were removed. The adapter, phase-3 audit, and phase-2 executor
-subset then returned to **46/46 passing**. The complete zero-network suite
-passed **1444 tests plus 627 subtests**. CI-equivalent coverage measured
+All four defects were removed. The current adapter, phase-3 audit, and phase-2
+executor subset, including five executor tests added after the original result,
+returned to **52/52 passing**. The complete zero-network suite passed **1445
+tests plus 627 subtests**. CI-equivalent coverage measured
 **87.07%**, above the frozen 85% floor. Latest Ruff and the narrow CI Pylint
 checks for exception order, unreachable code and undefined names also returned
 clean.

--- a/evidence_gap_phase3_audit.py
+++ b/evidence_gap_phase3_audit.py
@@ -44,6 +44,12 @@ from academic_agent.tools.tavily_evidence_search import (
 
 _ROOT = Path(__file__).resolve().parent
 DEFAULT_MANIFEST_PATH = _ROOT / "tests/fixtures/evidence_gap_phase3_manifest.json"
+# This is the SHA-256 of the bytes stored by the manifest's first committed Git
+# blob, not the pre-commit working-tree draft. A live pilot must bind to bytes
+# another reviewer can reproduce from the repository.
+EXPECTED_FIXTURE_SHA256 = (
+    "4f216d5a7ad0f44db0b973a10087fc6075ac1a2dddddde0430faf62595ca377f"
+)
 _COLLECTED_AT = datetime(2026, 8, 25, tzinfo=UTC)
 _ACCESSED_DATE = date(2026, 8, 25)
 _EXPECTED_CASE_TOOLS = {
@@ -353,6 +359,14 @@ def load_frozen_cases(
     enforce_hashes: bool = True,
 ) -> tuple[str, tuple[PreparedPhase3Case, ...]]:
     raw = manifest_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if enforce_hashes and fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+        # Check raw identity before parsing or expanding cases. Schema-valid
+        # JSON with only whitespace changed is still a different frozen input.
+        raise Phase3AuditError(
+            "phase-3 fixture byte identity drifted: "
+            f"expected {EXPECTED_FIXTURE_SHA256}, got {fixture_sha256}"
+        )
     manifest = Phase3Manifest.model_validate_json(raw)
     prepared = tuple(build_case(spec) for spec in manifest.cases)
     if enforce_hashes:
@@ -365,7 +379,7 @@ def load_frozen_cases(
                 raise Phase3AuditError(
                     f"{case.spec.case_id}: validated plan identity drifted"
                 )
-    return _sha256_bytes(raw), prepared
+    return fixture_sha256, prepared
 
 
 def dry_run(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> dict:

--- a/tests/test_evidence_gap_phase3_audit.py
+++ b/tests/test_evidence_gap_phase3_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import inspect
 import json
 from pathlib import Path
@@ -20,6 +21,7 @@ from academic_agent.tools.evidence_search import (
 )
 from evidence_gap_phase3_audit import (
     DEFAULT_MANIFEST_PATH,
+    EXPECTED_FIXTURE_SHA256,
     Phase3AuditError,
     Phase3ExecutionArtifact,
     Phase3Manifest,
@@ -121,6 +123,7 @@ def test_dry_run_validates_five_frozen_identities_without_constructing_adapter(
     assert result["maximum_request_count"] == 5
     assert result["production_connected"] is False
     assert result["real_network_calls_performed"] is False
+    assert result["fixture_sha256"] == EXPECTED_FIXTURE_SHA256
     assert [case["case_id"] for case in result["cases"]] == [
         "L01",
         "L02",
@@ -130,11 +133,35 @@ def test_dry_run_validates_five_frozen_identities_without_constructing_adapter(
     ]
 
 
-def test_manifest_identity_drift_fails_before_any_adapter_is_needed(tmp_path):
+def test_manifest_raw_identity_drift_fails_before_case_expansion(
+    tmp_path,
+    monkeypatch,
+):
+    changed = tmp_path / "whitespace-changed.json"
+    changed.write_bytes(DEFAULT_MANIFEST_PATH.read_bytes() + b"\n")
+
+    def forbidden_build_case(spec):
+        raise AssertionError(f"case expansion must not run for {spec.case_id}")
+
+    monkeypatch.setattr(phase3, "build_case", forbidden_build_case)
+
+    with pytest.raises(Phase3AuditError, match="fixture byte identity drifted"):
+        load_frozen_cases(changed)
+
+
+def test_manifest_semantic_identity_drift_still_fails_after_raw_hash_gate(
+    tmp_path,
+    monkeypatch,
+):
     payload = json.loads(DEFAULT_MANIFEST_PATH.read_text(encoding="utf-8"))
     payload["cases"][0]["topic"] += " changed"
     changed = tmp_path / "changed.json"
     changed.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(
+        phase3,
+        "EXPECTED_FIXTURE_SHA256",
+        hashlib.sha256(changed.read_bytes()).hexdigest(),
+    )
 
     with pytest.raises(Phase3AuditError, match="source collection identity drifted"):
         load_frozen_cases(changed)


### PR DESCRIPTION
## Why

The first authorized post-merge live-pilot preflight reproduced all five collection and plan identities but found that the published fixture SHA referred to an uncommitted draft. The pilot stopped before adapter construction, so it made zero Tavily requests and spent USD 0.00.

## What changed

- freeze the raw SHA-256 of the bytes in the manifest's first committed Git blob
- reject raw-byte drift before JSON parsing, case expansion, adapter construction, or billing
- retain the existing semantic collection and plan identity checks
- add seam tests and prove the new test fails when the gate is removed
- publish an explicit erratum and synchronize README, AGENTS, and the portfolio case study
- require fresh authorization for the corrected revision rather than carrying forward the authorization for 5be937e

## Verification

- 1,445 tests plus 627 subtests passed
- current adapter/audit/executor subset: 52/52 passed
- CI-equivalent coverage: 87.07 percent, above the 85 percent floor
- latest Ruff passed
- narrow CI Pylint passed
- zero-network Phase 3 dry-run reproduced fixture SHA 4f216d5a and all five frozen collection/plan identities
- defect re-injection failed at L01 case expansion, then passed after restoration

No live provider request was made by this change.