### PR TITLE
Add a two-stage target-user decision pilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1515 tests (627 subtests), CI green on Linux + Windows × Python
+Current state: 1524 tests (627 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -367,3 +367,14 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   evidence, not adoption, ROI, accuracy, or proof that six agents are necessary.
   See docs/results-2026-08-23-user-utility-audit.md. The largest remaining gap
   is independent utility evidence from more actual target users.
+- **A separate two-slot target-user decision pilot is prepared, not
+  completed.** It deliberately does not append new responses to the closed
+  five-reviewer audit. Each recruited target user first records their role and
+  baseline decision without seeing a report; only then does the coordinator
+  materialize one frozen report and collect a post-report decision. The packet
+  makes source checking, AI assistance, consent, and unusable observations
+  explicit, and its public projection excludes non-consented free text. There
+  are currently zero returned observations, so this is an implemented
+  measurement contract rather than user-value evidence. See
+  `docs/prereg-2026-08-26-target-user-decision-pilot.md` and
+  `docs/target-user-decision-pilot-guide.md`.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ not adoption or proof that six agents are necessary. See the
 [audit guide](docs/user-utility-audit-guide.md), and
 [full result](docs/results-2026-08-23-user-utility-audit.md).
 
+Because that denominator is closed and contained only one actual target user,
+a separate **two-slot target-user decision pilot** is now pre-registered and
+implemented without any provider calls. A reviewer must record their role,
+baseline decision, and confidence before the coordinator can materialize one
+frozen report; the second stage then records whether the report changed the
+decision, what evidence was useful, and how much review time it required.
+Source checking, substantive AI use, consent, and incomplete observations are
+represented as distinct states. No response has been returned yet, so this is
+a measurement contract—not a user-value result. See the
+[pre-registration](docs/prereg-2026-08-26-target-user-decision-pilot.md) and
+[operator guide](docs/target-user-decision-pilot-guide.md).
+
 A separate pre-registered checkpoint audit hard-terminated **30 worker
 processes** across ten frozen evidence collections and three post-commit
 boundaries. All 30 immutable children reached `Done`, reused exactly the
@@ -439,7 +451,7 @@ uninspectable cost; Lens is explicitly uninspectable rather than `$0`. Every
 provider row reaches a candidate or rejection index, and OpenAlex query-string
 credentials are suppressed from complete exception tracebacks. Both a hidden
 retry and missing-row-accounting defect were re-injected and caught. The full
-suite passes **1,515 tests plus 627 subtests** at **87.07% coverage**. No live
+suite passes **1,524 tests plus 627 subtests** at **87.07% coverage**. No live
 OpenAlex/Lens request has run and production still imports neither adapter, so
 candidate precision, novel-evidence yield and report benefit remain unobserved.
 See the [Phase 4 protocol](docs/prereg-2026-08-26-evidence-gap-domain-adapters-phase4.md)
@@ -1169,6 +1181,14 @@ Reviewer 版本。整体偏好的精确一致率为 9/9，引用支持为 8/9，
 ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-22-user-utility-audit.md)、
 [操作指南](docs/user-utility-audit-guide.md)和[完整结果](docs/results-2026-08-23-user-utility-audit.md)。
 
+由于该盲评的分母已经封闭且只有 1 名真实目标用户，项目另行预注册并实现了一项
+**双席位目标用户决策试点**，全程不调用模型或搜索供应商。评审者必须先填写自身
+角色、初始判断和信心，协调者才会生成一份冻结报告；第二阶段再记录报告是否改变
+判断、哪些证据有用以及实际审阅耗时。外部来源核验、实质性 AI 使用、公开同意和
+未完成观察均被区分记录。目前尚未收到任何返回，因此它只是评测合同，不是用户
+价值结果。详见[预注册](docs/prereg-2026-08-26-target-user-decision-pilot.md)和
+[操作指南](docs/target-user-decision-pilot-guide.md)。
+
 另有一组预注册 Checkpoint 故障恢复实验，在 10 份冻结证据和 3 个提交后边界上
 硬终止 **30 个 worker 进程**。30/30 个不可变子运行均到达 `Done`，精确复用预期
 连续前缀并只执行剩余后缀；子运行共跳过 **90 次已提交任务执行**，重复执行为
@@ -1425,7 +1445,7 @@ intake 子集 **19/19** 通过，覆盖完整身份、基线漂移、旧包基�
 美元成本和不可检查成本，Lens 不会被误报为 `$0`。每一条供应商返回行必须进入
 候选或拒绝索引，OpenAlex 查询参数中的 key 也不会出现在完整异常 traceback 中。
 项目重新注入了隐藏重试和漏记供应商行两个缺陷，新测试均能准确变红；恢复正确实现
-后，全量 **1,515 项测试与 627 个 subtests** 通过，覆盖率 **87.07%**。目前尚未
+后，全量 **1,524 项测试与 627 个 subtests** 通过，覆盖率 **87.07%**。目前尚未
 发起任何 OpenAlex/Lens 真实请求，生产 worker 也不会导入这两个适配器，因此不能
 宣称候选精度、新证据收益或报告质量改善。详见
 [第四阶段协议](docs/prereg-2026-08-26-evidence-gap-domain-adapters-phase4.md)与

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -66,7 +66,7 @@ source of truth.
 | Offline fault injection | 30/30 immutable children completed; 90 committed task executions were skipped with 0 duplicate task executions | Zero-network process evidence, not an exactly-once, latency, cost-saving, or production-SLO claim |
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
 | Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; the disconnected Phase 3 generic pilot completed 5/5 requests; Phase 4 passes a 71/71 adapter/executor seam set plus a 50/50 live-runner and source-locked Schema v2 review subset over eight OpenAlex/Lens cases | Production remains zero-call shadow mode: the Phase 3 form declared substantive AI use and only 5/25 candidates relevant; the Phase 4 runner has made no live request, so compatibility, precision and evidence gain remain unobserved |
-| Test and CI contract | 1,515 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor; a dedicated Chromium journey exercises the access gate, client admission, run history and report DOM | The browser smoke is loopback-only and blocks mutating requests, so it proves the shipped client/API seam without claiming provider compatibility or deployed-service availability |
+| Test and CI contract | 1,524 tests plus 627 subtests; Linux/Windows × Python 3.11/3.12; 87.07% measured coverage above an 85% floor; a dedicated Chromium journey exercises the access gate, client admission, run history and report DOM | The browser smoke is loopback-only and blocks mutating requests, so it proves the shipped client/API seam without claiming provider compatibility or deployed-service availability |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -108,6 +108,10 @@ project's engineering argument: evaluation should be capable of saying no.
   but the old result remains excluded and does not authorize production.
 - Code-package analysis is not implemented, and patent relevance has no second
   independent reviewer or inter-rater estimate.
+- The completed user-utility audit included only one actual target user. A
+  separate two-slot target-user decision pilot is prepared with a pre-report
+  baseline and post-report decision, but it currently has zero returned
+  observations and therefore contributes no user-value evidence yet.
 
 ## Reproduce or inspect
 
@@ -115,6 +119,8 @@ project's engineering argument: evaluation should be capable of saying no.
 - [Architecture and full documentation](../README.md)
 - [Topology ablation protocol and result](prereg-2026-08-21-agent-topology-ablation.md)
 - [User-utility result](results-2026-08-23-user-utility-audit.md)
+- [Target-user pilot pre-registration](prereg-2026-08-26-target-user-decision-pilot.md)
+- [Target-user pilot operator guide](target-user-decision-pilot-guide.md)
 - [Checkpoint recovery design](checkpoint-recovery.md)
 - [Production recovery canary](results-2026-08-24-paid-same-revision-recovery-post-fix.md)
 

