### PR TITLE
Correct the test-module count after Phase 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  71 test modules plus conftest, organised by subject
+tests/                  73 test modules plus conftest, organised by subject
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
 patent_relevance_candidate.py
                         offline frozen candidate screen; never production filtering


### PR DESCRIPTION
Phase 4 added two tracked test modules. This prose-only follow-up changes the repository layout index from 71 to the measured total of 73; no executable code changes.