### PR TITLE
Add an auditable live harness for claim-scope v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1630 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1647 tests (609 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -167,7 +167,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  86 test modules plus conftest, organised by subject
+tests/                  89 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -201,6 +201,8 @@ openalex_precision_audit.py
                         label-blind frozen development replay; zero-network only
 openalex_claim_scope_unseen.py
                         frozen V01-V08 claim-scope preflight; zero-network only
+openalex_claim_scope_live.py
+                        write-once V01-V08 runner; CLI defaults to dry-run
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -330,10 +332,18 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   preflight expands eight distinct collection/plan/profile/idempotency
   identities, and the new decision/adapter/preflight subset passes 16/16 tests.
   A deliberately wrong outbound filter made the transport-seam test fail before
-  being reverted. The complete suite now passes 1,630 tests plus 609 subtests at
-  87.43% statement coverage. No V01-V08 provider request or human review has
-  run, so compatibility, precision, source value and report value remain
-  `not_evaluated`. Do not connect or advertise v3 as completed Tool Calling.
+  being reverted. A separate write-once live runner now locks the fixture and
+  eight implementation hashes before output reservation, writes the complete
+  manifest before adapter construction, commits each one-request case journal
+  before a later request, distinguishes provider/accounting/cost states, records
+  per-request latency, and emits only ACCEPT rows to a blank review boundary.
+  Its 17/17 focused seams pass; moving manifest persistence after adapter
+  construction made the request
+  boundary test fail before the correct order was restored. The complete suite
+  now passes 1,647 tests plus 609 subtests at 87.43% statement coverage. No
+  V01-V08 provider request or human review has run, so compatibility,
+  precision, source value and report value remain `not_evaluated`. Do not
+  connect or advertise v3 as completed Tool Calling.
   Keep `pipeline_worker.py` disconnected from the executor, adapters, live
   runner and review module.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -358,7 +368,8 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-precision-v2-unseen-implementation.md`, and
   `docs/results-2026-08-27-openalex-precision-v2-unseen-live.md`, plus
   `docs/prereg-2026-08-27-openalex-claim-scope-v3.md` and
-  `docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md`.
+  `docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md`, plus
+  `docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ uninspectable cost; Lens is explicitly uninspectable rather than `$0`. Every
 provider row reaches a candidate or rejection index, and OpenAlex query-string
 credentials are suppressed from complete exception tracebacks. Both a hidden
 retry and missing-row-accounting defect were re-injected and caught. The full
-suite passes **1,630 tests plus 609 subtests** at **87.43% coverage**. No
+suite passes **1,647 tests plus 609 subtests** at **87.43% coverage**. No
 credentialed Phase 4 OpenAlex/Lens run has executed and production still
 imports neither adapter, so
 candidate precision, novel-evidence yield and report benefit remain unobserved.
@@ -569,10 +569,18 @@ match source text and one must match the title, so provider labels alone cannot
 authorize a source. The byte-locked zero-network preflight expands eight
 distinct collection/plan/profile/idempotency identities, 16/16 focused tests
 pass, and an intentionally wrong outbound filter made the transport-seam test
-fail before it was reverted. No V01-V08 request or human review has run, so
-provider compatibility, precision and source value remain `not_evaluated`, and
+fail before it was reverted. A separate write-once live runner now verifies the
+fixture and eight implementation hashes before output reservation, persists
+the full manifest before constructing an adapter, commits each one-request
+case journal before a later request, and keeps provider, accounting, cost,
+latency and human-review states distinct. Its 17/17 focused seams pass;
+deliberately moving manifest persistence after adapter construction made the
+request-boundary test fail before the correct order was restored. No V01-V08
+request or human review has run, so provider compatibility, precision and
+source value remain `not_evaluated`, and
 production remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)
