### PR TITLE
Record the precision-v2 unseen live result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,9 +306,16 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   correction, all eight collection/plan/profile identities, implementation
   hashes, and the request/cost gates before adapter construction. Its 19/19
   focused seams pass, including a re-injected broad-acceptance defect at the
-  review-output boundary. The unseen harness has not made a live request, no
-  execution is authorized, and production remains disconnected. Do not rerun
-  or connect the original adapter.
+  review-output boundary. A separately authorized run on merged revision
+  `9f84a9f` completed all eight one-attempt anonymous requests for USD 0.008 of
+  provider-reported usage. Forty provider rows became nine provider
+  rejections, eight legacy-quarantine rejections and 23 precision decisions;
+  precision v2 accepted five candidates across only 3/8 cases. The frozen
+  coverage gate requires at least 6/8, so no later human label could make the
+  all-gates rule pass. The study stopped before review; source value remains
+  `not_evaluated`, not zero-error. Do not rerun, tune on U01-U08 and call it
+  validation, or connect either the original adapter or precision v2. Any next
+  method must freeze a different unseen challenge first.
   Keep `pipeline_worker.py` disconnected from the executor, adapters, live
   runner and review module.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -329,8 +336,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/errata-2026-08-27-anonymous-openalex-review-declaration.md`,
   `docs/prereg-2026-08-27-openalex-precision-v2.md`,
   `docs/results-2026-08-27-openalex-precision-v2-development.md`,
-  `docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md`, and
-  `docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md`.
+  `docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md`,
+  `docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md`, and
+  `docs/results-2026-08-27-openalex-precision-v2-unseen-live.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -546,13 +546,19 @@ evidence in 4/4 cases. This qualifies only the frozen U01-U08 unseen harness.
 That disconnected harness is now implemented: its zero-network dry-run locks
 the original fixture, a separately recorded pre-provider duplicate-phrase
 correction, all eight collection/plan/profile identities and the implementation
-hashes before adapter construction. Its 19/19 focused seams pass, but no unseen
-request has run, no live execution is authorized, and production remains
-disconnected. See the
+hashes before adapter construction. Its 19/19 focused seams pass. A separately
+authorized run on merged revision `9f84a9f` then completed all eight one-attempt
+anonymous requests for USD 0.008 of provider-reported budget usage. Forty rows
+became nine provider rejections, eight legacy-quarantine rejections and 23
+precision decisions; precision v2 accepted five candidates across only 3/8
+cases. That is below the frozen 6/8 coverage floor, so no later label could make
+the all-gates rule pass. The study stopped before human review, source value
+remains `not_evaluated`, and production remains disconnected. See the
 [precision-v2 protocol](docs/prereg-2026-08-27-openalex-precision-v2.md) and
 [development result](docs/results-2026-08-27-openalex-precision-v2-development.md),
 plus the [fixture erratum](docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md)