--- a/docs/prereg-2026-08-26-target-user-decision-pilot.md
+++ b/docs/prereg-2026-08-26-target-user-decision-pilot.md
@@ -1,0 +1,177 @@
+# Pre-registration: two-stage target-user decision pilot
+
+**Registered:** 2026-08-26, before recruitment packets, target-user intake,
+or follow-up labels exist
+
+**Cost:** zero provider calls; frozen full-workflow reports only
+
+**Planned slots:** two (`T01` and `T02`)
+
+## Question
+
+When an actual commercialization decision-maker reads one previously generated
+production-workflow report in a topic they understand, what decision-useful
+information does it add relative to their topic-only baseline, how much work
+would they need to correct it, and would they choose to use this kind of report
+again?
+
+This is a small qualitative product pilot, not a topology experiment. It does
+not compare the six-stage workflow with the monolith, ordinary ChatGPT, an
+analyst team, or a freshly researched report. It cannot establish adoption,
+ROI, decision accuracy, hallucination rate, or population-level product value.
+
+## Why this is a separate study
+
+The completed 2026-08-23 utility audit is closed. It contains twenty eligible
+blinded judgments from five reviewers, but only one reviewer was an actual
+target user. Adding new people to that denominator after seeing its 6:4 result
+would invalidate the frozen design. This pilot therefore has new reviewer IDs,
+a different question, separate artifacts, and no attempt to rescue or reinterpret
+the failed topology criterion.
+
+The pilot also answers a more relevant product question. A target user normally
+receives one report and decides whether it helps; they do not compare two hidden
+workflow architectures. The two-stage procedure preserves a topic-only baseline
+without imposing a second 4,000-word report.
+
+## Frozen source material
+
+The source experiment is
+`outputs/ablation/20260821T234300Z-7dd894ef`. The catalog contains the ten
+benchmark topics already present in that experiment. For each topic, the source
+report is the successful `full` cell at repetition 1. All ten such cells exist.
+
+The coordinator lock records, before recruitment:
+
+- topic number, topic text, and industry;
+- source cell and frozen-evidence digest;
+- source report path and SHA-256; and
+- source metadata path and SHA-256.
+
+No report is regenerated, shortened, translated, or selected because of a known
+human preference. The exact delivered `commercialization_report.md` is used,
+including its limitations and reviewer appendix, because this pilot measures the
+delivered artifact rather than architecture blinding. The reports were generated
+on 2026-08-21 from frozen evidence and must be described that way; they are not
+fresh market research.
+
+## Recruitment and fixed denominator
+
+Two slots are registered: `T01` and `T02`. Eligible target roles are:
+
+1. technology-transfer or research-commercialization staff;
+2. investment, venture, or due-diligence personnel;
+3. industry research, consulting, product-strategy, or commercialization staff;
+4. founders or senior researchers with direct commercialization evaluation
+   responsibility.
+
+A technical reviewer without such responsibility is retained as a proxy but is
+not counted in the target-user headline. Relevant experience and domain are
+recorded instead of inferring expertise from a job title.
+
+A person may replace a slot only if its intake has not started. No third slot is
+added after either follow-up is seen. One eligible completion is reported as a
+`single_target_user_observation`; two are a `descriptive_pilot_complete`. Neither
+state means that the product passed a validation threshold.
+
+## Two-stage procedure
+
+### Stage 1: baseline before report exposure
+
+Each reviewer receives only a topic catalog and an intake form. They choose one
+topic based on direct professional familiarity before any candidate report is
+sent. The form records:
+
+- role category, experience band, domain, and AI-assistance declaration;
+- selected topic and why it is relevant to their work;
+- their current commercialization-assessment workflow;
+- estimated minutes their normal process would require;
+- topic-only `GO`, `NO_GO`, `DEFER`, or `UNCERTAIN` decision;
+- topic-only confidence from 1 to 5; and
+- information they would need before acting.
+
+The coordinator locks the completed intake before creating Stage 2. Choosing a
+familiar topic improves ecological relevance but introduces self-selection;
+cross-topic outcomes therefore cannot be compared as if topics were randomized.
+
+### Stage 2: frozen report and follow-up
+
+The coordinator sends exactly the locked topic's report plus a follow-up form.
+The reviewer records:
+
+- decision and confidence after reading;
+- decision usefulness, information gain, actionability, evidence trust, and
+  recommendation acceptance from 1 to 5;
+- reading minutes and estimated correction/revision minutes;
+- `YES`, `MAYBE`, or `NO` willingness to use this report type again;
+- whether no, some, or all cited sources were opened;
+- factual-error state as `NOT_CHECKED`, `NONE_FOUND`, `ONE_FOUND`, or
+  `TWO_PLUS_FOUND`;
+- whether a potentially decision-changing error was found, with details;
+- the most useful content, missing information, required corrections, and a
+  concise rationale.
+
+`NONE_FOUND` is invalid when no source was opened. A changed decision is not
+treated as a more correct decision. Estimated normal-process and revision times
+are self-reports, not instrumented productivity measurements.
+
+## AI use, privacy, and source checking
+
+The requested procedure is no generative AI for substantive judgments.
+Translation or clerical assistance is retained with disclosure. A form that
+declares substantive AI-generated judgment remains in the audit trail but is
+excluded from the human target-user summary.
+
+Reviewers are identified publicly only by `T01` or `T02`. Names, employers,
+contact details, and exact job titles are not collected in the public artifact.
+Anonymous aggregate publication requires explicit consent. Declining consent
+does not erase the private operational record, but that row cannot appear in a
+public case study.
+
+Opening external sources is optional because this pilot primarily measures
+workflow utility. Source truth is `not_evaluated` unless the reviewer actually
+opens sources. Report-internal plausibility must never be described as verified
+factual accuracy.
+
+## Analysis and reporting
+
+There is deliberately no pass/fail product threshold at this sample size. The
+result reports every eligible reviewer separately and, only when both complete,
+descriptive counts or medians for:
+
+- post-report decision and whether it changed;
+- confidence delta;
+- five utility ratings;
+- reading and estimated revision time;
+- willingness to use again;
+- citation-check coverage and factual-error state; and
+- blocking-error observations and requested corrections.
+
+The public result must disclose slot count, eligible target-user count, role
+mix, AI use, source-opening coverage, missing forms, topic self-selection, and
+the age and frozen nature of the reports. It may state exact observations such
+as “2/2 target users rated usefulness at least 4/5” only if that is what the
+locked forms say. It may not generalize those observations to target users as a
+population.
+
+## Artifact and implementation boundaries
+
+The implementation must remain zero-network and must:
+
+- freeze all ten source and metadata hashes before intake;
+- keep the source lock outside every reviewer delivery directory;
+- create Stage 1 without any report body or report path;
+- refuse Stage 2 until one complete, valid intake selects a catalog topic;
+- materialize exactly one locked report per reviewer;
+- preserve reviewer, topic, source, and delivered-report hashes at every seam;
+- distinguish not started, incomplete intake, report not materialized,
+  incomplete follow-up, proxy-only, AI-excluded, single-user, and complete-pilot
+  states;
+- reject changed identifiers, duplicate rows, invalid enum combinations, source
+  drift, report drift, and output overwrite; and
+- keep any public summary separate from private free-text responses.
+
+After implementation tests pass, the selected topic or delivered report hash
+will be deliberately changed. A boundary test must fail before the artifact is
+restored. This pre-registration must remain an earlier commit than packet
+implementation and every human response.

--- a/docs/target-user-decision-pilot-guide.md
+++ b/docs/target-user-decision-pilot-guide.md
@@ -1,0 +1,128 @@
+# Target-user decision pilot guide
+
+This guide operationalizes the frozen protocol in
+[`prereg-2026-08-26-target-user-decision-pilot.md`](prereg-2026-08-26-target-user-decision-pilot.md).
+It is a two-person descriptive pilot over existing reports, not an extension of
+the closed topology utility audit.
+
+## Who to recruit
+
+Use the two registered slots `T01` and `T02`. Prioritize people who actually
+make or support commercialization decisions:
+
+1. technology-transfer or research-commercialization staff;
+2. investors, venture analysts, or due-diligence personnel;
+3. industry strategy, product, consulting, or commercialization staff; or
+4. founders or senior researchers with direct commercialization evaluation
+   responsibility.
+
+A technically capable friend can still complete a packet, but their role must
+be `PROXY` and their response cannot become target-user evidence. Do not infer
+eligibility from prestige, education, or a job title; ask what decisions they
+actually make.
+
+## Honest recruitment message
+
+Send this before sending any packet:
+
+> 你好，我在验证一个科研成果商业化评估系统是否真的能帮助实际决策者，而不只是
+> 验证程序能运行。想邀请你参加一次两阶段的小型试用：第一阶段只看 10 个主题名称，
+> 选择一个你熟悉的方向并记录当前判断；我锁定这份基线后，再发送该主题的一份历史
+> 报告，请你评价它增加了什么信息、需要怎样修改、是否会影响判断。报告约 4,000–
+> 6,000 个英文词，预计阅读和填表需要 45–90 分钟。如果时间或专业方向不合适可以
+> 直接拒绝。这不是考试，也没有标准答案；请不要用生成式 AI 代替你的实质判断。
+> 结果仅使用 T01/T02 编号，姓名和单位不会写入公开材料。你愿意参加吗？
+
+Do not mention a desired outcome, the earlier 6:4 result, a pass threshold, or
+which workflow generated the report. There is no pass threshold in this pilot.
+
+## Prepare Stage 1
+
+The command is zero-network and makes no model or search call:
+
+```bash
+uv run python target_user_pilot.py prepare \
+  outputs/ablation/20260821T234300Z-7dd894ef \
+  outputs/target-user-pilot/20260826-packet \
+  outputs/target-user-pilot-private/20260826-source-lock.json
+```
+
+Keep the source lock private. Send only one of these directories:
+
+```text
+outputs/target-user-pilot/20260826-packet/stage-1/T01/
+outputs/target-user-pilot/20260826-packet/stage-1/T02/
+```
+
+Stage 1 contains a topic catalog, profile, and baseline form but no report.
+This is an information barrier, not a convenience split. If a reviewer sees a
+report before returning the baseline, do not reconstruct their initial answer
+from memory; archive the slot as protocol-deviating.
+
+## Lock intake and materialize Stage 2
+
+Copy the returned `reviewer_profile.csv` and `baseline_form.csv` into the same
+canonical Stage-1 directory. Preserve the reviewer ID and topic text exactly.
+Then run, for example:
+
+```bash
+uv run python target_user_pilot.py materialize \
+  outputs/ablation/20260821T234300Z-7dd894ef \
+  outputs/target-user-pilot/20260826-packet \
+  outputs/target-user-pilot-private/20260826-source-lock.json \
+  T01
+```
+
+The command refuses blank or partial intake, source drift, topic drift, and a
+second materialization. Send only the new `stage-2/T01/` directory. It contains
+the exact selected report, a follow-up form, and a selection snapshot binding
+the source, baseline, and delivered report hashes.
+
+If an untouched slot cannot be recruited, edit only
+`coordinator/slot_status.csv`: set it to `CLOSED_NO_RESPONSE` or `WITHDREW` and
+write a short reason. Never close a slot that already contains participant
+data, and do not add a third slot after seeing a follow-up.
+
+## Required response semantics
+
+- `citation_check=NONE` requires `factual_error_state=NOT_CHECKED`.
+- `NONE_FOUND` means external sources were actually opened and no error was
+  found among what was checked; it never means the report is proven correct.
+- `blocking_error=YES` requires details describing how the issue could change a
+  commercialization decision.
+- Substantive AI-generated judgment is retained but excluded.
+- Translation or clerical AI use is retained with disclosure.
+- A changed go/no-go/defer decision is not assumed to be more correct.
+- Time saved is a self-reported estimate, not an instrumented productivity
+  result.
+
+## Validate and summarize
+
+After returned follow-ups are copied into the canonical Stage-2 directories:
+
+```bash
+uv run python target_user_pilot.py summarize \
+  outputs/ablation/20260821T234300Z-7dd894ef \
+  outputs/target-user-pilot/20260826-packet \
+  outputs/target-user-pilot-private/20260826-source-lock.json \
+  outputs/target-user-pilot-private/20260826-private-result.json \
+  --public-output outputs/target-user-pilot-private/20260826-public-result.json
+```
+
+The private result retains free-text corrections for product learning. The
+public projection omits free text and calculates outcomes only from reviewers
+who consented to anonymous aggregate publication. Both outputs are immutable;
+choose a new filename if a disclosed normalization is ever required.
+
+Possible study states are deliberately distinct:
+
+- `in_progress`: an open slot has not reached a complete follow-up;
+- `single_target_user_observation`: one eligible target user completed and the
+  other slot was closed;
+- `descriptive_pilot_complete`: both eligible target users completed; or
+- `no_eligible_target_user_observation`: completed rows were proxies or excluded
+  for substantive AI use.
+
+None of these states is a product-validation pass. Report exact observations
+and limitations instead of converting two people into a percentage claim about
+the market.

