### PR TITLE
Record the failed Decision Context production canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  77 test modules plus conftest, organised by subject
+tests/                  78 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -390,21 +390,24 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/target-user-decision-pilot-guide.md`,
   `docs/errata-2026-08-26-target-user-pilot-form-enums-and-ai-timing.md`, and
   `docs/results-2026-08-26-target-user-decision-pilot.md`.
-- **Decision Context now has an offline execution contract, not a validated
-  decision-quality result.** Seven optional bounded fields cross the browser,
+- **Decision Context has one completed production canary, and it failed its
+  frozen all-mode criterion.** Seven optional bounded fields cross the browser,
   API, immutable RunSpec, checkpoint identity, Crew input, and public status.
   Code derives `orientation`, `decision_context_incomplete`, or
-  `decision_support`; clients cannot self-assert the mode, and Writer/Reviewer
-  must withhold actor-specific GO/NO_GO when the four core fields are absent.
-  The implementation used zero provider calls and passed the public-boundary,
-  identity, Worker/Crew, and status seams, including defect re-injection. It
-  does not prove prompt compliance, factual correctness, usefulness, adoption,
-  or time savings: the gate checks context completeness rather than truth. A
-  paid three-mode canary remains separate work and requires fresh authorization
-  with frozen criteria. Its protocol now binds three requests on benchmark case
-  08 to an exact manifest, sequential stop rules, structural verdicts, and a
-  `$0.12` soft study boundary. No provider call is authorized or completed by
-  that pre-registration, so the limitation remains open. See
-  `docs/prereg-2026-08-26-decision-context-report-contract.md` and
-  `docs/results-2026-08-26-decision-context-report-contract.md`, plus
-  `docs/prereg-2026-08-26-decision-context-paid-canary.md`.
+  `decision_support`, and clients cannot self-assert that mode. Three authorized
+  root runs then completed sequentially for `$0.109342` / 266,648 tokens / 21
+  requests, with exact status/progress gates, no child, zero evidence-gap tool
+  calls, and no supplementary-search cost. Seven of ten report/execution
+  criteria passed. `DC01` fell back to the Writer draft and committed 6/7
+  checkpoints; `DC03` humanized the frozen mode token; and `DC02` supplied an
+  unqualified commercial pass threshold that the incomplete context had not
+  established. The public run response also did not expose its own
+  `pipeline_revision`, so exact deployment identity was externally verified but
+  the per-run field remained `not_inspectable`. This is prompt-compliance and
+  operational evidence only: source truth, decision correctness, usefulness,
+  adoption, and time savings remain unmeasured. Do not call it a validated
+  decision-quality result or rerun it as post-fix evidence. See
+  `docs/prereg-2026-08-26-decision-context-report-contract.md`,
+  `docs/results-2026-08-26-decision-context-report-contract.md`,
+  `docs/prereg-2026-08-26-decision-context-paid-canary.md`, and
+  `docs/results-2026-08-26-decision-context-paid-canary.md`.

--- a/README.md
+++ b/README.md
@@ -147,9 +147,15 @@ are absent. This is an offline contract result, not evidence that a generated
 decision is correct or useful. See the [protocol](docs/prereg-2026-08-26-decision-context-report-contract.md)
 and [implementation result](docs/results-2026-08-26-decision-context-report-contract.md).
 A separate [three-mode production canary](docs/prereg-2026-08-26-decision-context-paid-canary.md)
-now freezes one topic, three public request bodies, structural criteria, and a
-USD 0.12 soft study boundary. It has not been authorized or run, so no
-provider-backed compliance result is claimed.
+then completed three sequential root runs for **$0.109342**, 266,648 tokens,
+and 21 provider requests. All reached `completed`, exposed the expected public
+mode gates, created no child, and made zero evidence-gap tool calls. The frozen
+primary criterion nevertheless **failed 7/10**: `DC01` used Reviewer fallback
+and committed 6/7 checkpoints, `DC03` humanized the required mode token, and
+`DC02` introduced an unqualified commercial pass threshold that its incomplete
+context had not established. This is provider-backed prompt-compliance and
+operational evidence, not source truth, decision correctness, or user value.
+See the [full canary result](docs/results-2026-08-26-decision-context-paid-canary.md).
 
 A separate pre-registered checkpoint audit hard-terminated **30 worker
 processes** across ten frozen evidence collections and three post-commit
@@ -1232,9 +1238,14 @@ ROI 或“六 Agent 必要性”证明。详见[预注册](docs/prereg-2026-08-2
 生成的决策正确或有用。详见
 [预注册](docs/prereg-2026-08-26-decision-context-report-contract.md)和
 [实现结果](docs/results-2026-08-26-decision-context-report-contract.md)。另有一份
-[三模式生产 canary 预注册](docs/prereg-2026-08-26-decision-context-paid-canary.md)
-已经冻结同一主题下的 3 个公开请求、结构判定标准和 0.12 美元研究软停止线；目前
-尚未获得付费执行授权，也尚未运行，因此不声称已有供应商支持的合同遵循结果。
+[三模式生产 canary](docs/prereg-2026-08-26-decision-context-paid-canary.md)
+随后完成 3 次顺序根运行，合计 **0.109342 美元**、266,648 Token 和 21 次供应商
+请求；三次均到达 `completed`，公开状态返回预期模式，没有子运行，也没有触发
+Evidence-gap 工具调用。但冻结主标准仍以 **7/10 未通过**：`DC01` 发生 Reviewer
+回退且只提交 6/7 个 Checkpoint，`DC03` 把要求的模式字面量改写成自然语言，
+`DC02` 则在上下文不完整时给出未标注为提案/未批准的商业通过阈值。该结果只提供
+真实供应商下的 Prompt 遵循与运行证据，不证明来源真值、决策正确性或用户价值。
+详见[完整 canary 结果](docs/results-2026-08-26-decision-context-paid-canary.md)。
 
 另有一组预注册 Checkpoint 故障恢复实验，在 10 份冻结证据和 3 个提交后边界上
 硬终止 **30 个 worker 进程**。30/30 个不可变子运行均到达 `Done`，精确复用预期

--- a/docs/portfolio-case-study.md
+++ b/docs/portfolio-case-study.md
@@ -73,7 +73,7 @@ source of truth.
 | Provider-backed recovery canary | One same-revision child reused a four-node prefix, made 0 new evidence-agent requests, and completed the remaining workflow | One observation only; interrupted-source usage was unavailable, so total cost and general savings are not inspectable |
 | Bounded Tool Calling contracts | Phase 2 passed 14/14 frozen execution cases; the disconnected Phase 3 generic pilot completed 5/5 requests; Phase 4 passes a 71/71 adapter/executor seam set plus a 50/50 live-runner and source-locked Schema v2 review subset over eight OpenAlex/Lens cases | Production remains zero-call shadow mode: the Phase 3 form declared substantive AI use and only 5/25 candidates relevant; the Phase 4 runner has made no live request, so compatibility, precision and evidence gain remain unobserved |
 | Decision-context contract | Seven bounded fields cross the browser, API, immutable RunSpec, checkpoint identity, Crew input and both public status endpoints; all frozen offline seams passed with 0 provider calls | This establishes applicability plumbing, not model compliance, decision correctness, or user value |
-| Test and CI contract | 1,540 tests plus 632 subtests; Linux/Windows × Python 3.11/3.12; 87.23% measured coverage above an 85% floor; a dedicated Chromium journey exercises the access gate, client admission, run history and report DOM | The browser smoke is loopback-only and blocks mutating requests, so it proves the shipped client/API seam without claiming provider compatibility or deployed-service availability |
+| Test and CI contract | 1,545 tests plus 632 subtests; Linux/Windows × Python 3.11/3.12; 87.23% measured coverage above an 85% floor; a dedicated Chromium journey exercises the access gate, client admission, run history and report DOM | The browser smoke is loopback-only and blocks mutating requests, so it proves the shipped client/API seam without claiming provider compatibility or deployed-service availability |
 
 The negative results are retained deliberately. For example, the first patent
 relevance candidate raised auto-kept precision to 94.6% but falsely removed six
@@ -127,11 +127,13 @@ project's engineering argument: evaluation should be capable of saying no.
   2/5. Both answered `MAYBE` to reuse and estimated substantial correction
   work. Neither checked external sources, so this is not source-truth evidence
   or product validation.
-- Decision Context has only offline contract evidence. A three-mode production
-  canary now has frozen requests, criteria, and cost boundaries, but it has not
-  been authorized or run. No provider-backed report has therefore tested
-  Writer/Reviewer compliance across the modes, and no target user has judged
-  whether the new framing improves a real decision.
+- The three-mode Decision Context production canary completed for $0.109342,
+  but failed its frozen primary criterion 7/10. One run used Reviewer fallback,
+  one report humanized the required mode token, and one incomplete-context
+  report introduced an unqualified commercial threshold. The result measures
+  prompt compliance and operational behavior only: source truth, decision
+  correctness, target-user value, and whether the framing improves a real
+  decision remain unmeasured.
 
 ## Reproduce or inspect
 
@@ -146,6 +148,7 @@ project's engineering argument: evaluation should be capable of saying no.
 - [Decision Context protocol](prereg-2026-08-26-decision-context-report-contract.md)
 - [Decision Context implementation result](results-2026-08-26-decision-context-report-contract.md)
 - [Decision Context three-mode paid-canary protocol](prereg-2026-08-26-decision-context-paid-canary.md)
+- [Decision Context three-mode paid-canary result](results-2026-08-26-decision-context-paid-canary.md)
 - [Checkpoint recovery design](checkpoint-recovery.md)
 - [Production recovery canary](results-2026-08-24-paid-same-revision-recovery-post-fix.md)
 

--- a/docs/results-2026-08-26-decision-context-paid-canary.md
+++ b/docs/results-2026-08-26-decision-context-paid-canary.md
@@ -1,0 +1,120 @@
+# Decision Context three-mode paid production canary — result
+
+**Date:** 2026-08-26
+**Protocol:** [`prereg-2026-08-26-decision-context-paid-canary.md`](prereg-2026-08-26-decision-context-paid-canary.md)
+**Authorized production revision:** `cf00c9a20118a552b8418b5770cce5336a28b9da`
+**Manifest SHA-256:** `bd18ecb13f91d0f4dc9a3dde5059259f0d39579a41e6b2d4f62992d2196b63ad`
+**Outcome:** valid three-case production observation; primary canary failed
+
+## Executive result
+
+All three frozen root requests were admitted once, ran sequentially on the
+authorized Railway deployment, and reached `completed`. Public status and
+progress returned the expected code-derived gate for each request. The study
+created no child run, executed no evidence-gap tool call, changed no accepted
+evidence collection, and stayed below both cost stops.
+
+The primary canary nevertheless failed. Seven of the ten frozen criteria
+passed and three did not:
+
+- `DC01` delivered the validated Writer draft after Reviewer fallback, so the
+  run committed six rather than seven checkpoints;
+- `DC03` used the human-readable heading `Decision Support Mode` rather than
+  the frozen report token `decision_support`; and
+- `DC02` supplied a commercial pass threshold — at least one pharmaceutical
+  partner or pilot customer — without marking that threshold as unapproved or
+  as an analyst proposal, even though the incomplete context had not supplied
+  a target application, owner, decision type, or success threshold.
+
+These are prompt-compliance and observability findings. No cited source was
+opened during this audit, so they say nothing about factual correctness or the
+commercial correctness of the `DEFER` recommendation.
+
+## Execution
+
+The operator authorized exactly three sequential root runs with USD 0.05 per
+run and USD 0.12 study soft stops. Before submission:
+
+- GitHub/Railway deployment `6103812791` reported `success` for the exact
+  revision above, and no newer production deployment appeared during the
+  study;
+- `/health/ready` returned HTTP 200 with `llm`, `search`, `outputs`, and
+  `paid_accounting` all `ok`;
+- `/api/access/check` accepted the selected owner code without persisting the
+  code in any study artifact;
+- active run and paid-operation counts were both zero; and
+- that owner's visible history contained five runs, with none started on
+  2026-08-26 UTC.
+
+The internal owner count in the durable paid-operation ledger is intentionally
+not exposed by the public API. Its schema/readability state was therefore
+observed through readiness, while its exact pre-run count remained
+`not_inspectable`. Admission of all three requests and the final owner history
+are additional boundary evidence; they do not make the hidden pre-run count
+publicly reconstructable.
+
+| Case | Public mode | State | Sources A/P/M | Review | Checkpoints | Tokens / requests | Cost | Duration |
+|---|---|---|---:|---|---|---:|---:|---:|
+| [`DC01`](https://academic-commercialization-agent.up.railway.app/run/20260826T124329Z-cfd5dc20e750ae6048e3dd503e577960) | `orientation` | completed | 3 / 8 / 8 | fallback | 6 / 7 | 80,643 / 7 | $0.032993 | 152 s |
+| [`DC02`](https://academic-commercialization-agent.up.railway.app/run/20260826T124828Z-7126fa03452d0ddc95e52ad3c6d6425e) | `decision_context_incomplete` | completed | 4 / 8 / 8 | passed | 7 / 7 | 87,623 / 7 | $0.035534 | 120 s |
+| [`DC03`](https://academic-commercialization-agent.up.railway.app/run/20260826T125132Z-17277cad7e2025ee8881b81687b851f4) | `decision_support` | completed | 4 / 8 / 8 | passed | 7 / 7 | 98,382 / 7 | $0.040815 | 185 s |
+| **Total** | — | 3 / 3 completed | — | — | — | **266,648 / 21** | **$0.109342** | **457 s** |
+
+The owner history increased from five to eight, and its newest three entries
+were exactly `DC01`, `DC02`, and `DC03` in execution order. Every run reported
+`recovery.state=not_requested`. No retry, resume, cancellation, replacement
+topic, or fourth paid operation was used.
+
+## Frozen criteria
+
+| # | Verdict | Observation |
+|---:|---|---|
+| 1 | **fail** | All three runs completed with no child, but `DC01` reported `quality_review.status=fallback` and committed retrieval, three evidence nodes, Writer, and Scorer only. Its Reviewer checkpoint was absent. The public run contract also does not expose `pipeline_revision`; the exact deployment was verified externally, while per-run revision reporting remained `not_inspectable`. |
+| 2 | **pass** | Status and progress both exposed byte-equivalent gates for `orientation`, `decision_context_incomplete`, and `decision_support`, including provided fields, missing core fields, and GO/NO_GO authority. |
+| 3 | **pass** | Each persisted shadow artifact reported `planner_state=not_run`, zero executed calls, USD 0 added search cost, `evidence_changed=false`, and its own source-collection SHA-256. |
+| 4 | **pass** | Every cost was complete and below USD 0.05; the USD 0.109342 total was below USD 0.12. |
+| 5 | **pass** | `DC01` named orientation mode, said actor-specific `GO/NO_GO is not assessed`, marked the decision owner and cost/time as not established, and contained none of the context unique to `DC02` or `DC03`. |
+| 6 | **pass** | `DC02` named `decision_context_incomplete`, withheld actor-specific GO/NO_GO, explicitly listed `target_application`, `decision_owner`, and `decision_type` as missing, and did not copy their values from `DC03`. |
+| 7 | **fail** | `DC03` addressed the supplied committee, application, horizons, and funding question and issued one operative, evidence-conditioned `DEFER`. Its report heading was `Decision Support Mode`, not the frozen literal `decision_support`; the criterion is not rewritten after observing that semantically equivalent wording. |
+| 8 | **pass** | The reports labelled supplied decision context separately from retrieved sources, marked analyst proposals/inferences, and repeated that patent white-space analysis was preliminary research rather than legal advice or an FTO opinion. The synthetic asset was attributed to decision context rather than presented as independently verified. |
+| 9 | **fail** | No report invented a budget, and `DC03` preserved the supplied 90-day/12-month horizons while stating that no success threshold was approved. `DC02`, however, introduced `At least one pharma partner or pilot customer` as a measurable pass threshold without the proposal/unapproved qualification used elsewhere. The all-cases criterion therefore failed. |
+| 10 | **pass** | `DC01` contained none of the asset, jurisdiction, application, owner, decision, horizon, or constraint prose from later cases. `DC02` contained its own asset only and none of the `DC03`-unique application, owner, decision, horizon, or validation constraints. |
+
+## Additional observations
+
+`DC01` spent two Reviewer requests and then exposed only the stable public
+classification `failure_type=Exception`. No reviewer notes artifact or Reviewer
+checkpoint was produced. The underlying exception is intentionally absent from
+the public response, and no operator log was exported into this study, so its
+root cause is `not_inspectable`; it must not be guessed from the fallback state.
+
+Claim-grounding screens completed but checked zero claims in all three reports.
+They recorded 2, 1, and 5 unverifiable quantitative claims respectively. That
+is neither a grounding pass nor evidence of hallucination: the check ran, but
+the retained source text could not verify those claims. Source truth remains
+`not_evaluated` as frozen in the protocol.
+
+Source retrieval varied across repeated requests for the same topic: `DC01`
+retained three academic sources, while `DC02` and `DC03` retained four, and all
+three source-collection hashes differed. This is expected for live retrieval
+and prevents treating the three reports as a causal comparison of context
+mode. The canary measures each mode's contract independently.
+
+## Next admissible work
+
+No production behavior changed during this result capture. The next work should
+be narrow and evidence-led:
+
+1. obtain the operator-side `DC01` exception and reproduce it offline before
+   changing Reviewer behavior;
+2. expose a non-secret immutable `pipeline_revision` at both status endpoints
+   so a future run can report its own execution identity rather than relying on
+   an external deployment timestamp;
+3. make the report's applicability label deterministic at the delivery seam,
+   and distinguish supplied/approved success thresholds from explicitly
+   labelled analyst proposals; and
+4. freeze a new regression protocol before any paid rerun. These three runs may
+   not be reused as post-fix evidence.
+
+This result does not authorize a rerun, a production fix, Tool Calling,
+supplementary search, source verification, or a user-value study.


### PR DESCRIPTION
## Why\n\nThe frozen three-mode canary was the first provider-backed check of the Decision Context report contract. All three root runs completed, but the pre-registered primary criterion failed 7/10. Recording that negative result prevents completed run status from being mistaken for contract success.\n\n## What this records\n\n- 3 sequential root runs, 266,648 tokens, 21 requests, USD 0.109342 total\n- zero recovery children, Planner calls, or supplementary searches\n- DC01 Reviewer fallback and 6/7 checkpoints\n- DC03 mode-token wording drift\n- DC02 unqualified threshold under incomplete context\n- public pipeline revision and the DC01 root exception remain not_inspectable\n\nNo production behavior changes and no paid rerun is authorized.\n\n## Verification\n\n- uv run pytest -q --basetemp outputs/pytest-canary-docs-final-20260826: 1545 passed, 632 subtests\n- uv run --with ruff ruff check .: passed