-and [unseen-harness implementation result](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md).
+and [unseen-harness implementation result](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md),
+followed by the [unseen live result](docs/results-2026-08-27-openalex-precision-v2-unseen-live.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1610,12 +1616,17 @@ Schema v2 评审包展示 4 组冻结基线并逐条保留 9 个候选身份。�
 开发候选、弃权 4/4 条已知错源，并在 4/4 个案例中保留相关证据。该结果只允许继续
 冻结的 U01-U08 未见挑战。该独立 harness 现已完成实现：零网络 dry-run 会在构造
 适配器前锁定原始 fixture、单独记录的供应商请求前重复短语勘误、8 组
-collection/plan/profile 身份和实现哈希，19/19 个聚焦接缝测试通过；但尚未发起未见
-请求、未授权真实运行，生产仍完全断开。详见
+collection/plan/profile 身份和实现哈希，19/19 个聚焦接缝测试通过。随后，一次针对
+合并版本 `9f84a9f` 的独立授权运行完成 8 个单次匿名请求，供应商报告匿名额度用量为
+`$0.008`。40 条供应商行中 9 条在解析层被拒绝、8 条被原有隔离规则拒绝，23 条进入
+precision-v2 判断；最终仅在 3/8 个案例中接受 5 条候选，低于冻结的 6/8 覆盖门槛。
+后续人工标签不可能挽救该门槛，因此实验没有继续消耗评审时间，来源价值保持
+`not_evaluated`，生产仍完全断开。详见
 [precision-v2 协议](docs/prereg-2026-08-27-openalex-precision-v2.md)、
 [开发集结果](docs/results-2026-08-27-openalex-precision-v2-development.md)、
 [fixture 勘误](docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md)与
-[未见 harness 实现结果](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md)。
+[未见 harness 实现结果](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md)，以及
+[未见真实运行结果](docs/results-2026-08-27-openalex-precision-v2-unseen-live.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-27-openalex-precision-v2-unseen-live.md
+++ b/docs/results-2026-08-27-openalex-precision-v2-unseen-live.md
@@ -1,0 +1,109 @@
+# Result: OpenAlex precision-v2 unseen live study
+
+**Date:** 2026-08-27
+
+**Executed revision:**
+`9f84a9faf57f558c242ab3ab44f41b7b4bccb70f`
+
+**Protocol:**
+[`prereg-2026-08-27-openalex-precision-v2.md`](prereg-2026-08-27-openalex-precision-v2.md)
+
+**Harness implementation:**
+[`results-2026-08-27-openalex-precision-v2-unseen-implementation.md`](results-2026-08-27-openalex-precision-v2-unseen-implementation.md)
+
+**Production connection authorized:** no
+
+## Outcome
+
+The separately authorized U01-U08 study completed all eight frozen cases. It
+made exactly eight sequential anonymous OpenAlex requests, used no API key,
+performed no retry, redirect, source-page fetch or model call, and retained
+`production_connected=false` and `report_workflow_connected=false` through the
+final artifact boundary.
+
+OpenAlex reported USD 0.001 of anonymous-budget usage per request, USD 0.008 in
+total, below the frozen USD 0.01 soft stop. This is a provider-reported budget
+value, not evidence that a payment was charged. All eight request identities
+were client-generated because the responses exposed no provider request id.
+
+The provider returned 40 rows. Nine were rejected because the record had no
+reconstructable abstract, the unchanged legacy quarantine rejected eight, and
+23 reached the precision-v2 seam. The conjunctive gate accepted five candidates
+across only three cases and abstained the other 18 candidates.
+
+The frozen first value gate requires an accepted candidate in at least 6/8
+cases. The observed 3/8 cannot be changed by any later relevance or novelty
+label, so this exact method cannot satisfy the all-gates rule. The study stopped
+before asking a reviewer to inspect five rows that could not rescue the failed
+coverage gate. Accordingly, the persisted state remains
+`human_review_state=not_prepared` and `source_value_state=not_evaluated`; this is
+a deterministic coverage non-qualification, not a measured wrong-source rate
+or source-truth result.
+
+## Execution and disposition audit
+
+| Case | Request latency | Provider rows | Provider rejected | Legacy rejected | Precision ACCEPT | Precision ABSTAIN |
+|---|---:|---:|---:|---:|---:|---:|
+| U01 | 1,732.44 ms | 5 | 2 | 2 | 1 | 0 |
+| U02 | 1,373.29 ms | 5 | 1 | 2 | 2 | 0 |
+| U03 | 1,397.58 ms | 5 | 0 | 0 | 2 | 3 |
+| U04 | 1,186.24 ms | 5 | 1 | 0 | 0 | 4 |
+| U05 | 741.30 ms | 5 | 1 | 1 | 0 | 3 |
+| U06 | 1,340.71 ms | 5 | 1 | 0 | 0 | 4 |
+| U07 | 1,498.60 ms | 5 | 2 | 0 | 0 | 3 |
+| U08 | 1,440.45 ms | 5 | 1 | 3 | 0 | 1 |
+| **Total** | **10,710.61 ms** | **40** | **9** | **8** | **5** | **18** |
+
+The five accepted rows occur only in U01-U03. U04-U08 contain no accepted
+candidate, even though their request and accounting seams all completed. An
+abstention is not an assertion that a paper is irrelevant; it records that the
+frozen exact-phrase conjunction lacked enough support to admit the row.
+
+## Persistence and integrity
+
+The runner committed the manifest before adapter construction and one
+write-once journal after each attempted case. The final output contains all
+eight journals, 40 candidate rows and five blank review rows. Every aggregate
+file matches the artifact index:
+
+| File | SHA-256 |
+|---|---|
+| `manifest.json` | `f07aa04d4943129120ae7f0c269a6401e1955d5cf9f13add73e4b5134ea5d5f5` |
+| `execution.json` | `4a3b39d7cbb571143a08c758bf20f5873598d66ee4fdcb049c0d13fdae08d5f3` |
+| `candidates.csv` | `815c42bcae0c59d917aa760108908e689757e4fab53eee648176c0c68e75ef7c` |
+| `review.csv` | `168accff2a5c10c4bbc5eeed05240092b7d218655acaa95720a18cf182ad6595` |
+
+The raw execution remains in the gitignored local directory
+`outputs/2026-08-27-openalex-precision-v2-unseen-live-9f84a9f/`. The public
+result records aggregate identities without claiming that the uncommitted raw
+directory is independently available.
+
+## Decision
+
+Do not connect precision v2 to the planner or production workflow. Do not tune
+the frozen profiles on U01-U08 and then report the same cases as validation,
+and do not repeat these provider requests: the exact unseen observation is
+already complete. If another retrieval or precision method is attempted, these
+rows become development evidence and the next evaluation must freeze a
+different unseen challenge first.
+
+The useful engineering result is narrower: the identity, request-budget,
+accounting, abstention and write-once boundaries worked under one live
+eight-case execution. The source-value hypothesis did not qualify because the
+precision rule was too selective to meet the pre-registered coverage floor.
+
+## Explicit non-claims
+
+This execution does not establish source truth, a wrong-source rate, retrieval
+recall, OpenAlex-wide precision, planner-trigger precision, report improvement,
+user utility, cost savings, latency performance, an SLO, autonomous tool choice
+or production Tool Calling readiness.
+
+## Supported claim
+
+> On one frozen eight-case unseen study, the production-disconnected
+> precision-v2 harness completed eight single-attempt anonymous OpenAlex
+> requests for USD 0.008 of provider-reported budget usage and preserved every
+> row and artifact identity. It accepted five candidates across 3/8 cases, below
+> the frozen 6/8 coverage floor, so the method did not qualify for a human
+> source-value review or production connection.


### PR DESCRIPTION
## Summary

- record the separately authorized U01-U08 anonymous OpenAlex execution on merged revision 9f84a9f
- preserve request, cost, disposition, latency, and aggregate artifact identities
- document that precision v2 accepted candidates in 3/8 cases, below the frozen 6/8 coverage gate
- stop before human review because later labels cannot rescue that gate, while keeping source value unevaluated and production disconnected

## Verification

- uv run pytest -q with an in-worktree basetemp: 1614 passed, 1 skipped, 609 subtests
- uv run --with ruff ruff check .
- CI-scope Pylint exception and unreachable checks

## Live boundary

The run made exactly eight one-attempt anonymous OpenAlex requests and reported USD 0.008 of anonymous-budget usage. It used no API key, retry, redirect, source-page fetch, model call, production connection, or report-workflow connection.