### PR TITLE
Record the Phase 3 live pilot and harden CLI JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1445 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1446 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -198,22 +198,30 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   found that the implementation result had recorded a pre-commit draft's raw
   fixture hash rather than the first committed artifact. It stopped before
   adapter construction with zero requests and zero cost. The runner now checks
-  the canonical committed bytes before JSON parsing or case expansion. The
-  adapter/audit/executor subset passed 52/52 tests; temporary fixture-identity,
-  hidden-second-request and provider-row-under-count defects made their seam
-  tests fail before restoration.
-  No live Tavily request has run, so no provider compatibility, evidence yield,
-  wrong-source rate, real cost, latency, report-quality improvement, reliability
-  or planner-precision result exists. A separately authorized live pilot is
-  required, and every accepted row must then receive complete relevance and
-  novelty review. Even a pilot pass would not authorize production connection:
-  planner trigger precision and disabled-path thresholds remain unsatisfied.
+  the canonical committed bytes before JSON parsing or case expansion.
+  A fresh authorization on deployed revision `adde83d` then completed the exact
+  five-case pilot: five single-attempt requests, five inspectable credits, USD
+  0.040 conservative cost, and 25 unique policy-valid rows reached the blank
+  human-review packet. Production and report connections remained false. All
+  automated provider-compatibility criteria passed, but all 25 relevance and
+  novelty labels remain blank, so wrong-source rate and novel evidence yield
+  are `not_inspected`.
+  The paid work and UTF-8 artifacts completed before the Windows GBK stdout
+  projection raised on U+2005 and returned exit code 1. The CLI now emits
+  reversible ASCII-safe JSON without changing authoritative UTF-8 artifacts.
+  The adapter/audit/executor subset passed 53/53 tests; temporary fixture-
+  identity, hidden-second-request, provider-row-under-count, and GBK-output
+  defects made their seam tests fail before restoration.
+  The compatibility pass does not establish source truth, evidence yield,
+  report improvement, reliability, or planner precision. Every accepted row
+  still requires complete human review. Even a value-threshold pass would not
+  authorize production connection: planner trigger precision and disabled-path
+  thresholds remain unsatisfied.
   Keep `pipeline_worker.py` disconnected from both executor and adapter.
-  See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`
-  and
+  See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,
-  plus
-  `docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md`.
+  `docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md`, and
+  `docs/results-2026-08-25-evidence-gap-live-provider-phase3.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -393,14 +393,22 @@ The first authorized post-merge preflight then found that the implementation
 result had recorded a pre-commit draft's fixture SHA instead of the first
 committed artifact; it stopped before adapter construction with zero provider
 requests and zero cost. The runner now checks the canonical raw-byte identity
-before parsing or case expansion. The adapter/audit/executor subset passed
-**52/52** tests, including deliberate fixture-identity, hidden-retry,
-row-accounting, and non-finite pricing defect re-injection. **No live Tavily
-pilot has run yet**, so this is implementation evidence rather than source
-quality, evidence gain, cost or report improvement. See the
+before parsing or case expansion. A fresh authorization on deployed revision
+`adde83d` then completed the exact pilot: 5/5 cases, five single-attempt
+requests, five inspectable credits, USD 0.040 conservative cost, and 25 unique
+policy-valid rows reached a blank human-review packet. Automated provider
+compatibility passed, but relevance and novelty remain `not_inspected`.
+The paid work and UTF-8 artifacts completed before a Windows GBK stdout
+projection failed on U+2005; the CLI now emits reversible ASCII-safe JSON while
+preserving original artifact text. The adapter/audit/executor subset passed
+**53/53** tests, including deliberate fixture-identity, hidden-retry,
+row-accounting, non-finite pricing, and GBK-output defect re-injection. This
+does not establish source truth, evidence gain, report improvement, or planner
+precision. See the
 [phase-3 protocol](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md),
 the [implementation result](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md),
