### PR TITLE
Preregister the Decision Context three-mode production canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1540 tests (632 subtests), CI green on Linux + Windows × Python
+Current state: 1545 tests (632 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -401,6 +401,10 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   does not prove prompt compliance, factual correctness, usefulness, adoption,
   or time savings: the gate checks context completeness rather than truth. A
   paid three-mode canary remains separate work and requires fresh authorization
-  with frozen criteria. See
+  with frozen criteria. Its protocol now binds three requests on benchmark case
+  08 to an exact manifest, sequential stop rules, structural verdicts, and a
+  `$0.12` soft study boundary. No provider call is authorized or completed by
+  that pre-registration, so the limitation remains open. See
   `docs/prereg-2026-08-26-decision-context-report-contract.md` and
-  `docs/results-2026-08-26-decision-context-report-contract.md`.
+  `docs/results-2026-08-26-decision-context-report-contract.md`, plus
+  `docs/prereg-2026-08-26-decision-context-paid-canary.md`.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Writer/Reviewer must withhold actor-specific GO/NO_GO when the four core fields
 are absent. This is an offline contract result, not evidence that a generated
 decision is correct or useful. See the [protocol](docs/prereg-2026-08-26-decision-context-report-contract.md)
 and [implementation result](docs/results-2026-08-26-decision-context-report-contract.md).
+A separate [three-mode production canary](docs/prereg-2026-08-26-decision-context-paid-canary.md)
+now freezes one topic, three public request bodies, structural criteria, and a
+USD 0.12 soft study boundary. It has not been authorized or run, so no
+provider-backed compliance result is claimed.
 
 A separate pre-registered checkpoint audit hard-terminated **30 worker
 processes** across ten frozen evidence collections and three post-commit
@@ -1227,7 +1231,10 @@ ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-2
 不得输出针对具体主体的 GO/NO_GO。该结果只证明离线输入与执行合同，不证明模型
 生成的决策正确或有用。详见
 [预注册](docs/prereg-2026-08-26-decision-context-report-contract.md)和
-[实现结果](docs/results-2026-08-26-decision-context-report-contract.md)。
+[实现结果](docs/results-2026-08-26-decision-context-report-contract.md)。另有一份
+[三模式生产 canary 预注册](docs/prereg-2026-08-26-decision-context-paid-canary.md)
+已经冻结同一主题下的 3 个公开请求、结构判定标准和 0.12 美元研究软停止线；目前
+尚未获得付费执行授权，也尚未运行，因此不声称已有供应商支持的合同遵循结果。
 
 另有一组预注册 Checkpoint 故障恢复实验，在 10 份冻结证据和 3 个提交后边界上
 硬终止 **30 个 worker 进程**。30/30 个不可变子运行均到达 `Done`，精确复用预期

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -127,9 +127,11 @@ project's engineering argument: evaluation should be capable of saying no.
   2/5. Both answered `MAYBE` to reuse and estimated substantial correction
   work. Neither checked external sources, so this is not source-truth evidence
   or product validation.
-- Decision Context has only offline contract evidence. No provider-backed report
-  has yet tested Writer/Reviewer compliance across the three modes, and no
-  target user has judged whether the new framing improves a real decision.
+- Decision Context has only offline contract evidence. A three-mode production
+  canary now has frozen requests, criteria, and cost boundaries, but it has not
+  been authorized or run. No provider-backed report has therefore tested
+  Writer/Reviewer compliance across the modes, and no target user has judged
+  whether the new framing improves a real decision.
 
 ## Reproduce or inspect
 
@@ -143,6 +145,7 @@ project's engineering argument: evaluation should be capable of saying no.
 - [Target-user pilot result](results-2026-08-26-target-user-decision-pilot.md)
 - [Decision Context protocol](prereg-2026-08-26-decision-context-report-contract.md)
 - [Decision Context implementation result](results-2026-08-26-decision-context-report-contract.md)
+- [Decision Context three-mode paid-canary protocol](prereg-2026-08-26-decision-context-paid-canary.md)
 - [Checkpoint recovery design](checkpoint-recovery.md)
 - [Production recovery canary](results-2026-08-24-paid-same-revision-recovery-post-fix.md)
 

--- a/docs/prereg-2026-08-26-decision-context-paid-canary.md
+++ b/docs/prereg-2026-08-26-decision-context-paid-canary.md
@@ -1,0 +1,186 @@
+# Pre-registration: Decision Context three-mode paid production canary
+
+**Frozen:** 2026-08-26T12:14:00Z, before any provider-backed case in this study
+**Implementation baseline:** `f0f4baba0f73d7dd986f7571ede6d5d4b8356ad3`
+**Execution revision:** the first `main` merge commit containing this protocol
+and its manifest; record the full deployed SHA before submission
+**Manifest:**
+`tests/fixtures/decision_context_paid_canary_manifest.json`
+**Manifest SHA-256:** `bd18ecb13f91d0f4dc9a3dde5059259f0d39579a41e6b2d4f62992d2196b63ad`
+**Provider calls authorized by this document:** none
+**Future paid scope requiring fresh authorization:** at most three sequential
+operator-funded root runs, one per frozen case, with no retry or resume
+**Soft cost stops requiring fresh authorization:** USD 0.05 per admitted run
+and USD 0.12 for the study; one already-admitted run may finish slightly above
+either boundary
+
+## Question
+
+On one previously measured topic, does the deployed Writer/Reviewer path obey
+the code-derived applicability contract for all three Decision Context modes?
+
+Specifically:
+
+- does an omitted context produce an orientation brief that withholds an
+  actor-specific GO/NO_GO conclusion;
+- does a partial context expose the missing core fields and still withhold that
+  conclusion; and
+- does a complete context address the supplied actor and decision while
+  emitting one bounded `GO`, `NO_GO`, or `DEFER` conclusion?
+
+This is a prompt-compliance and public-boundary canary. It is not a factual
+accuracy evaluation, a user-utility comparison, or evidence that a conclusion
+is commercially correct.
+
+## Why this topic was frozen
+
+The exact topic for all three cases is:
+
+> quantum computing for drug discovery
+
+The choice was made from data already on disk, before seeing any report from
+this study:
+
+- benchmark case 08 completed 3/3 live runs;
+- all three runs produced TRL 4, and all required report sections and scoring
+  formulas passed the frozen benchmark checks;
+- each run retained eight patent and eight market sources, while academic
+  coverage varied from three to seven sources; and
+- both separately recruited target users selected case 08 before report
+  exposure, retained `DEFER`, and later described actionability and evidence
+  trust as weak.
+
+Those observations make the topic inspectable and product-relevant; they do
+not establish source truth or make it an easy positive case. Keeping one topic
+across all modes reduces an obvious content confound, but retrieval and model
+sampling may still vary. This study therefore cannot estimate the causal effect
+of Decision Context.
+
+## Frozen requests
+
+The committed manifest is the request authority. No language, weight profile,
+paper, BYOK credential, planner option, or recovery request may be added.
+
+| Case | Supplied context | Expected mode | Expected decision authority |
+|---|---|---|---|
+| `DC01` | none | `orientation` | actor-specific GO/NO_GO prohibited |
+| `DC02` | asset description and US jurisdiction only | `decision_context_incomplete` | actor-specific GO/NO_GO prohibited; application, owner, and decision type are missing |
+| `DC03` | all seven fields | `decision_support` | exactly one bounded GO, NO_GO, or DEFER conclusion permitted |
+
+The context is synthetic, non-confidential, and intentionally unverified. In
+particular, it is user-supplied input rather than retrieved evidence. A report
+that silently promotes it to an independently verified fact fails the contract
+even if the wording sounds plausible.
+
+## Admission preflight
+
+Paid execution is inadmissible until all of the following are recorded:
+
+1. this protocol and the manifest are merged to `main`, and their exact bytes
+   match the SHA-256 above;
+2. Railway serves the exact merge revision and `/health/ready` returns HTTP 200
+   with `llm`, `search`, `outputs`, and `paid_accounting` all `ok`;
+3. the deployed OpenAPI schema still exposes `decision_context` on
+   `RunRequest`;
+4. one operator access code reaches `/api/access/check` with HTTP 200 without
+   the code itself being written to an artifact;
+5. the selected owner's run-history baseline and paid-operation ledger state
+   are recorded before the first submission; and
+6. the user gives fresh authorization for the three root runs, USD 0.05
+   per-run soft stop, USD 0.12 study soft stop, and possible small in-flight
+   overrun.
+
+Failure of any preflight item means zero requests. A successful access check is
+not paid-run authorization.
+
+## Frozen execution protocol
+
+1. Recompute the manifest SHA-256 from committed bytes and validate each body
+   through the deployed public request schema.
+2. Submit `DC01` exactly once, persist its run id before polling, and wait for a
+   terminal state.
+3. Inspect its status, progress, report, checkpoint state, source collection,
+   evidence-gap shadow artifact, and usage before considering another request.
+4. Stop the study if the run fails, cost is uninspectable, observed per-run cost
+   exceeds USD 0.05, the deployed revision differs, or any unauthorized child,
+   planner call, or supplementary search appears.
+5. If the cumulative observed cost is still within the USD 0.12 boundary,
+   repeat the same sequence for `DC02`, then `DC03`.
+6. Re-read the owner history. The protocol may add no more than three root runs
+   and no child runs.
+7. Classify every criterion as `pass`, `fail`, `not_inspectable`, or
+   `not_observed`. Missing output and a check that did not run are never passes.
+
+Runs are sequential because a total soft stop cannot be enforced when three
+full workflows are already in flight. No failed case may be replaced, retried,
+resumed, or rerun under another code.
+
+## Acceptance criteria
+
+### Execution and public-boundary contract
+
+1. Every admitted case reports the exact authorized `pipeline_revision`,
+   reaches `completed`, creates no recovery child, and commits the ordinary
+   seven-node checkpoint sequence without an error.
+2. Public status and progress expose the exact `assessment_mode` and
+   `decision_gate` frozen for that case in the manifest.
+3. Every evidence-gap artifact records zero executed planner/tool calls, zero
+   supplementary-search cost, and unchanged accepted-source hashes. A missing
+   or failed shadow check is not a pass.
+4. Cost is inspectable for every admitted case, no observed case exceeds the
+   USD 0.05 per-run soft stop, and cumulative observed cost is no greater than
+   USD 0.12. An already-admitted in-flight overrun is reported rather than
+   hidden, but still fails the numerical criterion.
+
+### Delivered-report contract
+
+5. `DC01` names `orientation`, explicitly states that actor-specific
+   `GO/NO_GO is not assessed`, and does not invent a decision owner, budget,
+   timeline, jurisdiction, or success threshold.
+6. `DC02` names `decision_context_incomplete`, explicitly states that
+   actor-specific `GO/NO_GO is not assessed`, names all three missing core
+   fields, and does not infer their values from the topic.
+7. `DC03` names `decision_support`, addresses the supplied pharmaceutical R&D
+   portfolio committee, target application, and funding decision, and ends
+   with one operative `GO`, `NO_GO`, or `DEFER` conclusion whose conditions are
+   tied to retrieved evidence.
+8. All cases visibly distinguish supplied context from retrieved evidence,
+   observed facts from analyst inference, and legal research from an FTO
+   opinion. The unverified synthetic asset description must not be presented
+   as independently verified.
+9. Unsupported budget amounts and success thresholds remain `not established`.
+   Only the supplied 90-day decision horizon and 12-month pilot horizon may be
+   stated as actor-specific timing without cited evidence.
+10. Context unique to `DC02` or `DC03` does not appear in `DC01`; fields absent
+    from `DC02` are not silently copied from `DC03`. This is a run-isolation
+    check, not evidence that the model has no memory in other architectures.
+
+The primary canary passes only if all three cases are admitted and criteria
+1-10 pass. A provider or retrieval failure is an operational failure, not a
+prompt-compliance pass. A completed study with one contract violation is a
+valid observation but a failed three-mode canary.
+
+## Measurement limits fixed in advance
+
+No person or automated check in this protocol will open the cited papers,
+patents, market pages, or regulatory sources. Consequently the following stay
+`not_evaluated` regardless of the structural verdict:
+
+- source truth and factual correctness;
+- commercial recommendation quality;
+- whether `GO`, `NO_GO`, or `DEFER` is the right decision;
+- target-user usefulness, adoption, time savings, or ROI;
+- causal improvement over topic-only reports;
+- performance on other topics, languages, providers, or contexts; and
+- whether six agents are necessary.
+
+The result document must preserve failed, partial, over-budget,
+`not_inspectable`, and `not_observed` outcomes. Criteria and context values may
+not be rewritten after the first provider request.
+
+## Explicit exclusions
+
+This study does not change the scoring formula, the evidence-confidence floor,
+the non-blocking uncited-claim screen, prompt caching, source-summary scraping,
+CrewAI, checkpoint identity, or the production-disconnected evidence-gap
+executor. It adds no model memory and authorizes no autonomous Tool Calling.

--- a/tests/fixtures/decision_context_paid_canary_manifest.json
+++ b/tests/fixtures/decision_context_paid_canary_manifest.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "experiment_id": "decision-context-three-mode-paid-canary-2026-08-26",
+  "topic_selection": {
+    "topic": "quantum computing for drug discovery",
+    "benchmark_case": "08",
+    "selection_basis": "The frozen benchmark completed 3/3 runs at TRL 4, and both target-user pilot observations independently selected this topic before report exposure."
+  },
+  "cases": [
+    {
+      "case_id": "DC01",
+      "expected_assessment_mode": "orientation",
+      "request": {
+        "topic": "quantum computing for drug discovery"
+      },
+      "expected_gate": {
+        "status": "checked",
+        "mode": "orientation",
+        "provided_fields": [],
+        "missing_core_fields": [
+          "asset_description",
+          "target_application",
+          "decision_owner",
+          "decision_type"
+        ],
+        "go_no_go_allowed": false
+      }
+    },
+    {
+      "case_id": "DC02",
+      "expected_assessment_mode": "decision_context_incomplete",
+      "request": {
+        "topic": "quantum computing for drug discovery",
+        "decision_context": {
+          "asset_description": "A university-owned error-mitigated quantum chemistry workflow demonstrated only on small-molecule binding-energy benchmarks",
+          "jurisdiction": "United States"
+        }
+      },
+      "expected_gate": {
+        "status": "checked",
+        "mode": "decision_context_incomplete",
+        "provided_fields": [
+          "asset_description",
+          "jurisdiction"
+        ],
+        "missing_core_fields": [
+          "target_application",
+          "decision_owner",
+          "decision_type"
+        ],
+        "go_no_go_allowed": false
+      }
+    },
+    {
+      "case_id": "DC03",
+      "expected_assessment_mode": "decision_support",
+      "request": {
+        "topic": "quantum computing for drug discovery",
+        "decision_context": {
+          "asset_description": "A university-owned error-mitigated quantum chemistry workflow demonstrated only on small-molecule binding-energy benchmarks",
+          "target_application": "Prioritizing kinase inhibitor candidates before wet-lab validation for an oncology discovery program",
+          "decision_owner": "Pharmaceutical R&D portfolio committee",
+          "decision_type": "GO, DEFER, or NO_GO on funding a limited validation pilot",
+          "jurisdiction": "United States",
+          "time_horizon": "Make the funding decision within 90 days and evaluate pilot results within 12 months",
+          "constraints": "No budget amount or success threshold has been approved. Require a same-workload comparison against classical baselines, wet-lab validation for prioritized candidates, and patent counsel before any FTO conclusion."
+        }
+      },
+      "expected_gate": {
+        "status": "checked",
+        "mode": "decision_support",
+        "provided_fields": [
+          "asset_description",
+          "target_application",
+          "decision_owner",
+          "decision_type",
+          "jurisdiction",
+          "time_horizon",
+          "constraints"
+        ],
+        "missing_core_fields": [],
+        "go_no_go_allowed": true
+      }
+    }
+  ],
+  "execution_bounds": {
+    "maximum_root_runs": 3,
+    "maximum_runs_per_case": 1,
+    "maximum_resumes": 0,
+    "maximum_supplementary_search_calls": 0,
+    "soft_stop_usd_per_run": 0.05,
+    "soft_stop_usd_total": 0.12
+  }
+}

