### PR TITLE
Record the excluded Phase 3 review and expose its baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1463 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1465 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -204,32 +204,33 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   A fresh authorization on deployed revision `adde83d` then completed the exact
   five-case pilot: five single-attempt requests, five inspectable credits, USD
   0.040 conservative cost, and 25 unique policy-valid rows reached the frozen
-  blank review artifact. Production and report connections remained false. A
-  separate zero-network human-review packet now freezes all 25 full row
-  identities and strictly validates labels plus reviewer provenance. Its
-  initial summary is `incomplete / not_evaluated`: all labels and the
-  declaration remain blank, so wrong-source rate and novel evidence yield are
-  still not inspected.
-  The paid work and UTF-8 artifacts completed before the Windows GBK stdout
-  projection raised on U+2005 and returned exit code 1. The CLI now emits
-  reversible ASCII-safe JSON without changing authoritative UTF-8 artifacts.
-  The adapter/audit/executor subset passed 53/53 tests; temporary fixture-
-  identity, hidden-second-request, provider-row-under-count, and GBK-output
-  defects made their seam tests fail before restoration. The separate review
-  intake passed 17/17 targeted tests; temporary full-row identity and
-  `UNVERIFIABLE`-state defects also made their seam tests fail before
-  restoration.
-  The compatibility pass does not establish source truth, evidence yield,
-  report improvement, reliability, or planner precision. Every accepted row
-  still requires complete human review. Even a value-threshold pass would not
-  authorize production connection: planner trigger precision and disabled-path
-  thresholds remain unsatisfied.
+  blank review artifact. Production and report connections remained false. The
+  separate review packet later returned 25/25 source-grounded rows and declared
+  every URL attempted, but its own provenance records `MOST_OR_ALL` substantive
+  AI use. The strict result is `excluded_substantive_ai / not_evaluated`, not a
+  human-value pass. The observed form contains 5 relevant and 20 not-relevant
+  candidates across the five cases. Three cases contain at least one
+  `YES/YES`; these are descriptive labels only. Even if treated as eligible,
+  the implied 80% wrong-source rate would fail the frozen 5% maximum.
+  Intake also found that packet schema v1 did not expose the frozen baseline
+  against which it asked the reviewer to judge novelty. Schema v2 now carries
+  and revalidates the collection identity, gap state and source summaries.
+  Legacy packets remain inspectable as history but explicitly report
+  `baseline_context_not_exposed_to_reviewer`; they cannot silently produce an
+  eligible novelty headline. The hardened review intake passes 19/19 targeted
+  tests, including baseline-drift and legacy-state seams.
+  This result does not establish source truth, general provider precision,
+  report improvement, reliability, or planner precision. The current generic
+  adapter missed its candidate-value gate and remains disconnected. A future
+  value study must use domain-specific retrieval on an unseen challenge before
+  planner-trigger precision is worth measuring.
   Keep `pipeline_worker.py` disconnected from both executor and adapter.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,
   `docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md`,
   `docs/results-2026-08-25-evidence-gap-live-provider-phase3.md`, and