-and [implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md).
+and [candidate implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md),
+plus the [live-harness implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1585,7 +1593,7 @@ intake 子集 **19/19** 通过，覆盖完整身份、基线漂移、旧包基�
 美元成本和不可检查成本，Lens 不会被误报为 `$0`。每一条供应商返回行必须进入
 候选或拒绝索引，OpenAlex 查询参数中的 key 也不会出现在完整异常 traceback 中。
 项目重新注入了隐藏重试和漏记供应商行两个缺陷，新测试均能准确变红；恢复正确实现
-后，全量 **1,630 项测试与 609 个 subtests** 通过，覆盖率 **87.43%**。目前尚未
+后，全量 **1,647 项测试与 609 个 subtests** 通过，覆盖率 **87.43%**。目前尚未
 发起带凭证的第四阶段 OpenAlex/Lens 运行，生产 worker 也不会导入这两个适配器，因此不能
 宣称候选精度、新证据收益或报告质量改善。详见
 [第四阶段协议](docs/prereg-2026-08-26-evidence-gap-domain-adapters-phase4.md)与
@@ -1648,10 +1656,16 @@ precision-v2 判断；最终仅在 3/8 个案例中接受 5 条候选，低于�
 补足一个必需概念；仍要求至少一个必需概念出现在来源文本中、至少一个出现在标题中，
 因此供应商标签不能单独放行来源。原始字节锁定的零网络预检已展开 8 组不同的
 collection/plan/profile/幂等身份，16/16 个聚焦测试通过；临时注入错误的出站过滤参数后，
-传输接缝测试会准确失败。目前没有发起 V01-V08 供应商请求，也没有人工来源真值评审，
+传输接缝测试会准确失败。另一套 write-once live runner 会在保留输出目录前校验 fixture
+与 8 个实现哈希，在构造适配器前写入完整 manifest，并在允许下一次请求前提交当前案例
+的一次请求 journal；供应商失败、记账异常、成本不可检查、逐调用时延和人工未评审会分别记录。
+该 runner 的 17/17 个聚焦接缝测试通过；临时把 manifest 持久化移动到适配器构造之后，
+请求边界测试会准确失败，恢复正确顺序后重新全绿。目前没有发起 V01-V08 供应商请求，
+也没有人工来源真值评审，
 所以兼容性、精度和来源价值仍为 `not_evaluated`，生产路径保持断开。详见
 [v3 协议](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)与
-[实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)。
+[候选实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)，以及
+[live harness 实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md
+++ b/docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md
@@ -1,0 +1,136 @@
+# Result: OpenAlex claim-scope v3 live harness implementation
+
+**Date:** 2026-08-27
+
+**Result state:** live harness complete; provider and source value
+`not_evaluated`.
+
+## Outcome
+
+The production-disconnected V01-V08 claim-scope study now has a write-once
+live runner. No provider request was made while implementing or testing it.
+The runner exists so a separately authorized execution can be attached to an
+exact merged implementation rather than an ad hoc local script.
+
+The default CLI path remains a zero-network dry-run. The live path requires an
+explicit flag, a provider-reported soft stop no greater than USD 0.01 and an
+acknowledgement of the anonymous OpenAlex daily budget. It refuses to run when
+`OPENALEX_API_KEY` is configured.
+
+Production and report connections remain false. `pipeline_worker.py` imports
+neither the runner, the V01-V08 preflight, the adapter nor the claim-scope
+decision module.
+
+## Durable request boundary
+
+`openalex_claim_scope_live.py` adds the following order and state guarantees:
+
+1. the raw fixture and eight implementation files are hash-checked before an
+   output directory or adapter exists;
+2. the output path is write-once, and `manifest.json` records every expanded
+   collection, validated plan, profile, idempotency key, gate and hash before
+   adapter construction;
+3. each attempted case owns exactly one outbound request, one deterministic
+   trace identity and one persisted monotonic request latency;
+4. its `case-executions/Vxx.json` journal is committed before the next case may
+   start;
+5. every valid provider row reaches a label-blind `ACCEPT` or `ABSTAIN`
+   decision, while every malformed row reaches an indexed provider rejection;
+6. provider failure, invalid accounting, unknown cost, soft stop and complete
+   execution remain distinct states, while the provider summary equals the sum
+   of case-journal latencies;
+7. `candidates.csv` carries channel-level decision provenance, and
+   `review.csv` contains only `ACCEPT` rows with blank human labels;
+8. aggregate files receive a final SHA-256 artifact index.
+
+A complete provider run does not imply source value. Fewer than six accepted
+cases records `mechanical_gate_failed`; six or more records only
+`eligible_for_source_lock`. Both keep `human_review_state=not_prepared` and
+`source_value_state=not_evaluated` until a separate provenance-locked human
+review applies the remaining novelty and wrong-source gates.
+
+## Frozen implementation identities
+
+The live runner locks these already committed inputs before any request:
+
+- `domain_evidence_search.py`:
+  `ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab`;
+- `evidence.py`:
+  `8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5`;
+- `evidence_gap.py`:
+  `f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25`;
+- `evidence_search.py`:
+  `2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0`;
+- `openalex_claim_scope.py`:
+  `739e165838ff5042ec863c3c510311e737216e8d90804c8d3da5095acce22f16`;
+- `openalex_claim_scope_search.py`:
+  `070d07ac8c4bcaa32bfbc563513b4034162b012aea1f47ce3208ed06cb085642`;
+- `openalex_claim_scope_unseen.py`:
+  `6104a060b80bb2126a7cbdb2d1c4eb74ae3a12291a43acda6d5dd14eb271d552`;
+- `openalex_precision.py`:
+  `7c6e0f2999aae68a9caa042584c886bc5273037a2eaf2e95d80c553b7a503029`.
+
+The V01-V08 fixture remains
+`f8084328d56fed9c5b2aaafa1eb2225b0798d30266cc12c34522e1cd1243be86`.
+
+## Verification
+
+Focused live-harness tests:
+
+```text
+17 passed in 1.68s
+```
+
+Full zero-network suite:
+
+```text
+1647 passed, 1 skipped, 609 subtests passed in 15.83s
+```
+
+CI-equivalent coverage run:
+
+```text
+7067 / 8083 statements covered = 87.43%
+1647 passed, 1 skipped, 609 subtests passed
+```
+
+The coverage run emitted third-party `ResourceWarning` messages about CrewAI
+SQLite connections. It emitted no `UserWarning`, changed no warning policy and
+passed the frozen 85% gate.
+
+Static checks:
+
+```text
+uv run --with ruff ruff check .
+All checks passed!
+
+uv run --with pylint pylint openalex_claim_scope_live.py \
+  --disable=all \
+  --enable=bad-except-order,unreachable,used-before-assignment,undefined-variable \
+  --score=n
+exit 0
+```
+
+The dry-run verified 8/8 collection, plan, profile and idempotency identities,
+the abstract-only request contract, topics/keywords aboutness fields, no
+redirects, no internal retry and zero live authority.
+
+## Defect re-injection
+
+After the focused suite passed, manifest persistence was temporarily moved
+after adapter construction. The exact full-run seam test failed inside the
+injected factory because `manifest.json` did not yet exist. The original order
+was restored and all 16 focused tests passed again.
+
+This demonstrates that the test observes the durable request boundary, not
+merely a final artifact that could have been written after spending budget.
+
+## What remains unobserved
+
+This result does not establish provider compatibility, candidate precision,
+wrong-source rate, novel-evidence yield, report improvement, planner-trigger
+quality or production reliability. The next valid step is one separately
+authorized execution on the exact merged revision, in a fresh write-once
+directory, with no retries and no more than eight single-attempt anonymous
+OpenAlex requests. If the six-case mechanical gate passes, source locking and
+an eligible human review are still required before any source-value claim.

--- a/openalex_claim_scope_live.py
+++ b/openalex_claim_scope_live.py
@@ -1,0 +1,1071 @@
+"""Production-disconnected live runner for the claim-scope v3 challenge.
+
+The default command is a zero-network preflight.  Live execution requires an
+explicit flag, a bounded provider-reported soft stop, and acknowledgement of
+the anonymous OpenAlex daily budget.  Every frozen input is persisted before
+adapter construction, and each one-request case journal is committed before a
+later request may start.  The resulting ACCEPT rows remain unregistered review
+candidates: this module is never imported by the production report worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence_gap import (
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    source_collection_sha256,
+)
+from academic_agent.openalex_claim_scope import (
+    OpenAlexClaimScopeCandidate,
+    OpenAlexClaimScopeDecision,
+    evaluate_openalex_claim_scope,
+)
+from academic_agent.source_pipeline import SourceCollection
+from academic_agent.tools.evidence_search import ToolAdapterFailure
+from academic_agent.tools.openalex_claim_scope_search import (
+    AnonymousOpenAlexClaimScopeAdapter,
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_claim_scope_unseen import (
+    EXPECTED_FIXTURE_SHA256,
+    ClaimScopeCaseSpec,
+    ClaimScopeSourceValueGates,
+    PreparedClaimScopeCase,
+    dry_run,
+    load_frozen_cases,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_IMPLEMENTATION_PATHS = {
+    "domain_evidence_search.py": (
+        _ROOT / "src/academic_agent/tools/domain_evidence_search.py"
+    ),
+    "evidence.py": _ROOT / "src/academic_agent/evidence.py",
+    "evidence_gap.py": _ROOT / "src/academic_agent/evidence_gap.py",
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_claim_scope.py": (
+        _ROOT / "src/academic_agent/openalex_claim_scope.py"
+    ),
+    "openalex_claim_scope_search.py": (
+        _ROOT / "src/academic_agent/tools/openalex_claim_scope_search.py"
+    ),
+    "openalex_claim_scope_unseen.py": _ROOT / "openalex_claim_scope_unseen.py",
+    "openalex_precision.py": _ROOT / "src/academic_agent/openalex_precision.py",
+}
+# These values are populated from the merge-candidate bytes before any live
+# request.  A later code drift must create a new study rather than silently
+# changing the method under the original V01-V08 identities.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "domain_evidence_search.py": (
+        "ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab"
+    ),
+    "evidence.py": (
+        "8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5"
+    ),
+    "evidence_gap.py": (
+        "f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_claim_scope.py": (
+        "739e165838ff5042ec863c3c510311e737216e8d90804c8d3da5095acce22f16"
+    ),
+    "openalex_claim_scope_search.py": (
+        "070d07ac8c4bcaa32bfbc563513b4034162b012aea1f47ce3208ed06cb085642"
+    ),
+    "openalex_claim_scope_unseen.py": (
+        "6104a060b80bb2126a7cbdb2d1c4eb74ae3a12291a43acda6d5dd14eb271d552"
+    ),
+    "openalex_precision.py": (
+        "7c6e0f2999aae68a9caa042584c886bc5273037a2eaf2e95d80c553b7a503029"
+    ),
+}
+MAXIMUM_REQUESTS = 8
+MAXIMUM_SOFT_STOP_USD = 0.01
+ANONYMOUS_DAILY_BUDGET_USD = 0.10
+_CASE_ORDER = tuple(f"V{index:02d}" for index in range(1, 9))
+_AGGREGATE_SOURCE_FILES = (
+    "manifest.json",
+    "execution.json",
+    "candidates.csv",
+    "review.csv",
+)
+_CANDIDATE_COLUMNS = (
+    "case_id",
+    "provider",
+    "tool",
+    "provider_request_id",
+    "provider_request_id_source",
+    "provider_cost_basis",
+    "provider_result_index",
+    "adapter_disposition",
+    "claim_scope_action",
+    "abstention_reasons",
+    "missing_required_groups",
+    "exact_required_groups",
+    "title_required_groups",
+    "provider_only_required_groups",
+    "required_match_provenance",
+    "supporting_match_provenance",
+    "aboutness_signal_count",
+    "candidate_sha256",
+    "profile_sha256",
+    "title",
+    "url",
+    "provider_rejection_code",
+    "rejection_detail",
+    "latency_ms",
+    "trace_id",
+)
+_REVIEW_COLUMNS = (
+    "case_id",
+    "provider",
+    "provider_result_index",
+    "candidate_sha256",
+    "title",
+    "url",
+    "relevant",
+    "novel",
+    "review_note",
+)
+
+
+ClaimScopeAdapter = Callable[
+    [ValidatedGapCall],
+    OpenAlexClaimScopeAdapterResponse | dict[str, Any],
+]
+AdapterFactory = Callable[[], ClaimScopeAdapter]
+Clock = Callable[[], float]
+StopReason = Literal[
+    "completed",
+    "soft_stop",
+    "cost_uninspectable",
+    "request_failed",
+    "accounting_invalid",
+]
+ReviewPacketEligibility = Literal[
+    "eligible_for_source_lock",
+    "mechanical_gate_failed",
+    "incomplete",
+]
+
+
+class OpenAlexClaimScopeLiveError(ValueError):
+    """Raised before provider work when a frozen live boundary fails."""
+
+
+class ClaimScopeFrozenCaseArtifact(BaseModel):
+    """Complete deterministic case input persisted before the first request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: ClaimScopeCaseSpec
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_collection: SourceCollection
+    validated_plan: ValidatedGapPlan
+
+    @model_validator(mode="after")
+    def _validate_expanded_identities(self) -> "ClaimScopeFrozenCaseArtifact":
+        if source_collection_sha256(self.source_collection) != self.collection_sha256:
+            raise ValueError("expanded source collection hash does not match")
+        plan_sha256 = _sha256_bytes(
+            self.validated_plan.model_dump_json(exclude_none=False).encode("utf-8")
+        )
+        if plan_sha256 != self.plan_sha256:
+            raise ValueError("expanded validated plan hash does not match")
+        if self.spec.profile.sha256() != self.profile_sha256:
+            raise ValueError("expanded claim-scope profile hash does not match")
+        return self
+
+
+class ClaimScopeManifestArtifact(BaseModel):
+    """Write-once expansion of all frozen inputs and implementation identities."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_claim_scope_v3_manifest"] = (
+        "openalex_claim_scope_v3_manifest"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    maximum_requests: Literal[8] = MAXIMUM_REQUESTS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    source_value_gates: ClaimScopeSourceValueGates
+    cases: tuple[ClaimScopeFrozenCaseArtifact, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_frozen_contract(self) -> "ClaimScopeManifestArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("manifest fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("manifest implementation identities do not match")
+        if tuple(case.spec.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("manifest cases must remain ordered V01 through V08")
+        return self
+
+
+class ClaimScopeCandidateEvaluation(BaseModel):
+    """One provider candidate joined to its label-blind v3 decision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider_result_index: int = Field(ge=0, le=7)
+    candidate: OpenAlexClaimScopeCandidate
+    decision: OpenAlexClaimScopeDecision
+
+    @model_validator(mode="after")
+    def _validate_candidate_identity(self) -> "ClaimScopeCandidateEvaluation":
+        if self.candidate.evidence.provider_result_index != self.provider_result_index:
+            raise ValueError("candidate provider index drifted from evaluation")
+        if self.candidate.sha256() != self.decision.candidate_sha256:
+            raise ValueError("claim-scope decision is attached to another candidate")
+        return self
+
+
+class ClaimScopeCaseExecution(BaseModel):
+    """One request journal, including explicit failure and accounting states."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^V0[1-8]$")
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trace_id: str = Field(pattern=r"^openalex-claim-scope-v3-v0[1-8]$")
+    state: Literal["completed", "failed"]
+    outbound_attempt_count: Literal[1] = 1
+    response: OpenAlexClaimScopeAdapterResponse | None = None
+    evaluations: tuple[ClaimScopeCandidateEvaluation, ...] = Field(
+        default=(),
+        max_length=8,
+    )
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    search_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    latency_ms: float = Field(
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+
+    @model_validator(mode="after")
+    def _validate_state_and_evaluations(self) -> "ClaimScopeCaseExecution":
+        if self.state == "completed":
+            if self.response is None:
+                raise ValueError("completed case requires an adapter response")
+            if any(
+                value is not None
+                for value in (
+                    self.failure_type,
+                    self.failure_detail,
+                    self.failure_retryable,
+                )
+            ):
+                raise ValueError("completed case cannot carry failure metadata")
+            if self.response.idempotency_key != self.idempotency_key:
+                raise ValueError("response idempotency identity drifted")
+            if self.response.search_cost_usd != self.search_cost_usd:
+                raise ValueError("case cost drifted from provider response")
+            expected = tuple(
+                (
+                    int(candidate.evidence.provider_result_index),
+                    candidate,
+                )
+                for candidate in self.response.candidates
+                if candidate.evidence.provider_result_index is not None
+            )
+            observed = tuple(
+                (item.provider_result_index, item.candidate)
+                for item in self.evaluations
+            )
+            if observed != expected:
+                raise ValueError("every provider candidate must reach v3 evaluation")
+            if any(
+                item.decision.profile_sha256 != self.profile_sha256
+                for item in self.evaluations
+            ):
+                raise ValueError("claim-scope decision profile identity drifted")
+        else:
+            if self.failure_type is None or self.failure_detail is None:
+                raise ValueError("failed case requires explicit failure metadata")
+            if self.evaluations:
+                raise ValueError("failed case cannot imply completed evaluations")
+            if self.response is not None and (
+                self.response.search_cost_usd != self.search_cost_usd
+            ):
+                raise ValueError("failed case cost drifted from provider response")
+        return self
+
+
+class ClaimScopeProviderSummary(BaseModel):
+    """Anonymous provider accounting where no observation is not a pass."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["openalex"] = "openalex"
+    access_mode: Literal["anonymous_no_key"] = "anonymous_no_key"
+    authorized_case_count: Literal[8] = MAXIMUM_REQUESTS
+    attempted_case_count: int = Field(ge=0, le=8)
+    successful_case_count: int = Field(ge=0, le=8)
+    request_count: int = Field(ge=0, le=8)
+    cost_state: Literal["known", "uninspectable", "not_observed"]
+    reported_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    total_latency_ms: float = Field(
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    stopped_reason: StopReason
+
+    @model_validator(mode="after")
+    def _validate_accounting(self) -> "ClaimScopeProviderSummary":
+        if self.successful_case_count > self.attempted_case_count:
+            raise ValueError("successful cases cannot exceed attempted cases")
+        if self.request_count != self.attempted_case_count:
+            raise ValueError("every attempted case must own exactly one request")
+        if self.cost_state == "known" and self.reported_cost_usd is None:
+            raise ValueError("known provider cost requires a numeric total")
+        if self.cost_state != "known" and self.reported_cost_usd is not None:
+            raise ValueError("uninspectable provider cost must keep USD null")
+        completed = self.successful_case_count == MAXIMUM_REQUESTS
+        if (self.stopped_reason == "completed") != completed:
+            raise ValueError("provider completion does not match successful cases")
+        return self
+
+
+class ClaimScopeExecutionArtifact(BaseModel):
+    """Final write-once state; source value still requires eligible humans."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_claim_scope_v3_execution"] = (
+        "openalex_claim_scope_v3_execution"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    maximum_requests: Literal[8] = MAXIMUM_REQUESTS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    request_count: int = Field(ge=0, le=8)
+    attempted_case_count: int = Field(ge=0, le=8)
+    successful_case_count: int = Field(ge=0, le=8)
+    overall_state: Literal["completed", "partial"]
+    claim_scope_accepted_candidate_count: int = Field(ge=0, le=64)
+    claim_scope_abstained_candidate_count: int = Field(ge=0, le=64)
+    claim_scope_accepted_case_count: int = Field(ge=0, le=8)
+    review_packet_eligibility: ReviewPacketEligibility
+    source_lock_state: Literal["not_created"] = "not_created"
+    human_review_state: Literal["not_prepared"] = "not_prepared"
+    source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    source_value_gates: ClaimScopeSourceValueGates
+    provider_summary: ClaimScopeProviderSummary
+    cases: tuple[ClaimScopeCaseExecution, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_totals_and_states(self) -> "ClaimScopeExecutionArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("execution fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("execution implementation identities do not match")
+        case_ids = tuple(case.case_id for case in self.cases)
+        if case_ids != _CASE_ORDER[: len(case_ids)]:
+            raise ValueError("case executions must preserve the frozen prefix")
+        if len(self.cases) != self.attempted_case_count:
+            raise ValueError("attempted cases must equal persisted journals")
+        if self.request_count != sum(
+            case.outbound_attempt_count for case in self.cases
+        ):
+            raise ValueError("request count must equal journal attempt total")
+        successful = sum(case.state == "completed" for case in self.cases)
+        if successful != self.successful_case_count:
+            raise ValueError("successful cases must equal completed journals")
+        if self.provider_summary.request_count != self.request_count:
+            raise ValueError("provider request count drifted from execution")
+        if self.provider_summary.attempted_case_count != self.attempted_case_count:
+            raise ValueError("provider attempted-case count drifted")
+        if self.provider_summary.successful_case_count != self.successful_case_count:
+            raise ValueError("provider successful-case count drifted")
+        expected_latency = sum(case.latency_ms for case in self.cases)
+        if not math.isclose(
+            self.provider_summary.total_latency_ms,
+            expected_latency,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise ValueError("provider latency total drifted from case journals")
+
+        evaluations = tuple(
+            item for case in self.cases for item in case.evaluations
+        )
+        accepted = sum(item.decision.action == "ACCEPT" for item in evaluations)
+        abstained = sum(item.decision.action == "ABSTAIN" for item in evaluations)
+        accepted_cases = sum(
+            any(item.decision.action == "ACCEPT" for item in case.evaluations)
+            for case in self.cases
+        )
+        if accepted != self.claim_scope_accepted_candidate_count:
+            raise ValueError("accepted-candidate count drifted")
+        if abstained != self.claim_scope_abstained_candidate_count:
+            raise ValueError("abstained-candidate count drifted")
+        if accepted_cases != self.claim_scope_accepted_case_count:
+            raise ValueError("accepted-case count drifted")
+
+        completed = self.successful_case_count == MAXIMUM_REQUESTS
+        if (self.overall_state == "completed") != completed:
+            raise ValueError("overall state does not match provider completion")
+        expected_eligibility: ReviewPacketEligibility
+        if not completed:
+            expected_eligibility = "incomplete"
+        elif accepted_cases < self.source_value_gates.accepted_case_count_min:
+            expected_eligibility = "mechanical_gate_failed"
+        else:
+            expected_eligibility = "eligible_for_source_lock"
+        if self.review_packet_eligibility != expected_eligibility:
+            raise ValueError("review-packet eligibility drifted from frozen gates")
+        return self
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects because one case authorizes one outbound request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _OneRequestTransport:
+    """Concrete transport with neither redirect following nor internal retry."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method=method,
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read()
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    try:
+        return _sha256_bytes(path.read_bytes())
+    except OSError as exc:
+        raise OpenAlexClaimScopeLiveError(
+            f"could not read frozen implementation file {path.name}: {exc}"
+        ) from exc
+
+
+def verify_frozen_implementation() -> dict[str, str]:
+    """Reject code drift before output reservation or adapter construction."""
+
+    if set(_IMPLEMENTATION_PATHS) != set(EXPECTED_IMPLEMENTATION_SHA256):
+        raise OpenAlexClaimScopeLiveError(
+            "claim-scope implementation lock names are inconsistent"
+        )
+    observed = {
+        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+    if observed != EXPECTED_IMPLEMENTATION_SHA256:
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if EXPECTED_IMPLEMENTATION_SHA256.get(name) != digest
+        )
+        raise OpenAlexClaimScopeLiveError(
+            "claim-scope implementation identity drifted: " + ", ".join(changed)
+        )
+    return observed
+
+
+def protocol_dry_run() -> dict[str, Any]:
+    """Expose fixture and implementation identities while opening zero sockets."""
+
+    result = dry_run()
+    result["implementation_sha256"] = verify_frozen_implementation()
+    return result
+
+
+def _manifest_artifact(
+    cases: tuple[PreparedClaimScopeCase, ...],
+    fixture_sha256: str,
+    implementation_sha256: dict[str, str],
+    gates: ClaimScopeSourceValueGates,
+    soft_stop_usd: float,
+) -> ClaimScopeManifestArtifact:
+    return ClaimScopeManifestArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        soft_stop_usd=soft_stop_usd,
+        source_value_gates=gates,
+        cases=tuple(
+            ClaimScopeFrozenCaseArtifact(
+                spec=case.spec,
+                collection_sha256=case.collection_sha256,
+                plan_sha256=case.plan_sha256,
+                profile_sha256=case.profile_sha256,
+                source_collection=case.collection,
+                validated_plan=case.plan,
+            )
+            for case in cases
+        ),
+    )
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise OpenAlexClaimScopeLiveError(
+            f"could not create write-once artifact {path}: {exc}"
+        ) from exc
+
+
+def _json_text(value: BaseModel | dict[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _write_case_journal(
+    output_dir: Path,
+    execution: ClaimScopeCaseExecution,
+) -> None:
+    journal_dir = output_dir / "case-executions"
+    journal_dir.mkdir(exist_ok=True)
+    _write_new(journal_dir / f"{execution.case_id}.json", _json_text(execution))
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    """Describe a failed response shape without copying provider input."""
+
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "adapter response failed validation"
+
+
+def _failure_execution(
+    case: PreparedClaimScopeCase,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool | None,
+    latency_ms: float,
+    response: OpenAlexClaimScopeAdapterResponse | None = None,
+    search_cost_usd: float | None = None,
+) -> ClaimScopeCaseExecution:
+    return ClaimScopeCaseExecution(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-claim-scope-v3-{case.spec.case_id.casefold()}",
+        state="failed",
+        response=response,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        search_cost_usd=search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _completed_execution(
+    case: PreparedClaimScopeCase,
+    response: OpenAlexClaimScopeAdapterResponse,
+    latency_ms: float,
+) -> ClaimScopeCaseExecution:
+    return ClaimScopeCaseExecution(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-claim-scope-v3-{case.spec.case_id.casefold()}",
+        state="completed",
+        response=response,
+        evaluations=tuple(
+            ClaimScopeCandidateEvaluation(
+                provider_result_index=int(
+                    candidate.evidence.provider_result_index
+                ),
+                candidate=candidate,
+                decision=evaluate_openalex_claim_scope(
+                    candidate,
+                    case.spec.profile,
+                ),
+            )
+            for candidate in response.candidates
+            if candidate.evidence.provider_result_index is not None
+        ),
+        search_cost_usd=response.search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _provider_cost(
+    executions: list[ClaimScopeCaseExecution],
+) -> tuple[Literal["known", "uninspectable", "not_observed"], float | None]:
+    if not executions:
+        return "not_observed", None
+    values = [item.search_cost_usd for item in executions]
+    if any(value is None for value in values):
+        return "uninspectable", None
+    return "known", sum(value for value in values if value is not None)
+
+
+def _elapsed_ms(clock: Clock, started_at: float) -> float:
+    """Return monotonic request latency without losing a spent-request journal."""
+
+    elapsed_ms = (clock() - started_at) * 1000.0
+    if not math.isfinite(elapsed_ms):
+        raise OpenAlexClaimScopeLiveError("request clock produced non-finite latency")
+    # perf_counter is monotonic. Clamping a custom test clock's backwards
+    # reading is safer than dropping the journal for an already-spent request.
+    return max(0.0, elapsed_ms)
+
+
+def _json_compact(value: object) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def _candidate_rows(
+    executions: tuple[ClaimScopeCaseExecution, ...],
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    rows: list[dict[str, str]] = []
+    reviews: list[dict[str, str]] = []
+    for execution in executions:
+        response = execution.response
+        if response is None:
+            continue
+        evaluations = {
+            item.provider_result_index: item for item in execution.evaluations
+        }
+        usage = response.provider_usage
+        for candidate in response.candidates:
+            index = candidate.evidence.provider_result_index
+            if index is None:
+                raise OpenAlexClaimScopeLiveError(
+                    "provider-accounted candidate lost its result index"
+                )
+            evaluation = evaluations.get(index)
+            decision = evaluation.decision if evaluation is not None else None
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "provider": "openalex",
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(index),
+                    "adapter_disposition": "candidate",
+                    "claim_scope_action": (
+                        decision.action if decision is not None else "NOT_EVALUATED"
+                    ),
+                    "abstention_reasons": _json_compact(
+                        decision.abstention_reasons if decision else ()
+                    ),
+                    "missing_required_groups": _json_compact(
+                        decision.missing_required_groups if decision else ()
+                    ),
+                    "exact_required_groups": _json_compact(
+                        decision.exact_required_groups if decision else ()
+                    ),
+                    "title_required_groups": _json_compact(
+                        decision.title_required_groups if decision else ()
+                    ),
+                    "provider_only_required_groups": _json_compact(
+                        decision.provider_only_required_groups if decision else ()
+                    ),
+                    "required_match_provenance": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.required_matches
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "supporting_match_provenance": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.supporting_matches
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "aboutness_signal_count": str(len(candidate.aboutness)),
+                    "candidate_sha256": (
+                        decision.candidate_sha256 if decision else candidate.sha256()
+                    ),
+                    "profile_sha256": execution.profile_sha256,
+                    "title": candidate.evidence.title,
+                    "url": candidate.evidence.url,
+                    "provider_rejection_code": "",
+                    "rejection_detail": "",
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+            if decision is not None and decision.action == "ACCEPT":
+                reviews.append(
+                    {
+                        "case_id": execution.case_id,
+                        "provider": "openalex",
+                        "provider_result_index": str(index),
+                        "candidate_sha256": decision.candidate_sha256,
+                        "title": candidate.evidence.title,
+                        "url": candidate.evidence.url,
+                        "relevant": "",
+                        "novel": "",
+                        "review_note": "",
+                    }
+                )
+        for rejection in response.provider_rejections:
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "provider": "openalex",
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(rejection.provider_result_index),
+                    "adapter_disposition": "provider_rejected",
+                    "claim_scope_action": "NOT_EVALUATED",
+                    "abstention_reasons": "[]",
+                    "missing_required_groups": "[]",
+                    "exact_required_groups": "[]",
+                    "title_required_groups": "[]",
+                    "provider_only_required_groups": "[]",
+                    "required_match_provenance": "[]",
+                    "supporting_match_provenance": "[]",
+                    "aboutness_signal_count": "0",
+                    "candidate_sha256": "",
+                    "profile_sha256": execution.profile_sha256,
+                    "title": rejection.title or "",
+                    "url": rejection.url or "",
+                    "provider_rejection_code": rejection.code,
+                    "rejection_detail": rejection.detail,
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+    rows.sort(key=lambda row: (row["case_id"], int(row["provider_result_index"])))
+    reviews.sort(
+        key=lambda row: (row["case_id"], int(row["provider_result_index"]))
+    )
+    return rows, reviews
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    artifact: ClaimScopeExecutionArtifact,
+) -> None:
+    rows, reviews = _candidate_rows(artifact.cases)
+    _write_new(output_dir / "execution.json", _json_text(artifact))
+    _write_new(
+        output_dir / "candidates.csv",
+        _csv_text(_CANDIDATE_COLUMNS, rows),
+    )
+    _write_new(output_dir / "review.csv", _csv_text(_REVIEW_COLUMNS, reviews))
+    file_hashes = {
+        name: _sha256_bytes((output_dir / name).read_bytes())
+        for name in _AGGREGATE_SOURCE_FILES
+    }
+    _write_new(
+        output_dir / "artifact-index.json",
+        _json_text(
+            {
+                "schema_version": 1,
+                "mode": "openalex_claim_scope_v3_artifact_index",
+                "production_connected": False,
+                "report_workflow_connected": False,
+                "source_file_sha256": file_hashes,
+            }
+        ),
+    )
+
+
+def _review_packet_eligibility(
+    *,
+    successful_case_count: int,
+    accepted_case_count: int,
+    gates: ClaimScopeSourceValueGates,
+) -> ReviewPacketEligibility:
+    if successful_case_count != MAXIMUM_REQUESTS:
+        return "incomplete"
+    if accepted_case_count < gates.accepted_case_count_min:
+        return "mechanical_gate_failed"
+    return "eligible_for_source_lock"
+
+
+def execute_live_study(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    acknowledge_anonymous_daily_budget: bool,
+    adapter_factory: AdapterFactory | None = None,
+    monotonic_clock: Clock | None = None,
+) -> ClaimScopeExecutionArtifact:
+    """Run V01-V08 under a provider-reported soft stop and write-once seams."""
+
+    if not 0.0 < soft_stop_usd <= MAXIMUM_SOFT_STOP_USD:
+        raise OpenAlexClaimScopeLiveError(
+            "claim-scope v3 soft stop must be greater than zero and at most USD 0.01"
+        )
+    if not acknowledge_anonymous_daily_budget:
+        raise OpenAlexClaimScopeLiveError(
+            "claim-scope v3 execution requires daily-budget acknowledgement"
+        )
+    if (os.getenv("OPENALEX_API_KEY") or "").strip():
+        raise OpenAlexClaimScopeLiveError(
+            "anonymous claim-scope v3 study refuses a configured OPENALEX_API_KEY"
+        )
+    if output_dir.exists():
+        raise FileExistsError(f"claim-scope v3 output already exists: {output_dir}")
+
+    fixture_sha256, challenge, cases = load_frozen_cases()
+    implementation_sha256 = verify_frozen_implementation()
+    # Reserve the path and persist the complete method before constructing a
+    # network-capable object.  This ordering is a crash/retry boundary, not a
+    # cosmetic artifact convention.
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest_artifact(
+        cases,
+        fixture_sha256,
+        implementation_sha256,
+        challenge.source_value_gates,
+        soft_stop_usd,
+    )
+    _write_new(output_dir / "manifest.json", _json_text(manifest))
+    adapter: ClaimScopeAdapter
+    if adapter_factory is not None:
+        adapter = adapter_factory()
+    else:
+        adapter = AnonymousOpenAlexClaimScopeAdapter(
+            transport=_OneRequestTransport()
+        )
+
+    executions: list[ClaimScopeCaseExecution] = []
+    clock = monotonic_clock or time.perf_counter
+    known_cost = 0.0
+    stopped_reason: StopReason = "completed"
+    for case in cases:
+        if known_cost + 1e-12 >= soft_stop_usd:
+            stopped_reason = "soft_stop"
+            break
+        call = case.plan.calls[0]
+        case_stop_reason: StopReason | None = None
+        started_at = clock()
+        try:
+            raw_response = adapter(call)
+        except ToolAdapterFailure as exc:
+            latency_ms = _elapsed_ms(clock, started_at)
+            execution = _failure_execution(
+                case,
+                failure_type=exc.failure_type,
+                failure_detail=str(exc),
+                failure_retryable=exc.retryable,
+                latency_ms=latency_ms,
+                search_cost_usd=exc.search_cost_usd,
+            )
+            case_stop_reason = "request_failed"
+        else:
+            latency_ms = _elapsed_ms(clock, started_at)
+            try:
+                response = OpenAlexClaimScopeAdapterResponse.model_validate(
+                    raw_response
+                )
+            except ValidationError as exc:
+                execution = _failure_execution(
+                    case,
+                    failure_type="adapter_response_invalid",
+                    failure_detail=_validation_detail(exc),
+                    failure_retryable=False,
+                    latency_ms=latency_ms,
+                )
+                case_stop_reason = "accounting_invalid"
+            else:
+                if response.idempotency_key != call.idempotency_key:
+                    execution = _failure_execution(
+                        case,
+                        failure_type="adapter_identity_mismatch",
+                        failure_detail=(
+                            "adapter response idempotency key does not match the "
+                            "authorized call"
+                        ),
+                        failure_retryable=False,
+                        latency_ms=latency_ms,
+                        response=response,
+                        search_cost_usd=response.search_cost_usd,
+                    )
+                    case_stop_reason = "accounting_invalid"
+                else:
+                    execution = _completed_execution(case, response, latency_ms)
+
+        # Commit the one-request journal before checking whether another case
+        # may run.  If the process dies after this line, the spent request and
+        # its disposition remain independently inspectable.
+        _write_case_journal(output_dir, execution)
+        executions.append(execution)
+        if execution.search_cost_usd is None:
+            stopped_reason = case_stop_reason or "cost_uninspectable"
+            break
+        known_cost += execution.search_cost_usd
+        if case_stop_reason is not None:
+            stopped_reason = case_stop_reason
+            break
+
+    cost_state, reported_cost = _provider_cost(executions)
+    successful_case_count = sum(item.state == "completed" for item in executions)
+    provider_summary = ClaimScopeProviderSummary(
+        attempted_case_count=len(executions),
+        successful_case_count=successful_case_count,
+        request_count=sum(item.outbound_attempt_count for item in executions),
+        cost_state=cost_state,
+        reported_cost_usd=reported_cost,
+        total_latency_ms=sum(item.latency_ms for item in executions),
+        stopped_reason=stopped_reason,
+    )
+    evaluations = tuple(item for case in executions for item in case.evaluations)
+    accepted_case_count = sum(
+        any(item.decision.action == "ACCEPT" for item in case.evaluations)
+        for case in executions
+    )
+    artifact = ClaimScopeExecutionArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        soft_stop_usd=soft_stop_usd,
+        request_count=provider_summary.request_count,
+        attempted_case_count=provider_summary.attempted_case_count,
+        successful_case_count=provider_summary.successful_case_count,
+        overall_state=(
+            "completed" if stopped_reason == "completed" else "partial"
+        ),
+        claim_scope_accepted_candidate_count=sum(
+            item.decision.action == "ACCEPT" for item in evaluations
+        ),
+        claim_scope_abstained_candidate_count=sum(
+            item.decision.action == "ABSTAIN" for item in evaluations
+        ),
+        claim_scope_accepted_case_count=accepted_case_count,
+        review_packet_eligibility=_review_packet_eligibility(
+            successful_case_count=successful_case_count,
+            accepted_case_count=accepted_case_count,
+            gates=challenge.source_value_gates,
+        ),
+        source_value_gates=challenge.source_value_gates,
+        provider_summary=provider_summary,
+        cases=tuple(executions),
+    )
+    _write_final_artifacts(output_dir, artifact)
+    return artifact
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    parser.add_argument(
+        "--acknowledge-anonymous-daily-budget",
+        action="store_true",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(_stdout_json(protocol_dry_run()))
+        return 0
+    if args.output_dir is None or args.soft_stop_usd is None:
+        raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
+    artifact = execute_live_study(
+        output_dir=args.output_dir,
+        soft_stop_usd=args.soft_stop_usd,
+        acknowledge_anonymous_daily_budget=(
+            args.acknowledge_anonymous_daily_budget
+        ),
+    )
+    print(_stdout_json(artifact))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_claim_scope_live.py
+++ b/tests/test_openalex_claim_scope_live.py
@@ -1,0 +1,453 @@
+"""Zero-network seams for the claim-scope v3 live harness."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+import openalex_claim_scope_live as live
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_claim_scope_live import (
+    OpenAlexClaimScopeLiveError,
+    execute_live_study,
+)
+from openalex_claim_scope_unseen import PreparedClaimScopeCase, load_frozen_cases
+
+
+def _accepted_candidate(
+    case: PreparedClaimScopeCase,
+    index: int,
+) -> OpenAlexClaimScopeCandidate:
+    required = [
+        group.text_phrases[0] for group in case.spec.profile.required_groups
+    ]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups[
+            : case.spec.profile.minimum_supporting_groups
+        ]
+    ]
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{' '.join(required)} controlled study",
+            url=f"https://openalex.org/W{case.spec.case_id[1:]}00000001",
+            publisher="OpenAlex zero-network claim-scope fixture",
+            evidence_summary=(
+                f"{' '.join(required + supporting)}. The study reports a direct "
+                f"measurement for {case.spec.query}."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+def _abstained_candidate(
+    case: PreparedClaimScopeCase,
+    index: int,
+) -> OpenAlexClaimScopeCandidate:
+    first_required = case.spec.profile.required_groups[0].text_phrases[0]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups
+    ]
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{first_required} broad application review",
+            url=f"https://openalex.org/W{case.spec.case_id[1:]}00000002",
+            publisher="OpenAlex zero-network claim-scope review",
+            evidence_summary=(
+                f"{first_required} {' '.join(supporting)}. This broad review "
+                "intentionally omits the second required concept."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+def _response(
+    case: PreparedClaimScopeCase,
+    call: ValidatedGapCall,
+    *,
+    reported_cost_usd: float,
+    include_rejection: bool,
+    only_abstained: bool,
+    identity_mismatch: bool,
+) -> OpenAlexClaimScopeAdapterResponse:
+    candidates = (
+        (_abstained_candidate(case, 0),)
+        if only_abstained
+        else (
+            _accepted_candidate(case, 0),
+            _abstained_candidate(case, 1),
+        )
+    )
+    rejection_index = len(candidates)
+    rejections = (
+        (
+            ProviderResultRejection(
+                provider_result_index=rejection_index,
+                code="provider_result_not_object",
+                detail="zero-network fixture row is not an object",
+            ),
+        )
+        if include_rejection
+        else ()
+    )
+    idempotency_key = "0" * 64 if identity_mismatch else call.idempotency_key
+    usage = ToolProviderUsage(
+        provider="openalex",
+        request_id=f"client-openalex-claim-scope-{call.idempotency_key[:12]}",
+        request_id_source="client_generated",
+        result_count=len(candidates) + len(rejections),
+        cost_basis="reported_usd",
+        reported_cost_usd=reported_cost_usd,
+    )
+    return OpenAlexClaimScopeAdapterResponse(
+        idempotency_key=idempotency_key,
+        candidates=candidates,
+        provider_rejections=rejections,
+        search_cost_usd=reported_cost_usd,
+        provider_request_id=usage.request_id,
+        provider_usage=usage,
+    )
+
+
+class RecordingFactory:
+    """Injected adapter proving construction and request journal ordering."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        *,
+        reported_cost_usd: float = 0.001,
+        include_rejection: bool = False,
+        fail: bool = False,
+        invalid_response: bool = False,
+        identity_mismatch: bool = False,
+        only_abstained: bool = False,
+    ) -> None:
+        self.output_dir = output_dir
+        self.reported_cost_usd = reported_cost_usd
+        self.include_rejection = include_rejection
+        self.fail = fail
+        self.invalid_response = invalid_response
+        self.identity_mismatch = identity_mismatch
+        self.only_abstained = only_abstained
+        self.constructed = 0
+        self.calls: list[str] = []
+        _, _, cases = load_frozen_cases()
+        self.case_by_key = {
+            case.plan.calls[0].idempotency_key: case for case in cases
+        }
+
+    def __call__(self):
+        # The manifest is the durable authorization and identity boundary.  A
+        # socket-capable adapter must never exist before these bytes do.
+        assert (self.output_dir / "manifest.json").is_file()
+        self.constructed += 1
+
+        def run(call: ValidatedGapCall):
+            case = self.case_by_key[call.idempotency_key]
+            for previous_case in self.calls:
+                assert (
+                    self.output_dir
+                    / "case-executions"
+                    / f"{previous_case}.json"
+                ).is_file()
+            self.calls.append(case.spec.case_id)
+            if self.fail:
+                raise ToolAdapterFailure(
+                    "offline injected provider failure",
+                    retryable=False,
+                    failure_type="provider_authentication",
+                    search_cost_usd=None,
+                )
+            if self.invalid_response:
+                return {
+                    "tool": "academic_search",
+                    "idempotency_key": call.idempotency_key,
+                    "outbound_request_count": 1,
+                }
+            return _response(
+                case,
+                call,
+                reported_cost_usd=self.reported_cost_usd,
+                include_rejection=self.include_rejection,
+                only_abstained=self.only_abstained,
+                identity_mismatch=self.identity_mismatch,
+            )
+
+        return run
+
+
+def _run(tmp_path: Path, *, monotonic_clock=None, **factory_options):
+    output = tmp_path / "claim-scope-v3"
+    factory = RecordingFactory(output, **factory_options)
+    artifact = execute_live_study(
+        output_dir=output,
+        soft_stop_usd=0.01,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=factory,
+        monotonic_clock=monotonic_clock,
+    )
+    return output, factory, artifact
+
+
+def test_protocol_dry_run_locks_eight_cases_without_live_authority():
+    result = live.protocol_dry_run()
+
+    assert result["case_count"] == 8
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"V{index:02d}" for index in range(1, 9)
+    ]
+    assert result["implementation_sha256"] == live.EXPECTED_IMPLEMENTATION_SHA256
+    assert result["live_provider_requests_authorized"] is False
+    assert result["real_network_calls_performed"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+
+
+def test_complete_run_reaches_decision_and_artifact_seams(tmp_path):
+    output, factory, artifact = _run(tmp_path)
+
+    assert factory.constructed == 1
+    assert factory.calls == [f"V{index:02d}" for index in range(1, 9)]
+    assert artifact.overall_state == "completed"
+    assert artifact.request_count == 8
+    assert artifact.successful_case_count == 8
+    assert artifact.claim_scope_accepted_candidate_count == 8
+    assert artifact.claim_scope_abstained_candidate_count == 8
+    assert artifact.claim_scope_accepted_case_count == 8
+    assert artifact.review_packet_eligibility == "eligible_for_source_lock"
+    assert artifact.provider_summary.reported_cost_usd == pytest.approx(0.008)
+    assert {path.name for path in (output / "case-executions").glob("*.json")} == {
+        f"V{index:02d}.json" for index in range(1, 9)
+    }
+    assert (output / "artifact-index.json").is_file()
+
+
+def test_request_latency_reaches_journal_csv_and_provider_summary(tmp_path):
+    ticks = iter(float(value) for value in range(16))
+    output, _, artifact = _run(
+        tmp_path,
+        monotonic_clock=lambda: next(ticks),
+    )
+
+    assert artifact.provider_summary.total_latency_ms == pytest.approx(8000.0)
+    assert {case.latency_ms for case in artifact.cases} == {1000.0}
+    first_journal = (
+        output / "case-executions" / "V01.json"
+    ).read_text(encoding="utf-8")
+    assert '"latency_ms": 1000.0' in first_journal
+    with (output / "candidates.csv").open(
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["latency_ms"] for row in rows} == {"1000.0"}
+
+
+def test_every_provider_row_and_decision_reaches_csv_boundary(tmp_path):
+    output, _, _ = _run(tmp_path, include_rejection=True)
+
+    with (output / "candidates.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    with (output / "review.csv").open(encoding="utf-8", newline="") as handle:
+        reviews = list(csv.DictReader(handle))
+
+    assert len(rows) == 24
+    assert len(reviews) == 8
+    actions = [row["claim_scope_action"] for row in rows]
+    assert actions.count("ACCEPT") == 8
+    assert actions.count("ABSTAIN") == 8
+    assert actions.count("NOT_EVALUATED") == 8
+    assert all(
+        row["missing_required_groups"] != "[]"
+        for row in rows
+        if row["claim_scope_action"] == "ABSTAIN"
+    )
+    assert all(
+        row["required_match_provenance"] != "[]"
+        for row in rows
+        if row["claim_scope_action"] in {"ACCEPT", "ABSTAIN"}
+    )
+    assert {row["case_id"] for row in reviews} == {
+        f"V{index:02d}" for index in range(1, 9)
+    }
+    assert all(row["candidate_sha256"] for row in reviews)
+
+
+@pytest.mark.parametrize(
+    ("soft_stop", "acknowledge"),
+    [(0.0, True), (0.0101, True), (0.01, False)],
+)
+def test_invalid_authorization_fails_before_adapter_and_output(
+    tmp_path,
+    soft_stop,
+    acknowledge,
+):
+    output = tmp_path / "forbidden"
+    factory = RecordingFactory(output)
+
+    with pytest.raises(OpenAlexClaimScopeLiveError):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=soft_stop,
+            acknowledge_anonymous_daily_budget=acknowledge,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_configured_key_fails_before_adapter_and_output(tmp_path, monkeypatch):
+    output = tmp_path / "configured-key"
+    factory = RecordingFactory(output)
+    monkeypatch.setenv("OPENALEX_API_KEY", "configured-secret")
+
+    with pytest.raises(OpenAlexClaimScopeLiveError, match="refuses"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_existing_output_fails_before_adapter_construction(tmp_path):
+    output = tmp_path / "existing"
+    output.mkdir()
+    factory = RecordingFactory(output)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+
+
+def test_implementation_hash_drift_fails_before_factory_and_output(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "hash-drift"
+    factory = RecordingFactory(output)
+    monkeypatch.setitem(
+        live.EXPECTED_IMPLEMENTATION_SHA256,
+        "openalex_claim_scope.py",
+        "0" * 64,
+    )
+
+    with pytest.raises(OpenAlexClaimScopeLiveError, match="identity drifted"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_soft_stop_commits_first_case_before_stopping(tmp_path):
+    output, factory, artifact = _run(tmp_path, reported_cost_usd=0.01)
+
+    assert factory.calls == ["V01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "soft_stop"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "case-executions" / "V01.json").is_file()
+    assert not (output / "case-executions" / "V02.json").exists()
+
+
+def test_provider_failure_remains_an_inspectable_partial_result(tmp_path):
+    output, factory, artifact = _run(tmp_path, fail=True)
+
+    assert factory.calls == ["V01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "request_failed"
+    assert artifact.provider_summary.cost_state == "uninspectable"
+    assert artifact.cases[0].failure_type == "provider_authentication"
+    assert (output / "case-executions" / "V01.json").is_file()
+
+
+def test_invalid_response_is_not_reported_as_a_provider_pass(tmp_path):
+    output, factory, artifact = _run(tmp_path, invalid_response=True)
+
+    assert factory.calls == ["V01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.cases[0].failure_type == "adapter_response_invalid"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "case-executions" / "V01.json").is_file()
+
+
+def test_identity_mismatch_preserves_response_but_blocks_evaluation(tmp_path):
+    output, factory, artifact = _run(tmp_path, identity_mismatch=True)
+
+    assert factory.calls == ["V01"]
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.cases[0].response is not None
+    assert artifact.cases[0].evaluations == ()
+    assert artifact.cases[0].failure_type == "adapter_identity_mismatch"
+    with (output / "candidates.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["claim_scope_action"] for row in rows} == {"NOT_EVALUATED"}
+
+
+def test_completed_mechanical_failure_is_not_a_source_value_pass(tmp_path):
+    _, _, artifact = _run(tmp_path, only_abstained=True)
+
+    assert artifact.overall_state == "completed"
+    assert artifact.claim_scope_accepted_case_count == 0
+    assert artifact.review_packet_eligibility == "mechanical_gate_failed"
+    assert artifact.human_review_state == "not_prepared"
+    assert artifact.source_value_state == "not_evaluated"
+
+
+def test_artifacts_expose_no_key_or_unrelated_process_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNRELATED_PROCESS_SECRET", "must-not-reach-artifacts")
+    output, _, _ = _run(tmp_path)
+
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in output.rglob("*")
+        if path.is_file()
+    )
+    assert "must-not-reach-artifacts" not in rendered
+    assert "configured-secret" not in rendered
+    assert '"api_key_used": false' in rendered
+
+
+def test_production_worker_does_not_import_claim_scope_live_components():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
+
+    assert "openalex_claim_scope_live" not in worker
+    assert "openalex_claim_scope_unseen" not in worker
+    assert "openalex_claim_scope_search" not in worker
+    assert "openalex_claim_scope" not in worker


### PR DESCRIPTION
## Why

Claim-scope v3 had a frozen challenge and one-request adapter but no auditable way to execute the authorized study. An ad hoc script would lose implementation lineage, crash journals, and cost/latency accounting.

## What changed

- add a dry-run-by-default, production-disconnected V01-V08 live harness
- lock fixture and eight implementation hashes before output or adapter construction
- persist manifest first and each one-request case journal before the next request
- preserve every provider row, decision, failure, cost, latency, trace, and blank human-review seam
- keep mechanical eligibility distinct from source-value validation

## Verification

- 17 focused zero-network tests
- 1,647 tests + 609 subtests
- 87.43% coverage
- latest Ruff and narrow Pylint green
- manifest-order defect re-injected and caught
- zero OpenAlex requests; production remains disconnected