### PR TITLE
Make target-user forms readable and time-correct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,8 +373,14 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   baseline decision without seeing a report; only then does the coordinator
   materialize one frozen report and collect a post-report decision. The packet
   makes source checking, AI assistance, consent, and unusable observations
-  explicit, and its public projection excludes non-consented free text. There
-  are currently zero returned observations, so this is an implemented
-  measurement contract rather than user-value evidence. See
+  explicit, and its public projection excludes non-consented free text. Both
+  registered target users have now returned complete Stage 1 baselines; both
+  independently selected topic 08 before report exposure. Schema-v1 packets
+  did not expose the legal enums, so the raw forms are retained privately and
+  every natural-language-to-enum mapping is disclosed. Follow-up schema v2
+  separately records Stage 2 AI use. Both Stage 2 packets are materialized,
+  but neither follow-up has returned: completed observations remain zero, so
+  this is still measurement readiness rather than user-value evidence. See
   `docs/prereg-2026-08-26-target-user-decision-pilot.md` and
-  `docs/target-user-decision-pilot-guide.md`.
+  `docs/target-user-decision-pilot-guide.md`, plus
+  `docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md`.

--- a/README.md
+++ b/README.md
@@ -122,10 +122,16 @@ baseline decision, and confidence before the coordinator can materialize one
 frozen report; the second stage then records whether the report changed the
 decision, what evidence was useful, and how much review time it required.
 Source checking, substantive AI use, consent, and incomplete observations are
-represented as distinct states. No response has been returned yet, so this is
-a measurement contract—not a user-value result. See the
+represented as distinct states. Both target users have returned complete
+pre-report baselines and independently selected topic 08. Their schema-v1
+natural-language enums are preserved and owner-coded with explicit disclosure;
+follow-up schema v2 now records AI use again after report exposure. Both Stage
+2 packets have been materialized, but neither follow-up has returned, so the
+completed-observation count remains zero. This is still a measurement contract,
+not a user-value result. See the
 [pre-registration](docs/prereg-2026-08-26-target-user-decision-pilot.md) and
-[operator guide](docs/target-user-decision-pilot-guide.md).
+[operator guide](docs/target-user-decision-pilot-guide.md), plus the
+[form-timing erratum](docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md).
 
 A separate pre-registered checkpoint audit hard-terminated **30 worker
 processes** across ten frozen evidence collections and three post-commit
@@ -1185,9 +1191,13 @@ ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-2
 **双席位目标用户决策试点**，全程不调用模型或搜索供应商。评审者必须先填写自身
 角色、初始判断和信心，协调者才会生成一份冻结报告；第二阶段再记录报告是否改变
 判断、哪些证据有用以及实际审阅耗时。外部来源核验、实质性 AI 使用、公开同意和
-未完成观察均被区分记录。目前尚未收到任何返回，因此它只是评测合同，不是用户
-价值结果。详见[预注册](docs/prereg-2026-08-26-target-user-decision-pilot.md)和
-[操作指南](docs/target-user-decision-pilot-guide.md)。
+未完成观察均被区分记录。两位目标用户现已返回完整的报告前基线，并在报告暴露前
+独立选择主题 08；schema v1 的自然语言枚举被原样保留并做披露式编码，schema v2
+会在报告暴露后重新记录 AI 使用。两份第二阶段材料已经物化，但跟进表均未返回，
+完整观察数仍为 0，因此它依旧只是评测合同，不是用户价值结果。详见
+[预注册](docs/prereg-2026-08-26-target-user-decision-pilot.md)、
+[操作指南](docs/target-user-decision-pilot-guide.md)和
+[表单时序勘误](docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md)。
 
 另有一组预注册 Checkpoint 故障恢复实验，在 10 份冻结证据和 3 个提交后边界上
 硬终止 **30 个 worker 进程**。30/30 个不可变子运行均到达 `Done`，精确复用预期