-  `docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md`.
+  `docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md`, and
+  `docs/results-2026-08-26-evidence-gap-human-review-phase3.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -397,26 +397,35 @@ before parsing or case expansion. A fresh authorization on deployed revision
 `adde83d` then completed the exact pilot: 5/5 cases, five single-attempt
 requests, five inspectable credits, USD 0.040 conservative cost, and 25 unique
 policy-valid rows reached the frozen blank review artifact. Automated provider
-compatibility passed. A separate zero-network human-review packet now freezes
-every full row identity and strictly validates returned labels plus reviewer
-provenance. Its initial state is `incomplete / not_evaluated`: all 25 labels
-and the declaration remain blank, so relevance and novelty are still not
-inspected.
-The paid work and UTF-8 artifacts completed before a Windows GBK stdout
-projection failed on U+2005; the CLI now emits reversible ASCII-safe JSON while
-preserving original artifact text. The adapter/audit/executor subset passed
-**53/53** tests, including deliberate fixture-identity, hidden-retry,
-row-accounting, non-finite pricing, and GBK-output defect re-injection. The
-separate human-review intake passed **17/17** targeted tests, including full-
-identity and `UNVERIFIABLE` state defect re-injection. This
-does not establish source truth, evidence gain, report improvement, or planner
-precision. See the
+compatibility passed. A separate zero-network human-review packet froze every
+full row identity and strictly validated returned labels plus reviewer
+provenance. Its initial state was `incomplete / not_evaluated`. The returned
+form later completed 25/25 rows and declared all URLs attempted, but it also
+declared `MOST_OR_ALL` substantive AI use. The strict result is therefore
+`excluded_substantive_ai / not_evaluated`, not a human-value pass. The observed
+form contains 5 relevant and 20 not-relevant candidates; three of five cases
+have at least one `YES/YES`. Those are descriptive labels only. Even if treated
+as eligible, the implied 80% wrong-source rate would fail the frozen 5% gate.
+
+Intake also found that packet schema v1 asked for novelty against a frozen
+baseline without exposing that collection to the reviewer. Schema v2 now
+carries and revalidates the baseline identity, gap state and source summaries;
+legacy packets remain readable but explicitly report
+`baseline_context_not_exposed_to_reviewer`. The paid work and UTF-8 artifacts
+completed before a Windows GBK stdout projection failed on U+2005; the CLI now
+emits reversible ASCII-safe JSON while preserving original artifact text. The
+adapter/audit/executor subset passed **53/53** tests. The hardened review intake
+passed **19/19** targeted tests, including full identity, baseline drift,
+legacy-baseline visibility and `UNVERIFIABLE` state seams. This does not
+establish source truth, general provider precision, report improvement, or
+planner precision. See the
 [phase-3 protocol](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md),
 the [implementation result](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md),
 the [fixture-identity erratum](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md),
 the [live-provider result](docs/results-2026-08-25-evidence-gap-live-provider-phase3.md),
 the [human-review protocol](docs/prereg-2026-08-25-evidence-gap-human-review-phase3.md),
-and the [packet-readiness result](docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md).
+the [packet-readiness result](docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md),
+and the [returned-form result](docs/results-2026-08-26-evidence-gap-human-review-phase3.md).
 Production remains phase-1 zero-call shadow mode.
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
@@ -1354,21 +1363,29 @@ evidence_gap_phase3_audit.py` 仍是零网络身份检查，已验证 5/5 集合
 解析 JSON 或展开案例前校验规范的原始字节身份。修复部署后获得新的明确授权，
 精确五案例 pilot 完成 5/5 案例、5 次单次尝试请求、5 个可检查 credits 和
 USD 0.040 保守成本；25 个唯一且通过策略校验的 URL 进入冻结空白人审表。自动
-供应商兼容性标准通过。现已另行生成零网络人工评审包，冻结每一行的完整身份，
-并严格校验回收标签与评审者声明。初始状态为 `incomplete / not_evaluated`：25 个
-标签和声明仍为空，因此相关性与新颖性依然未检查。付费工作与 UTF-8 产物
-完成后，Windows GBK stdout 在 U+2005 上打印失败；CLI 现改为可逆的 ASCII-safe
-JSON，原始 UTF-8 产物不变。适配器、审计和执行器子集 **53/53** 通过，并通过
-临时回注夹具身份、隐藏重试、行数漏记、非有限计费和 GBK 输出缺陷证明测试会
-真实变红。独立人审 intake 子集 **17/17** 通过，并回注完整行身份与
-`UNVERIFIABLE` 状态缺陷验证测试会变红。这些结果不代表来源真值、证据增量、
-报告改善或 Planner 精度。详见
+供应商兼容性标准通过。另行生成的零网络人工评审包冻结了每一行完整身份并严格
+校验标签与声明。回收表后来完成 25/25 行并声明逐个尝试 URL，但同时声明实质判断
+由生成式 AI `MOST_OR_ALL` 完成，因此严格结果是
+`excluded_substantive_ai / not_evaluated`，不能成为人工价值标题。表面标签为
+5 条相关、20 条不相关，3/5 案例至少有一条 `YES/YES`；这些仅是描述性结果。
+即使暂按合格评审计算，80% 错源率也会远超冻结的 5% 上限。
+
+回收还暴露了 packet schema v1 的接缝问题：它要求对照冻结基线判断 novelty，
+却没有把基线集合展示给评审者。schema v2 现会携带并重新校验集合身份、缺口状态
+和来源摘要；旧包仍可读取，但会明确报告
+`baseline_context_not_exposed_to_reviewer`。付费工作与 UTF-8 产物完成后，
+Windows GBK stdout 在 U+2005 上打印失败；CLI 已改为可逆的 ASCII-safe JSON，
+原始 UTF-8 产物不变。适配器、审计和执行器子集 **53/53** 通过；加固后的人审
+intake 子集 **19/19** 通过，覆盖完整身份、基线漂移、旧包基线不可见和
+`UNVERIFIABLE` 状态接缝。这些结果不代表来源真值、通用供应商精度、报告改善
+或 Planner 精度。详见
 [第三阶段协议](docs/prereg-2026-08-25-evidence-gap-live-adapter-phase3.md)、
 [实现结果](docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md)、
 [夹具身份勘误](docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md)、
 [真实供应商结果](docs/results-2026-08-25-evidence-gap-live-provider-phase3.md)、
