### PR TITLE
Add a claim-scope OpenAlex candidate for a new unseen study

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1614 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1630 tests (609 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -150,10 +150,14 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         phase-2 bounded executor; disconnected from production
   openalex_precision.py
                         conjunctive ACCEPT/ABSTAIN source gate; experimental only
+  openalex_claim_scope.py
+                        provider-assisted source gate; experimental only
   tools/evidence_search.py
                         one-request read-only adapter response contract
   tools/anonymous_openalex_search.py
                         key-free experimental wrapper; never production imported
+  tools/openalex_claim_scope_search.py
+                        abstract-filtered aboutness adapter; never production imported
   pipeline_worker.py    the subprocess one run executes in
   checkpoint_runtime.py
                         CrewAI hydration, task identity, and post-guardrail commits
@@ -163,7 +167,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  83 test modules plus conftest, organised by subject
+tests/                  86 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -195,6 +199,8 @@ openalex_precision_live.py
                         disconnected unseen runner; CLI defaults to dry-run
 openalex_precision_audit.py
                         label-blind frozen development replay; zero-network only
+openalex_claim_scope_unseen.py
+                        frozen V01-V08 claim-scope preflight; zero-network only
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -314,8 +320,20 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   coverage gate requires at least 6/8, so no later human label could make the
   all-gates rule pass. The study stopped before review; source value remains
   `not_evaluated`, not zero-error. Do not rerun, tune on U01-U08 and call it
-  validation, or connect either the original adapter or precision v2. Any next
-  method must freeze a different unseen challenge first.
+  validation, or connect either the original adapter or precision v2. A
+  provider-assisted claim-scope v3 method is now implemented against a
+  different, byte-frozen V01-V08 challenge. It requests only abstract-bearing
+  Works and preserves OpenAlex topics/keywords as scored aboutness metadata.
+  Provider metadata may bridge at most one required concept; at least one
+  required concept must still match source text and one must match the title.
+  Provider labels alone therefore cannot authorize a source. The zero-network
+  preflight expands eight distinct collection/plan/profile/idempotency
+  identities, and the new decision/adapter/preflight subset passes 16/16 tests.
+  A deliberately wrong outbound filter made the transport-seam test fail before
+  being reverted. The complete suite now passes 1,630 tests plus 609 subtests at
+  87.43% statement coverage. No V01-V08 provider request or human review has
+  run, so compatibility, precision, source value and report value remain
+  `not_evaluated`. Do not connect or advertise v3 as completed Tool Calling.
   Keep `pipeline_worker.py` disconnected from the executor, adapters, live
   runner and review module.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -338,7 +356,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-precision-v2-development.md`,
   `docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md`,
   `docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md`, and
-  `docs/results-2026-08-27-openalex-precision-v2-unseen-live.md`.
+  `docs/results-2026-08-27-openalex-precision-v2-unseen-live.md`, plus
+  `docs/prereg-2026-08-27-openalex-claim-scope-v3.md` and
+  `docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ uninspectable cost; Lens is explicitly uninspectable rather than `$0`. Every
 provider row reaches a candidate or rejection index, and OpenAlex query-string
 credentials are suppressed from complete exception tracebacks. Both a hidden
 retry and missing-row-accounting defect were re-injected and caught. The full
-suite passes **1,614 tests plus 609 subtests** at **87.31% coverage**. No
+suite passes **1,630 tests plus 609 subtests** at **87.43% coverage**. No
 credentialed Phase 4 OpenAlex/Lens run has executed and production still
 imports neither adapter, so
 candidate precision, novel-evidence yield and report benefit remain unobserved.
@@ -559,6 +559,20 @@ remains `not_evaluated`, and production remains disconnected. See the
 plus the [fixture erratum](docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md)
 and [unseen-harness implementation result](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md),
 followed by the [unseen live result](docs/results-2026-08-27-openalex-precision-v2-unseen-live.md).
+
+A different **provider-assisted claim-scope v3** candidate is now frozen
+against V01-V08 rather than tuned on the failed U01-U08 challenge. Its
+one-request adapter asks OpenAlex only for abstract-bearing Works and preserves
+scored topics/keywords as auditable aboutness signals. Provider metadata may
+bridge at most one required concept; at least one required concept must still
+match source text and one must match the title, so provider labels alone cannot
+authorize a source. The byte-locked zero-network preflight expands eight
+distinct collection/plan/profile/idempotency identities, 16/16 focused tests
+pass, and an intentionally wrong outbound filter made the transport-seam test
+fail before it was reverted. No V01-V08 request or human review has run, so
+provider compatibility, precision and source value remain `not_evaluated`, and
+production remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)
+and [implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1571,7 +1585,7 @@ intake 子集 **19/19** 通过，覆盖完整身份、基线漂移、旧包基�
 美元成本和不可检查成本，Lens 不会被误报为 `$0`。每一条供应商返回行必须进入
 候选或拒绝索引，OpenAlex 查询参数中的 key 也不会出现在完整异常 traceback 中。
 项目重新注入了隐藏重试和漏记供应商行两个缺陷，新测试均能准确变红；恢复正确实现
-后，全量 **1,614 项测试与 609 个 subtests** 通过，覆盖率 **87.31%**。目前尚未
+后，全量 **1,630 项测试与 609 个 subtests** 通过，覆盖率 **87.43%**。目前尚未
 发起带凭证的第四阶段 OpenAlex/Lens 运行，生产 worker 也不会导入这两个适配器，因此不能
 宣称候选精度、新证据收益或报告质量改善。详见
 [第四阶段协议](docs/prereg-2026-08-26-evidence-gap-domain-adapters-phase4.md)与
@@ -1627,6 +1641,17 @@ precision-v2 判断；最终仅在 3/8 个案例中接受 5 条候选，低于�
 [fixture 勘误](docs/errata-2026-08-27-openalex-precision-v2-unseen-fixture.md)与
 [未见 harness 实现结果](docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md)，以及
 [未见真实运行结果](docs/results-2026-08-27-openalex-precision-v2-unseen-live.md)。
+
+项目没有在失败的 U01-U08 上放宽阈值，而是另行冻结了 V01-V08，并实现一个不同的
+**供应商辅助 claim-scope v3** 候选。它的单请求适配器只请求有摘要的 OpenAlex Works，
+同时保留带分数的 topics/keywords 作为可审计的 aboutness 信号。供应商元数据最多只能
+补足一个必需概念；仍要求至少一个必需概念出现在来源文本中、至少一个出现在标题中，
+因此供应商标签不能单独放行来源。原始字节锁定的零网络预检已展开 8 组不同的
+collection/plan/profile/幂等身份，16/16 个聚焦测试通过；临时注入错误的出站过滤参数后，
+传输接缝测试会准确失败。目前没有发起 V01-V08 供应商请求，也没有人工来源真值评审，
+所以兼容性、精度和来源价值仍为 `not_evaluated`，生产路径保持断开。详见
+[v3 协议](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)与
+[实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-27-openalex-claim-scope-v3.md
+++ b/docs/prereg-2026-08-27-openalex-claim-scope-v3.md
@@ -1,0 +1,146 @@
+# Pre-registration: provider-assisted OpenAlex claim-scope candidate v3
+
+**Frozen:** 2026-08-27, before any OpenAlex response was requested for V01-V08.
+
+**Authority:** implementation and zero-network dry-run only. This document does
+not authorize a live provider request, a production import, a report-workflow
+connection, or a change to the existing precision-v2 result.
+
+## Why a different method is needed
+
+The precision-v2 unseen run returned 40 OpenAlex rows across U01-U08:
+
+| Observation | Count |
+|---|---:|
+| Provider rows | 40 |
+| Provider-schema/abstract rejections | 9 |
+| Legacy quarantine rejections | 8 |
+| Rows evaluated by precision v2 | 23 |
+| `ACCEPT` | 5 |
+| `ABSTAIN` | 18 |
+| Abstentions carrying `missing_required_groups` | 18 |
+| Cases with at least one acceptance | 3/8 |
+
+This establishes a mechanical failure mode: all 18 v2 abstentions missed at
+least one exact required phrase. It does **not** establish that those rows were
+relevant. No human source-truth review was performed on the 23 rows, so lowering
+the exact-conjunction threshold against them would tune to an unknown label.
+
+The provider rejection count also exposes a separate retrieval-budget problem:
+works without a reconstructable abstract consumed 9 of 40 bounded result slots.
+The next request contract therefore asks OpenAlex for `has_abstract:true`
+rather than trying to fetch missing abstracts after the request. A second fetch
+would violate the one-request budget.
+
+## Provider-native signal, not provider truth
+
+OpenAlex documents that Works search covers title, abstract and full text and
+uses stemming and stop-word removal:
+<https://help.openalex.org/api/searching/>. Hand-writing a larger synonym list
+inside the query would therefore duplicate provider behavior without making
+the downstream decision auditable.
+
+OpenAlex also exposes Works `topics` and `keywords`. Topics are assigned from
+work metadata by a classifier, while keywords are derived from topic
+assignments and carry scores:
+
+- <https://help.openalex.org/data/works/attributes/>
+- <https://help.openalex.org/data/topics/>
+- <https://help.openalex.org/data/keywords/>
+
+Those fields can describe document aboutness, but they do not prove a paper's
+claim and may be wrong. Candidate v3 treats them as a bounded secondary channel
+whose contribution is visible in every decision.
+
+## Frozen candidate rule
+
+Every case declares independent required and supporting concept groups. Each
+group has two vocabularies:
+
+1. `text_phrases`, matched as complete Unicode-normalized token sequences in
+   the title or abstract;
+2. `provider_terms`, matched as complete token sequences in OpenAlex topic or
+   keyword labels whose score is at least `0.55`.
+
+A candidate is `ACCEPT` only when all of the following hold:
+
+1. every required concept group matches through either channel;
+2. at least one required group matches source text;
+3. at least one required group matches the title;
+4. at most one required group is supported only by provider aboutness;
+5. at least two supporting groups match.
+
+Otherwise the action is `ABSTAIN`, with explicit reasons. There is no `DROP`
+action. Every match records the exact title phrases, abstract phrases, provider
+label, provider field, score and frozen term that matched. Candidate identity
+includes the evidence row and all provider aboutness metadata.
+
+This design permits one semantic bridge such as a provider label for an alias
+that is absent from the abstract, while preventing provider labels alone from
+authorizing an apparently relevant paper.
+
+## Frozen request contract
+
+Each attempted case permits exactly one anonymous OpenAlex Works request:
+
+- `search=<frozen query>`;
+- `filter=has_abstract:true`;
+- `per-page=8`;
+- `select` includes the existing evidence fields plus `topics` and `keywords`;
+- no API key;
+- no redirect following, internal retry, result-page fetch or enrichment;
+- every returned row must become either a candidate or an explicit provider
+  rejection, with complete row indices and provider-reported USD accounting.
+
+OpenAlex documents `has_abstract` as a Works filter and root-field `select`:
+<https://help.openalex.org/api/filtering/> and
+<https://help.openalex.org/api/selecting-fields/>. A future live runner must
+still freeze its own transport and implementation hashes before it may rely on
+this request shape.
+
+## Unseen challenge
+
+The byte-frozen fixture is
+`tests/fixtures/openalex_claim_scope_v3_challenge.json`, SHA-256
+`f8084328d56fed9c5b2aaafa1eb2225b0798d30266cc12c34522e1cd1243be86`.
+Its eight topics were not used in D01-D04 or U01-U08:
+
+| ID | Frozen topic |
+|---|---|
+| V01 | Near-field thermophotovoltaic conversion with nanophotonic gap control |
+| V02 | Photocatalytic methane coupling to ethylene under ambient conditions |
+| V03 | Focused-ultrasound drug delivery across the blood-brain barrier |
+| V04 | Silicon-photonic FMCW LiDAR with integrated lasers |
+| V05 | Electrochemical lithium extraction from geothermal brines |
+| V06 | Passive-radiative-cooling textiles for personal thermal management |
+| V07 | Spray-induced RNA silencing for fungal crop disease control |
+| V08 | Biomass-aerogel interfacial solar evaporation for desalination |
+
+The preflight must produce eight distinct collection, plan, profile and
+idempotency identities while opening zero sockets. Case order, result limit,
+request fields, profiles and source-value gates are part of the raw-byte lock.
+
+## Future live and human-value gates
+
+A separately authorized complete observation may make at most eight requests.
+It is a candidate only if a provenance-locked human review later establishes:
+
+1. at least one v3-accepted candidate in at least 6/8 cases;
+2. at least one relevant and novel candidate in at least 6/8 cases;
+3. a wrong-source rate no greater than 5% among evaluated candidates;
+4. every attempted source was reviewed;
+5. no substantive generative AI produced the review judgments.
+
+Failure is a result. No profile, score floor, case, query or gate may be edited
+after a provider response. Failed cases may not be replaced or rerun.
+
+## What any future result may and may not establish
+
+Even a pass would be evidence only for candidate-source value on these eight
+frozen academic cases. It would not establish source truth beyond the review,
+report improvement, planner-trigger precision, production reliability,
+commercial value, adoption, or a general OpenAlex precision rate.
+
+Until both live execution and an eligible human review pass, the correct state
+is `not_evaluated`. `pipeline_worker.py` must remain disconnected from the new
+gate, adapter and any later runner.

--- a/docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md
+++ b/docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md
@@ -1,0 +1,131 @@
+# Result: OpenAlex claim-scope v3 implementation and unseen preflight
+
+**Date:** 2026-08-27
+
+**Result state:** implementation complete; provider and source value
+`not_evaluated`.
+
+## Outcome
+
+The production-disconnected claim-scope v3 candidate is implemented together
+with a byte-frozen V01-V08 preflight. The implementation addresses the two
+mechanical observations from precision v2 without treating unlabelled rows as
+truth:
+
+1. the request contract uses `filter=has_abstract:true` so missing-abstract
+   works do not intentionally consume the eight bounded result slots;
+2. OpenAlex topics and keywords are retained as scored, auditable aboutness
+   signals that may bridge at most one required concept.
+
+At least one required concept must still match source text, at least one must
+match the title, and provider labels alone cannot authorize a candidate. Every
+decision preserves channel-level match provenance and emits only `ACCEPT` or
+`ABSTAIN`.
+
+No provider request was made. No API key was read. No production or report
+workflow import was added.
+
+## Added boundaries
+
+- `src/academic_agent/openalex_claim_scope.py`: deterministic claim-scope
+  profile, provider aboutness schema, candidate identity and explainable gate;
+- `src/academic_agent/tools/openalex_claim_scope_search.py`: anonymous,
+  injected-transport, one-invocation OpenAlex adapter with complete row and
+  reported-cost accounting;
+- `tests/fixtures/openalex_claim_scope_v3_challenge.json`: V01-V08 queries,
+  profiles, request contract and unchanged human-value gates, locked at
+  SHA-256
+  `f8084328d56fed9c5b2aaafa1eb2225b0798d30266cc12c34522e1cd1243be86`;
+- `openalex_claim_scope_unseen.py`: zero-network fixture validation and
+  deterministic collection/plan/profile/idempotency expansion;
+- three focused test modules covering the decision, outbound HTTP seam and
+  preflight identity boundary.
+
+The adapter deliberately duplicates the small amount of response parsing it
+needs instead of modifying the frozen Phase 4 adapter. Changing that older
+implementation would invalidate the hash lineage attached to completed and
+unexecuted Phase 4 studies.
+
+## Verification
+
+The zero-network dry-run produced:
+
+- 8/8 ordered V01-V08 cases;
+- eight distinct source-collection hashes;
+- eight distinct validated-plan hashes;
+- eight distinct profile hashes;
+- eight distinct idempotency keys;
+- `result_limit=8`, `has_abstract:true`, topics + keywords, no redirects and no
+  internal retry;
+- `real_network_calls_performed=false` and
+  `live_provider_requests_authorized=false`.
+
+Focused tests:
+
+```text
+16 passed in 1.52s
+```
+
+Full zero-network suite:
+
+```text
+1630 passed, 1 skipped, 609 subtests passed in 21.10s
+```
+
+CI-equivalent coverage run:
+
+```text
+7067 / 8083 statements covered = 87.43040950142274%
+```
+
+Static checks:
+
+```text
+uv run --python 3.12 --with ruff ruff check .
+All checks passed!
+
+uv run --python 3.12 --with pylint pylint src/ ui/ api/ \
+  --disable=all \
+  --enable=bad-except-order,unreachable,used-before-assignment,undefined-variable \
+  --score=n
+exit 0
+```
+
+The first default-temp full test attempt failed during fixture setup because
+Windows denied access to
+`C:\Users\shuxia\AppData\Local\Temp\pytest-of-shuxia`. No test body had
+failed. Re-running with a worktree-local `--basetemp` executed the complete
+suite successfully; no warning was ignored and no assertion was changed.
+
+## Defect re-injection
+
+After the outbound seam passed, the implementation was temporarily changed
+from `filter=has_abstract:true` to `filter=has_fulltext:true`. The exact test
+
+`test_adapter_uses_one_abstract_filtered_request_and_preserves_aboutness`
+
+failed at the parsed HTTP query boundary:
+
+```text
+assert ['has_fulltext:true'] == ['has_abstract:true']
+```
+
+The defect was then reverted and all 16 focused tests passed again. This shows
+the test observes the request that reaches the transport, not merely a profile
+or fixture field.
+
+## What remains unobserved
+
+This implementation result establishes schemas, deterministic authorization,
+request shape, accounting and fail-closed behavior only. It does not establish:
+
+- OpenAlex compatibility for this new selected-field combination;
+- that `has_abstract:true` eliminates every abstract rejection;
+- precision, recall, wrong-source rate or novel-evidence yield;
+- report improvement or planner-trigger quality;
+- production reliability, user value or commercial benefit.
+
+A later live study requires a separate explicit authorization, a new
+write-once output directory, frozen implementation hashes and at most eight
+single-attempt requests. Its output must remain disconnected until an eligible
+human review passes all pre-registered source-value gates.

--- a/openalex_claim_scope_unseen.py
+++ b/openalex_claim_scope_unseen.py
@@ -1,0 +1,327 @@
+"""Zero-network preflight for the frozen OpenAlex claim-scope v3 challenge.
+
+V01-V08 were authored after the precision-v2 U01-U08 observation but before
+any provider response for these topics.  This module validates the fixture's
+raw bytes, expands deterministic source collections and one-call plans, and
+exposes every identity required by a future live runner.  It imports neither a
+provider adapter nor a transport and therefore cannot spend the anonymous
+OpenAlex budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeProfile
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = (
+    _ROOT / "tests/fixtures/openalex_claim_scope_v3_challenge.json"
+)
+EXPECTED_FIXTURE_SHA256 = (
+    "f8084328d56fed9c5b2aaafa1eb2225b0798d30266cc12c34522e1cd1243be86"
+)
+_CASE_ORDER = tuple(f"V{index:02d}" for index in range(1, 9))
+_COLLECTED_AT = datetime(2026, 8, 27, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 8, 27)
+
+
+class OpenAlexClaimScopePreflightError(ValueError):
+    """Raised before case expansion when the frozen challenge drifts."""
+
+
+class ClaimScopeRequestContract(BaseModel):
+    """Provider request shape frozen without constructing a transport."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    result_limit: Literal[8] = 8
+    filter: Literal["has_abstract:true"] = "has_abstract:true"
+    aboutness_fields: tuple[Literal["topics", "keywords"], ...] = (
+        "topics",
+        "keywords",
+    )
+    redirects: Literal[False] = False
+    internal_retries: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_aboutness_order(self) -> "ClaimScopeRequestContract":
+        if self.aboutness_fields != ("topics", "keywords"):
+            raise ValueError("aboutness fields must remain topics then keywords")
+        return self
+
+
+class ClaimScopeDevelopmentObservation(BaseModel):
+    """Mechanical v2 observation; deliberately carries no relevance truth."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_document: Literal[
+        "docs/results-2026-08-27-openalex-precision-v2-unseen-live.md"
+    ]
+    provider_rows: Literal[40] = 40
+    provider_rejections: Literal[9] = 9
+    legacy_quarantine_rejections: Literal[8] = 8
+    precision_evaluated_rows: Literal[23] = 23
+    precision_v2_accepts: Literal[5] = 5
+    precision_v2_abstains: Literal[18] = 18
+    abstains_with_missing_required_groups: Literal[18] = 18
+    accepted_case_count: Literal[3] = 3
+    source_truth_state: Literal["not_evaluated"] = "not_evaluated"
+
+
+class ClaimScopeSourceValueGates(BaseModel):
+    """Human-review gates that a future live result cannot rewrite."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    accepted_case_count_min: Literal[6] = 6
+    novel_relevant_case_count_min: Literal[6] = 6
+    wrong_source_rate_max: Literal[0.05] = 0.05
+    all_attempted_sources_reviewed: Literal[True] = True
+    substantive_generative_ai_allowed: Literal[False] = False
+
+
+class ClaimScopeCaseSpec(BaseModel):
+    """One unseen query and provider-assisted profile."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^V0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    query: str = Field(min_length=20, max_length=500)
+    result_limit: Literal[8] = 8
+    profile: OpenAlexClaimScopeProfile
+
+
+class ClaimScopeChallengeManifest(BaseModel):
+    """Complete byte-frozen v3 preflight input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_claim_scope_v3_unseen_challenge"]
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    maximum_live_requests: Literal[8] = 8
+    request_contract: ClaimScopeRequestContract
+    development_observation: ClaimScopeDevelopmentObservation
+    challenge_cases: tuple[ClaimScopeCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+    source_value_gates: ClaimScopeSourceValueGates
+
+    @model_validator(mode="after")
+    def _validate_case_order(self) -> "ClaimScopeChallengeManifest":
+        observed = tuple(case.case_id for case in self.challenge_cases)
+        if observed != _CASE_ORDER:
+            raise ValueError("claim-scope cases must remain ordered V01 through V08")
+        if any(
+            case.result_limit != self.request_contract.result_limit
+            for case in self.challenge_cases
+        ):
+            raise ValueError("case result limits drifted from the request contract")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedClaimScopeCase:
+    """Expanded deterministic identity for a later, separately locked runner."""
+
+    spec: ClaimScopeCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+    profile_sha256: str
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _seed_source(spec: ClaimScopeCaseSpec) -> EvidenceSource:
+    """Create valid context without pretending a provider result already exists."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen claim-scope baseline context",
+        url=(
+            "https://doi.org/10.5555/"
+            f"openalex-claim-scope-v3.{spec.case_id.casefold()}"
+        ),
+        publisher="Frozen Claim-scope v3 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider row and does not satisfy the explicit "
+            "academic retrieval gap used by this disconnected study."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(spec: ClaimScopeCaseSpec) -> PreparedClaimScopeCase:
+    """Expand one recipe without network, clocks, randomness or model calls."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen claim-scope v3 retrieval challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexClaimScopePreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen unseen case authorizes one read-only academic "
+                "request for its explicit evidence gap."
+            ),
+            calls=(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=spec.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=spec.result_limit,
+                ),
+            ),
+        ),
+    )
+    return PreparedClaimScopeCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+        profile_sha256=spec.profile.sha256(),
+    )
+
+
+def load_frozen_cases(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    ClaimScopeChallengeManifest,
+    tuple[PreparedClaimScopeCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding any case."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexClaimScopePreflightError(
+            "claim-scope v3 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = ClaimScopeChallengeManifest.model_validate_json(raw)
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(build_case(spec) for spec in manifest.challenge_cases),
+    )
+
+
+def dry_run(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose complete frozen identities while opening zero sockets."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    return {
+        "mode": "openalex_claim_scope_v3_unseen_dry_run",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "real_network_calls_performed": False,
+        "live_provider_requests_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_request_count": manifest.maximum_live_requests,
+        "request_contract": manifest.request_contract.model_dump(mode="json"),
+        "development_observation": manifest.development_observation.model_dump(
+            mode="json"
+        ),
+        "source_value_gates": manifest.source_value_gates.model_dump(mode="json"),
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+                "profile_sha256": case.profile_sha256,
+                "idempotency_key": case.plan.calls[0].idempotency_key,
+                "result_limit": case.plan.calls[0].result_limit,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE_PATH)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(json.dumps(dry_run(args.fixture), ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/openalex_claim_scope.py
+++ b/src/academic_agent/openalex_claim_scope.py
@@ -1,0 +1,322 @@
+"""Provider-assisted claim-scope gate for disconnected OpenAlex studies.
+
+Precision v2 required every concept to occur as an exact phrase in a title or
+abstract.  Its first unseen run exposed a mechanical recall limit, but the
+returned rows were not human-labelled, so simply weakening that conjunction
+would be tuning against unknown truth.  This candidate adds a second,
+inspectable channel: OpenAlex topic and keyword labels may bridge at most one
+required concept while at least one required concept must still be supported
+by source text and anchored in the title.
+
+The provider labels are therefore evidence about document *aboutness*, not a
+replacement for the paper's text and not proof that a claim is true.  Every
+match records its channel and provider score.  The only safe negative action is
+ABSTAIN; this module neither drops sources nor enters the production worker.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from academic_agent.openalex_precision import _contains_phrase, _phrase_key, _tokens
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+
+
+ClaimScopeAction = Literal["ACCEPT", "ABSTAIN"]
+AboutnessKind = Literal["topic", "keyword"]
+ClaimScopeAbstentionReason = Literal[
+    "missing_required_groups",
+    "insufficient_supporting_groups",
+    "insufficient_exact_required_groups",
+    "missing_title_anchor",
+    "too_many_provider_only_required_groups",
+]
+
+_GROUP_ID_PATTERN = r"^[a-z][a-z0-9_]{2,63}$"
+
+
+class OpenAlexAboutnessSignal(BaseModel):
+    """One source-native OpenAlex topic or keyword assignment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: AboutnessKind
+    provider_id: str = Field(min_length=10, max_length=300)
+    display_name: str = Field(min_length=2, max_length=300)
+    score: float = Field(ge=0.0, le=1.0, allow_inf_nan=False)
+
+
+class OpenAlexClaimScopeCandidate(BaseModel):
+    """Evidence candidate plus the exact provider metadata used by the gate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    evidence: ToolEvidenceCandidate
+    aboutness: tuple[OpenAlexAboutnessSignal, ...] = Field(max_length=100)
+
+    @model_validator(mode="after")
+    def _validate_unique_signals(self) -> "OpenAlexClaimScopeCandidate":
+        identities = tuple((item.kind, item.provider_id) for item in self.aboutness)
+        if len(identities) != len(set(identities)):
+            raise ValueError("OpenAlex aboutness signals must be unique by kind and ID")
+        return self
+
+    def sha256(self) -> str:
+        """Bind the decision to evidence text and provider aboutness metadata."""
+
+        payload = self.model_dump_json(exclude_none=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class ClaimScopeConceptGroup(BaseModel):
+    """One independent concept with text and provider-label vocabularies."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group_id: str = Field(pattern=_GROUP_ID_PATTERN)
+    text_phrases: tuple[str, ...] = Field(min_length=1, max_length=8)
+    provider_terms: tuple[str, ...] = Field(min_length=1, max_length=8)
+
+    @field_validator("text_phrases", "provider_terms")
+    @classmethod
+    def _validate_phrases(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_phrase_key(value) for value in values)
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("concept group contains duplicate normalized phrases")
+        return values
+
+
+class OpenAlexClaimScopeProfile(BaseModel):
+    """Frozen, explainable authorization rule for one academic query."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_groups: tuple[ClaimScopeConceptGroup, ...] = Field(
+        min_length=2,
+        max_length=4,
+    )
+    supporting_groups: tuple[ClaimScopeConceptGroup, ...] = Field(
+        min_length=2,
+        max_length=8,
+    )
+    minimum_supporting_groups: int = Field(ge=1, le=8)
+    minimum_exact_required_groups: int = Field(ge=1, le=4)
+    minimum_title_required_groups: int = Field(ge=1, le=4)
+    maximum_provider_only_required_groups: int = Field(ge=0, le=1)
+    provider_score_floor: float = Field(ge=0.5, le=1.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_independent_groups(self) -> "OpenAlexClaimScopeProfile":
+        groups = (*self.required_groups, *self.supporting_groups)
+        group_ids = tuple(group.group_id for group in groups)
+        if len(group_ids) != len(set(group_ids)):
+            raise ValueError("claim-scope concept group IDs must be unique")
+
+        # Cross-group duplicates let one lexical hit masquerade as independent
+        # scope coverage.  Text and provider vocabularies are checked
+        # separately because the same phrase may legitimately be the text and
+        # provider representation of one concept.
+        for field_name in ("text_phrases", "provider_terms"):
+            owners: dict[str, str] = {}
+            for group in groups:
+                for phrase in getattr(group, field_name):
+                    key = _phrase_key(phrase)
+                    previous = owners.get(key)
+                    if previous is not None:
+                        raise ValueError(
+                            f"normalized {field_name} phrase appears in multiple "
+                            f"groups: {key!r} in {previous!r} and {group.group_id!r}"
+                        )
+                    owners[key] = group.group_id
+
+        if self.minimum_supporting_groups > len(self.supporting_groups):
+            raise ValueError(
+                "minimum_supporting_groups exceeds the supporting-group count"
+            )
+        if self.minimum_exact_required_groups > len(self.required_groups):
+            raise ValueError(
+                "minimum_exact_required_groups exceeds the required-group count"
+            )
+        if self.minimum_title_required_groups > len(self.required_groups):
+            raise ValueError(
+                "minimum_title_required_groups exceeds the required-group count"
+            )
+        if self.maximum_provider_only_required_groups >= len(self.required_groups):
+            raise ValueError(
+                "provider-only allowance must leave at least one required text group"
+            )
+        return self
+
+    def sha256(self) -> str:
+        payload = self.model_dump_json(exclude_none=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class ProviderAboutnessMatch(BaseModel):
+    """The exact provider signal and frozen term that produced one match."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: AboutnessKind
+    provider_id: str
+    display_name: str
+    score: float = Field(ge=0.0, le=1.0, allow_inf_nan=False)
+    matched_term: str
+
+
+class ClaimScopeConceptMatch(BaseModel):
+    """Channel-level provenance for one concept group."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group_id: str
+    exact_title_phrases: tuple[str, ...]
+    exact_summary_phrases: tuple[str, ...]
+    provider_aboutness: tuple[ProviderAboutnessMatch, ...]
+
+    @property
+    def matched(self) -> bool:
+        return bool(
+            self.exact_title_phrases
+            or self.exact_summary_phrases
+            or self.provider_aboutness
+        )
+
+    @property
+    def exact_text_matched(self) -> bool:
+        return bool(self.exact_title_phrases or self.exact_summary_phrases)
+
+
+class OpenAlexClaimScopeDecision(BaseModel):
+    """One label-blind ACCEPT/ABSTAIN decision with auditable provenance."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    action: ClaimScopeAction
+    candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    required_matches: tuple[ClaimScopeConceptMatch, ...]
+    supporting_matches: tuple[ClaimScopeConceptMatch, ...]
+    missing_required_groups: tuple[str, ...]
+    exact_required_groups: tuple[str, ...]
+    title_required_groups: tuple[str, ...]
+    provider_only_required_groups: tuple[str, ...]
+    abstention_reasons: tuple[ClaimScopeAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_action_shape(self) -> "OpenAlexClaimScopeDecision":
+        if self.action == "ACCEPT":
+            if self.missing_required_groups or self.abstention_reasons:
+                raise ValueError("ACCEPT cannot carry missing groups or reasons")
+        elif not self.abstention_reasons:
+            raise ValueError("ABSTAIN requires at least one explicit reason")
+        return self
+
+
+def _matching_phrases(
+    field_tokens: tuple[str, ...],
+    phrases: tuple[str, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        phrase
+        for phrase in phrases
+        if _contains_phrase(field_tokens, _tokens(phrase))
+    )
+
+
+def _group_match(
+    group: ClaimScopeConceptGroup,
+    candidate: OpenAlexClaimScopeCandidate,
+    *,
+    provider_score_floor: float,
+) -> ClaimScopeConceptMatch:
+    title_tokens = _tokens(candidate.evidence.title)
+    summary_tokens = _tokens(candidate.evidence.evidence_summary)
+    provider_matches: list[ProviderAboutnessMatch] = []
+    for signal in candidate.aboutness:
+        if signal.score < provider_score_floor:
+            continue
+        signal_tokens = _tokens(signal.display_name)
+        for term in group.provider_terms:
+            if _contains_phrase(signal_tokens, _tokens(term)):
+                provider_matches.append(
+                    ProviderAboutnessMatch(
+                        kind=signal.kind,
+                        provider_id=signal.provider_id,
+                        display_name=signal.display_name,
+                        score=signal.score,
+                        matched_term=term,
+                    )
+                )
+                break
+    return ClaimScopeConceptMatch(
+        group_id=group.group_id,
+        exact_title_phrases=_matching_phrases(title_tokens, group.text_phrases),
+        exact_summary_phrases=_matching_phrases(summary_tokens, group.text_phrases),
+        provider_aboutness=tuple(provider_matches),
+    )
+
+
+def evaluate_openalex_claim_scope(
+    candidate: OpenAlexClaimScopeCandidate,
+    profile: OpenAlexClaimScopeProfile,
+) -> OpenAlexClaimScopeDecision:
+    """Apply the frozen provider-assisted rule without a relevance label."""
+
+    required = tuple(
+        _group_match(
+            group,
+            candidate,
+            provider_score_floor=profile.provider_score_floor,
+        )
+        for group in profile.required_groups
+    )
+    supporting = tuple(
+        _group_match(
+            group,
+            candidate,
+            provider_score_floor=profile.provider_score_floor,
+        )
+        for group in profile.supporting_groups
+    )
+    missing_required = tuple(item.group_id for item in required if not item.matched)
+    exact_required = tuple(
+        item.group_id for item in required if item.exact_text_matched
+    )
+    title_required = tuple(
+        item.group_id for item in required if item.exact_title_phrases
+    )
+    provider_only_required = tuple(
+        item.group_id
+        for item in required
+        if item.provider_aboutness and not item.exact_text_matched
+    )
+    matched_supporting_count = sum(item.matched for item in supporting)
+
+    reasons: list[ClaimScopeAbstentionReason] = []
+    if missing_required:
+        reasons.append("missing_required_groups")
+    if matched_supporting_count < profile.minimum_supporting_groups:
+        reasons.append("insufficient_supporting_groups")
+    if len(exact_required) < profile.minimum_exact_required_groups:
+        reasons.append("insufficient_exact_required_groups")
+    if len(title_required) < profile.minimum_title_required_groups:
+        reasons.append("missing_title_anchor")
+    if len(provider_only_required) > profile.maximum_provider_only_required_groups:
+        reasons.append("too_many_provider_only_required_groups")
+
+    return OpenAlexClaimScopeDecision(
+        action="ABSTAIN" if reasons else "ACCEPT",
+        candidate_sha256=candidate.sha256(),
+        profile_sha256=profile.sha256(),
+        required_matches=required,
+        supporting_matches=supporting,
+        missing_required_groups=missing_required,
+        exact_required_groups=exact_required,
+        title_required_groups=title_required,
+        provider_only_required_groups=provider_only_required,
+        abstention_reasons=tuple(reasons),
+    )

--- a/src/academic_agent/tools/openalex_claim_scope_search.py
+++ b/src/academic_agent/tools/openalex_claim_scope_search.py
@@ -1,0 +1,379 @@
+"""One-request OpenAlex adapter for the disconnected claim-scope study.
+
+The Phase 4 adapter is byte-frozen evidence and intentionally remains
+unchanged.  This separate adapter requests OpenAlex topics and keywords and
+filters for works with abstracts before ranking consumes the bounded result
+slots.  It requires an injected transport, performs exactly one invocation,
+and sends no API key.  Production code must not import this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, Literal
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence import normalize_doi
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.openalex_claim_scope import (
+    OpenAlexAboutnessSignal,
+    OpenAlexClaimScopeCandidate,
+)
+from academic_agent.tools.domain_evidence_search import (
+    OPENALEX_WORKS_ENDPOINT,
+    DomainOneRequestTransport,
+)
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+
+
+_OPENALEX_SCOPE_SELECT = ",".join(
+    (
+        "id",
+        "title",
+        "doi",
+        "publication_date",
+        "primary_location",
+        "cited_by_count",
+        "abstract_inverted_index",
+        "topics",
+        "keywords",
+    )
+)
+_MIN_SUMMARY_LENGTH = 60
+
+
+class _OpenAlexMeta(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+
+
+class _OpenAlexSource(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    display_name: str = Field(min_length=2, max_length=300)
+
+
+class _OpenAlexLocation(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    source: _OpenAlexSource | None = None
+
+
+class _OpenAlexAboutnessRow(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str = Field(min_length=10, max_length=300)
+    display_name: str = Field(min_length=2, max_length=300)
+    score: float = Field(ge=0.0, le=1.0, allow_inf_nan=False)
+
+
+class _OpenAlexResult(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str = Field(min_length=10, max_length=300)
+    title: str = Field(min_length=5, max_length=600)
+    doi: str | None = Field(default=None, max_length=300)
+    publication_date: str | None = None
+    primary_location: _OpenAlexLocation | None = None
+    cited_by_count: int | None = Field(default=None, ge=0)
+    abstract_inverted_index: dict[str, tuple[int, ...]] | None = None
+    topics: tuple[_OpenAlexAboutnessRow, ...] = Field(default=(), max_length=50)
+    keywords: tuple[_OpenAlexAboutnessRow, ...] = Field(default=(), max_length=50)
+
+
+class _OpenAlexEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    meta: _OpenAlexMeta
+    results: tuple[Any, ...] = Field(max_length=10)
+
+
+class OpenAlexClaimScopeAdapterResponse(BaseModel):
+    """One provider request with complete row and aboutness accounting."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tool: Literal["academic_search"] = "academic_search"
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    outbound_request_count: Literal[1] = 1
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...] = Field(
+        default=(),
+        max_length=10,
+    )
+    provider_rejections: tuple[ProviderResultRejection, ...] = Field(
+        default=(),
+        max_length=10,
+    )
+    search_cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+    provider_request_id: str = Field(min_length=3, max_length=300)
+    provider_usage: ToolProviderUsage
+
+    @model_validator(mode="after")
+    def _validate_complete_accounting(self) -> "OpenAlexClaimScopeAdapterResponse":
+        usage = self.provider_usage
+        if usage.provider != "openalex":
+            raise ValueError("claim-scope adapter requires OpenAlex accounting")
+        if self.provider_request_id != usage.request_id:
+            raise ValueError("provider request identity drifted from usage")
+        if usage.cost_basis != "reported_usd" or usage.reported_cost_usd is None:
+            raise ValueError("claim-scope adapter requires reported USD accounting")
+        if self.search_cost_usd != usage.reported_cost_usd:
+            raise ValueError("search cost drifted from provider accounting")
+        if usage.result_count != len(self.candidates) + len(self.provider_rejections):
+            raise ValueError("every provider row must be a candidate or rejection")
+        candidate_indices = [
+            item.evidence.provider_result_index for item in self.candidates
+        ]
+        if any(index is None for index in candidate_indices):
+            raise ValueError("provider candidates require result indices")
+        all_indices = [int(index) for index in candidate_indices] + [
+            item.provider_result_index for item in self.provider_rejections
+        ]
+        if sorted(all_indices) != list(range(usage.result_count)):
+            raise ValueError("provider result indices must be complete and unique")
+        return self
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "row"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "provider row failed schema validation"
+
+
+def _optional_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        # Date metadata is not the evidence claim.  A formatting quirk must not
+        # trigger a hidden enrichment request in a one-request adapter.
+        return None
+
+
+def _openalex_abstract(index: dict[str, tuple[int, ...]] | None) -> str:
+    if not index:
+        raise ValueError("OpenAlex row has no reconstructable abstract")
+    positioned: list[tuple[int, str]] = []
+    seen_positions: set[int] = set()
+    for token, positions in index.items():
+        normalized = " ".join(token.split())
+        if not normalized:
+            raise ValueError("OpenAlex abstract contains an empty token")
+        for position in positions:
+            if position < 0 or position > 20_000 or position in seen_positions:
+                raise ValueError("OpenAlex abstract positions are invalid")
+            seen_positions.add(position)
+            positioned.append((position, normalized))
+            if len(positioned) > 5_000:
+                raise ValueError("OpenAlex abstract exceeds the token safety limit")
+    abstract = " ".join(token for _, token in sorted(positioned))[:8000].strip()
+    if len(abstract) < _MIN_SUMMARY_LENGTH:
+        raise ValueError("OpenAlex abstract is too short for evidence registration")
+    return abstract
+
+
+def _approved_openalex_url(value: str, *, label: str) -> None:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").casefold() != "openalex.org"
+    ):
+        raise ValueError(f"{label} is not an approved OpenAlex record URL")
+
+
+def _request_id(call: ValidatedGapCall, request_shape: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        {
+            "provider": "openalex-claim-scope",
+            "idempotency_key": call.idempotency_key,
+            "request": request_shape,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"client-openalex-claim-scope-{digest}"
+
+
+def _row_rejection(
+    index: int,
+    raw_result: object,
+    exc: ValidationError | ValueError,
+) -> ProviderResultRejection:
+    raw = raw_result if isinstance(raw_result, dict) else {}
+    title = raw.get("title")
+    url = raw.get("id")
+    return ProviderResultRejection(
+        provider_result_index=index,
+        code="provider_result_schema_invalid",
+        detail=(
+            _validation_detail(exc)
+            if isinstance(exc, ValidationError)
+            else str(exc)[:500] or "provider row failed semantic validation"
+        ),
+        title=title[:600] if isinstance(title, str) else None,
+        url=url[:2000] if isinstance(url, str) else None,
+    )
+
+
+def _aboutness(
+    result: _OpenAlexResult,
+) -> tuple[OpenAlexAboutnessSignal, ...]:
+    signals: list[OpenAlexAboutnessSignal] = []
+    for kind, rows in (("topic", result.topics), ("keyword", result.keywords)):
+        for row in rows:
+            _approved_openalex_url(row.id, label=f"OpenAlex {kind} id")
+            signals.append(
+                OpenAlexAboutnessSignal(
+                    kind=kind,
+                    provider_id=row.id,
+                    display_name=row.display_name,
+                    score=row.score,
+                )
+            )
+    return tuple(signals)
+
+
+class AnonymousOpenAlexClaimScopeAdapter:
+    """Fetch abstract-bearing works and preserve provider semantic metadata."""
+
+    def __init__(
+        self,
+        *,
+        transport: DomainOneRequestTransport,
+        timeout: float = 20.0,
+    ) -> None:
+        if not 0 < timeout <= 60:
+            raise ValueError("timeout must be greater than zero and at most 60 seconds")
+        self._transport = transport
+        self._timeout = timeout
+
+    def __call__(
+        self,
+        call: ValidatedGapCall,
+    ) -> OpenAlexClaimScopeAdapterResponse:
+        if call.tool != "academic_search":
+            raise ValueError("OpenAlex claim-scope adapter accepts academic_search only")
+        request_shape = {
+            "search": call.query,
+            "filter": "has_abstract:true",
+            "per-page": call.result_limit,
+            "select": _OPENALEX_SCOPE_SELECT,
+        }
+        endpoint = f"{OPENALEX_WORKS_ENDPOINT}?{urlencode(request_shape)}"
+        request_id = _request_id(call, request_shape)
+        try:
+            raw_payload = self._transport(
+                endpoint=endpoint,
+                method="GET",
+                body=None,
+                headers={"User-Agent": "AcademicAgentClaimScopeStudy/1.0"},
+                timeout=self._timeout,
+            )
+        except HTTPError as exc:
+            raise ToolAdapterFailure(
+                f"OpenAlex HTTP {exc.code}",
+                retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
+                failure_type="provider_http",
+                search_cost_usd=None,
+            ) from None
+        except (URLError, TimeoutError, OSError) as exc:
+            raise ToolAdapterFailure(
+                f"OpenAlex transport failed: {type(exc).__name__}",
+                retryable=True,
+                failure_type="provider_transport",
+                search_cost_usd=None,
+            ) from None
+
+        try:
+            decoded = json.loads(raw_payload.decode("utf-8"))
+            envelope = _OpenAlexEnvelope.model_validate(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            raise ToolAdapterFailure(
+                f"OpenAlex response failed schema validation: {type(exc).__name__}",
+                retryable=False,
+                failure_type="provider_response_invalid",
+                search_cost_usd=None,
+            ) from exc
+        if len(envelope.results) > call.result_limit:
+            raise ToolAdapterFailure(
+                "OpenAlex returned more rows than the authorized result limit",
+                retryable=False,
+                failure_type="provider_result_limit_exceeded",
+                search_cost_usd=envelope.meta.cost_usd,
+            )
+
+        candidates: list[OpenAlexClaimScopeCandidate] = []
+        rejections: list[ProviderResultRejection] = []
+        for index, raw_result in enumerate(envelope.results):
+            if not isinstance(raw_result, dict):
+                rejections.append(
+                    ProviderResultRejection(
+                        provider_result_index=index,
+                        code="provider_result_not_object",
+                        detail="provider result must be a JSON object",
+                    )
+                )
+                continue
+            try:
+                result = _OpenAlexResult.model_validate(raw_result)
+                _approved_openalex_url(result.id, label="OpenAlex work id")
+                evidence = ToolEvidenceCandidate(
+                    title=result.title,
+                    url=result.id,
+                    doi=normalize_doi(result.doi),
+                    publisher=(
+                        result.primary_location.source.display_name
+                        if result.primary_location is not None
+                        and result.primary_location.source is not None
+                        else "OpenAlex"
+                    ),
+                    published_date=_optional_date(result.publication_date),
+                    evidence_summary=_openalex_abstract(
+                        result.abstract_inverted_index
+                    ),
+                    summary_source="abstract",
+                    citation_count=result.cited_by_count,
+                    provider_result_index=index,
+                )
+                candidates.append(
+                    OpenAlexClaimScopeCandidate(
+                        evidence=evidence,
+                        aboutness=_aboutness(result),
+                    )
+                )
+            except (ValidationError, ValueError) as exc:
+                rejections.append(_row_rejection(index, raw_result, exc))
+
+        usage = ToolProviderUsage(
+            provider="openalex",
+            request_id=request_id,
+            request_id_source="client_generated",
+            result_count=len(envelope.results),
+            cost_basis="reported_usd",
+            reported_cost_usd=envelope.meta.cost_usd,
+        )
+        return OpenAlexClaimScopeAdapterResponse(
+            idempotency_key=call.idempotency_key,
+            candidates=tuple(candidates),
+            provider_rejections=tuple(rejections),
+            search_cost_usd=envelope.meta.cost_usd,
+            provider_request_id=request_id,
+            provider_usage=usage,
+        )

--- a/tests/fixtures/openalex_claim_scope_v3_challenge.json
+++ b/tests/fixtures/openalex_claim_scope_v3_challenge.json
@@ -1,0 +1,411 @@
+{
+  "schema_version": 1,
+  "mode": "openalex_claim_scope_v3_unseen_challenge",
+  "production_connected": false,
+  "report_workflow_connected": false,
+  "maximum_live_requests": 8,
+  "request_contract": {
+    "result_limit": 8,
+    "filter": "has_abstract:true",
+    "aboutness_fields": ["topics", "keywords"],
+    "redirects": false,
+    "internal_retries": false
+  },
+  "development_observation": {
+    "source_document": "docs/results-2026-08-27-openalex-precision-v2-unseen-live.md",
+    "provider_rows": 40,
+    "provider_rejections": 9,
+    "legacy_quarantine_rejections": 8,
+    "precision_evaluated_rows": 23,
+    "precision_v2_accepts": 5,
+    "precision_v2_abstains": 18,
+    "abstains_with_missing_required_groups": 18,
+    "accepted_case_count": 3,
+    "source_truth_state": "not_evaluated"
+  },
+  "challenge_cases": [
+    {
+      "case_id": "V01",
+      "topic": "Near-field thermophotovoltaic energy conversion using nanophotonic gap control",
+      "query": "near field thermophotovoltaic nanophotonic vacuum gap energy conversion efficiency",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "near_field_transfer",
+            "text_phrases": ["near field", "evanescent wave"],
+            "provider_terms": ["near-field radiative heat transfer", "near-field optics"]
+          },
+          {
+            "group_id": "thermophotovoltaic",
+            "text_phrases": ["thermophotovoltaic", "thermo photovoltaic", "tpv"],
+            "provider_terms": ["thermophotovoltaic energy conversion", "thermophotovoltaics"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "nanoscale_gap",
+            "text_phrases": ["nanoscale gap", "vacuum gap", "nanogap"],
+            "provider_terms": ["nanoscale heat transfer", "nanophotonic gap"]
+          },
+          {
+            "group_id": "photovoltaic_cell",
+            "text_phrases": ["photovoltaic cell", "photovoltaic diode", "pv cell"],
+            "provider_terms": ["photovoltaic devices", "photovoltaic cells"]
+          },
+          {
+            "group_id": "thermal_emitter",
+            "text_phrases": ["thermal emitter", "selective emitter", "radiator"],
+            "provider_terms": ["thermal emitters", "selective thermal emission"]
+          },
+          {
+            "group_id": "conversion_performance",
+            "text_phrases": ["conversion efficiency", "power density", "electrical power"],
+            "provider_terms": ["energy conversion efficiency", "power conversion"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V02",
+      "topic": "Photocatalytic methane coupling to ethylene under ambient reaction conditions",
+      "query": "photocatalytic methane coupling ethylene ambient conditions selectivity catalyst",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "methane_coupling",
+            "text_phrases": ["methane coupling", "methane conversion", "coupling of methane"],
+            "provider_terms": ["oxidative coupling of methane", "methane conversion"]
+          },
+          {
+            "group_id": "ethylene_product",
+            "text_phrases": ["ethylene", "ethene"],
+            "provider_terms": ["ethylene production", "ethylene synthesis"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "photocatalysis",
+            "text_phrases": ["photocatalytic", "photocatalysis", "light driven"],
+            "provider_terms": ["photocatalysis", "photochemical reactions"]
+          },
+          {
+            "group_id": "ambient_conditions",
+            "text_phrases": ["ambient conditions", "room temperature", "atmospheric pressure"],
+            "provider_terms": ["ambient temperature", "mild reaction conditions"]
+          },
+          {
+            "group_id": "selectivity",
+            "text_phrases": ["selectivity", "selective conversion", "product distribution"],
+            "provider_terms": ["reaction selectivity", "product selectivity"]
+          },
+          {
+            "group_id": "catalyst_material",
+            "text_phrases": ["catalyst", "catalytic", "photocatalyst"],
+            "provider_terms": ["heterogeneous catalysis", "photocatalysts"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V03",
+      "topic": "Focused-ultrasound drug delivery across the blood-brain barrier using microbubbles",
+      "query": "focused ultrasound microbubble blood brain barrier drug delivery permeability safety",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "blood_brain_barrier",
+            "text_phrases": ["blood brain barrier", "bbb"],
+            "provider_terms": ["blood-brain barrier", "brain drug delivery"]
+          },
+          {
+            "group_id": "ultrasound_microbubble",
+            "text_phrases": ["focused ultrasound", "microbubble", "microbubbles"],
+            "provider_terms": ["focused ultrasound", "ultrasound contrast agents"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "drug_delivery",
+            "text_phrases": ["drug delivery", "therapeutic delivery", "cargo delivery"],
+            "provider_terms": ["targeted drug delivery", "central nervous system delivery"]
+          },
+          {
+            "group_id": "barrier_opening",
+            "text_phrases": ["barrier opening", "permeability", "barrier disruption"],
+            "provider_terms": ["barrier permeability", "blood-brain barrier opening"]
+          },
+          {
+            "group_id": "safety",
+            "text_phrases": ["safety", "tissue damage", "hemorrhage"],
+            "provider_terms": ["treatment safety", "adverse effects"]
+          },
+          {
+            "group_id": "in_vivo",
+            "text_phrases": ["in vivo", "animal model", "clinical"],
+            "provider_terms": ["in vivo studies", "clinical translation"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V04",
+      "topic": "Silicon-photonic frequency-modulated continuous-wave LiDAR with integrated lasers",
+      "query": "silicon photonic FMCW lidar integrated laser coherent ranging resolution",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "fmcw_lidar",
+            "text_phrases": ["fmcw lidar", "frequency modulated continuous wave lidar", "coherent lidar"],
+            "provider_terms": ["frequency-modulated continuous-wave lidar", "coherent laser ranging"]
+          },
+          {
+            "group_id": "silicon_photonics",
+            "text_phrases": ["silicon photonic", "silicon photonics", "silicon on insulator"],
+            "provider_terms": ["silicon photonics", "photonic integrated circuits"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "integrated_laser",
+            "text_phrases": ["integrated laser", "on chip laser", "laser integration"],
+            "provider_terms": ["integrated lasers", "semiconductor laser integration"]
+          },
+          {
+            "group_id": "ranging",
+            "text_phrases": ["ranging", "distance measurement", "range measurement"],
+            "provider_terms": ["laser ranging", "distance sensing"]
+          },
+          {
+            "group_id": "coherent_detection",
+            "text_phrases": ["coherent detection", "heterodyne detection", "optical coherence"],
+            "provider_terms": ["coherent detection", "optical heterodyne detection"]
+          },
+          {
+            "group_id": "lidar_performance",
+            "text_phrases": ["range resolution", "velocity resolution", "signal to noise"],
+            "provider_terms": ["lidar performance", "range resolution"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V05",
+      "topic": "Electrochemical lithium extraction from geothermal brines using ion-selective membranes",
+      "query": "electrochemical lithium extraction geothermal brine ion selective membrane selectivity cycling",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "lithium_extraction",
+            "text_phrases": ["lithium extraction", "lithium recovery", "extract lithium"],
+            "provider_terms": ["lithium extraction", "direct lithium extraction"]
+          },
+          {
+            "group_id": "geothermal_brine",
+            "text_phrases": ["geothermal brine", "geothermal water", "geothermal fluid"],
+            "provider_terms": ["geothermal brines", "geothermal resources"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "electrochemical_route",
+            "text_phrases": ["electrochemical", "electrosorption", "electrodialysis"],
+            "provider_terms": ["electrochemical separation", "electrochemical extraction"]
+          },
+          {
+            "group_id": "selective_membrane",
+            "text_phrases": ["ion selective membrane", "selective membrane", "membrane separation"],
+            "provider_terms": ["ion-selective membranes", "membrane separation"]
+          },
+          {
+            "group_id": "ion_selectivity",
+            "text_phrases": ["selectivity", "separation factor", "selective transport"],
+            "provider_terms": ["ion selectivity", "selective ion transport"]
+          },
+          {
+            "group_id": "cycling_stability",
+            "text_phrases": ["cycling stability", "regeneration", "cycle life"],
+            "provider_terms": ["electrochemical cycling", "material regeneration"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V06",
+      "topic": "Passive-radiative-cooling textiles for personal thermal management",
+      "query": "passive radiative cooling textile personal thermal management infrared solar reflectance",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "radiative_cooling",
+            "text_phrases": ["radiative cooling", "passive cooling", "thermal radiation cooling"],
+            "provider_terms": ["passive radiative cooling", "radiative cooling"]
+          },
+          {
+            "group_id": "textile_material",
+            "text_phrases": ["textile", "fabric", "clothing"],
+            "provider_terms": ["functional textiles", "smart textiles"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "infrared_emission",
+            "text_phrases": ["infrared emission", "thermal emissivity", "mid infrared"],
+            "provider_terms": ["infrared emissivity", "thermal radiation"]
+          },
+          {
+            "group_id": "solar_reflectance",
+            "text_phrases": ["solar reflectance", "solar reflection", "reflect sunlight"],
+            "provider_terms": ["solar reflectivity", "solar radiation reflection"]
+          },
+          {
+            "group_id": "wearable_context",
+            "text_phrases": ["wearable", "personal thermal", "human body"],
+            "provider_terms": ["wearable technology", "personal thermal management"]
+          },
+          {
+            "group_id": "cooling_performance",
+            "text_phrases": ["temperature reduction", "cooling power", "thermal comfort"],
+            "provider_terms": ["cooling performance", "thermal comfort"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V07",
+      "topic": "Spray-induced RNA silencing for fungal disease control in crops",
+      "query": "spray induced gene silencing dsRNA fungal crop disease control efficacy delivery",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "spray_rna_silencing",
+            "text_phrases": ["spray induced gene silencing", "sigs", "rna spray"],
+            "provider_terms": ["spray-induced gene silencing", "rna interference"]
+          },
+          {
+            "group_id": "fungal_crop_disease",
+            "text_phrases": ["fungal disease", "fungal pathogen", "plant fungus"],
+            "provider_terms": ["plant fungal diseases", "crop disease control"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "double_stranded_rna",
+            "text_phrases": ["double stranded rna", "dsrna", "small interfering rna"],
+            "provider_terms": ["double-stranded rna", "small interfering rna"]
+          },
+          {
+            "group_id": "topical_delivery",
+            "text_phrases": ["topical application", "foliar spray", "spray delivery"],
+            "provider_terms": ["topical delivery", "foliar application"]
+          },
+          {
+            "group_id": "disease_efficacy",
+            "text_phrases": ["disease reduction", "disease control", "antifungal efficacy"],
+            "provider_terms": ["plant disease resistance", "fungal control efficacy"]
+          },
+          {
+            "group_id": "crop_context",
+            "text_phrases": ["crop", "plant", "field trial"],
+            "provider_terms": ["crop protection", "plant pathology"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "V08",
+      "topic": "Solar-driven interfacial evaporation using biomass-derived aerogels for desalination",
+      "query": "solar interfacial evaporation biomass aerogel desalination evaporation rate salt resistance",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "interfacial_evaporation",
+            "text_phrases": ["interfacial evaporation", "interfacial steam generation", "solar evaporation"],
+            "provider_terms": ["solar interfacial evaporation", "interfacial solar steam generation"]
+          },
+          {
+            "group_id": "desalination",
+            "text_phrases": ["desalination", "seawater purification", "saltwater purification"],
+            "provider_terms": ["solar desalination", "water desalination"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "biomass_aerogel",
+            "text_phrases": ["biomass aerogel", "cellulose aerogel", "bio derived aerogel"],
+            "provider_terms": ["biomass-derived aerogels", "cellulose aerogels"]
+          },
+          {
+            "group_id": "solar_absorption",
+            "text_phrases": ["solar absorption", "photothermal", "light absorption"],
+            "provider_terms": ["photothermal conversion", "solar energy absorption"]
+          },
+          {
+            "group_id": "evaporation_performance",
+            "text_phrases": ["evaporation rate", "evaporation efficiency", "water production"],
+            "provider_terms": ["water evaporation rate", "solar steam efficiency"]
+          },
+          {
+            "group_id": "salt_resistance",
+            "text_phrases": ["salt resistance", "salt rejection", "salt accumulation"],
+            "provider_terms": ["salt rejection", "anti-salt fouling"]
+          }
+        ],
+        "minimum_supporting_groups": 2,
+        "minimum_exact_required_groups": 1,
+        "minimum_title_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    }
+  ],
+  "source_value_gates": {
+    "accepted_case_count_min": 6,
+    "novel_relevant_case_count_min": 6,
+    "wrong_source_rate_max": 0.05,
+    "all_attempted_sources_reviewed": true,
+    "substantive_generative_ai_allowed": false
+  }
+}

--- a/tests/test_openalex_claim_scope.py
+++ b/tests/test_openalex_claim_scope.py
@@ -1,0 +1,214 @@
+"""Zero-network tests for the provider-assisted claim-scope gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from academic_agent.openalex_claim_scope import (
+    OpenAlexAboutnessSignal,
+    OpenAlexClaimScopeCandidate,
+    OpenAlexClaimScopeProfile,
+    evaluate_openalex_claim_scope,
+)
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _profile() -> OpenAlexClaimScopeProfile:
+    return OpenAlexClaimScopeProfile.model_validate(
+        {
+            "required_groups": [
+                {
+                    "group_id": "quantum_dot",
+                    "text_phrases": ["quantum dot", "colloidal quantum"],
+                    "provider_terms": ["colloidal quantum dots", "quantum dots"],
+                },
+                {
+                    "group_id": "short_wave_infrared",
+                    "text_phrases": ["short wave infrared", "swir"],
+                    "provider_terms": [
+                        "short-wave infrared photodetectors",
+                        "shortwave infrared",
+                    ],
+                },
+            ],
+            "supporting_groups": [
+                {
+                    "group_id": "photodetector",
+                    "text_phrases": ["photodetector", "photodiode"],
+                    "provider_terms": ["photodetectors", "photodiodes"],
+                },
+                {
+                    "group_id": "silicon_integration",
+                    "text_phrases": ["silicon", "cmos"],
+                    "provider_terms": ["silicon integration", "cmos image sensors"],
+                },
+                {
+                    "group_id": "performance",
+                    "text_phrases": ["detectivity", "responsivity"],
+                    "provider_terms": ["photodetector performance", "detectivity"],
+                },
+            ],
+            "minimum_supporting_groups": 2,
+            "minimum_exact_required_groups": 1,
+            "minimum_title_required_groups": 1,
+            "maximum_provider_only_required_groups": 1,
+            "provider_score_floor": 0.55,
+        }
+    )
+
+
+def _candidate(
+    *,
+    title: str = "Integrated colloidal quantum-dot photodetector on silicon",
+    summary: str = (
+        "The integrated silicon photodetector reports high detectivity and "
+        "responsivity across its measured spectral range."
+    ),
+    aboutness: tuple[OpenAlexAboutnessSignal, ...] = (),
+) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=title,
+            url="https://openalex.org/W4300000001",
+            publisher="Frozen Test Journal",
+            evidence_summary=summary,
+            summary_source="abstract",
+            provider_result_index=0,
+        ),
+        aboutness=aboutness,
+    )
+
+
+def _signal(
+    display_name: str,
+    *,
+    score: float = 0.9,
+    kind: str = "keyword",
+    suffix: str = "K1",
+) -> OpenAlexAboutnessSignal:
+    return OpenAlexAboutnessSignal.model_validate(
+        {
+            "kind": kind,
+            "provider_id": f"https://openalex.org/{suffix}",
+            "display_name": display_name,
+            "score": score,
+        }
+    )
+
+
+def test_provider_aboutness_may_bridge_exactly_one_required_concept():
+    candidate = _candidate(
+        aboutness=(_signal("Short-wave infrared photodetectors"),)
+    )
+
+    decision = evaluate_openalex_claim_scope(candidate, _profile())
+
+    assert decision.action == "ACCEPT"
+    assert decision.exact_required_groups == ("quantum_dot",)
+    assert decision.title_required_groups == ("quantum_dot",)
+    assert decision.provider_only_required_groups == ("short_wave_infrared",)
+    infrared = decision.required_matches[1]
+    assert infrared.provider_aboutness[0].matched_term == (
+        "short-wave infrared photodetectors"
+    )
+    assert infrared.provider_aboutness[0].score == pytest.approx(0.9)
+
+
+def test_provider_labels_alone_cannot_authorize_a_source():
+    candidate = _candidate(
+        title="Integrated optoelectronic sensing platform",
+        summary=(
+            "The sensor reports detectivity and silicon integration for a "
+            "general imaging platform without naming the target material."
+        ),
+        aboutness=(
+            _signal("Colloidal quantum dots", suffix="K1"),
+            _signal("Short-wave infrared photodetectors", suffix="K2"),
+        ),
+    )
+
+    decision = evaluate_openalex_claim_scope(candidate, _profile())
+
+    assert decision.action == "ABSTAIN"
+    assert decision.provider_only_required_groups == (
+        "quantum_dot",
+        "short_wave_infrared",
+    )
+    assert "insufficient_exact_required_groups" in decision.abstention_reasons
+    assert "missing_title_anchor" in decision.abstention_reasons
+    assert (
+        "too_many_provider_only_required_groups" in decision.abstention_reasons
+    )
+
+
+def test_low_score_provider_label_does_not_satisfy_required_scope():
+    candidate = _candidate(
+        aboutness=(
+            _signal(
+                "Short-wave infrared photodetectors",
+                score=0.54,
+            ),
+        )
+    )
+
+    decision = evaluate_openalex_claim_scope(candidate, _profile())
+
+    assert decision.action == "ABSTAIN"
+    assert decision.missing_required_groups == ("short_wave_infrared",)
+    assert decision.provider_only_required_groups == ()
+
+
+def test_exact_text_path_remains_valid_without_provider_metadata():
+    candidate = _candidate(
+        title=(
+            "Short-wave infrared colloidal quantum-dot photodetector on silicon"
+        )
+    )
+
+    decision = evaluate_openalex_claim_scope(candidate, _profile())
+
+    assert decision.action == "ACCEPT"
+    assert decision.exact_required_groups == (
+        "quantum_dot",
+        "short_wave_infrared",
+    )
+    assert decision.provider_only_required_groups == ()
+
+
+def test_candidate_identity_includes_provider_aboutness_score():
+    first = _candidate(
+        aboutness=(_signal("Short-wave infrared photodetectors", score=0.8),)
+    )
+    second = _candidate(
+        aboutness=(_signal("Short-wave infrared photodetectors", score=0.9),)
+    )
+
+    assert first.sha256() != second.sha256()
+
+
+def test_duplicate_provider_term_across_independent_groups_fails_closed():
+    payload = _profile().model_dump(mode="json")
+    payload["supporting_groups"][0]["provider_terms"][0] = (
+        payload["required_groups"][0]["provider_terms"][0]
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="provider_terms phrase appears in multiple groups",
+    ):
+        OpenAlexClaimScopeProfile.model_validate(payload)
+
+
+def test_production_worker_remains_disconnected():
+    worker = (_ROOT / "src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "openalex_claim_scope" not in worker
+    assert "openalex_claim_scope_search" not in worker

--- a/tests/test_openalex_claim_scope_search.py
+++ b/tests/test_openalex_claim_scope_search.py
@@ -1,0 +1,200 @@
+"""Outbound-seam tests for the disconnected claim-scope OpenAlex adapter."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.tools.domain_evidence_search import OPENALEX_WORKS_ENDPOINT
+from academic_agent.tools.evidence_search import ToolAdapterFailure
+from academic_agent.tools.openalex_claim_scope_search import (
+    AnonymousOpenAlexClaimScopeAdapter,
+)
+
+
+_QUERY = (
+    "near field thermophotovoltaic nanophotonic vacuum gap energy conversion"
+)
+_SUMMARY = (
+    "The integrated thermophotovoltaic experiment measures electrical power "
+    "density across a controlled nanoscale vacuum gap and reports conversion "
+    "efficiency under calibrated thermal-emitter conditions."
+)
+
+
+def _call(
+    tool: str = "academic_search",
+    *,
+    result_limit: int = 8,
+) -> ValidatedGapCall:
+    return ValidatedGapCall(
+        tool=tool,
+        query=_QUERY,
+        trigger_ids=("claim-scope-gap",),
+        result_limit=result_limit,
+        output_domain="academic",
+        idempotency_key="c" * 64,
+    )
+
+
+def _inverted_abstract(value: str) -> dict[str, list[int]]:
+    result: dict[str, list[int]] = {}
+    for position, token in enumerate(value.split()):
+        result.setdefault(token, []).append(position)
+    return result
+
+
+def _result(
+    *,
+    work_id: str = "https://openalex.org/W4300000001",
+    title: str = "Near-field thermophotovoltaic conversion across a vacuum gap",
+) -> dict:
+    return {
+        "id": work_id,
+        "title": title,
+        "doi": "https://doi.org/10.1000/claim-scope",
+        "publication_date": "2026-04-03",
+        "primary_location": {
+            "source": {"display_name": "Thermal Photonics Journal"}
+        },
+        "cited_by_count": 6,
+        "abstract_inverted_index": _inverted_abstract(_SUMMARY),
+        "topics": [
+            {
+                "id": "https://openalex.org/T100000001",
+                "display_name": "Near-field radiative heat transfer",
+                "score": 0.91,
+            }
+        ],
+        "keywords": [
+            {
+                "id": "https://openalex.org/keywords/thermophotovoltaics",
+                "display_name": "Thermophotovoltaics",
+                "score": 0.88,
+            }
+        ],
+    }
+
+
+def _payload(*results: object, cost: float = 0.001) -> dict:
+    return {
+        "meta": {"count": len(results), "cost_usd": cost},
+        "results": list(results),
+    }
+
+
+class RecordingTransport:
+    """Injected socket seam; one invocation equals one provider request."""
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_adapter_uses_one_abstract_filtered_request_and_preserves_aboutness(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENALEX_API_KEY", "must-not-reach-claim-scope-request")
+    transport = RecordingTransport(_payload(_result()))
+
+    response = AnonymousOpenAlexClaimScopeAdapter(transport=transport)(_call())
+
+    assert len(transport.calls) == 1
+    request = transport.calls[0]
+    parsed = urlsplit(request["endpoint"])
+    query = parse_qs(parsed.query)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == OPENALEX_WORKS_ENDPOINT
+    assert query["search"] == [_QUERY]
+    assert query["filter"] == ["has_abstract:true"]
+    assert query["per-page"] == ["8"]
+    assert "api_key" not in query
+    assert set(query["select"][0].split(",")) == {
+        "id",
+        "title",
+        "doi",
+        "publication_date",
+        "primary_location",
+        "cited_by_count",
+        "abstract_inverted_index",
+        "topics",
+        "keywords",
+    }
+    assert request["method"] == "GET"
+    assert request["body"] is None
+
+    assert response.outbound_request_count == 1
+    assert response.search_cost_usd == pytest.approx(0.001)
+    assert response.provider_usage.result_count == 1
+    candidate = response.candidates[0]
+    assert candidate.evidence.doi == "10.1000/claim-scope"
+    assert [(item.kind, item.display_name) for item in candidate.aboutness] == [
+        ("topic", "Near-field radiative heat transfer"),
+        ("keyword", "Thermophotovoltaics"),
+    ]
+    serialized = response.model_dump_json()
+    assert "must-not-reach-claim-scope-request" not in serialized
+
+
+def test_every_malformed_provider_row_remains_explicitly_accounted():
+    no_abstract = _result(
+        work_id="https://openalex.org/W4300000002",
+        title="A result that violates the requested abstract filter",
+    )
+    no_abstract["abstract_inverted_index"] = None
+    malformed_aboutness = _result(
+        work_id="https://openalex.org/W4300000003",
+        title="A result with malformed provider topic metadata",
+    )
+    malformed_aboutness["topics"][0]["score"] = "unknown"
+    transport = RecordingTransport(
+        _payload(_result(), no_abstract, malformed_aboutness, "not-an-object")
+    )
+
+    response = AnonymousOpenAlexClaimScopeAdapter(transport=transport)(_call())
+
+    assert len(transport.calls) == 1
+    assert [
+        item.evidence.provider_result_index for item in response.candidates
+    ] == [0]
+    assert [
+        item.provider_result_index for item in response.provider_rejections
+    ] == [1, 2, 3]
+    assert response.provider_usage.result_count == 4
+
+
+def test_wrong_tool_fails_before_transport_construction():
+    transport = RecordingTransport(_payload())
+    adapter = AnonymousOpenAlexClaimScopeAdapter(transport=transport)
+
+    with pytest.raises(ValueError, match="academic_search"):
+        adapter(_call("patent_search"))
+
+    assert transport.calls == []
+
+
+def test_provider_cannot_exceed_the_authorized_result_limit():
+    transport = RecordingTransport(
+        _payload(
+            _result(),
+            _result(work_id="https://openalex.org/W4300000002"),
+        )
+    )
+
+    with pytest.raises(
+        ToolAdapterFailure,
+        match="authorized result limit",
+    ) as caught:
+        AnonymousOpenAlexClaimScopeAdapter(transport=transport)(
+            _call(result_limit=1)
+        )
+
+    assert len(transport.calls) == 1
+    assert caught.value.failure_type == "provider_result_limit_exceeded"
+    assert caught.value.search_cost_usd == pytest.approx(0.001)

--- a/tests/test_openalex_claim_scope_unseen.py
+++ b/tests/test_openalex_claim_scope_unseen.py
@@ -1,0 +1,106 @@
+"""Zero-network seams for the frozen claim-scope v3 unseen preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import openalex_claim_scope_unseen as unseen
+
+
+def test_dry_run_expands_the_exact_unseen_contract_without_live_authority():
+    result = unseen.dry_run()
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"V{index:02d}" for index in range(1, 9)
+    ]
+    assert len({case["collection_sha256"] for case in result["cases"]}) == 8
+    assert len({case["plan_sha256"] for case in result["cases"]}) == 8
+    assert len({case["profile_sha256"] for case in result["cases"]}) == 8
+    assert len({case["idempotency_key"] for case in result["cases"]}) == 8
+    assert {case["result_limit"] for case in result["cases"]} == {8}
+    assert result["request_contract"] == {
+        "result_limit": 8,
+        "filter": "has_abstract:true",
+        "aboutness_fields": ["topics", "keywords"],
+        "redirects": False,
+        "internal_retries": False,
+    }
+    assert result["development_observation"]["source_truth_state"] == (
+        "not_evaluated"
+    )
+    assert result["development_observation"]["precision_v2_abstains"] == 18
+    assert result["source_value_gates"] == {
+        "accepted_case_count_min": 6,
+        "novel_relevant_case_count_min": 6,
+        "wrong_source_rate_max": 0.05,
+        "all_attempted_sources_reviewed": True,
+        "substantive_generative_ai_allowed": False,
+    }
+    assert result["real_network_calls_performed"] is False
+    assert result["live_provider_requests_authorized"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    with pytest.raises(
+        unseen.OpenAlexClaimScopePreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases(fixture)
+
+
+def test_semantic_case_order_drift_is_rejected_even_with_matching_raw_hash(
+    tmp_path,
+):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["challenge_cases"][0], payload["challenge_cases"][1] = (
+        payload["challenge_cases"][1],
+        payload["challenge_cases"][0],
+    )
+    fixture = tmp_path / "reordered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="ordered V01 through V08"):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_request_contract_cannot_silently_drop_the_abstract_filter(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["request_contract"]["filter"] = ""
+    fixture = tmp_path / "unfiltered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_preflight_source_imports_neither_provider_nor_live_runner():
+    source = Path("openalex_claim_scope_unseen.py").read_text(encoding="utf-8")
+
+    assert "openalex_claim_scope_search" not in source
+    assert "anonymous_openalex_search" not in source
+    assert "execute_gap_plan" not in source
+    assert "urllib" not in source


### PR DESCRIPTION
Why: the U01-U08 precision-v2 study failed its mechanical coverage gate because all eighteen abstentions missed exact-phrase groups, but it had no human labels that could justify treating those rows as relevant misses. Retuning that observed challenge would not measure generalization. This PR freezes V01-V08 and adds a production-disconnected claim-scope method in which OpenAlex topics and keywords may bridge at most one concept while title or abstract evidence, a title anchor, and independent support groups remain mandatory. It also adds a separate anonymous one-request adapter with complete provider accounting, a zero-network identity-locking preflight, preregistration and implementation records, sixteen focused seam tests, and defect-reinjection evidence. It does not connect the executor or adapter to pipeline_worker, authorize a live provider study, or claim source-value improvement. Validation: 1630 passed, 1 skipped, 609 subtests; 87.43 percent coverage; latest Ruff; narrow CI-equivalent Pylint; 20 focused public-doc and claim-scope tests.