--- a/docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md
+++ b/docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md
@@ -1,0 +1,62 @@
+# Erratum: target-user form enums and Stage 2 AI-use timing
+
+**Recorded:** 2026-08-26, after both Stage 1 folders were returned and before
+either Stage 2 report was materialized or exposed
+
+## What the first returns revealed
+
+Both reviewers completed the substantive Stage 1 questions, but both used
+natural-language labels where packet schema v1 expected fixed enums. Examples
+included `No` instead of `NONE`, a prose decision instead of `DEFER`, and a
+percentage confidence instead of an integer from 1 to 5. The validator rejected
+these mechanically even though their intended meaning was inspectable.
+
+This was an instrument-usability defect, not a reviewer-quality result. The
+generated README described the concepts but did not enumerate the legal CSV
+values. A schema can be strict internally and still fail at its human boundary
+if the person filling it cannot see the contract.
+
+The returned folders are retained byte for byte in the private audit packet.
+The study owner created separate normalized copies with a field-by-field coding
+record before any report or follow-up outcome existed. No original response was
+overwritten. The coding does not change the two registered slots, selected
+topics, reports, questions, or result threshold.
+
+## A second timing defect found before Stage 2
+
+The Stage 1 profile asked for generative-AI use, but it was locked before a
+reviewer could read the Stage 2 report. If the reviewer later used AI for the
+follow-up, schema v1 had no field in which to disclose that new behavior. The
+summary could therefore classify a response using a declaration that only
+described work performed before report exposure.
+
+Follow-up schema v2 adds its own `generative_ai_use` and
+`generative_ai_notes`. Eligibility now excludes substantive AI use declared at
+either stage. Translation or clerical use remains retained with disclosure and
+requires notes. The Stage 2 snapshot records the follow-up schema version so a
+legacy form cannot be interpreted under the new rule silently.
+
+## Implementation correction
+
+- Stage 1 and Stage 2 README files render enum options directly from the
+  validator constants instead of maintaining a second handwritten list.
+- Numeric scales and required free-text behavior are explicit.
+- Packet and source-lock schema v1 are now checked at every later command.
+- Stage 2 snapshots are schema v2 and bind that version alongside the existing
+  reviewer, baseline, source, and delivered-report hashes.
+- Public AI-use disclosure separates Stage 1 from Stage 2.
+- Substantive AI use at either stage excludes the row from target-user evidence.
+
+The test suite asserts that every accepted enum is present in the generated
+instructions, that the Stage 2 schema reaches the snapshot, that non-`NONE` AI
+use requires notes, and that Stage 2 substantive AI use reaches the eligibility
+decision. The old profile-only eligibility expression is deliberately
+re-injected before release; the seam test must fail before the implementation
+is restored.
+
+## Claim boundary
+
+At the time of this correction there are two coded Stage 1 baselines and zero
+follow-up observations. This erratum establishes a cleaner measurement seam;
+it is not evidence of report usefulness, factual accuracy, adoption, ROI, or a
+six-stage advantage.

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -110,8 +110,10 @@ project's engineering argument: evaluation should be capable of saying no.
   independent reviewer or inter-rater estimate.
 - The completed user-utility audit included only one actual target user. A
   separate two-slot target-user decision pilot is prepared with a pre-report
-  baseline and post-report decision, but it currently has zero returned
-  observations and therefore contributes no user-value evidence yet.
+  baseline and post-report decision. Both Stage 1 baselines have returned and
+  both reviewers selected topic 08; owner-coded enum normalization is disclosed
+  and Stage 2 AI use is collected separately. Neither Stage 2 follow-up has
+  returned, so completed observations and user-value evidence remain zero.
 
 ## Reproduce or inspect
 
@@ -121,6 +123,7 @@ project's engineering argument: evaluation should be capable of saying no.
 - [User-utility result](results-2026-08-23-user-utility-audit.md)
 - [Target-user pilot pre-registration](prereg-2026-08-26-target-user-decision-pilot.md)
 - [Target-user pilot operator guide](target-user-decision-pilot-guide.md)
+- [Target-user pilot form-timing erratum](errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md)
 - [Checkpoint recovery design](checkpoint-recovery.md)
 - [Production recovery canary](results-2026-08-24-paid-same-revision-recovery-post-fix.md)
 