-[人工评审协议](docs/prereg-2026-08-25-evidence-gap-human-review-phase3.md)和
-[评审包就绪结果](docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md)。
+[人工评审协议](docs/prereg-2026-08-25-evidence-gap-human-review-phase3.md)、
+[评审包就绪结果](docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md)和
+[回收表结果](docs/results-2026-08-26-evidence-gap-human-review-phase3.md)。
 生产环境仍保持第一阶段零补充调用的影子模式。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -65,8 +65,8 @@ source of truth.
 | Blinded utility audit | Five reviewers returned 20/20 eligible judgments; both rounds preferred the full workflow 6:4 for decision usefulness | The pre-registered success rule failed; the monolith led information gain 11:5, so this is not proof of six-stage superiority or adoption |
 | Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
-| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; one Phase 3 live pilot completed 5/5 single-attempt requests, 5 credits and USD 0.040 conservative cost, with 25 rows reaching a provenance-locked human packet; the adapter/audit/executor subset passed 53/53 and the review intake passed 17/17 | Production remains zero-call shadow mode; the strict initial summary is `incomplete / not_evaluated` because all 25 labels and the reviewer declaration remain blank, so source quality, evidence yield, and report improvement are not inspected |
-| Test and CI contract | 1,463 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
+| Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; one disconnected Phase 3 pilot completed 5/5 requests at USD 0.040; review intake passes 19/19 and the returned form contains 25/25 labels | Production remains zero-call shadow mode: the form declared substantive AI use and only 5/25 candidates relevant, so the strict result is `excluded_substantive_ai / not_evaluated`; the generic adapter failed its value gate |
+| Test and CI contract | 1,465 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor | Most CI tests are intentionally zero-network and do not replace provider or browser canaries |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -101,11 +101,11 @@ project's engineering argument: evaluation should be capable of saying no.
   horizontal scaling requires shared transactional storage and a distributed
   work queue.
 - Evidence-gap production planning remains shadow-only and issues zero
-  supplementary searches. A disconnected phase-2 executor and phase-3
-  single-request adapter exist. One five-case live pilot passed the automated
-  compatibility thresholds at USD 0.040, but all 25 relevance and novelty
-  labels remain blank. It therefore establishes neither evidence value nor
-  permission to connect the adapter to reports.
+  supplementary searches. A disconnected five-case pilot passed provider
+  compatibility at USD 0.040, but its returned form declared substantive AI
+  use and labeled only 5/25 candidates directly relevant. Packet v1 also hid
+  the frozen novelty baseline from the reviewer; schema v2 fixes that seam,
+  but the old result remains excluded and does not authorize production.
 - Code-package analysis is not implemented, and patent relevance has no second
   independent reviewer or inter-rater estimate.
 

--- a/docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md
+++ b/docs/results-2026-08-25-evidence-gap-human-review-packet-phase3.md
@@ -122,3 +122,12 @@ completes with `protocol_status=complete` and `decision=pass`.
 > A zero-network, provenance-locked review packet now carries all 25 live
 > Tavily candidates through an immutable human-label intake; the packet is
 > ready, but no human evidence-value result exists yet.
+
+## Post-return status (2026-08-26)
+
+The returned form later completed 25/25 rows, but its declaration recorded
+`MOST_OR_ALL` substantive AI use and packet schema v1 had not exposed the
+frozen baseline collection. The strict result is therefore
+`excluded_substantive_ai / not_evaluated`; the generic adapter remains
+disconnected. See the
+[returned-form result](results-2026-08-26-evidence-gap-human-review-phase3.md).

--- a/docs/results-2026-08-25-evidence-gap-live-provider-phase3.md
+++ b/docs/results-2026-08-25-evidence-gap-live-provider-phase3.md
@@ -162,3 +162,9 @@ without modifying this result or making another provider request. Its initial
 state is `incomplete / not_evaluated`, not a human-value pass. See the
 [frozen protocol](prereg-2026-08-25-evidence-gap-human-review-phase3.md) and
 [packet-readiness result](results-2026-08-25-evidence-gap-human-review-packet-phase3.md).
+
+The form was subsequently returned with 25/25 labels. Its declared substantive
+AI use excludes it from the human-value headline, and a method audit found that
+packet schema v1 did not expose the frozen novelty baseline. See the
+[returned-form result](results-2026-08-26-evidence-gap-human-review-phase3.md).
+Production remains disconnected.