--- a/target_user_pilot.py
+++ b/target_user_pilot.py
@@ -1,0 +1,957 @@
+"""Prepare and inspect a zero-provider two-stage target-user pilot.
+
+The earlier topology audit is a closed randomized comparison.  This tool does
+not append to it.  It exposes only a topic catalog at Stage 1, locks the user's
+baseline before report exposure, and materializes one historical full-workflow
+report at Stage 2.  Every source and delivery seam is hashed because the useful
+claim is about the artifact a person actually read, not merely the file that a
+coordinator intended to send.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+STUDY_ID = "target-user-decision-pilot-20260826"
+SOURCE_REPORT_DATE = "2026-08-21"
+REVIEWER_IDS = ("T01", "T02")
+TARGET_ROLES = {
+    "TTO_COMMERCIALIZATION",
+    "INVESTMENT_DUE_DILIGENCE",
+    "INDUSTRY_STRATEGY",
+    "OTHER_COMMERCIALIZATION_DECISION_MAKER",
+}
+ROLE_LABELS = {*TARGET_ROLES, "PROXY"}
+EXPERIENCE_LABELS = {"0_2", "3_5", "6_10", "11_PLUS"}
+AI_USE_LABELS = {"NONE", "TRANSLATION_OR_CLERICAL", "SUBSTANTIVE"}
+CONSENT_LABELS = {"YES", "NO"}
+COMPENSATION_LABELS = {"NONE", "HONORARIUM", "OTHER"}
+DECISION_LABELS = {"GO", "NO_GO", "DEFER", "UNCERTAIN"}
+REUSE_LABELS = {"YES", "MAYBE", "NO"}
+CITATION_CHECK_LABELS = {"NONE", "SOME", "ALL"}
+FACT_ERROR_LABELS = {"NOT_CHECKED", "NONE_FOUND", "ONE_FOUND", "TWO_PLUS_FOUND"}
+BLOCKING_ERROR_LABELS = {"YES", "NO", "UNCERTAIN"}
+SLOT_LABELS = {"OPEN", "CLOSED_NO_RESPONSE", "WITHDREW"}
+
+CATALOG_FIELDS = ("topic_num", "topic", "industry")
+PROFILE_FIELDS = (
+    "reviewer_id",
+    "role_category",
+    "experience_band",
+    "professional_context",
+    "domain_experience",
+    "generative_ai_use",
+    "generative_ai_notes",
+    "anonymous_aggregate_consent",
+    "compensation",
+    "compensation_notes",
+)
+BASELINE_FIELDS = (
+    "reviewer_id",
+    "selected_topic_num",
+    "selected_topic",
+    "selection_reason",
+    "current_workflow_summary",
+    "expected_research_minutes",
+    "initial_decision",
+    "initial_confidence",
+    "information_needed",
+)
+FOLLOWUP_FIELDS = (
+    "reviewer_id",
+    "selected_topic_num",
+    "selected_topic",
+    "report_sha256",
+    "post_report_decision",
+    "post_report_confidence",
+    "decision_usefulness",
+    "information_gain",
+    "actionability",
+    "evidence_trust",
+    "recommendation_acceptance",
+    "reading_minutes",
+    "estimated_revision_minutes",
+    "would_use_again",
+    "citation_check",
+    "factual_error_state",
+    "blocking_error",
+    "blocking_error_details",
+    "most_useful_content",
+    "missing_information",
+    "required_corrections",
+    "rationale",
+)
+SLOT_FIELDS = ("reviewer_id", "slot_status", "closure_reason")
+FOLLOWUP_REQUIRED_FIELDS = tuple(
+    field for field in FOLLOWUP_FIELDS[4:] if field != "blocking_error_details"
+)
+
+
+class TargetUserPilotError(ValueError):
+    """Raised when an artifact would overstate or corrupt the pilot evidence."""
+
+
+@dataclass(frozen=True)
+class FrozenReport:
+    """One exact historical full-workflow report available in the catalog."""
+
+    topic_num: str
+    topic: str
+    industry: str
+    source_cell: str
+    fixture_digest: str
+    report_sha256: str
+    meta_sha256: str
+    report_path: Path
+    meta_path: Path
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return _sha256_bytes(encoded)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TargetUserPilotError(f"{path} must contain a JSON object")
+    return value
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_csv(path: Path, expected_fields: tuple[str, ...]) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if tuple(reader.fieldnames or ()) != expected_fields:
+            raise TargetUserPilotError(f"{path} has an unexpected CSV schema")
+        return list(reader)
+
+
+def _write_csv(path: Path, fields: tuple[str, ...], rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _assert_separate(packet_dir: Path, source_lock_path: Path) -> None:
+    packet = packet_dir.resolve()
+    lock = source_lock_path.resolve()
+    if lock == packet or packet in lock.parents:
+        raise TargetUserPilotError("the source lock must stay outside every reviewer packet directory")
+
+
+def discover_reports(experiment_dir: Path, *, expected_count: int = 10) -> list[FrozenReport]:
+    """Freeze each topic's successful full-workflow repetition-one artifact.
+
+    Selecting by this rule is intentionally less flexible than "first report
+    that looks useful".  A failed or missing repetition-one cell stops packet
+    preparation instead of silently changing the human denominator.
+    """
+
+    reports: dict[str, FrozenReport] = {}
+    for meta_path in sorted(experiment_dir.glob("*/meta.json")):
+        raw_meta = meta_path.read_bytes()
+        try:
+            meta = json.loads(raw_meta.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TargetUserPilotError(f"{meta_path} is not valid UTF-8 JSON") from exc
+        if not isinstance(meta, dict) or meta.get("variant") != "full" or meta.get("rep") != 1:
+            continue
+        if meta.get("status") != "success":
+            raise TargetUserPilotError(f"frozen full cell {meta_path.parent.name} is not successful")
+
+        topic_num = str(meta.get("num", "")).strip()
+        topic = str(meta.get("topic", "")).strip()
+        industry = str(meta.get("industry", "")).strip()
+        fixture_digest = str(meta.get("fixture_digest", "")).strip()
+        if not topic_num or not topic or not industry or not fixture_digest:
+            raise TargetUserPilotError(f"{meta_path} is missing catalog or evidence identity")
+        if topic_num in reports:
+            raise TargetUserPilotError(f"duplicate full repetition-one topic: {topic_num}")
+
+        report_path = meta_path.parent / "commercialization_report.md"
+        if not report_path.is_file():
+            raise TargetUserPilotError(f"{meta_path.parent.name} is missing commercialization_report.md")
+        report_bytes = report_path.read_bytes()
+        try:
+            report_body = report_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise TargetUserPilotError(f"{report_path} is not UTF-8") from exc
+        if not report_body.strip():
+            raise TargetUserPilotError(f"{report_path} is empty")
+
+        reports[topic_num] = FrozenReport(
+            topic_num=topic_num,
+            topic=topic,
+            industry=industry,
+            source_cell=meta_path.parent.name,
+            fixture_digest=fixture_digest,
+            report_sha256=_sha256_bytes(report_bytes),
+            meta_sha256=_sha256_bytes(raw_meta),
+            report_path=report_path,
+            meta_path=meta_path,
+        )
+
+    if len(reports) != expected_count:
+        raise TargetUserPilotError(f"expected {expected_count} frozen full reports, found {len(reports)}")
+    return [reports[key] for key in sorted(reports)]
+
+
+def _catalog_rows(reports: list[FrozenReport]) -> list[dict[str, str]]:
+    return [{field: getattr(report, field) for field in CATALOG_FIELDS} for report in reports]
+
+
+def _source_rows(reports: list[FrozenReport]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for report in reports:
+        row = asdict(report)
+        # Absolute developer paths do not belong in an audit lock that may be
+        # archived elsewhere.  The source cell plus fixed filenames is enough
+        # to re-resolve the artifact against the explicit experiment argument.
+        row["report_path"] = f"{report.source_cell}/commercialization_report.md"
+        row["meta_path"] = f"{report.source_cell}/meta.json"
+        rows.append(row)
+    return rows
+
+
+def _stage_one_readme(reviewer_id: str) -> str:
+    return f"""# 目标用户决策试点：第一阶段
+
+评审编号：`{reviewer_id}`
+
+这一阶段**不包含任何系统报告**。请先完成：
+
+1. `reviewer_profile.csv`：填写你的角色背景和 AI 使用声明；
+2. 查看 `case_catalog.csv`，选择一个与你真实工作最接近、你有直接经验的主题；
+3. 在 `baseline_form.csv` 记录看报告之前的判断、信心和你通常需要的信息。
+
+请不要搜索或向他人询问系统对这些主题的既有结论。可以查阅你正常工作中
+本来就会使用的资料，但请在 `current_workflow_summary` 中如实说明。不要使用生成式
+AI 代替实质判断；翻译或表格整理用途必须在 profile 中披露。
+
+请只修改两个 CSV，不要改动主题目录。完成后把整个文件夹原样返还。第二阶段会在
+这份基线锁定后才发送一份与你所选主题对应的历史报告。
+"""
+
+
+def _coordinator_readme() -> str:
+    return """# Target-user pilot coordinator workspace
+
+Do not send this whole directory. Stage 1 contains no report by design; send
+only one reviewer's `stage-1/<reviewer_id>` directory. After the returned
+profile and baseline are copied into the canonical directory, run the
+`materialize` command to create that reviewer's Stage 2 packet.
+
+The source lock must remain outside this packet root. Do not add a third slot,
+replace a started slot, or reveal another reviewer's response. If an untouched
+slot cannot be recruited, set its coordinator status to `CLOSED_NO_RESPONSE`.
+"""
+
+
+def _stage_two_readme(reviewer_id: str, topic: str) -> str:
+    return f"""# 目标用户决策试点：第二阶段
+
+- 评审编号：`{reviewer_id}`
+- 锁定主题：`{topic}`
+
+请完整阅读 `report.md`，然后填写 `followup_form.csv`。报告来自 2026-08-21
+冻结证据，不是刚刚重新联网检索的材料。请按真实工作标准记录它是否有决策价值、
+需要多少修订，以及哪些内容可能误导。
+
+不要求逐个打开引用；但如果没有打开任何外部来源，`citation_check` 必须填写
+`NONE`，`factual_error_state` 必须填写 `NOT_CHECKED`。这代表“没有核查”，不是
+“没有错误”。不要使用生成式 AI 代替你的实质判断。
+
+请只修改 `followup_form.csv`，不要修改报告或 selection snapshot。完成后原样返还
+整个文件夹。
+"""
+
+
+def prepare_pilot(experiment_dir: Path, packet_dir: Path, source_lock_path: Path) -> dict[str, Any]:
+    """Create report-free Stage 1 packets and a physically separate source lock."""
+
+    _assert_separate(packet_dir, source_lock_path)
+    if packet_dir.exists() or source_lock_path.exists():
+        raise TargetUserPilotError("packet and source-lock paths must not already exist")
+
+    reports = discover_reports(experiment_dir)
+    catalog = _catalog_rows(reports)
+    catalog_digest = _canonical_sha256(catalog)
+    packet_dir.mkdir(parents=True)
+    (packet_dir / "README.md").write_text(_coordinator_readme(), encoding="utf-8")
+    _write_csv(
+        packet_dir / "coordinator" / "slot_status.csv",
+        SLOT_FIELDS,
+        [
+            {"reviewer_id": reviewer_id, "slot_status": "OPEN", "closure_reason": ""}
+            for reviewer_id in REVIEWER_IDS
+        ],
+    )
+
+    for reviewer_id in REVIEWER_IDS:
+        reviewer_dir = packet_dir / "stage-1" / reviewer_id
+        reviewer_dir.mkdir(parents=True)
+        (reviewer_dir / "README.md").write_text(_stage_one_readme(reviewer_id), encoding="utf-8")
+        _write_csv(reviewer_dir / "case_catalog.csv", CATALOG_FIELDS, catalog)
+        _write_csv(
+            reviewer_dir / "reviewer_profile.csv",
+            PROFILE_FIELDS,
+            [{"reviewer_id": reviewer_id}],
+        )
+        _write_csv(
+            reviewer_dir / "baseline_form.csv",
+            BASELINE_FIELDS,
+            [{"reviewer_id": reviewer_id}],
+        )
+
+    manifest = {
+        "schema_version": 1,
+        "study_id": STUDY_ID,
+        "reviewer_ids": list(REVIEWER_IDS),
+        "source_count": len(reports),
+        "catalog_sha256": catalog_digest,
+        "stage_1_contains_reports": False,
+        "human_response_count": 0,
+        "status": "not_started",
+    }
+    _write_json(packet_dir / "manifest.json", manifest)
+    source_lock = {
+        "schema_version": 1,
+        "study_id": STUDY_ID,
+        "source_experiment": experiment_dir.name,
+        "reviewer_ids": list(REVIEWER_IDS),
+        "catalog_sha256": catalog_digest,
+        "packet_manifest_sha256": _sha256_bytes((packet_dir / "manifest.json").read_bytes()),
+        "sources": _source_rows(reports),
+    }
+    _write_json(source_lock_path, source_lock)
+    return manifest
+
+
+def _source_projection(report: FrozenReport) -> dict[str, str]:
+    return _source_rows([report])[0]
+
+
+def _verify_base(
+    experiment_dir: Path, packet_dir: Path, source_lock_path: Path
+) -> dict[str, FrozenReport]:
+    _assert_separate(packet_dir, source_lock_path)
+    manifest = _read_json(packet_dir / "manifest.json")
+    source_lock = _read_json(source_lock_path)
+    if manifest.get("study_id") != STUDY_ID or source_lock.get("study_id") != STUDY_ID:
+        raise TargetUserPilotError("packet or source lock belongs to a different study")
+    if manifest.get("reviewer_ids") != list(REVIEWER_IDS) or source_lock.get("reviewer_ids") != list(REVIEWER_IDS):
+        raise TargetUserPilotError("reviewer slots drifted from the pre-registration")
+    if source_lock.get("packet_manifest_sha256") != _sha256_bytes((packet_dir / "manifest.json").read_bytes()):
+        raise TargetUserPilotError("packet manifest drifted after source lock creation")
+
+    reports = discover_reports(experiment_dir)
+    expected_sources = _source_rows(reports)
+    if source_lock.get("sources") != expected_sources:
+        raise TargetUserPilotError("frozen source report or metadata drifted")
+    catalog = _catalog_rows(reports)
+    catalog_digest = _canonical_sha256(catalog)
+    if manifest.get("catalog_sha256") != catalog_digest or source_lock.get("catalog_sha256") != catalog_digest:
+        raise TargetUserPilotError("catalog identity drifted")
+
+    for reviewer_id in REVIEWER_IDS:
+        reviewer_dir = packet_dir / "stage-1" / reviewer_id
+        rows = _read_csv(reviewer_dir / "case_catalog.csv", CATALOG_FIELDS)
+        if rows != catalog:
+            raise TargetUserPilotError(f"{reviewer_id} catalog drifted after packet creation")
+        # Stage 1 must remain a real information barrier.  Checking filenames
+        # rather than searching for one sample phrase protects every future
+        # report body and catches accidental coordinator copies.
+        unexpected = [path for path in reviewer_dir.rglob("*") if path.is_file() and path.suffix.lower() == ".md" and path.name != "README.md"]
+        if unexpected:
+            raise TargetUserPilotError(f"{reviewer_id} Stage 1 unexpectedly contains a report-like file")
+    return {report.topic_num: report for report in reports}
+
+
+def _single_row(path: Path, fields: tuple[str, ...]) -> dict[str, str]:
+    rows = _read_csv(path, fields)
+    if len(rows) != 1:
+        raise TargetUserPilotError(f"{path} must contain exactly one row")
+    return rows[0]
+
+
+def _empty_except_identity(row: dict[str, str], identity_fields: set[str]) -> bool:
+    return all(not value.strip() for key, value in row.items() if key not in identity_fields)
+
+
+def _require_complete(row: dict[str, str], required: tuple[str, ...], *, context: str) -> None:
+    missing = [field for field in required if not row.get(field, "").strip()]
+    if missing:
+        raise TargetUserPilotError(f"{context} is partially completed; missing {', '.join(missing)}")
+
+
+def _parse_int(value: str, *, field: str, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise TargetUserPilotError(f"{field} must be an integer") from exc
+    if not minimum <= parsed <= maximum:
+        raise TargetUserPilotError(f"{field} must be between {minimum} and {maximum}")
+    return parsed
+
+
+def _validate_profile(row: dict[str, str], reviewer_id: str) -> dict[str, Any] | None:
+    if row.get("reviewer_id", "").strip() != reviewer_id:
+        raise TargetUserPilotError(f"{reviewer_id} profile changed reviewer_id")
+    if _empty_except_identity(row, {"reviewer_id"}):
+        return None
+    required = (
+        "role_category",
+        "experience_band",
+        "professional_context",
+        "domain_experience",
+        "generative_ai_use",
+        "anonymous_aggregate_consent",
+        "compensation",
+    )
+    _require_complete(row, required, context=f"{reviewer_id} profile")
+    role = row["role_category"].strip().upper()
+    experience = row["experience_band"].strip().upper()
+    ai_use = row["generative_ai_use"].strip().upper()
+    consent = row["anonymous_aggregate_consent"].strip().upper()
+    compensation = row["compensation"].strip().upper()
+    if role not in ROLE_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid role_category")
+    if experience not in EXPERIENCE_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid experience_band")
+    if ai_use not in AI_USE_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid generative_ai_use")
+    if consent not in CONSENT_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid anonymous_aggregate_consent")
+    if compensation not in COMPENSATION_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid compensation")
+    if ai_use != "NONE" and not row["generative_ai_notes"].strip():
+        raise TargetUserPilotError(f"{reviewer_id} must describe non-NONE generative AI use")
+    if compensation == "OTHER" and not row["compensation_notes"].strip():
+        raise TargetUserPilotError(f"{reviewer_id} must describe OTHER compensation")
+    return {
+        **row,
+        "role_category": role,
+        "experience_band": experience,
+        "generative_ai_use": ai_use,
+        "anonymous_aggregate_consent": consent,
+        "compensation": compensation,
+    }
+
+
+def _validate_baseline(
+    row: dict[str, str], reviewer_id: str, reports: dict[str, FrozenReport]
+) -> dict[str, Any] | None:
+    if row.get("reviewer_id", "").strip() != reviewer_id:
+        raise TargetUserPilotError(f"{reviewer_id} baseline changed reviewer_id")
+    if _empty_except_identity(row, {"reviewer_id"}):
+        return None
+    _require_complete(row, BASELINE_FIELDS[1:], context=f"{reviewer_id} baseline")
+    topic_num = row["selected_topic_num"].strip()
+    if topic_num not in reports:
+        raise TargetUserPilotError(f"{reviewer_id} selected an unknown topic")
+    report = reports[topic_num]
+    if row["selected_topic"].strip() != report.topic:
+        raise TargetUserPilotError(f"{reviewer_id} changed the selected topic text")
+    decision = row["initial_decision"].strip().upper()
+    if decision not in DECISION_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid initial_decision")
+    return {
+        **row,
+        "selected_topic_num": topic_num,
+        "selected_topic": report.topic,
+        "expected_research_minutes": _parse_int(
+            row["expected_research_minutes"],
+            field=f"{reviewer_id} expected_research_minutes",
+            minimum=1,
+            maximum=10000,
+        ),
+        "initial_decision": decision,
+        "initial_confidence": _parse_int(
+            row["initial_confidence"],
+            field=f"{reviewer_id} initial_confidence",
+            minimum=1,
+            maximum=5,
+        ),
+    }
+
+
+def _profile_and_baseline(
+    packet_dir: Path, reviewer_id: str, reports: dict[str, FrozenReport]
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    reviewer_dir = packet_dir / "stage-1" / reviewer_id
+    profile = _validate_profile(
+        _single_row(reviewer_dir / "reviewer_profile.csv", PROFILE_FIELDS), reviewer_id
+    )
+    baseline = _validate_baseline(
+        _single_row(reviewer_dir / "baseline_form.csv", BASELINE_FIELDS), reviewer_id, reports
+    )
+    if (profile is None) != (baseline is None):
+        raise TargetUserPilotError(f"{reviewer_id} intake has only one of profile and baseline")
+    return profile, baseline
+
+
+def materialize_followup(
+    experiment_dir: Path, packet_dir: Path, source_lock_path: Path, reviewer_id: str
+) -> dict[str, Any]:
+    """Release one report only after the corresponding baseline is complete."""
+
+    if reviewer_id not in REVIEWER_IDS:
+        raise TargetUserPilotError("unknown reviewer_id")
+    reports = _verify_base(experiment_dir, packet_dir, source_lock_path)
+    profile, baseline = _profile_and_baseline(packet_dir, reviewer_id, reports)
+    if profile is None or baseline is None:
+        raise TargetUserPilotError(f"{reviewer_id} intake must be complete before Stage 2")
+
+    stage_two = packet_dir / "stage-2" / reviewer_id
+    if stage_two.exists():
+        raise TargetUserPilotError(f"{reviewer_id} Stage 2 already exists")
+    report = reports[baseline["selected_topic_num"]]
+    report_bytes = report.report_path.read_bytes()
+    if _sha256_bytes(report_bytes) != report.report_sha256:
+        raise TargetUserPilotError("selected source report drifted before materialization")
+
+    stage_two.mkdir(parents=True)
+    (stage_two / "README.md").write_text(
+        _stage_two_readme(reviewer_id, report.topic), encoding="utf-8"
+    )
+    (stage_two / "report.md").write_bytes(report_bytes)
+    snapshot = {
+        "schema_version": 1,
+        "study_id": STUDY_ID,
+        "reviewer_id": reviewer_id,
+        "selected_topic_num": report.topic_num,
+        "selected_topic": report.topic,
+        "fixture_digest": report.fixture_digest,
+        "source_cell": report.source_cell,
+        "source_report_sha256": report.report_sha256,
+        "delivered_report_sha256": _sha256_bytes((stage_two / "report.md").read_bytes()),
+        "profile_sha256": _canonical_sha256(profile),
+        "baseline_sha256": _canonical_sha256(baseline),
+    }
+    _write_json(stage_two / "selection_snapshot.json", snapshot)
+    _write_csv(
+        stage_two / "followup_form.csv",
+        FOLLOWUP_FIELDS,
+        [
+            {
+                "reviewer_id": reviewer_id,
+                "selected_topic_num": report.topic_num,
+                "selected_topic": report.topic,
+                "report_sha256": report.report_sha256,
+            }
+        ],
+    )
+    return snapshot
+
+
+def _validate_followup(
+    row: dict[str, str], reviewer_id: str, report: FrozenReport
+) -> dict[str, Any] | None:
+    identities = {
+        "reviewer_id": reviewer_id,
+        "selected_topic_num": report.topic_num,
+        "selected_topic": report.topic,
+        "report_sha256": report.report_sha256,
+    }
+    for field, expected in identities.items():
+        if row.get(field, "").strip() != expected:
+            raise TargetUserPilotError(f"{reviewer_id} follow-up changed {field}")
+    if _empty_except_identity(row, set(identities)):
+        return None
+    _require_complete(row, FOLLOWUP_REQUIRED_FIELDS, context=f"{reviewer_id} follow-up")
+
+    decision = row["post_report_decision"].strip().upper()
+    reuse = row["would_use_again"].strip().upper()
+    citation_check = row["citation_check"].strip().upper()
+    factual = row["factual_error_state"].strip().upper()
+    blocking = row["blocking_error"].strip().upper()
+    if decision not in DECISION_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid post_report_decision")
+    if reuse not in REUSE_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid would_use_again")
+    if citation_check not in CITATION_CHECK_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid citation_check")
+    if factual not in FACT_ERROR_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid factual_error_state")
+    if blocking not in BLOCKING_ERROR_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid blocking_error")
+    if citation_check == "NONE" and factual != "NOT_CHECKED":
+        raise TargetUserPilotError(f"{reviewer_id} cannot report factual errors without source checking")
+    if citation_check != "NONE" and factual == "NOT_CHECKED":
+        raise TargetUserPilotError(f"{reviewer_id} opened sources but left factual errors unchecked")
+    if blocking == "YES" and not row["blocking_error_details"].strip():
+        raise TargetUserPilotError(f"{reviewer_id} must describe a blocking error")
+
+    parsed: dict[str, Any] = {
+        **row,
+        "post_report_decision": decision,
+        "would_use_again": reuse,
+        "citation_check": citation_check,
+        "factual_error_state": factual,
+        "blocking_error": blocking,
+    }
+    for field in (
+        "post_report_confidence",
+        "decision_usefulness",
+        "information_gain",
+        "actionability",
+        "evidence_trust",
+        "recommendation_acceptance",
+    ):
+        parsed[field] = _parse_int(row[field], field=f"{reviewer_id} {field}", minimum=1, maximum=5)
+    parsed["reading_minutes"] = _parse_int(
+        row["reading_minutes"], field=f"{reviewer_id} reading_minutes", minimum=1, maximum=10000
+    )
+    parsed["estimated_revision_minutes"] = _parse_int(
+        row["estimated_revision_minutes"],
+        field=f"{reviewer_id} estimated_revision_minutes",
+        minimum=0,
+        maximum=10000,
+    )
+    return parsed
+
+
+def _slot_states(packet_dir: Path) -> dict[str, dict[str, str]]:
+    rows = _read_csv(packet_dir / "coordinator" / "slot_status.csv", SLOT_FIELDS)
+    if len(rows) != len(REVIEWER_IDS):
+        raise TargetUserPilotError("slot status must contain exactly the registered reviewers")
+    states: dict[str, dict[str, str]] = {}
+    for row in rows:
+        reviewer_id = row["reviewer_id"].strip()
+        state = row["slot_status"].strip().upper()
+        reason = row["closure_reason"].strip()
+        if reviewer_id not in REVIEWER_IDS or reviewer_id in states:
+            raise TargetUserPilotError("slot status has an unknown or duplicate reviewer")
+        if state not in SLOT_LABELS:
+            raise TargetUserPilotError(f"{reviewer_id} has invalid slot_status")
+        if state == "OPEN" and reason:
+            raise TargetUserPilotError(f"{reviewer_id} OPEN slot cannot have a closure reason")
+        if state != "OPEN" and not reason:
+            raise TargetUserPilotError(f"{reviewer_id} closed slot requires a reason")
+        states[reviewer_id] = {"slot_status": state, "closure_reason": reason}
+    if set(states) != set(REVIEWER_IDS):
+        raise TargetUserPilotError("slot status does not match the registered reviewers")
+    return states
+
+
+def _verify_stage_two(
+    stage_two: Path,
+    reviewer_id: str,
+    report: FrozenReport,
+    profile: dict[str, Any],
+    baseline: dict[str, Any],
+) -> dict[str, Any] | None:
+    snapshot = _read_json(stage_two / "selection_snapshot.json")
+    expected = {
+        "study_id": STUDY_ID,
+        "reviewer_id": reviewer_id,
+        "selected_topic_num": report.topic_num,
+        "selected_topic": report.topic,
+        "fixture_digest": report.fixture_digest,
+        "source_cell": report.source_cell,
+        "source_report_sha256": report.report_sha256,
+        "delivered_report_sha256": report.report_sha256,
+        "profile_sha256": _canonical_sha256(profile),
+        "baseline_sha256": _canonical_sha256(baseline),
+    }
+    for field, value in expected.items():
+        if snapshot.get(field) != value:
+            raise TargetUserPilotError(f"{reviewer_id} selection snapshot drifted at {field}")
+    if _sha256_bytes((stage_two / "report.md").read_bytes()) != report.report_sha256:
+        raise TargetUserPilotError(f"{reviewer_id} delivered report drifted")
+    return _validate_followup(
+        _single_row(stage_two / "followup_form.csv", FOLLOWUP_FIELDS), reviewer_id, report
+    )
+
+
+def _median(values: list[int]) -> float | None:
+    return float(statistics.median(values)) if values else None
+
+
+def _aggregate_observations(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Project only structured outcomes from the explicitly supplied rows."""
+
+    metric_fields = (
+        "decision_usefulness",
+        "information_gain",
+        "actionability",
+        "evidence_trust",
+        "recommendation_acceptance",
+        "reading_minutes",
+        "estimated_revision_minutes",
+    )
+    return {
+        "decision_changed_count": sum(1 for row in rows if row["derived"]["decision_changed"]),
+        "would_use_again": {
+            label: sum(1 for row in rows if row["followup"]["would_use_again"] == label)
+            for label in sorted(REUSE_LABELS)
+        },
+        "citation_check": {
+            label: sum(1 for row in rows if row["followup"]["citation_check"] == label)
+            for label in sorted(CITATION_CHECK_LABELS)
+        },
+        "blocking_error": {
+            label: sum(1 for row in rows if row["followup"]["blocking_error"] == label)
+            for label in sorted(BLOCKING_ERROR_LABELS)
+        },
+        "eligible_medians": {
+            field: _median([int(row["followup"][field]) for row in rows])
+            for field in metric_fields
+        },
+    }
+
+
+def summarize_pilot(experiment_dir: Path, packet_dir: Path, source_lock_path: Path) -> dict[str, Any]:
+    """Validate every handoff and return private plus consent-safe projections."""
+
+    reports = _verify_base(experiment_dir, packet_dir, source_lock_path)
+    slot_states = _slot_states(packet_dir)
+    reviewers: list[dict[str, Any]] = []
+    open_incomplete = False
+
+    for reviewer_id in REVIEWER_IDS:
+        profile, baseline = _profile_and_baseline(packet_dir, reviewer_id, reports)
+        slot = slot_states[reviewer_id]
+        stage_two = packet_dir / "stage-2" / reviewer_id
+        if slot["slot_status"] != "OPEN":
+            if profile is not None or baseline is not None or stage_two.exists():
+                raise TargetUserPilotError(f"{reviewer_id} closed slot contains participant data")
+            reviewers.append({"reviewer_id": reviewer_id, "status": slot["slot_status"].lower()})
+            continue
+        if profile is None or baseline is None:
+            open_incomplete = True
+            reviewers.append({"reviewer_id": reviewer_id, "status": "not_started"})
+            continue
+
+        report = reports[baseline["selected_topic_num"]]
+        if not stage_two.is_dir():
+            open_incomplete = True
+            reviewers.append(
+                {
+                    "reviewer_id": reviewer_id,
+                    "status": "report_not_materialized",
+                    "profile": profile,
+                    "baseline": baseline,
+                }
+            )
+            continue
+        followup = _verify_stage_two(stage_two, reviewer_id, report, profile, baseline)
+        if followup is None:
+            open_incomplete = True
+            reviewers.append(
+                {
+                    "reviewer_id": reviewer_id,
+                    "status": "followup_incomplete",
+                    "profile": profile,
+                    "baseline": baseline,
+                }
+            )
+            continue
+
+        is_target = profile["role_category"] in TARGET_ROLES
+        ai_excluded = profile["generative_ai_use"] == "SUBSTANTIVE"
+        eligible = is_target and not ai_excluded
+        reviewers.append(
+            {
+                "reviewer_id": reviewer_id,
+                "status": "complete",
+                "eligible_target_user": eligible,
+                "publicly_reportable": eligible and profile["anonymous_aggregate_consent"] == "YES",
+                "profile": profile,
+                "baseline": baseline,
+                "followup": followup,
+                "derived": {
+                    "decision_changed": baseline["initial_decision"] != followup["post_report_decision"],
+                    "confidence_delta": followup["post_report_confidence"] - baseline["initial_confidence"],
+                    "self_reported_estimated_minutes_delta": baseline["expected_research_minutes"]
+                    - followup["reading_minutes"]
+                    - followup["estimated_revision_minutes"],
+                    "source_truth_status": (
+                        "not_evaluated" if followup["citation_check"] == "NONE" else "partially_checked"
+                    ),
+                },
+            }
+        )
+
+    completed = [row for row in reviewers if row["status"] == "complete"]
+    eligible = [row for row in completed if row["eligible_target_user"]]
+    public_rows = [row for row in eligible if row["publicly_reportable"]]
+    if open_incomplete:
+        status = "in_progress"
+    elif len(eligible) == 2:
+        status = "descriptive_pilot_complete"
+    elif len(eligible) == 1:
+        status = "single_target_user_observation"
+    else:
+        status = "no_eligible_target_user_observation"
+
+    private_metrics = _aggregate_observations(eligible)
+    public_metrics = _aggregate_observations(public_rows)
+    if not eligible:
+        publication_status = "no_eligible_observations"
+    elif len(public_rows) == len(eligible):
+        publication_status = "all_eligible_observations_public"
+    elif public_rows:
+        publication_status = "partial_public_consent"
+    else:
+        publication_status = "no_eligible_observation_consent"
+
+    reportable_role_mix = {
+        label: sum(1 for row in public_rows if row["profile"]["role_category"] == label)
+        for label in sorted(TARGET_ROLES)
+        if any(row["profile"]["role_category"] == label for row in public_rows)
+    }
+    reportable_ai_use = {
+        label: sum(1 for row in public_rows if row["profile"]["generative_ai_use"] == label)
+        for label in sorted(AI_USE_LABELS)
+        if any(row["profile"]["generative_ai_use"] == label for row in public_rows)
+    }
+    closed_states = {"closed_no_response", "withdrew"}
+    closed_count = sum(1 for row in reviewers if row["status"] in closed_states)
+    incomplete_count = len(REVIEWER_IDS) - len(completed) - closed_count
+    public_projection = {
+        "schema_version": 1,
+        "study_id": STUDY_ID,
+        # Study completion and publication consent are orthogonal.  Folding
+        # them into one status made a complete two-user pilot look unfinished
+        # when one person declined publication.
+        "status": status,
+        "publication_status": publication_status,
+        "registered_slots": len(REVIEWER_IDS),
+        "complete_observation_count": len(completed),
+        "closed_slot_count": closed_count,
+        "incomplete_slot_count": incomplete_count,
+        "publicly_reportable_count": len(public_rows),
+        "reportable_role_mix": reportable_role_mix,
+        "reportable_ai_use": reportable_ai_use,
+        "reportable_selected_topics": [
+            {
+                "topic_num": row["baseline"]["selected_topic_num"],
+                "topic": row["baseline"]["selected_topic"],
+            }
+            for row in public_rows
+        ],
+        "source_material": {
+            "report_generation_date": SOURCE_REPORT_DATE,
+            "evidence_state": "frozen_historical",
+            "fresh_retrieval": False,
+            "topic_assignment": "reviewer_self_selected_before_report",
+        },
+        **public_metrics,
+        "claim_boundary": (
+            "descriptive target-user observations only; not adoption, ROI, decision accuracy, "
+            "hallucination rate, or population-level product validation"
+        ),
+    }
+    return {
+        "schema_version": 1,
+        "study_id": STUDY_ID,
+        "status": status,
+        "registered_slots": len(REVIEWER_IDS),
+        "completed_count": len(completed),
+        "eligible_target_user_count": len(eligible),
+        "publicly_reportable_count": len(public_rows),
+        "substantive_ai_excluded_count": sum(
+            1
+            for row in completed
+            if row["profile"]["generative_ai_use"] == "SUBSTANTIVE"
+        ),
+        "proxy_completed_count": sum(
+            1 for row in completed if row["profile"]["role_category"] == "PROXY"
+        ),
+        **private_metrics,
+        "claim_boundary": public_projection["claim_boundary"],
+        "reviewers": reviewers,
+        "public_projection": public_projection,
+    }
+
+
+def write_summary(path: Path, result: dict[str, Any], *, public_only: bool = False) -> None:
+    """Persist an immutable private result or its consent-safe projection."""
+
+    if path.exists():
+        raise TargetUserPilotError("summary output already exists")
+    value = result["public_projection"] if public_only else result
+    _write_json(path, value)
+
+
+def write_summaries(
+    private_path: Path, public_path: Path | None, result: dict[str, Any]
+) -> None:
+    """Preflight the output pair so an expected collision cannot half-write it."""
+
+    paths = [private_path, *([] if public_path is None else [public_path])]
+    resolved = [path.resolve() for path in paths]
+    if len(set(resolved)) != len(resolved):
+        raise TargetUserPilotError("private and public summary outputs must be distinct")
+    existing = [path for path in paths if path.exists()]
+    if existing:
+        raise TargetUserPilotError(
+            "summary output already exists: " + ", ".join(str(path) for path in existing)
+        )
+
+    write_summary(private_path, result)
+    if public_path is not None:
+        write_summary(public_path, result, public_only=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare = commands.add_parser("prepare", help="create report-free Stage 1 packets")
+    prepare.add_argument("experiment_dir", type=Path)
+    prepare.add_argument("packet_dir", type=Path)
+    prepare.add_argument("source_lock", type=Path)
+
+    materialize = commands.add_parser("materialize", help="create one Stage 2 packet after intake")
+    materialize.add_argument("experiment_dir", type=Path)
+    materialize.add_argument("packet_dir", type=Path)
+    materialize.add_argument("source_lock", type=Path)
+    materialize.add_argument("reviewer_id", choices=REVIEWER_IDS)
+
+    summarize = commands.add_parser("summarize", help="validate and summarize the pilot")
+    summarize.add_argument("experiment_dir", type=Path)
+    summarize.add_argument("packet_dir", type=Path)
+    summarize.add_argument("source_lock", type=Path)
+    summarize.add_argument("output", type=Path)
+    summarize.add_argument("--public-output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "prepare":
+        result = prepare_pilot(args.experiment_dir, args.packet_dir, args.source_lock)
+    elif args.command == "materialize":
+        result = materialize_followup(
+            args.experiment_dir, args.packet_dir, args.source_lock, args.reviewer_id
+        )
+    else:
+        result = summarize_pilot(args.experiment_dir, args.packet_dir, args.source_lock)
+        write_summaries(args.output, args.public_output, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_target_user_pilot.py
+++ b/tests/test_target_user_pilot.py
@@ -1,0 +1,371 @@
+"""Offline seam tests for the two-stage target-user decision pilot."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from target_user_pilot import (
+    BASELINE_FIELDS,
+    FOLLOWUP_FIELDS,
+    PROFILE_FIELDS,
+    SLOT_FIELDS,
+    TargetUserPilotError,
+    discover_reports,
+    materialize_followup,
+    prepare_pilot,
+    summarize_pilot,
+    write_summary,
+    write_summaries,
+)
+
+
+def _write_csv(path: Path, fields: tuple[str, ...], rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_cell(
+    experiment_dir: Path,
+    *,
+    topic_num: int,
+    repetition: int = 1,
+    variant: str = "full",
+    status: str = "success",
+    suffix: str = "",
+) -> Path:
+    cell = experiment_dir / f"cell-{topic_num:02d}-{variant}-r{repetition}{suffix}"
+    cell.mkdir(parents=True)
+    topic = f"Commercialization topic {topic_num:02d}"
+    meta = {
+        "num": f"{topic_num:02d}",
+        "rep": repetition,
+        "variant": variant,
+        "topic": topic,
+        "industry": f"Industry {topic_num:02d}",
+        "fixture_digest": f"fixture-{topic_num:02d}",
+        "status": status,
+    }
+    (cell / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (cell / "commercialization_report.md").write_text(
+        f"# {topic}\n\nFROZEN_REPORT_{topic_num:02d}\n", encoding="utf-8"
+    )
+    return cell
+
+
+def _experiment(tmp_path: Path) -> Path:
+    experiment = tmp_path / "frozen-experiment"
+    for topic_num in range(1, 11):
+        _write_cell(experiment, topic_num=topic_num)
+        # These distractors prove that discovery is frozen to full/r1 rather
+        # than whichever report happens to sort first on disk.
+        _write_cell(experiment, topic_num=topic_num, variant="monolith")
+        _write_cell(experiment, topic_num=topic_num, repetition=2)
+    return experiment
+
+
+def _prepare(tmp_path: Path) -> tuple[Path, Path, Path]:
+    experiment = _experiment(tmp_path)
+    packet = tmp_path / "packet"
+    source_lock = tmp_path / "private" / "source-lock.json"
+    prepare_pilot(experiment, packet, source_lock)
+    return experiment, packet, source_lock
+
+
+def _fill_intake(
+    packet: Path,
+    reviewer_id: str,
+    *,
+    topic_num: str,
+    role: str = "TTO_COMMERCIALIZATION",
+    ai_use: str = "NONE",
+    consent: str = "YES",
+) -> None:
+    reviewer_dir = packet / "stage-1" / reviewer_id
+    topic = f"Commercialization topic {topic_num}"
+    _write_csv(
+        reviewer_dir / "reviewer_profile.csv",
+        PROFILE_FIELDS,
+        [
+            {
+                "reviewer_id": reviewer_id,
+                "role_category": role,
+                "experience_band": "3_5",
+                "professional_context": "I evaluate research commercialization opportunities.",
+                "domain_experience": f"Direct experience with topic {topic_num}.",
+                "generative_ai_use": ai_use,
+                "generative_ai_notes": (
+                    "AI generated substantive judgments." if ai_use == "SUBSTANTIVE" else ""
+                ),
+                "anonymous_aggregate_consent": consent,
+                "compensation": "NONE",
+                "compensation_notes": "",
+            }
+        ],
+    )
+    _write_csv(
+        reviewer_dir / "baseline_form.csv",
+        BASELINE_FIELDS,
+        [
+            {
+                "reviewer_id": reviewer_id,
+                "selected_topic_num": topic_num,
+                "selected_topic": topic,
+                "selection_reason": "This topic overlaps my professional decisions.",
+                "current_workflow_summary": "I search primary sources and compare alternatives.",
+                "expected_research_minutes": "180",
+                "initial_decision": "DEFER",
+                "initial_confidence": "2",
+                "information_needed": "Evidence quality, IP constraints, and market timing.",
+            }
+        ],
+    )
+
+
+def _fill_followup(
+    packet: Path,
+    reviewer_id: str,
+    *,
+    usefulness: int = 4,
+    citation_check: str = "NONE",
+    factual_error_state: str = "NOT_CHECKED",
+) -> None:
+    path = packet / "stage-2" / reviewer_id / "followup_form.csv"
+    row = _read_csv(path)[0]
+    row.update(
+        {
+            "post_report_decision": "GO",
+            "post_report_confidence": "4",
+            "decision_usefulness": str(usefulness),
+            "information_gain": "4",
+            "actionability": "4",
+            "evidence_trust": "3",
+            "recommendation_acceptance": "4",
+            "reading_minutes": "35",
+            "estimated_revision_minutes": "25",
+            "would_use_again": "YES",
+            "citation_check": citation_check,
+            "factual_error_state": factual_error_state,
+            "blocking_error": "NO",
+            "blocking_error_details": "",
+            "most_useful_content": "The evidence boundaries made the decision easier to frame.",
+            "missing_information": "More customer-specific economics would improve the report.",
+            "required_corrections": "Prioritize the top two actions and shorten background sections.",
+            "rationale": "The report added structured evidence while retaining visible uncertainty.",
+        }
+    )
+    _write_csv(path, FOLLOWUP_FIELDS, [row])
+
+
+def _close_slot(packet: Path, reviewer_id: str, *, state: str = "CLOSED_NO_RESPONSE") -> None:
+    path = packet / "coordinator" / "slot_status.csv"
+    rows = _read_csv(path)
+    for row in rows:
+        if row["reviewer_id"] == reviewer_id:
+            row["slot_status"] = state
+            row["closure_reason"] = "Recruitment ended before this slot started."
+    _write_csv(path, SLOT_FIELDS, rows)
+
+
+def test_prepare_freezes_sources_and_keeps_stage_one_report_free(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+
+    lock = json.loads(source_lock.read_text(encoding="utf-8"))
+    manifest = json.loads((packet / "manifest.json").read_text(encoding="utf-8"))
+    assert source_lock.parent != packet
+    assert len(lock["sources"]) == 10
+    assert manifest["stage_1_contains_reports"] is False
+    assert manifest["human_response_count"] == 0
+
+    for reviewer_id in ("T01", "T02"):
+        stage_one = packet / "stage-1" / reviewer_id
+        assert len(_read_csv(stage_one / "case_catalog.csv")) == 10
+        assert not (stage_one / "report.md").exists()
+        stage_one_text = "\n".join(
+            path.read_text(encoding="utf-8") for path in stage_one.rglob("*") if path.is_file()
+        )
+        assert "FROZEN_REPORT_" not in stage_one_text
+        assert "commercialization_report.md" not in stage_one_text
+
+    with pytest.raises(TargetUserPilotError, match="must not already exist"):
+        prepare_pilot(experiment, packet, source_lock)
+    with pytest.raises(TargetUserPilotError, match="outside"):
+        prepare_pilot(experiment, tmp_path / "leaky", tmp_path / "leaky" / "source-lock.json")
+
+
+def test_discovery_rejects_duplicate_or_drifting_frozen_sources(tmp_path: Path) -> None:
+    experiment = _experiment(tmp_path)
+    _write_cell(experiment, topic_num=1, suffix="-duplicate")
+    with pytest.raises(TargetUserPilotError, match="duplicate"):
+        discover_reports(experiment)
+
+    duplicate = experiment / "cell-01-full-r1-duplicate"
+    for path in duplicate.iterdir():
+        path.unlink()
+    duplicate.rmdir()
+    packet = tmp_path / "packet"
+    source_lock = tmp_path / "private" / "source-lock.json"
+    prepare_pilot(experiment, packet, source_lock)
+    report = experiment / "cell-01-full-r1" / "commercialization_report.md"
+    report.write_text("changed after source lock", encoding="utf-8")
+    with pytest.raises(TargetUserPilotError, match="source report or metadata drifted"):
+        materialize_followup(experiment, packet, source_lock, "T01")
+
+
+def test_materialize_requires_baseline_and_delivers_only_the_selected_report(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    with pytest.raises(TargetUserPilotError, match="intake must be complete"):
+        materialize_followup(experiment, packet, source_lock, "T01")
+
+    _fill_intake(packet, "T01", topic_num="03")
+    snapshot = materialize_followup(experiment, packet, source_lock, "T01")
+    delivered = (packet / "stage-2" / "T01" / "report.md").read_text(encoding="utf-8")
+    assert snapshot["selected_topic_num"] == "03"
+    assert "FROZEN_REPORT_03" in delivered
+    assert "FROZEN_REPORT_01" not in delivered
+    assert snapshot["source_report_sha256"] == snapshot["delivered_report_sha256"]
+    assert not (packet / "stage-2" / "T02").exists()
+
+    with pytest.raises(TargetUserPilotError, match="already exists"):
+        materialize_followup(experiment, packet, source_lock, "T01")
+
+
+def test_summary_distinguishes_open_stages_and_single_target_user(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    initial = summarize_pilot(experiment, packet, source_lock)
+    assert initial["status"] == "in_progress"
+    assert {row["status"] for row in initial["reviewers"]} == {"not_started"}
+
+    _fill_intake(packet, "T01", topic_num="01")
+    awaiting_report = summarize_pilot(experiment, packet, source_lock)
+    assert awaiting_report["reviewers"][0]["status"] == "report_not_materialized"
+
+    materialize_followup(experiment, packet, source_lock, "T01")
+    awaiting_followup = summarize_pilot(experiment, packet, source_lock)
+    assert awaiting_followup["reviewers"][0]["status"] == "followup_incomplete"
+
+    _fill_followup(packet, "T01")
+    _close_slot(packet, "T02")
+    result = summarize_pilot(experiment, packet, source_lock)
+    assert result["status"] == "single_target_user_observation"
+    assert result["eligible_target_user_count"] == 1
+    assert result["decision_changed_count"] == 1
+    assert result["eligible_medians"]["decision_usefulness"] == 4.0
+    assert result["reviewers"][0]["derived"]["source_truth_status"] == "not_evaluated"
+
+
+def test_two_target_users_complete_but_public_projection_respects_consent(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    _fill_intake(packet, "T01", topic_num="01", consent="YES")
+    _fill_intake(packet, "T02", topic_num="02", consent="NO")
+    materialize_followup(experiment, packet, source_lock, "T01")
+    materialize_followup(experiment, packet, source_lock, "T02")
+    _fill_followup(packet, "T01", usefulness=5)
+    _fill_followup(packet, "T02", usefulness=2)
+
+    result = summarize_pilot(experiment, packet, source_lock)
+    public = result["public_projection"]
+    assert result["status"] == "descriptive_pilot_complete"
+    assert result["eligible_target_user_count"] == 2
+    assert result["eligible_medians"]["decision_usefulness"] == 3.5
+    assert public["publicly_reportable_count"] == 1
+    assert public["eligible_medians"]["decision_usefulness"] == 5.0
+    assert public["status"] == "descriptive_pilot_complete"
+    assert public["publication_status"] == "partial_public_consent"
+    assert public["complete_observation_count"] == 2
+    assert public["closed_slot_count"] == 0
+    assert public["incomplete_slot_count"] == 0
+    assert public["reportable_role_mix"] == {"TTO_COMMERCIALIZATION": 1}
+    assert public["reportable_ai_use"] == {"NONE": 1}
+    assert public["reportable_selected_topics"] == [
+        {"topic_num": "01", "topic": "Commercialization topic 01"}
+    ]
+    assert public["source_material"] == {
+        "report_generation_date": "2026-08-21",
+        "evidence_state": "frozen_historical",
+        "fresh_retrieval": False,
+        "topic_assignment": "reviewer_self_selected_before_report",
+    }
+
+
+def test_proxy_and_substantive_ai_rows_do_not_become_target_user_evidence(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    _fill_intake(packet, "T01", topic_num="01", role="PROXY")
+    _fill_intake(packet, "T02", topic_num="02", ai_use="SUBSTANTIVE")
+    for reviewer_id in ("T01", "T02"):
+        materialize_followup(experiment, packet, source_lock, reviewer_id)
+        _fill_followup(packet, reviewer_id)
+
+    result = summarize_pilot(experiment, packet, source_lock)
+    assert result["status"] == "no_eligible_target_user_observation"
+    assert result["eligible_target_user_count"] == 0
+    assert result["proxy_completed_count"] == 1
+    assert result["substantive_ai_excluded_count"] == 1
+
+
+def test_unchecked_sources_cannot_be_reported_as_zero_errors(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    _fill_intake(packet, "T01", topic_num="01")
+    materialize_followup(experiment, packet, source_lock, "T01")
+    _fill_followup(packet, "T01", citation_check="NONE", factual_error_state="NONE_FOUND")
+
+    with pytest.raises(TargetUserPilotError, match="without source checking"):
+        summarize_pilot(experiment, packet, source_lock)
+
+
+def test_snapshot_and_delivered_report_drift_fail_at_the_summary_seam(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    _fill_intake(packet, "T01", topic_num="01")
+    materialize_followup(experiment, packet, source_lock, "T01")
+    _fill_followup(packet, "T01")
+    _close_slot(packet, "T02")
+
+    delivered = packet / "stage-2" / "T01" / "report.md"
+    original = delivered.read_text(encoding="utf-8")
+    delivered.write_text(original + "\nmutated after delivery\n", encoding="utf-8")
+    with pytest.raises(TargetUserPilotError, match="delivered report drifted"):
+        summarize_pilot(experiment, packet, source_lock)
+
+    delivered.write_text(original, encoding="utf-8")
+    baseline_path = packet / "stage-1" / "T01" / "baseline_form.csv"
+    baseline = _read_csv(baseline_path)[0]
+    baseline["initial_confidence"] = "3"
+    _write_csv(baseline_path, BASELINE_FIELDS, [baseline])
+    with pytest.raises(TargetUserPilotError, match="baseline_sha256"):
+        summarize_pilot(experiment, packet, source_lock)
+
+
+def test_summary_files_are_immutable_and_public_output_drops_free_text(tmp_path: Path) -> None:
+    experiment, packet, source_lock = _prepare(tmp_path)
+    _fill_intake(packet, "T01", topic_num="01")
+    materialize_followup(experiment, packet, source_lock, "T01")
+    _fill_followup(packet, "T01")
+    _close_slot(packet, "T02")
+    result = summarize_pilot(experiment, packet, source_lock)
+
+    private_path = tmp_path / "private-result.json"
+    public_path = tmp_path / "public-result.json"
+    write_summaries(private_path, public_path, result)
+    assert "most_useful_content" in private_path.read_text(encoding="utf-8")
+    assert "most_useful_content" not in public_path.read_text(encoding="utf-8")
+    with pytest.raises(TargetUserPilotError, match="already exists"):
+        write_summary(private_path, result)
+
+    unwritten_private = tmp_path / "must-not-be-partially-written.json"
+    with pytest.raises(TargetUserPilotError, match="already exists"):
+        write_summaries(unwritten_private, public_path, result)
+    assert not unwritten_private.exists()
+
+    same_path = tmp_path / "same-output.json"
+    with pytest.raises(TargetUserPilotError, match="must be distinct"):
+        write_summaries(same_path, same_path, result)


### PR DESCRIPTION
## Why

The completed topology utility audit is a closed denominator and contains only one actual target user. Adding reviewers after observing its result would invalidate that experiment, while exposing a report before recording a baseline would contaminate the product-usefulness observation.

## What this adds

- pre-registers a separate two-slot descriptive target-user pilot before recruitment;
- creates report-free Stage 1 packets and keeps the frozen source lock outside reviewer deliveries;
- materializes exactly one frozen historical report only after a complete baseline;
- binds profile, baseline, source, and delivered report identities with SHA-256;
- distinguishes incomplete, closed, proxy, substantive-AI-excluded, single-user, and complete states;
- separates private correction text from consent-safe public outcomes;
- preflights paired summary outputs to prevent partial writes;
- documents recruitment and operation while explicitly retaining a zero-response, no-user-value claim boundary.

## Verification

- uv run pytest -q: 1,524 passed, 627 subtests passed
- CI coverage command: 87.07%, above the 85% floor
- uv run --with ruff ruff check .
- CI-matched narrow Pylint check
- report-hash defect reinjection: expected seam test failure confirmed, then restored
- paired-output preflight defect reinjection: expected partial-write assertion failure confirmed, then restored

This remains zero-network and makes no model or search-provider call. No human response exists yet, so the PR does not claim adoption, ROI, accuracy, or user-value validation.