--- a/docs/target-user-decision-pilot-guide.md
+++ b/docs/target-user-decision-pilot-guide.md
@@ -59,6 +59,13 @@ This is an information barrier, not a convenience split. If a reviewer sees a
 report before returning the baseline, do not reconstruct their initial answer
 from memory; archive the slot as protocol-deviating.
 
+The generated README lists every legal enum and numeric scale. If a legacy
+schema-v1 packet is returned with natural-language equivalents, do not silently
+overwrite it. Preserve the returned directory byte for byte, create a separate
+owner-coded copy, record every original-to-enum mapping and its reason, and do
+all coding before report exposure. See
+[`errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md`](errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md).
+
 ## Lock intake and materialize Stage 2
 
 Copy the returned `reviewer_profile.csv` and `baseline_form.csv` into the same
@@ -78,6 +85,10 @@ second materialization. Send only the new `stage-2/T01/` directory. It contains
 the exact selected report, a follow-up form, and a selection snapshot binding
 the source, baseline, and delivered report hashes.
 
+The current follow-up schema is v2. Its snapshot records that version, and the
+form asks about generative-AI use during Stage 2 separately from the profile
+completed before report exposure. Do not copy the Stage 1 declaration forward.
+
 If an untouched slot cannot be recruited, edit only
 `coordinator/slot_status.csv`: set it to `CLOSED_NO_RESPONSE` or `WITHDREW` and
 write a short reason. Never close a slot that already contains participant
@@ -88,6 +99,9 @@ data, and do not add a third slot after seeing a follow-up.
 - `citation_check=NONE` requires `factual_error_state=NOT_CHECKED`.
 - `NONE_FOUND` means external sources were actually opened and no error was
   found among what was checked; it never means the report is proven correct.
+- Stage 2 `generative_ai_use` must describe work performed after report
+  exposure. `TRANSLATION_OR_CLERICAL` and `SUBSTANTIVE` require notes;
+  substantive use at either stage excludes the row from target-user evidence.
 - `blocking_error=YES` requires details describing how the issue could change a
   commercialization decision.
 - Substantive AI-generated judgment is retained but excluded.

--- a/target_user_pilot.py
+++ b/target_user_pilot.py
@@ -22,6 +22,7 @@ from typing import Any
 
 STUDY_ID = "target-user-decision-pilot-20260826"
 SOURCE_REPORT_DATE = "2026-08-21"