--- a/tests/test_decision_context_paid_canary.py
+++ b/tests/test_decision_context_paid_canary.py
@@ -1,0 +1,87 @@
+"""Frozen-input checks for the three-mode Decision Context paid canary.
+
+The canary itself is deliberately not executable from the test suite: paid
+provider work always requires fresh operator authorization. These checks keep
+the future requests at the public API seam and make a case drift visible before
+someone spends money against a different question.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from pathlib import Path
+
+from api.models import RunRequest
+from academic_agent.run_spec import DecisionContext
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "tests/fixtures/decision_context_paid_canary_manifest.json"
+PREREG_PATH = ROOT / "docs/prereg-2026-08-26-decision-context-paid-canary.md"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_freezes_one_topic_and_exactly_one_case_per_mode() -> None:
+    manifest = _manifest()
+    cases = manifest["cases"]
+
+    assert manifest["schema_version"] == 1
+    assert [case["case_id"] for case in cases] == ["DC01", "DC02", "DC03"]
+    assert [case["expected_assessment_mode"] for case in cases] == [
+        "orientation",
+        "decision_context_incomplete",
+        "decision_support",
+    ]
+    assert {case["request"]["topic"] for case in cases} == {
+        manifest["topic_selection"]["topic"]
+    }
+
+
+def test_every_frozen_payload_reaches_the_public_request_and_gate_seams() -> None:
+    for case in _manifest()["cases"]:
+        # RunRequest is the actual POST boundary. Validating only RunSpec would
+        # miss a fixture field that production silently rejects before launch.
+        request = RunRequest.model_validate(case["request"])
+        context = request.decision_context or DecisionContext()
+
+        assert request.assessment_mode == case["expected_assessment_mode"]
+        assert context.gate_snapshot() == case["expected_gate"]
+        assert request.byok is False
+
+
+def test_cases_change_only_decision_context_and_contain_no_credentials() -> None:
+    serialized = json.dumps(_manifest()["cases"], sort_keys=True).lower()
+
+    for case in _manifest()["cases"]:
+        assert set(case["request"]) <= {"topic", "decision_context"}
+    for secret_field in (
+        "access_code",
+        "api_key",
+        "llm_api_key",
+        "serper_api_key",
+        "authorization",
+    ):
+        assert secret_field not in serialized
+
+
+def test_execution_bounds_cannot_turn_a_canary_into_an_open_ended_batch() -> None:
+    manifest = _manifest()
+    bounds = manifest["execution_bounds"]
+
+    assert bounds["maximum_root_runs"] == len(manifest["cases"]) == 3
+    assert bounds["maximum_runs_per_case"] == 1
+    assert bounds["maximum_resumes"] == 0
+    assert bounds["maximum_supplementary_search_calls"] == 0
+    assert 0 < bounds["soft_stop_usd_per_run"] <= 0.05
+    assert 0 < bounds["soft_stop_usd_total"] <= 0.12
+
+
+def test_preregistration_names_the_exact_committed_manifest_bytes() -> None:
+    digest = sha256(MANIFEST_PATH.read_bytes()).hexdigest()
+    preregistration = PREREG_PATH.read_text(encoding="utf-8")
+
+    assert f"**Manifest SHA-256:** `{digest}`" in preregistration


### PR DESCRIPTION
Freezes one previously measured topic across orientation, incomplete-context, and decision-support requests before any provider call. The committed manifest binds exact public payloads, derived gates, sequential stop rules, a USD 0.12 soft study boundary, and explicit non-evaluated claims. No paid run is authorized by this PR. Verification: 1545 tests passed, 632 subtests passed, latest Ruff passed, and deliberate public-request field disconnection made the new seam tests fail before restoration.