--- a/docs/results-2026-08-26-evidence-gap-human-review-phase3.md
+++ b/docs/results-2026-08-26-evidence-gap-human-review-phase3.md
@@ -1,0 +1,160 @@
+# Result: Phase 3 evidence-gap review return and method audit
+
+**Date:** 2026-08-26
+**Source pilot revision:** `adde83dfd7d40c7fdd425b6f665eb121bb300e33`
+**Protocol:**
+[`prereg-2026-08-25-evidence-gap-human-review-phase3.md`](prereg-2026-08-25-evidence-gap-human-review-phase3.md)
+
+## Outcome
+
+The returned form contains complete, source-grounded labels for all 25
+candidates, and every URL is declared attempted. It does **not** produce an
+eligible human-value headline. The frozen summarizer reports
+`protocol_status=excluded_substantive_ai`, `decision=not_evaluated`, and
+`metrics=null` because the returned declaration names
+`OpenAI-Codex-GPT-5` and records `generative_ai_use=MOST_OR_ALL`.
+
+After return, the study owner stated that a person had checked the content and
+that parts of the declaration might imperfectly describe the process. That
+clarification is retained here, but it does not identify an eligible
+`NONE` or `LANGUAGE_ONLY` category or retract the returned declaration.
+The raw form was therefore not rewritten, and the review remains excluded
+under the pre-registered rule.
+
+A second method issue was discovered during intake: packet schema v1 told the
+reviewer to compare novelty against the frozen baseline but did not expose the
+expanded baseline collection in the reviewer packet. A post-audit summary
+therefore adds
+`method_issues=["baseline_context_not_exposed_to_reviewer"]` and
+`baseline_context_exposed_to_reviewer=false`. It also remains
+`excluded_substantive_ai / not_evaluated`.
+
+Production Tool Calling stays disconnected.
+
+## Returned labels
+
+All 25 row identities, titles and URLs matched the frozen packet. No row was
+blank, partially completed, duplicated, changed, or marked
+`UNVERIFIABLE`.
+
+| Case | Gap domain | Relevant | Not relevant | Rows |
+|---|---|---:|---:|---:|
+| L01 | academic | 0 | 5 | 5 |
+| L02 | patent | 0 | 5 | 5 |
+| L03 | market | 2 | 3 | 5 |
+| L04 | regulatory | 1 | 4 | 5 |
+| L05 | clinical registry | 2 | 3 | 5 |
+| **Total** | — | **5** | **20** | **25** |
+
+The form contains five `YES/YES` pairs and twenty `NO/N/A` pairs. For
+transparency only, direct arithmetic over those labels would be:
+
+- wrong-source count: 20/25;
+- wrong-source rate: 80%;
+- cases with at least one `YES/YES`: L03, L04 and L05, or 3/5.
+
+These are **descriptive counts, not protocol headline metrics**. The formal
+summary correctly leaves both thresholds `not_evaluated`. Even if the
+returned labels were treated as eligible, the 80% wrong-source rate would miss
+the frozen maximum of 5% by a wide margin; the 3/5 case-level novelty threshold
+alone would be met. The combined decision would therefore still be a fail.
+
+## What the labels suggest
+
+The mixed-domain basic-search adapter was transport-compatible but not
+selective enough for production evidence injection:
+
+- general web search found no directly relevant academic performance source in
+  L01 and no directly relevant closed-pore patent claim in L02;
+- market retrieval found two concrete medium-voltage data-centre signals, but
+  three broad forecasts or adjacent transformer pages were not direct evidence;
+- the regulatory case found one device-specific FDA authorization signal among
+  four generic pages; and
+- the clinical case found two matching registered mRNA-vaccine studies among
+  three modality, tumour-scope, or personalization mismatches.
+
+This is one five-case diagnostic sample. It does not estimate a general
+provider precision rate, but it is strong enough to reject connecting the
+current generic adapter to reports.
+
+## Baseline visibility erratum
+
+The write-once source manifest already contained each frozen
+`source_collection`, its collection hash, failed-domain state, authority
+coverage and synthetic baseline source. Packet schema v1 copied only the case
+target and candidate identities. The reviewer could infer that a directly
+relevant source filled a declared failed or missing category, but could not
+inspect the baseline representation from the packet itself.
+
+That omission matters because “the check found novelty” and “the reviewer was
+not given the comparison material” must not collapse into the same state. The
+review tool now:
+
+1. projects the frozen collection identity, gap state and complete baseline
+   source identity/summary into `baseline_contexts`;
+2. writes those contexts into packet schema v2 and explains the relative-
+   novelty boundary in the reviewer README;
+3. verifies the contexts again against the write-once source manifest during
+   summarization; and
+4. keeps schema-v1 packets readable but marks
+   `baseline_context_not_exposed_to_reviewer`, preventing an otherwise
+   eligible old packet from producing headline metrics.
+
+This does not retroactively repair the returned form. The original packet,
+original summary and post-audit interpretation remain separate immutable
+artifacts.
+
+## Artifact identities
+
+The raw returned forms remain local and Git-ignored. Their identities are
+recorded for audit:
+
+| Artifact | SHA-256 |
+|---|---|
+| `labels.csv` | `5e1d67004fd1d98ae589859f3e62f6f728c395f5be81db42b9124014dbbafc0d` |
+| `reviewer_declaration.csv` | `261be9531e51f3fbed7d0c44a711290dd0c4abc54762087c2fbeff25350573d8` |
+| `final-summary.json` | `fb8623e38404303b1a2be0c77311bc2620eabcc383e0b556edaf4bca13e3813f` |
+| `post-audit-summary.json` | `b00f7cddd3d871c1b490ad9eeecfd6d179eaebc70f3de88dc40b4aa1fb377edf` |
+
+The original paid source hashes and packet-manifest hash remain unchanged.
+
+## Verification
+
+The review subset passes **19/19**. The original omission was then re-injected
+by removing the legacy baseline method issue: the new seam test failed because
+a schema-v1 packet incorrectly became `complete`. Restoring the check returned
+the test to green. The complete zero-network suite passes **1,465 tests plus
+627 subtests**. Latest Ruff, the narrow CI Pylint checks, and the **87.07%**
+coverage result all pass the existing gates.
+A real zero-network schema-v2 packet was also generated from the original four
+paid artifacts rather than a test fixture. It exposes all five baseline
+contexts, reports `baseline_context_exposed_to_reviewer=true`, remains
+`incomplete / not_evaluated` at 0/25 labels, and has packet-manifest SHA-256
+`7d1e4e23b65d6aedfe4854768e1dd7431b6819b09c7af9770e7aefc2d60198d7`.
+
+
+## Decision and next gate
+
+Do not connect supplementary results to `validated_sources.json`, and do not
+run the planner-trigger study yet. The next value experiment should first
+replace the one-size-fits-all search with narrow domain strategies and freeze
+an unseen challenge:
+
+- academic: scholarly APIs and performance-study filters;
+- patent: claim-oriented patent retrieval rather than generic web results;
+- market: company, customer, funding or deployment evidence;
+- regulatory: exact device/action records from authority sources; and
+- clinical: registry-native condition, intervention and study-type fields.
+
+A future packet must use schema v2 and an independently declared eligible
+review process. Only after candidate relevance clears its own gate is planner
+trigger precision worth measuring.
+
+## Supported claim
+
+> One disconnected five-case Tavily pilot proved request, quarantine and cost
+> compatibility, but its returned form contained only 5/25 directly relevant
+> candidates and was ineligible for a human-value headline because substantive
+> AI use was declared. The generic adapter remains out of production, and the
+> reviewer packet now exposes its frozen comparison baseline instead of treating
+> missing comparison context as a successful novelty check.