+FOLLOWUP_SCHEMA_VERSION = 2
 REVIEWER_IDS = ("T01", "T02")
 TARGET_ROLES = {
     "TTO_COMMERCIALIZATION",
@@ -70,6 +71,8 @@ FOLLOWUP_FIELDS = (
     "selected_topic_num",
     "selected_topic",
     "report_sha256",
+    "generative_ai_use",
+    "generative_ai_notes",
     "post_report_decision",
     "post_report_confidence",
     "decision_usefulness",
@@ -91,7 +94,9 @@ FOLLOWUP_FIELDS = (
 )
 SLOT_FIELDS = ("reviewer_id", "slot_status", "closure_reason")
 FOLLOWUP_REQUIRED_FIELDS = tuple(
-    field for field in FOLLOWUP_FIELDS[4:] if field != "blocking_error_details"
+    field
+    for field in FOLLOWUP_FIELDS[4:]
+    if field not in {"blocking_error_details", "generative_ai_notes"}
 )
 
 
@@ -232,7 +237,23 @@ def _source_rows(reports: list[FrozenReport]) -> list[dict[str, str]]:
     return rows
 
 
+def _option_line(field: str, values: set[str]) -> str:
+    """Render legal CSV enums from the validator's own source of truth."""
+
+    return f"- `{field}`: " + ", ".join(f"`{value}`" for value in sorted(values))
+
+
 def _stage_one_readme(reviewer_id: str) -> str:
+    options = "\n".join(
+        (
+            _option_line("role_category", ROLE_LABELS),
+            _option_line("experience_band", EXPERIENCE_LABELS),
+            _option_line("generative_ai_use", AI_USE_LABELS),
+            _option_line("anonymous_aggregate_consent", CONSENT_LABELS),
+            _option_line("compensation", COMPENSATION_LABELS),
+            _option_line("initial_decision", DECISION_LABELS),
+        )
+    )
     return f"""# 目标用户决策试点：第一阶段
 
 评审编号：`{reviewer_id}`
@@ -246,6 +267,16 @@ def _stage_one_readme(reviewer_id: str) -> str:
 请不要搜索或向他人询问系统对这些主题的既有结论。可以查阅你正常工作中
 本来就会使用的资料，但请在 `current_workflow_summary` 中如实说明。不要使用生成式
 AI 代替实质判断；翻译或表格整理用途必须在 profile 中披露。
+
+以下字段只能填写列出的固定值，不要写同义词、百分数或解释句：
+
+{options}
+- `initial_confidence`：整数 `1`–`5`
+- `expected_research_minutes`：大于 `0` 的整数分钟
+
+判断理由写入 `selection_reason`、`current_workflow_summary` 或
+`information_needed`，不要把理由写进 `initial_decision`。非固定文本字段也必须
+填写；确实没有内容时写 `NONE`，不要留空。
 
 请只修改两个 CSV，不要改动主题目录。完成后把整个文件夹原样返还。第二阶段会在
 这份基线锁定后才发送一份与你所选主题对应的历史报告。
@@ -267,6 +298,16 @@ slot cannot be recruited, set its coordinator status to `CLOSED_NO_RESPONSE`.
 
 
 def _stage_two_readme(reviewer_id: str, topic: str) -> str:
+    options = "\n".join(
+        (
+            _option_line("generative_ai_use", AI_USE_LABELS),
+            _option_line("post_report_decision", DECISION_LABELS),
+            _option_line("would_use_again", REUSE_LABELS),
+            _option_line("citation_check", CITATION_CHECK_LABELS),
+            _option_line("factual_error_state", FACT_ERROR_LABELS),
+            _option_line("blocking_error", BLOCKING_ERROR_LABELS),
+        )
+    )
     return f"""# 目标用户决策试点：第二阶段
 
 - 评审编号：`{reviewer_id}`
@@ -279,6 +320,19 @@ def _stage_two_readme(reviewer_id: str, topic: str) -> str:
 不要求逐个打开引用；但如果没有打开任何外部来源，`citation_check` 必须填写
 `NONE`，`factual_error_state` 必须填写 `NOT_CHECKED`。这代表“没有核查”，不是
 “没有错误”。不要使用生成式 AI 代替你的实质判断。
+
+以下字段只能填写列出的固定值：
+
+{options}
+- `post_report_confidence`、`decision_usefulness`、`information_gain`、
+  `actionability`、`evidence_trust`、`recommendation_acceptance`：整数 `1`–`5`
+- `reading_minutes`：大于 `0` 的整数分钟
+- `estimated_revision_minutes`：大于等于 `0` 的整数分钟
+
+`generative_ai_use` 只声明本阶段实际发生的使用；第一阶段填写的 `NONE` 不能代替
+第二阶段声明。选择 `TRANSLATION_OR_CLERICAL` 或 `SUBSTANTIVE` 时必须在
+`generative_ai_notes` 说明用途。`blocking_error=YES` 时必须填写详情。四个自由文本
+评价字段也必须填写；确实没有内容时写 `NONE`，不要留空或改动前四个身份字段。
 
 请只修改 `followup_form.csv`，不要修改报告或 selection snapshot。完成后原样返还
 整个文件夹。
@@ -356,6 +410,8 @@ def _verify_base(
     _assert_separate(packet_dir, source_lock_path)
     manifest = _read_json(packet_dir / "manifest.json")
     source_lock = _read_json(source_lock_path)
+    if manifest.get("schema_version") != 1 or source_lock.get("schema_version") != 1:
+        raise TargetUserPilotError("packet or source lock has an unsupported schema version")
     if manifest.get("study_id") != STUDY_ID or source_lock.get("study_id") != STUDY_ID:
         raise TargetUserPilotError("packet or source lock belongs to a different study")
     if manifest.get("reviewer_ids") != list(REVIEWER_IDS) or source_lock.get("reviewer_ids") != list(REVIEWER_IDS):
@@ -535,7 +591,8 @@ def materialize_followup(
     )
     (stage_two / "report.md").write_bytes(report_bytes)
     snapshot = {
-        "schema_version": 1,
+        "schema_version": FOLLOWUP_SCHEMA_VERSION,
+        "followup_schema_version": FOLLOWUP_SCHEMA_VERSION,
         "study_id": STUDY_ID,
         "reviewer_id": reviewer_id,
         "selected_topic_num": report.topic_num,
@@ -579,11 +636,14 @@ def _validate_followup(
         return None
     _require_complete(row, FOLLOWUP_REQUIRED_FIELDS, context=f"{reviewer_id} follow-up")
 
+    ai_use = row["generative_ai_use"].strip().upper()
     decision = row["post_report_decision"].strip().upper()
     reuse = row["would_use_again"].strip().upper()
     citation_check = row["citation_check"].strip().upper()
     factual = row["factual_error_state"].strip().upper()
     blocking = row["blocking_error"].strip().upper()
+    if ai_use not in AI_USE_LABELS:
+        raise TargetUserPilotError(f"{reviewer_id} has invalid Stage 2 generative_ai_use")
     if decision not in DECISION_LABELS:
         raise TargetUserPilotError(f"{reviewer_id} has invalid post_report_decision")
     if reuse not in REUSE_LABELS:
@@ -594,6 +654,10 @@ def _validate_followup(
         raise TargetUserPilotError(f"{reviewer_id} has invalid factual_error_state")
     if blocking not in BLOCKING_ERROR_LABELS:
         raise TargetUserPilotError(f"{reviewer_id} has invalid blocking_error")
+    if ai_use != "NONE" and not row["generative_ai_notes"].strip():
+        raise TargetUserPilotError(
+            f"{reviewer_id} must describe non-NONE Stage 2 generative AI use"
+        )
     if citation_check == "NONE" and factual != "NOT_CHECKED":
         raise TargetUserPilotError(f"{reviewer_id} cannot report factual errors without source checking")
     if citation_check != "NONE" and factual == "NOT_CHECKED":
@@ -603,6 +667,7 @@ def _validate_followup(
 
     parsed: dict[str, Any] = {
         **row,
+        "generative_ai_use": ai_use,
         "post_report_decision": decision,
         "would_use_again": reuse,
         "citation_check": citation_check,
@@ -662,6 +727,8 @@ def _verify_stage_two(
 ) -> dict[str, Any] | None:
     snapshot = _read_json(stage_two / "selection_snapshot.json")
     expected = {
+        "schema_version": FOLLOWUP_SCHEMA_VERSION,
+        "followup_schema_version": FOLLOWUP_SCHEMA_VERSION,
         "study_id": STUDY_ID,
         "reviewer_id": reviewer_id,
         "selected_topic_num": report.topic_num,
@@ -768,7 +835,10 @@ def summarize_pilot(experiment_dir: Path, packet_dir: Path, source_lock_path: Pa
             continue
 
         is_target = profile["role_category"] in TARGET_ROLES
-        ai_excluded = profile["generative_ai_use"] == "SUBSTANTIVE"
+        ai_excluded = (
+            profile["generative_ai_use"] == "SUBSTANTIVE"
+            or followup["generative_ai_use"] == "SUBSTANTIVE"
+        )
         eligible = is_target and not ai_excluded
         reviewers.append(
             {
@@ -821,9 +891,16 @@ def summarize_pilot(experiment_dir: Path, packet_dir: Path, source_lock_path: Pa
         if any(row["profile"]["role_category"] == label for row in public_rows)
     }
     reportable_ai_use = {
-        label: sum(1 for row in public_rows if row["profile"]["generative_ai_use"] == label)
-        for label in sorted(AI_USE_LABELS)
-        if any(row["profile"]["generative_ai_use"] == label for row in public_rows)
+        "stage_1": {
+            label: sum(1 for row in public_rows if row["profile"]["generative_ai_use"] == label)
+            for label in sorted(AI_USE_LABELS)
+            if any(row["profile"]["generative_ai_use"] == label for row in public_rows)
+        },
+        "stage_2": {
+            label: sum(1 for row in public_rows if row["followup"]["generative_ai_use"] == label)
+            for label in sorted(AI_USE_LABELS)
+            if any(row["followup"]["generative_ai_use"] == label for row in public_rows)
+        },
     }
     closed_states = {"closed_no_response", "withdrew"}
     closed_count = sum(1 for row in reviewers if row["status"] in closed_states)
@@ -874,6 +951,7 @@ def summarize_pilot(experiment_dir: Path, packet_dir: Path, source_lock_path: Pa
             1
             for row in completed
             if row["profile"]["generative_ai_use"] == "SUBSTANTIVE"
+            or row["followup"]["generative_ai_use"] == "SUBSTANTIVE"
         ),
         "proxy_completed_count": sum(
             1 for row in completed if row["profile"]["role_category"] == "PROXY"

--- a/tests/test_target_user_pilot.py
+++ b/tests/test_target_user_pilot.py
@@ -9,9 +9,18 @@ from pathlib import Path
 import pytest
 
 from target_user_pilot import (
+    AI_USE_LABELS,
     BASELINE_FIELDS,
+    BLOCKING_ERROR_LABELS,
+    CITATION_CHECK_LABELS,
+    DECISION_LABELS,
+    EXPERIENCE_LABELS,
+    FACT_ERROR_LABELS,
     FOLLOWUP_FIELDS,
+    FOLLOWUP_SCHEMA_VERSION,
     PROFILE_FIELDS,
+    REUSE_LABELS,
+    ROLE_LABELS,
     SLOT_FIELDS,
     TargetUserPilotError,
     discover_reports,
@@ -139,11 +148,18 @@ def _fill_followup(
     usefulness: int = 4,
     citation_check: str = "NONE",
     factual_error_state: str = "NOT_CHECKED",
+    ai_use: str = "NONE",
 ) -> None:
     path = packet / "stage-2" / reviewer_id / "followup_form.csv"
     row = _read_csv(path)[0]
     row.update(
         {
+            "generative_ai_use": ai_use,
+            "generative_ai_notes": (
+                "AI generated substantive judgments."
+                if ai_use == "SUBSTANTIVE"
+                else ""
+            ),
             "post_report_decision": "GO",
             "post_report_confidence": "4",
             "decision_usefulness": str(usefulness),
@@ -196,6 +212,11 @@ def test_prepare_freezes_sources_and_keeps_stage_one_report_free(tmp_path: Path)
         )
         assert "FROZEN_REPORT_" not in stage_one_text
         assert "commercialization_report.md" not in stage_one_text
+        readme = (stage_one / "README.md").read_text(encoding="utf-8")
+        for option in ROLE_LABELS | EXPERIENCE_LABELS | AI_USE_LABELS | DECISION_LABELS:
+            assert f"`{option}`" in readme
+        assert "`initial_confidence`" in readme
+        assert "整数 `1`–`5`" in readme
 
     with pytest.raises(TargetUserPilotError, match="must not already exist"):
         prepare_pilot(experiment, packet, source_lock)
@@ -234,6 +255,13 @@ def test_materialize_requires_baseline_and_delivers_only_the_selected_report(tmp
     assert "FROZEN_REPORT_03" in delivered
     assert "FROZEN_REPORT_01" not in delivered
     assert snapshot["source_report_sha256"] == snapshot["delivered_report_sha256"]
+    assert snapshot["schema_version"] == FOLLOWUP_SCHEMA_VERSION
+    assert snapshot["followup_schema_version"] == FOLLOWUP_SCHEMA_VERSION
+    readme = (packet / "stage-2" / "T01" / "README.md").read_text(encoding="utf-8")
+    followup_options = AI_USE_LABELS | DECISION_LABELS | REUSE_LABELS
+    followup_options |= CITATION_CHECK_LABELS | FACT_ERROR_LABELS | BLOCKING_ERROR_LABELS
+    for option in followup_options:
+        assert f"`{option}`" in readme
     assert not (packet / "stage-2" / "T02").exists()
 
     with pytest.raises(TargetUserPilotError, match="already exists"):
@@ -286,7 +314,10 @@ def test_two_target_users_complete_but_public_projection_respects_consent(tmp_pa
     assert public["closed_slot_count"] == 0
     assert public["incomplete_slot_count"] == 0
     assert public["reportable_role_mix"] == {"TTO_COMMERCIALIZATION": 1}
-    assert public["reportable_ai_use"] == {"NONE": 1}
+    assert public["reportable_ai_use"] == {
+        "stage_1": {"NONE": 1},
+        "stage_2": {"NONE": 1},
+    }
     assert public["reportable_selected_topics"] == [
         {"topic_num": "01", "topic": "Commercialization topic 01"}
     ]
@@ -300,23 +331,31 @@ def test_two_target_users_complete_but_public_projection_respects_consent(tmp_pa
 
 def test_proxy_and_substantive_ai_rows_do_not_become_target_user_evidence(tmp_path: Path) -> None:
     experiment, packet, source_lock = _prepare(tmp_path)
-    _fill_intake(packet, "T01", topic_num="01", role="PROXY")
-    _fill_intake(packet, "T02", topic_num="02", ai_use="SUBSTANTIVE")
+    _fill_intake(packet, "T01", topic_num="01", role="PROXY", ai_use="SUBSTANTIVE")
+    _fill_intake(packet, "T02", topic_num="02")
     for reviewer_id in ("T01", "T02"):
         materialize_followup(experiment, packet, source_lock, reviewer_id)
-        _fill_followup(packet, reviewer_id)
+        _fill_followup(packet, reviewer_id, ai_use="SUBSTANTIVE" if reviewer_id == "T02" else "NONE")
 
     result = summarize_pilot(experiment, packet, source_lock)
     assert result["status"] == "no_eligible_target_user_observation"
     assert result["eligible_target_user_count"] == 0
     assert result["proxy_completed_count"] == 1
-    assert result["substantive_ai_excluded_count"] == 1
+    assert result["substantive_ai_excluded_count"] == 2
 
 
 def test_unchecked_sources_cannot_be_reported_as_zero_errors(tmp_path: Path) -> None:
     experiment, packet, source_lock = _prepare(tmp_path)
     _fill_intake(packet, "T01", topic_num="01")
     materialize_followup(experiment, packet, source_lock, "T01")
+    _fill_followup(packet, "T01", ai_use="TRANSLATION_OR_CLERICAL")
+    followup_path = packet / "stage-2" / "T01" / "followup_form.csv"
+    followup = _read_csv(followup_path)[0]
+    followup["generative_ai_notes"] = ""
+    _write_csv(followup_path, FOLLOWUP_FIELDS, [followup])
+    with pytest.raises(TargetUserPilotError, match="must describe non-NONE Stage 2"):
+        summarize_pilot(experiment, packet, source_lock)
+
     _fill_followup(packet, "T01", citation_check="NONE", factual_error_state="NONE_FOUND")
 
     with pytest.raises(TargetUserPilotError, match="without source checking"):


### PR DESCRIPTION
## Why

Two real Stage 1 reviewers completed the substantive work but both used natural-language values because the generated packet did not show its legal enums. The strict validator was correct; the human-facing contract was incomplete.

The original profile also described AI use only before report exposure, so it could not honestly represent assistance used during the later follow-up.

## What changed

- render every accepted enum and numeric scale from validator-owned constants
- add versioned Stage 2 AI-use disclosure and bind it in the selection snapshot
- exclude substantive AI use at either stage and report both stages separately
- verify packet and source-lock schema versions at later commands
- document the real form failure, disclosed normalization, and zero-result boundary
- add seam tests for reviewer instructions, snapshot delivery, notes, and eligibility

## Verification

- 1524 tests passed
- 627 subtests passed
- coverage 87.07 percent against an 85 percent floor
- latest Ruff passed
- narrow CI Pylint passed
- old profile-only eligibility expression was re-injected and the new test failed before restoration