-and the [fixture-identity erratum](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md).
+the [fixture-identity erratum](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md),
+and the [live-provider result](docs/results-2026-08-25-evidence-gap-live-provider-phase3.md).
 Production remains phase-1 zero-call shadow mode.
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
@@ -1335,12 +1343,18 @@ usage 记账，不包含隐藏重试、重定向跟随、正文提取或结果�
 evidence_gap_phase3_audit.py` 仍是零网络身份检查，已验证 5/5 集合及计划哈希；
 首次获授权的合并后预检发现，实现结果误记了提交前草稿的夹具 SHA，而不是首个
 已提交产物；系统在构造适配器前停止，供应商请求和成本均为 0。runner 现在会在
-解析 JSON 或展开案例前校验规范的原始字节身份。适配器、审计和执行器子集
-**52/52** 通过，并通过临时回注夹具身份、隐藏重试、行数漏记与非有限计费配置
-证明测试会真实变红。**目前尚未运行真实 Tavily pilot**，因此这些结果不代表来源
-质量、证据增量、真实成本或报告改善。详见[第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)、
-[实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)
-和[夹具身份勘误](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md)。
+解析 JSON 或展开案例前校验规范的原始字节身份。修复部署后获得新的明确授权，
+精确五案例 pilot 完成 5/5 案例、5 次单次尝试请求、5 个可检查 credits 和
+USD 0.040 保守成本；25 个唯一且通过策略校验的 URL 进入空白人审表。自动供应商
+兼容性标准通过，但相关性和新颖性仍为 `not_inspected`。付费工作与 UTF-8 产物
+完成后，Windows GBK stdout 在 U+2005 上打印失败；CLI 现改为可逆的 ASCII-safe
+JSON，原始 UTF-8 产物不变。适配器、审计和执行器子集 **53/53** 通过，并通过
+临时回注夹具身份、隐藏重试、行数漏记、非有限计费和 GBK 输出缺陷证明测试会
+真实变红。这些结果不代表来源真值、证据增量、报告改善或 Planner 精度。详见
+[第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)、
+[实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)、
+[夹具身份勘误](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md)
+和[真实供应商结果](docs/results-2026-08-25-evidence-gap-live-provider-phase3.md)。
 生产环境仍保持第一阶段零补充调用的影子模式。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次

--- a/docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md
+++ b/docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md
@@ -47,11 +47,14 @@ value was never published.
 
 ## Experiment status
 
-The live-provider pilot remains **not run**. The earlier authorization applied
-to revision `5be937e`, whose preflight exposed this defect, and is not silently
-carried to a corrected revision. After the correction merges and CI/deployment
-checks pass, live execution requires a new explicit authorization with the same
-five-request maximum and USD 0.04 soft stop.
+At publication, the live-provider pilot remained **not run**. The earlier
+authorization applied to revision `5be937e`, whose preflight exposed this
+defect, and was not silently carried to a corrected revision.
+
+After the correction merged, the study owner issued a fresh authorization for
+deployed revision `adde83d`. The exact five-case run then completed five
+requests and five credits at a conservative USD 0.04. See the
+[live-provider result](results-2026-08-25-evidence-gap-live-provider-phase3.md).
 
 No other acceptance threshold changes:
 

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -65,8 +65,8 @@ source of truth.
 | Blinded utility audit | Five reviewers returned 20/20 eligible judgments; both rounds preferred the full workflow 6:4 for decision usefulness | The pre-registered success rule failed; the monolith led information gain 11:5, so this is not proof of six-stage superiority or adoption |
 | Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
-| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; Phase 3 validated 5/5 collection/plan identities and 52/52 adapter/audit/executor tests; its first authorized preflight stopped on a raw fixture-identity discrepancy before any provider request | Production remains zero-call shadow mode; no live Tavily quality, evidence-yield, cost, or report-improvement result exists |
-| Test and CI contract | 1,445 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
+| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; one Phase 3 live pilot completed 5/5 single-attempt requests, 5 credits and USD 0.040 conservative cost, with 25 rows reaching human review; the current adapter/audit/executor subset passed 53/53 | Production remains zero-call shadow mode; all 25 human labels remain blank, so source quality, evidence yield, and report improvement are not inspected |
+| Test and CI contract | 1,446 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -102,9 +102,10 @@ project's engineering argument: evaluation should be capable of saying no.
   work queue.
 - Evidence-gap production planning remains shadow-only and issues zero
   supplementary searches. A disconnected phase-2 executor and phase-3
-  single-request adapter exist. The first authorized Phase 3 preflight exposed
-  and fail-closed on an artifact-provenance defect at zero cost; no live Tavily
-  pilot has run.
+  single-request adapter exist. One five-case live pilot passed the automated
+  compatibility thresholds at USD 0.040, but all 25 relevance and novelty
+  labels remain blank. It therefore establishes neither evidence value nor
+  permission to connect the adapter to reports.
 - Code-package analysis is not implemented, and patent relevance has no second
   independent reviewer or inter-rater estimate.
 

--- a/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
+++ b/docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md
@@ -11,6 +11,13 @@ live provider pilot not run**
 > and fail-closed correction are documented in the
 > [fixture-identity erratum](errata-2026-08-25-evidence-gap-phase3-fixture-identity.md).
 
+> **Post-correction follow-up (2026-08-25):** a fresh authorization on deployed
+> revision `adde83d` completed the exact five-case pilot with five requests,
+> five credits, and USD 0.040 conservative cost. Automated provider
+> compatibility passed; all 25 relevance and novelty labels remain blank. A
+> post-artifact Windows GBK stdout defect is disclosed in the
+> [live-provider result](results-2026-08-25-evidence-gap-live-provider-phase3.md).
+
 ## Frozen question
 
 Can the phase-2 executor call Tavily through an adapter that performs exactly

--- a/docs/results-2026-08-25-evidence-gap-live-provider-phase3.md
+++ b/docs/results-2026-08-25-evidence-gap-live-provider-phase3.md
@@ -1,0 +1,156 @@
+# Result: Phase 3 live-provider compatibility pilot
+
+**Date:** 2026-08-25
+
+**Authorized revision:** `adde83dfd7d40c7fdd425b6f665eb121bb300e33`
+
+**Status:** **AUTOMATED PROVIDER-COMPATIBILITY PASS; HUMAN VALUE REVIEW NOT
+INSPECTED; WINDOWS CLI PRESENTATION DEFECT FOUND**
+
+## Scope and authorization
+
+The study owner explicitly authorized the frozen five-case Tavily pilot on the
+exact deployed revision above, with at most five requests, a USD 0.04 soft
+stop, permission for one in-flight request to cause a small overrun, and no
+connection to the production report workflow.
+
+The run used:
+
+- the canonical manifest SHA-256
+  `4f216d5a7ad0f44db0b973a10087fc6075ac1a2dddddde0430faf62595ca377f`;
+- the five collection and validated-plan identities frozen in the Phase 3
+  protocol;
+- one Tavily basic-search attempt per case;
+- the conservative accounting rate of USD 0.008 per observed credit; and
+- the local write-once directory
+  `outputs/evidence-gap-phase3-live-20260825-adde83d/`.
+
+The preflight confirmed a clean worktree at the authorized revision, a new
+output path, key availability without reading or printing the secret, all ten
+semantic identities, and the corrected raw fixture identity. The dry-run
+reported `production_connected=false` and
+`real_network_calls_performed=false` before live execution began.
+
+## Automated result
+
+The provider and executor work completed all five cases. The write-once
+artifact is internally consistent:
+
+| Measure | Observed |
+|---|---:|
+| Completed cases | 5/5 |
+| Outbound attempts | 5 |
+| Successful responses with request identity | 5/5 |
+| Observed Tavily credits | 5 |
+| Conservative incremental cost | USD 0.040 |
+| Provider-returned rows | 25 |
+| Adapter-rejected rows | 0 |
+| Locally quarantine-rejected rows | 0 |
+| Quarantined accepted rows | 25 |
+| Unique accepted URLs | 25 |
+| Empty titles / URLs | 0 / 0 |
+| Review rows with completed human labels | 0/25 |
+| Production connected | false |
+| Report workflow connected | false |
+
+Each provider response returned five rows and one inspectable credit. There
+were no transport, schema, usage-accounting, or quarantine failures.
+
+| Case | Tool | Provider request ID | Latency (ms) | Accepted |
+|---|---|---|---:|---:|
+| L01 | `academic_search` | `4112b268-bb86-4bef-9976-505d2e765949` | 3,743.716 | 5 |
+| L02 | `patent_search` | `c3e8b533-bee1-4357-80e9-c116e061333a` | 4,989.810 | 5 |
+| L03 | `market_search` | `f9a7e1ac-c6c1-4160-b2fc-786540d1ca55` | 3,775.543 | 5 |
+| L04 | `authority_search` | `ed9d9673-9911-42bf-a4e2-68797b94ab70` | 2,885.986 | 5 |
+| L05 | `authority_search` | `ea4b43a6-54f7-41fc-8ec8-3fde6891c476` | 3,809.252 | 5 |
+
+The sum of recorded provider latency was 19,204.307 ms; median case latency
+was 3,775.543 ms. This is a five-request compatibility observation, not a
+latency distribution or SLO.
+
+## Frozen criteria
+
+| Pre-registered compatibility criterion | Observation | Result |
+|---|---|---|
+| All identities validate before the first request | Raw fixture plus five collection and five plan hashes matched | pass |
+| No more than five requests and credits | 5 requests; 5 credits | pass |
+| Conservative cost no greater than USD 0.04 | USD 0.040 | pass |
+| Every successful response exposes request ID and usage | 5/5 | pass |
+| No invalid row enters accepted evidence | 0 adapter/schema rejections and 0 quarantine rejections were misregistered | pass |
+| Failure and uninspectable states remain distinct | No failure occurred; all five costs and usages were inspectable | pass |
+| At least one accepted candidate reaches human review | 25 rows reached `review.csv` | pass |
+
+This supports an **automated provider-compatibility pass** only. It does not
+complete the separately registered exploratory value criteria.
+
+## Human review remains open
+
+All 25 accepted rows have blank `relevant`, `novel`, and `review_note` fields.
+The artifact therefore correctly reports `review_state=not_inspected`.
+
+Until a human labels every row, the following remain unknown:
+
+- wrong-source rate;
+- case-level novel relevant evidence yield; and
+- whether at least three of five cases gained useful evidence.
+
+The domain census is descriptive only: five Google Patents URLs, five FDA
+URLs, five ClinicalTrials.gov/CDN URLs, four PubMed/NCBI URLs, one Semantic
+Scholar URL, and five market/news URLs. Domain validity is not semantic
+relevance.
+
+## CLI presentation defect
+
+The paid work and all four files completed before the process tried to print
+the final artifact. One L01 evidence summary contained U+2005 FOUR-PER-EM SPACE
+in `91\u2005mg`. The Windows process stdout used strict GBK, so the final
+`print(artifact.model_dump_json(...))` raised `UnicodeEncodeError` and returned
+exit code 1 after artifact persistence.
+
+The pilot was not rerun: doing so would duplicate paid requests and the
+existing output path correctly prevents reuse. The defect is classified as a
+CLI presentation failure, not a provider or artifact failure.
+
+The follow-up changes only the console projection to ASCII-safe, reversible
+JSON escapes. Authoritative files remain original UTF-8. A strict GBK seam test
+restores the observed U+2005, proves the rendered JSON round-trips, and fails
+with the same `UnicodeEncodeError` when the old print call is re-injected.
+
+## Artifact identities
+
+The raw provider artifacts remain local and ignored by Git because they
+contain provider-returned text. Their identities are fixed here for audit:
+
+| File | SHA-256 |
+|---|---|
+| `manifest.json` | `8989acda104e55066b91f42c7f3f78ec33141f440a9f91c6e2b322e315f6c84b` |
+| `execution.json` | `2625c20b40d216fb067cbda307880342843ec22d38b76c1ea39e6762ce77b133` |
+| `candidates.csv` | `0ba0c36518deff990dd36bf3c9a212aa1e61860c54bd0dd4ad273f5f50b762a5` |
+| `review.csv` | `3eaee269f838c4d5b36a4dc16d1c797a713c9c95f2635c572686e8312020d52d` |
+
+No API key appears in the command, result summary, or public artifacts.
+
+## Decision
+
+The single-request Tavily boundary is compatible with the frozen executor and
+accounting contract. Production remains phase-1 zero-call shadow mode.
+
+Production connection is still blocked by:
+
+1. incomplete human relevance and novelty review;
+2. no measured wrong-source or novel-evidence result; and
+3. the earlier 90% planner-trigger-precision requirement, which this injected-
+   intent pilot cannot test.
+
+## Explicit non-claims
+
+This result does not establish autonomous tool choice, planner precision,
+report improvement, source-truth accuracy, production reliability, invoice
+cost, latency SLO, user adoption, or permission to merge supplementary sources
+into `validated_sources.json`.
+
+The supported claim is:
+
+> One production-disconnected five-case Tavily compatibility pilot completed
+> five single-attempt requests with complete request and credit accounting at a
+> conservative USD 0.04; evidence value remains not inspected.

--- a/evidence_gap_phase3_audit.py
+++ b/evidence_gap_phase3_audit.py
@@ -651,6 +651,16 @@ def write_artifacts(
     _write_new(output_dir / "review.csv", _csv_text(_REVIEW_COLUMNS, reviews))
 
 
+def _stdout_json(value: object, *, sort_keys: bool = False) -> str:
+    """Render reversible CLI JSON independently of the caller's locale."""
+
+    # Write-once artifacts preserve the provider's original UTF-8 text. Stdout
+    # is only a projection and may be strict GBK or another legacy codec, so
+    # escaping non-ASCII code points prevents a completed paid run from being
+    # reported as failed after its artifacts have already been committed.
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=sort_keys)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST_PATH)
@@ -663,7 +673,7 @@ def _parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = _parser().parse_args()
     if not args.execute_live:
-        print(json.dumps(dry_run(args.manifest), indent=2, sort_keys=True))
+        print(_stdout_json(dry_run(args.manifest), sort_keys=True))
         return 0
     if args.output_dir is None or args.soft_stop_usd is None:
         raise SystemExit(
@@ -674,7 +684,7 @@ def main() -> int:
         soft_stop_usd=args.soft_stop_usd,
         manifest_path=args.manifest,
     )
-    print(artifact.model_dump_json(indent=2))
+    print(_stdout_json(artifact.model_dump(mode="json")))
     return 0
 
 

--- a/tests/test_evidence_gap_phase3_audit.py
+++ b/tests/test_evidence_gap_phase3_audit.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import csv
 import hashlib
 import inspect
+import io
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -334,6 +336,55 @@ def test_invalid_budget_existing_output_and_missing_key_fail_before_request(
             soft_stop_usd=0.04,
         )
     assert not missing_key_output.exists()
+
+
+def test_live_cli_projection_survives_strict_gbk_stdout(tmp_path, monkeypatch):
+    """The paid pilot completed before a U+2005 stdout encoding crash."""
+
+    payload = {
+        "mode": "phase3_live_provider_compatibility",
+        "evidence_summary": "releasing 91\u2005mg per hour",
+    }
+
+    class UnicodeArtifact:
+        def model_dump(self, *, mode):
+            assert mode == "json"
+            return payload
+
+        def model_dump_json(self, *, indent):
+            # This mirrors the production defect closely enough that restoring
+            # the old main() call reaches the strict stream and raises there.
+            return json.dumps(payload, ensure_ascii=False, indent=indent)
+
+    captured = {}
+
+    def fake_execute_live_pilot(**kwargs):
+        captured.update(kwargs)
+        return UnicodeArtifact()
+
+    monkeypatch.setattr(phase3, "execute_live_pilot", fake_execute_live_pilot)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evidence_gap_phase3_audit.py",
+            "--execute-live",
+            "--output-dir",
+            str(tmp_path / "unused"),
+            "--soft-stop-usd",
+            "0.04",
+        ],
+    )
+    sink = io.BytesIO()
+    strict_gbk = io.TextIOWrapper(sink, encoding="gbk", errors="strict")
+    monkeypatch.setattr(sys, "stdout", strict_gbk)
+
+    assert phase3.main() == 0
+    strict_gbk.flush()
+    rendered = sink.getvalue().decode("gbk")
+    assert "\\u2005" in rendered
+    assert json.loads(rendered) == payload
+    assert captured["soft_stop_usd"] == pytest.approx(0.04)
 
 
 def test_phase3_executor_and_adapter_remain_disconnected_from_worker():


### PR DESCRIPTION
Summary: record the authorized five-case Tavily compatibility result; preserve the explicit boundary that 25 human value labels remain uninspected; and make the final CLI JSON projection reversible on strict GBK terminals without altering authoritative UTF-8 artifacts. The paid pilot was not rerun after the post-artifact presentation failure. Validation: 1446 tests and 627 subtests passed, Tool Calling subset 53/53, latest Ruff passed, narrow E0701 Pylint passed, and coverage remains 87.07 percent.