--- a/evidence_gap_phase3_review.py
+++ b/evidence_gap_phase3_review.py
@@ -145,6 +145,7 @@ class SourceSnapshot:
 
     file_hashes: dict[str, str]
     candidates: tuple[ReviewCandidate, ...]
+    baseline_contexts: tuple[dict[str, Any], ...]
 
 
 def _sha256_bytes(value: bytes) -> str:
@@ -210,7 +211,67 @@ def _expected_hashes(value: Mapping[str, str] | None) -> dict[str, str]:
     return hashes
 
 
-def _validate_source_cases(manifest: dict[str, Any]) -> None:
+def _baseline_context(
+    case_id: str,
+    item: Mapping[str, Any],
+    context: Mapping[str, str],
+) -> dict[str, Any]:
+    """Project the frozen pre-search evidence into reviewer-visible data."""
+
+    collection_sha256 = item.get("collection_sha256")
+    if not isinstance(collection_sha256, str) or len(collection_sha256) != 64:
+        raise Phase3ReviewError(f"{case_id}: baseline collection identity is missing")
+    source_collection = item.get("source_collection")
+    if not isinstance(source_collection, dict):
+        raise Phase3ReviewError(f"{case_id}: source manifest is missing its baseline collection")
+
+    failed_domains = source_collection.get("failed_domains")
+    authority_coverage = source_collection.get("authority_coverage")
+    if not isinstance(failed_domains, dict) or not isinstance(authority_coverage, dict):
+        raise Phase3ReviewError(f"{case_id}: baseline gap state is not inspectable")
+
+    gap_subject = context["gap_subject"]
+    if context["gap_code"] == "retrieval_domain_failed":
+        failure_reason = failed_domains.get(gap_subject)
+        if not isinstance(failure_reason, str) or not failure_reason.strip():
+            raise Phase3ReviewError(f"{case_id}: frozen retrieval failure is missing")
+        gap_state = f"{gap_subject} retrieval failed: {failure_reason.strip()}"
+    else:
+        missing = authority_coverage.get("missing_categories")
+        if not isinstance(missing, list) or gap_subject not in missing:
+            raise Phase3ReviewError(f"{case_id}: frozen authority gap is missing")
+        gap_state = f"{gap_subject} authority category is absent from the baseline"
+
+    baseline_sources: list[dict[str, str]] = []
+    for domain in ("academic", "patent", "market"):
+        rows = source_collection.get(f"{domain}_sources")
+        if not isinstance(rows, list):
+            raise Phase3ReviewError(f"{case_id}: baseline {domain} sources are missing")
+        for row in rows:
+            if not isinstance(row, dict):
+                raise Phase3ReviewError(f"{case_id}: baseline source must be an object")
+            projected = {
+                "domain": domain,
+                "source_id": str(row.get("source_id", "")).strip(),
+                "title": str(row.get("title", "")).strip(),
+                "url": str(row.get("url", "")).strip(),
+                "evidence_summary": str(row.get("evidence_summary", "")).strip(),
+            }
+            if not all(projected.values()):
+                raise Phase3ReviewError(f"{case_id}: baseline source projection is incomplete")
+            baseline_sources.append(projected)
+
+    return {
+        "case_id": case_id,
+        "collection_sha256": collection_sha256,
+        "gap_code": context["gap_code"],
+        "gap_subject": gap_subject,
+        "gap_state": gap_state,
+        "baseline_sources": baseline_sources,
+    }
+
+
+def _validate_source_cases(manifest: dict[str, Any]) -> tuple[dict[str, Any], ...]:
     if manifest.get("mode") != "phase3_frozen_provider_compatibility":
         raise Phase3ReviewError("source manifest has the wrong mode")
     if manifest.get("production_connected") is not False:
@@ -220,6 +281,7 @@ def _validate_source_cases(manifest: dict[str, Any]) -> None:
         raise Phase3ReviewError("source manifest must contain the five frozen cases")
 
     observed: dict[str, dict[str, str]] = {}
+    items_by_case: dict[str, dict[str, Any]] = {}
     for item in cases:
         if not isinstance(item, dict) or not isinstance(item.get("spec"), dict):
             raise Phase3ReviewError("every source manifest case must contain a spec object")
@@ -233,8 +295,14 @@ def _validate_source_cases(manifest: dict[str, Any]) -> None:
             "gap_subject": str(spec.get("gap_subject", "")),
             "query": str(spec.get("query", "")),
         }
+        items_by_case[case_id] = item
     if observed != FROZEN_CASES:
         raise Phase3ReviewError("source manifest case definitions drifted from the preregistration")
+
+    return tuple(
+        _baseline_context(case_id, items_by_case[case_id], context)
+        for case_id, context in FROZEN_CASES.items()
+    )
 
 
 def _validate_execution(execution: dict[str, Any]) -> None:
@@ -288,7 +356,7 @@ def validate_source_artifacts(
         }
         raise Phase3ReviewError(f"source artifact identity drifted: {drift}")
 
-    _validate_source_cases(_read_json_object(source_dir / "manifest.json"))
+    baseline_contexts = _validate_source_cases(_read_json_object(source_dir / "manifest.json"))
     _validate_execution(_read_json_object(source_dir / "execution.json"))
     candidate_rows = _read_csv(source_dir / "candidates.csv", CANDIDATE_FIELDS)
     review_rows = _read_csv(source_dir / "review.csv", REVIEW_FIELDS)
@@ -332,13 +400,21 @@ def validate_source_artifacts(
         raise Phase3ReviewError(f"every frozen case must contain five candidates, got {dict(case_counts)}")
 
     ordered = tuple(review_by_key[key] for key in sorted(review_by_key))
-    return SourceSnapshot(file_hashes=file_hashes, candidates=ordered)
+    return SourceSnapshot(
+        file_hashes=file_hashes,
+        candidates=ordered,
+        baseline_contexts=baseline_contexts,
+    )
 
 
-def _packet_readme() -> str:
+def _packet_readme(baseline_contexts: tuple[dict[str, Any], ...]) -> str:
     rows = "\n".join(
         f"| {case_id} | {case['topic']} | {case['gap_subject']} | {case['query']} |"
         for case_id, case in FROZEN_CASES.items()
+    )
+    baseline_rows = "\n".join(
+        f"| {context['case_id']} | {context['gap_state']} | {len(context['baseline_sources'])} |"
+        for context in baseline_contexts
     )
     return f"""# Phase 3 evidence-gap human review packet
 
@@ -354,6 +430,20 @@ IDs, accepted source IDs, titles, or URLs.
 | Case | Topic | Gap | Search target |
 |---|---|---|---|
 {rows}
+
+## Frozen baseline visible to the reviewer
+
+| Case | Frozen gap state | Baseline sources |
+|---|---|---:|
+{baseline_rows}
+
+The full baseline source identities and evidence summaries are frozen under
+`baseline_contexts` in `packet_manifest.json`. Inspect them before assigning
+`novel`. These fixtures record the target domain or authority category as
+absent, so a directly relevant candidate will normally be `YES/YES`; use
+`YES/NO` only if the candidate's material evidence is already present in the
+listed baseline. This establishes novelty only relative to this synthetic
+collection, not novelty in the wider literature, patent landscape, or market.
 
 Judge relevance against the named gap, not broad topic overlap. Attempt every
 URL and inspect the abstract, claims, market evidence, regulatory document, or
@@ -387,7 +477,7 @@ unmeasured.
 
 def _packet_manifest(snapshot: SourceSnapshot) -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "mode": "phase3_human_value_review_packet",
         "prepared_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "source_mode": "frozen live-provider artifacts; zero network",
@@ -396,6 +486,7 @@ def _packet_manifest(snapshot: SourceSnapshot) -> dict[str, Any]:
             {"case_id": case_id, **context} for case_id, context in FROZEN_CASES.items()
         ],
         "row_count": len(snapshot.candidates),
+        "baseline_contexts": list(snapshot.baseline_contexts),
         "rows": [
             {
                 "case_id": candidate.case_id,
@@ -451,7 +542,7 @@ def prepare_packet(
     ]
     _write_csv_new(packet_dir / "labels.csv", REVIEW_FIELDS, label_rows)
     _write_csv_new(packet_dir / "reviewer_declaration.csv", DECLARATION_FIELDS, [{}])
-    _write_text_new(packet_dir / "README.md", _packet_readme())
+    _write_text_new(packet_dir / "README.md", _packet_readme(snapshot.baseline_contexts))
     _write_text_new(
         packet_dir / "packet_manifest.json",
         json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
@@ -459,13 +550,24 @@ def prepare_packet(
     return manifest
 
 
-def _manifest_candidates(manifest: dict[str, Any]) -> dict[tuple[str, str], ReviewCandidate]:
-    if manifest.get("schema_version") != 1 or manifest.get("mode") != "phase3_human_value_review_packet":
+def _manifest_candidates(
+    manifest: dict[str, Any],
+    expected_baseline_contexts: tuple[dict[str, Any], ...],
+) -> tuple[dict[tuple[str, str], ReviewCandidate], bool]:
+    schema_version = manifest.get("schema_version")
+    if schema_version not in {1, 2} or manifest.get("mode") != "phase3_human_value_review_packet":
         raise Phase3ReviewError("packet manifest has an unsupported schema or mode")
     if manifest.get("production_connected") is not False:
         raise Phase3ReviewError("packet manifest must remain production-disconnected")
     if manifest.get("source_file_sha256") is None:
         raise Phase3ReviewError("packet manifest is missing source artifact identities")
+    baseline_context_exposed = schema_version == 2
+    if baseline_context_exposed and manifest.get("baseline_contexts") != list(
+        expected_baseline_contexts
+    ):
+        raise Phase3ReviewError(
+            "packet baseline contexts do not match the frozen source manifest"
+        )
     if manifest.get("case_contexts") != [
         {"case_id": case_id, **context} for case_id, context in FROZEN_CASES.items()
     ]:
@@ -494,25 +596,27 @@ def _manifest_candidates(manifest: dict[str, Any]) -> dict[tuple[str, str], Revi
         if key in candidates:
             raise Phase3ReviewError(f"packet manifest contains duplicate identity {candidate.row_id}")
         candidates[key] = candidate
-    return candidates
+    return candidates, baseline_context_exposed
 
 
 def _validate_packet_provenance(
     packet_dir: Path,
     snapshot: SourceSnapshot,
-) -> tuple[dict[str, Any], dict[tuple[str, str], ReviewCandidate]]:
+) -> tuple[dict[str, Any], dict[tuple[str, str], ReviewCandidate], bool]:
     manifest_path = packet_dir / "packet_manifest.json"
     manifest = _read_json_object(manifest_path)
     if manifest.get("source_file_sha256") != snapshot.file_hashes:
         raise Phase3ReviewError("packet source hashes do not match the frozen source directory")
-    manifest_candidates = _manifest_candidates(manifest)
+    manifest_candidates, baseline_context_exposed = _manifest_candidates(
+        manifest, snapshot.baseline_contexts
+    )
     source_candidates = {
         (candidate.case_id, candidate.accepted_source_id): candidate
         for candidate in snapshot.candidates
     }
     if manifest_candidates != source_candidates:
         raise Phase3ReviewError("packet candidate identities do not match the frozen source artifacts")
-    return manifest, manifest_candidates
+    return manifest, manifest_candidates, baseline_context_exposed
 
 
 def _validated_label(
@@ -606,7 +710,9 @@ def summarize_packet(
     if not packet_dir.is_dir():
         raise Phase3ReviewError(f"packet directory does not exist: {packet_dir}")
     snapshot = validate_source_artifacts(source_dir, expected_hashes=expected_hashes)
-    manifest, expected_candidates = _validate_packet_provenance(packet_dir, snapshot)
+    manifest, expected_candidates, baseline_context_exposed = (
+        _validate_packet_provenance(packet_dir, snapshot)
+    )
 
     label_rows = _read_csv(packet_dir / "labels.csv", REVIEW_FIELDS)
     observed_keys = [
@@ -654,6 +760,8 @@ def summarize_packet(
         }
 
     method_issues: list[str] = []
+    if not baseline_context_exposed:
+        method_issues.append("baseline_context_not_exposed_to_reviewer")
     if declaration is not None:
         if declaration["reviewed_all"] != "YES":
             method_issues.append("reviewer_did_not_confirm_all_rows")
@@ -709,6 +817,7 @@ def summarize_packet(
         "source_file_sha256": snapshot.file_hashes,
         "packet_manifest_sha256": _file_sha256(packet_dir / "packet_manifest.json"),
         "protocol_status": protocol_status,
+        "baseline_context_exposed_to_reviewer": baseline_context_exposed,
         "decision": decision,
         "row_count": len(expected_candidates),
         "completed_row_count": len(completed),

--- a/tests/test_evidence_gap_phase3_review.py
+++ b/tests/test_evidence_gap_phase3_review.py
@@ -47,6 +47,43 @@ def _source_hashes(source: Path) -> dict[str, str]:
     }
 
 
+def _source_case(case_id: str, context: dict[str, str]) -> dict[str, object]:
+    """Expose the same synthetic baseline shape that the real reviewer must see."""
+
+    gap_subject = context["gap_subject"]
+    retrieval_failed = context["gap_code"] == "retrieval_domain_failed"
+    return {
+        "collection_sha256": hashlib.sha256(case_id.encode()).hexdigest(),
+        "source_collection": {
+            "academic_sources": [
+                {
+                    "source_id": "A1",
+                    "title": f"{case_id} frozen baseline placeholder",
+                    "url": f"https://doi.org/10.5555/{case_id.lower()}",
+                    "evidence_summary": (
+                        "Synthetic schema-valid baseline evidence that explicitly does "
+                        "not answer the declared gap."
+                    ),
+                }
+            ],
+            "patent_sources": [],
+            "market_sources": [],
+            "failed_domains": (
+                {gap_subject: "frozen provider-compatibility retrieval failure"}
+                if retrieval_failed
+                else {}
+            ),
+            "authority_coverage": {
+                "status": "not_applicable" if retrieval_failed else "incomplete",
+                "required_categories": [] if retrieval_failed else [gap_subject],
+                "missing_categories": [] if retrieval_failed else [gap_subject],
+                "covered_source_ids": {},
+            },
+        },
+        "spec": {"case_id": case_id, **context},
+    }
+
+
 def _build_source(tmp_path: Path) -> tuple[Path, dict[str, str]]:
     """Build a synthetic source with the same frozen seams, never the network."""
 
@@ -56,7 +93,7 @@ def _build_source(tmp_path: Path) -> tuple[Path, dict[str, str]]:
         "mode": "phase3_frozen_provider_compatibility",
         "production_connected": False,
         "cases": [
-            {"spec": {"case_id": case_id, **context}}
+            _source_case(case_id, context)
             for case_id, context in FROZEN_CASES.items()
         ],
     }
@@ -190,6 +227,12 @@ def test_prepare_packet_preserves_source_and_freezes_every_review_identity(tmp_p
         "reviewer_declaration.csv",
     }
     assert manifest["source_file_sha256"] == hashes
+    assert manifest["schema_version"] == 2
+    assert len(manifest["baseline_contexts"]) == 5
+    assert all(context["baseline_sources"] for context in manifest["baseline_contexts"])
+    assert "Frozen baseline visible to the reviewer" in (
+        packet / "README.md"
+    ).read_text(encoding="utf-8")
     assert manifest["row_count"] == 25
     assert len({row["identity_sha256"] for row in manifest["rows"]}) == 25
     assert all(
@@ -242,6 +285,44 @@ def test_complete_labels_pass_only_at_both_frozen_boundaries(tmp_path):
         "disabled_path_regression",
     ]
     assert result["production_connection_authorized"] is False
+
+
+def test_legacy_packet_without_baseline_context_is_not_inspectable(tmp_path):
+    """The returned v1 packet cannot support an eligible novelty headline."""
+
+    source, packet, hashes = _prepare(tmp_path)
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["schema_version"] = 1
+    manifest.pop("baseline_contexts")
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _complete_labels(packet)
+    _write_declaration(packet)
+
+    result = summarize_packet(source, packet, expected_hashes=hashes)
+
+    assert result["protocol_status"] == "not_inspectable"
+    assert result["decision"] == "not_evaluated"
+    assert result["metrics"] is None
+    assert result["baseline_context_exposed_to_reviewer"] is False
+    assert result["method_issues"] == ["baseline_context_not_exposed_to_reviewer"]
+
+
+def test_packet_baseline_context_drift_is_rejected(tmp_path):
+    source, packet, hashes = _prepare(tmp_path)
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["baseline_contexts"][0]["gap_state"] = "Rewritten after packet preparation"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Phase3ReviewError, match="baseline contexts do not match"):
+        summarize_packet(source, packet, expected_hashes=hashes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Records the completed but protocol-ineligible Phase 3 return without rewriting reviewer provenance. The observed 5/25 relevance pattern remains descriptive only and keeps the generic supplementary-search adapter disconnected. Fixes the reviewer seam by adding schema-v2 baseline contexts, preserving legacy readability with an explicit method issue, and validating the visible baseline against the write-once source manifest. Adds regression and seam coverage, synchronizes public decision records, and documents the defect-reinjection result. Local verification: 1,465 tests plus 627 subtests, latest Ruff, narrow Pylint, and 87.07% coverage all pass.