### PR TITLE
Record claim-scope v3 live evidence and lock source review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1647 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1663 tests (609 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -167,7 +167,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  89 test modules plus conftest, organised by subject
+tests/                  90 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -203,6 +203,8 @@ openalex_claim_scope_unseen.py
                         frozen V01-V08 claim-scope preflight; zero-network only
 openalex_claim_scope_live.py
                         write-once V01-V08 runner; CLI defaults to dry-run
+openalex_claim_scope_review.py
+                        exact-run source lock plus Schema v2 human review
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -339,11 +341,19 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   per-request latency, and emits only ACCEPT rows to a blank review boundary.
   Its 17/17 focused seams pass; moving manifest persistence after adapter
   construction made the request
-  boundary test fail before the correct order was restored. The complete suite
-  now passes 1,647 tests plus 609 subtests at 87.43% statement coverage. No
-  V01-V08 provider request or human review has run, so compatibility,
-  precision, source value and report value remain `not_evaluated`. Do not
-  connect or advertise v3 as completed Tool Calling.
+  boundary test fail before the correct order was restored. A separately
+  authorized run on merged revision `ad70d721` then completed all eight
+  anonymous requests for USD 0.008 of provider-reported usage. Sixty-four
+  provider rows became 13 ACCEPT and 51 ABSTAIN decisions; 7/8 cases retained
+  at least one candidate. The exact manifest, aggregate, artifact index and
+  eight case journals passed mechanical validation. This establishes the
+  frozen harness's provider compatibility and bounded accounting only. A
+  separate source-lock and Schema v2 review boundary now exposes every frozen
+  baseline, profile, source abstract, aboutness signal and exact decision
+  provenance without importing production code. Its 16/16 focused seams pass,
+  including a re-injected valid-JSON byte-drift defect. No eligible human source
+  review has returned, so precision, source value and report value remain
+  `not_evaluated`. Do not connect or advertise v3 as completed Tool Calling.
   Keep `pipeline_worker.py` disconnected from the executor, adapters, live
   runner and review module.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -369,7 +379,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-precision-v2-unseen-live.md`, plus
   `docs/prereg-2026-08-27-openalex-claim-scope-v3.md` and
   `docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md`, plus
-  `docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md`.
+  `docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md`,
+  `docs/results-2026-08-27-openalex-claim-scope-v3-live.md`, and
+  `docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ uninspectable cost; Lens is explicitly uninspectable rather than `$0`. Every
 provider row reaches a candidate or rejection index, and OpenAlex query-string
 credentials are suppressed from complete exception tracebacks. Both a hidden
 retry and missing-row-accounting defect were re-injected and caught. The full
-suite passes **1,647 tests plus 609 subtests** at **87.43% coverage**. No
+suite passes **1,663 tests plus 609 subtests** at **87.43% coverage**. No
 credentialed Phase 4 OpenAlex/Lens run has executed and production still
 imports neither adapter, so
 candidate precision, novel-evidence yield and report benefit remain unobserved.
@@ -575,12 +575,21 @@ the full manifest before constructing an adapter, commits each one-request
 case journal before a later request, and keeps provider, accounting, cost,
 latency and human-review states distinct. Its 17/17 focused seams pass;
 deliberately moving manifest persistence after adapter construction made the
-request-boundary test fail before the correct order was restored. No V01-V08
-request or human review has run, so provider compatibility, precision and
-source value remain `not_evaluated`, and
-production remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)
-and [candidate implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md),
-plus the [live-harness implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md).
+request-boundary test fail before the correct order was restored. A separately
+authorized run on merged revision `ad70d721` then completed all eight anonymous
+requests for USD 0.008 of provider-reported usage. Sixty-four provider rows
+became 13 ACCEPT and 51 ABSTAIN decisions, with at least one candidate retained
+in 7/8 cases. The exact manifest, aggregate, artifact index and eight journals
+passed mechanical validation. This demonstrates bounded provider compatibility
+and accounting, not source truth. A separate 16-test source-lock and Schema v2
+review boundary exposes every frozen baseline, profile, source abstract,
+aboutness signal and exact decision provenance. No eligible human review has
+returned, so precision and source value remain `not_evaluated`, and production
+remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-claim-scope-v3.md),
+[candidate implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md),
+[live-harness implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md),
+[live result](docs/results-2026-08-27-openalex-claim-scope-v3-live.md), and
+[review-boundary implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1593,7 +1602,7 @@ intake 子集 **19/19** 通过，覆盖完整身份、基线漂移、旧包基�
 美元成本和不可检查成本，Lens 不会被误报为 `$0`。每一条供应商返回行必须进入
 候选或拒绝索引，OpenAlex 查询参数中的 key 也不会出现在完整异常 traceback 中。
 项目重新注入了隐藏重试和漏记供应商行两个缺陷，新测试均能准确变红；恢复正确实现
-后，全量 **1,647 项测试与 609 个 subtests** 通过，覆盖率 **87.43%**。目前尚未
+后，全量 **1,663 项测试与 609 个 subtests** 通过，覆盖率 **87.43%**。目前尚未
 发起带凭证的第四阶段 OpenAlex/Lens 运行，生产 worker 也不会导入这两个适配器，因此不能
 宣称候选精度、新证据收益或报告质量改善。详见
 [第四阶段协议](docs/prereg-2026-08-26-evidence-gap-domain-adapters-phase4.md)与
@@ -1660,12 +1669,19 @@ collection/plan/profile/幂等身份，16/16 个聚焦测试通过；临时注�
 与 8 个实现哈希，在构造适配器前写入完整 manifest，并在允许下一次请求前提交当前案例
 的一次请求 journal；供应商失败、记账异常、成本不可检查、逐调用时延和人工未评审会分别记录。
 该 runner 的 17/17 个聚焦接缝测试通过；临时把 manifest 持久化移动到适配器构造之后，
-请求边界测试会准确失败，恢复正确顺序后重新全绿。目前没有发起 V01-V08 供应商请求，
-也没有人工来源真值评审，
-所以兼容性、精度和来源价值仍为 `not_evaluated`，生产路径保持断开。详见
-[v3 协议](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)与
-[候选实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)，以及
-[live harness 实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md)。
+请求边界测试会准确失败，恢复正确顺序后重新全绿。随后，一次针对合并版本
+`ad70d721` 的独立授权运行完成 8 个单次匿名请求，供应商报告用量为 `$0.008`。
+64 条供应商结果被确定性判为 13 条 `ACCEPT` 与 51 条 `ABSTAIN`，7/8 个案例至少保留
+一条候选；manifest、汇总、artifact index 与 8 份案例 journal 的精确字节均通过机械
+校验。这只能证明冻结 harness 的供应商兼容性与有界记账，不能证明来源真实或相关。
+另一套包含 16 个聚焦测试的 source-lock 与 Schema v2 评审边界现已实现，会向评审者
+展示每个冻结基线、profile、来源摘要、aboutness 信号与精确决策依据。目前尚无合格的
+人工来源评审返回，因此精度和来源价值仍为 `not_evaluated`，生产路径保持断开。详见
+[v3 协议](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)、
+[候选实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)、
+[live harness 实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md)、
+[真实运行结果](docs/results-2026-08-27-openalex-claim-scope-v3-live.md)与
+[评审边界实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-27-openalex-claim-scope-v3-live.md
+++ b/docs/results-2026-08-27-openalex-claim-scope-v3-live.md
@@ -1,0 +1,126 @@
+# Result: OpenAlex claim-scope v3 frozen live execution
+
+**Executed:** 2026-08-27
+
+**Revision:** `ad70d72120e86dad5d04f99cce319a61a623508e`
+
+**Protocol:**
+[`prereg-2026-08-27-openalex-claim-scope-v3.md`](prereg-2026-08-27-openalex-claim-scope-v3.md)
+
+## Result in one sentence
+
+The production-disconnected V01-V08 run completed eight anonymous OpenAlex
+requests for USD 0.008 of provider-reported usage and the frozen claim-scope
+gate retained 13 candidates across 7/8 cases, so the mechanical source-lock
+gate passed; source relevance, baseline-relative novelty, wrong-source rate,
+planner precision and report value remain `not_evaluated` until an eligible
+human review is returned.
+
+## Preconditions and authority
+
+The study owner authorized one complete observation with:
+
+- at most eight V01-V08 cases in frozen order;
+- exactly one request per attempted case;
+- a USD 0.01 provider-reported soft stop;
+- no retry, redirect, API key, LLM, supplementary search or recovery;
+- no Planner, report-workflow or production connection.
+
+Before execution:
+
+1. PR #63 was merged as revision `ad70d721...`;
+2. all eight `main` CI jobs passed on Linux and Windows, Python 3.11/3.12,
+   coverage, lint, Chromium smoke and Docker;
+3. Railway deployment `6121001674` reported `success` for the same revision;
+4. `/health/ready` returned HTTP 200 with all four checks `ok`;
+5. `/health` reported zero active runs and zero active paid operations;
+6. the zero-network preflight revalidated all eight collection, plan, profile,
+   idempotency, fixture and implementation identities;
+7. `OPENALEX_API_KEY` was confirmed unset without reading or printing a value;
+8. the write-once output directory did not already exist.
+
+## Observed execution
+
+| Measure | Observation |
+|---|---:|
+| Authorized cases | 8 |
+| Attempted / successful cases | 8 / 8 |
+| Requests | 8 |
+| Retries / redirects | 0 / 0 |
+| Provider rows | 64 |
+| Claim-scope `ACCEPT` | 13 |
+| Claim-scope `ABSTAIN` | 51 |
+| Cases with at least one `ACCEPT` | 7/8 |
+| Provider-reported cost | USD 0.008 |
+| Summed request latency | 13,120.4 ms |
+| Stopped reason | `completed` |
+| Review packet eligibility | `eligible_for_source_lock` |
+| Source value | `not_evaluated` |
+
+Every case made one request and reported USD 0.001. Per-case results were:
+
+| Case | Provider rows | `ACCEPT` | `ABSTAIN` | Latency (ms) |
+|---|---:|---:|---:|---:|
+| V01 | 8 | 2 | 6 | 2,023.9 |
+| V02 | 8 | 1 | 7 | 893.7 |
+| V03 | 8 | 4 | 4 | 1,835.1 |
+| V04 | 8 | 0 | 8 | 1,630.2 |
+| V05 | 8 | 1 | 7 | 1,635.5 |
+| V06 | 8 | 2 | 6 | 1,666.8 |
+| V07 | 8 | 1 | 7 | 1,731.3 |
+| V08 | 8 | 2 | 6 | 1,703.9 |
+
+The frozen mechanical threshold was at least one accepted candidate in 6/8
+cases. The observed 7/8 passes only that threshold. It is not evidence that any
+accepted paper is relevant or novel.
+
+## Write-once evidence identity
+
+The source directory is
+`outputs/2026-08-27-openalex-claim-scope-v3-live-ad70d72/`. It is intentionally
+gitignored because it contains full provider responses. The public result
+records the hashes needed to detect later byte drift:
+
+| File | SHA-256 |
+|---|---|
+| `manifest.json` | `a28e6d2d84d539b256917ee89d0bb58e043b34592bc2e97899a4bb44a8630ede` |
+| `execution.json` | `aea0ded720262bb013df9c244d673acd3398f7efb8738d61d5f89ba3774eb60a` |
+| `candidates.csv` | `391fafd74a1b1ed6b3eb5eb20abd88e32dfea5692d5f9ab251880d38d79b912b` |
+| `review.csv` | `117b6256d3122bd1308f073648abf7e07528c22805d479801ae2bb2206bc2bd6` |
+| `artifact-index.json` | `ac4387fecd94394b20fed5e861af717204053182ff0897e5d9e32ab2b4457c4d` |
+| `case-executions/V01.json` | `002e0714aaad07c2c340d3770223258f73647334c186125fa379e93de5783fbf` |
+| `case-executions/V02.json` | `c89241f3ecb5677f4f26633be624e12ef0a8690be994001e1f608e31c186f296` |
+| `case-executions/V03.json` | `8ffd57429135f14a07a71d16fe813c5a5788d66674d60f1a2042cf92e0fd318c` |
+| `case-executions/V04.json` | `211091ae9ce2fc00cd080c3fc758b884aa10201701c8a53981ba731ba306ecff` |
+| `case-executions/V05.json` | `aa487770203a4dc3eec14feabd8358c73e822682e63e2ecd8e7e8f76e9d633ea` |
+| `case-executions/V06.json` | `3f4ae61ecc4c1e91e91ee97704e522a83263c698277822c770ab820914f2adb7` |
+| `case-executions/V07.json` | `1c7ff909b5a82b9b57f63eeadf01297d5880be4ecf5d77e7db8088f2be5e1e68` |
+| `case-executions/V08.json` | `9239a761e2b1e872e50b79d8d134aba4d3ae02ce09276e1ad0d751950e45142d` |
+
+The four aggregate hashes were independently recomputed after the run and
+matched `artifact-index.json` byte for byte.
+
+## What passed and what did not
+
+Passed:
+
+- anonymous OpenAlex provider compatibility for these eight one-request cases;
+- complete request/result/cost accounting for this run;
+- the pre-registered 6/8 mechanical accepted-case gate;
+- write-once case journals and aggregate artifact integrity;
+- continued production and report-workflow disconnection.
+
+Not yet evaluated:
+
+- whether any of the 13 accepted candidates is directly relevant;
+- whether a relevant candidate adds evidence absent from the frozen baseline;
+- the frozen 5% maximum wrong-source rate;
+- whether at least 6/8 cases contain novel relevant evidence;
+- planner-trigger precision, report improvement, source truth, adoption or ROI.
+
+A provenance-locked Schema v2 packet has now been generated for all 13
+candidates, and its blank preflight correctly reports
+`incomplete / not_evaluated`. The next admissible step is one eligible human
+return using that exact packet. Profiles, queries, cases, labels, thresholds
+and provider responses may not be changed or rerun after this observation.
+

--- a/docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md
+++ b/docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md
@@ -1,0 +1,71 @@
+# Result: claim-scope v3 source-lock and human-review boundary
+
+**Implemented:** 2026-08-27
+
+**Authority:** zero-network implementation and packet preparation only. This
+does not label a source, pass the source-value gate, authorize a planner study,
+or connect Tool Calling to production.
+
+## Why a separate review module exists
+
+The completed v3 run passed its mechanical 6/8 accepted-case gate, but its 13
+accepted rows are still model-free heuristic decisions rather than source
+truth. Reusing the older D01-D04 review module would silently substitute a
+different case set, denominator and candidate identity. The new
+`openalex_claim_scope_review.py` therefore freezes this execution separately
+instead of rewriting an earlier experiment after observation.
+
+## Implemented boundary
+
+The module provides three explicit zero-network operations:
+
+1. `lock` validates and binds all four aggregate files, the artifact index and
+   eight case journals to their exact SHA-256 values and the executed revision;
+2. `prepare` creates a separate Schema v2 packet containing the frozen
+   baseline, claim-scope profiles, provider abstract/metadata, aboutness signals
+   and exact acceptance provenance for all 13 candidates;
+3. `summarize` revalidates the source bytes, source lock, packet manifest,
+   candidate identities, labels and reviewer declaration before calculating
+   any metric.
+
+The live output stays immutable. A reviewer edits only `labels.csv` and
+`reviewer_declaration.csv` in the separate packet. Reordering is allowed;
+changing case id, provider result index, candidate hash, title or URL is not.
+
+The result states remain distinct:
+
+- a blank or partial return is `incomplete / not_evaluated`;
+- substantive generated judgments are
+  `excluded_substantive_ai / not_evaluated`;
+- unattempted or uninspectable sources are
+  `not_inspectable / not_evaluated`;
+- only a complete eligible return can produce `pass` or `fail`.
+
+The frozen pass rule remains unchanged: accepted candidates in at least 6/8
+cases, zero or at most 5% directly irrelevant rows, novel relevant evidence in
+at least 6/8 cases, every source attempted, and no substantive generative-AI
+judgment. A pass still authorizes no production connection.
+
+## Verification
+
+Sixteen focused zero-network tests cover the source lock, all source and
+candidate identities, visible baselines, blank-packet semantics, each value
+gate, substantive-AI exclusion, source-attempt declarations, uninspectable
+sources, mechanical-gate refusal, journal drift, packet baseline drift, label
+identity drift and the production import boundary.
+
+The lock-after-drift defect was then re-injected by temporarily disabling the
+expected-hash comparison. A journal received one whitespace-only byte change,
+so its parsed model remained identical. The seam test failed because no
+exception was raised. Restoring the byte check made the same test pass again.
+This demonstrates that the test protects the content-addressed boundary rather
+than merely detecting invalid JSON.
+
+The real source directory independently validates as 13 candidates, eight
+baseline contexts and 13 joined candidate contexts. The study owner then
+created source lock `479fd2a7...` and packet manifest `b3c62047...` in the
+separate private artifacts repository. Summarizing that exact blank packet
+reported 0/13 complete rows, `incomplete / not_evaluated`, all 13 row ids
+explicitly missing, and no calculated provider metric. No human labels have
+been supplied, so the current source-value state remains `not_evaluated`.
+

--- a/openalex_claim_scope_review.py
+++ b/openalex_claim_scope_review.py
@@ -1,0 +1,1213 @@
+"""Lock and review the frozen OpenAlex claim-scope v3 execution.
+
+The live runner intentionally stops at a mechanical candidate gate.  This
+module binds the exact V01-V08 bytes to a separate owner attestation, exposes
+the frozen baseline and candidate context in a Schema v2 packet, and validates
+returned human labels without opening a socket or invoking a model.  It never
+authorizes production Tool Calling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from evidence_gap_phase4_review import (
+    DECLARATION_FIELDS,
+    ELIGIBLE_AI_USE,
+    VALID_LABEL_PAIRS,
+    Phase4ReviewError as ClaimScopeReviewError,
+    _file_sha256,
+    _read_csv,
+    _read_json_object,
+    _validated_declaration,
+    _write_csv_new,
+    _write_text_new,
+)
+from openalex_claim_scope_live import (
+    EXPECTED_IMPLEMENTATION_SHA256,
+    ClaimScopeCaseExecution,
+    ClaimScopeExecutionArtifact,
+    ClaimScopeManifestArtifact,
+    _AGGREGATE_SOURCE_FILES,
+    _CANDIDATE_COLUMNS,
+    _REVIEW_COLUMNS,
+    _candidate_rows,
+)
+from openalex_claim_scope_unseen import EXPECTED_FIXTURE_SHA256
+
+
+EXPECTED_EXECUTED_REVISION = "ad70d72120e86dad5d04f99cce319a61a623508e"
+EXPECTED_SOURCE_FILE_SHA256 = {
+    "manifest.json": (
+        "a28e6d2d84d539b256917ee89d0bb58e043b34592bc2e97899a4bb44a8630ede"
+    ),
+    "execution.json": (
+        "aea0ded720262bb013df9c244d673acd3398f7efb8738d61d5f89ba3774eb60a"
+    ),
+    "candidates.csv": (
+        "391fafd74a1b1ed6b3eb5eb20abd88e32dfea5692d5f9ab251880d38d79b912b"
+    ),
+    "review.csv": (
+        "117b6256d3122bd1308f073648abf7e07528c22805d479801ae2bb2206bc2bd6"
+    ),
+    "artifact-index.json": (
+        "ac4387fecd94394b20fed5e861af717204053182ff0897e5d9e32ab2b4457c4d"
+    ),
+    "case-executions/V01.json": (
+        "002e0714aaad07c2c340d3770223258f73647334c186125fa379e93de5783fbf"
+    ),
+    "case-executions/V02.json": (
+        "c89241f3ecb5677f4f26633be624e12ef0a8690be994001e1f608e31c186f296"
+    ),
+    "case-executions/V03.json": (
+        "8ffd57429135f14a07a71d16fe813c5a5788d66674d60f1a2042cf92e0fd318c"
+    ),
+    "case-executions/V04.json": (
+        "211091ae9ce2fc00cd080c3fc758b884aa10201701c8a53981ba731ba306ecff"
+    ),
+    "case-executions/V05.json": (
+        "aa487770203a4dc3eec14feabd8358c73e822682e63e2ecd8e7e8f76e9d633ea"
+    ),
+    "case-executions/V06.json": (
+        "3f4ae61ecc4c1e91e91ee97704e522a83263c698277822c770ab820914f2adb7"
+    ),
+    "case-executions/V07.json": (
+        "1c7ff909b5a82b9b57f63eeadf01297d5880be4ecf5d77e7db8088f2be5e1e68"
+    ),
+    "case-executions/V08.json": (
+        "9239a761e2b1e872e50b79d8d134aba4d3ae02ce09276e1ad0d751950e45142d"
+    ),
+}
+CASE_IDS = tuple(f"V{index:02d}" for index in range(1, 9))
+SOURCE_FILES = (
+    *_AGGREGATE_SOURCE_FILES,
+    "artifact-index.json",
+    *(f"case-executions/{case_id}.json" for case_id in CASE_IDS),
+)
+REVIEW_FIELDS = _REVIEW_COLUMNS
+EXPECTED_ACCEPTED_PER_CASE = {
+    "V01": 2,
+    "V02": 1,
+    "V03": 4,
+    "V04": 0,
+    "V05": 1,
+    "V06": 2,
+    "V07": 1,
+    "V08": 2,
+}
+EXPECTED_REVIEW_ROW_COUNT = 13
+ACCEPTED_CASES_MIN = 6
+WRONG_SOURCE_RATE_MAX = 0.05
+NOVEL_RELEVANT_CASES_MIN = 6
+MEASUREMENT_LIMIT = (
+    "This source-locked study measures candidate relevance and baseline-relative "
+    "novelty for one frozen eight-case OpenAlex execution. It does not measure "
+    "planner-trigger precision, provider-wide source truth, report improvement, "
+    "production reliability, adoption, or commercial value."
+)
+
+
+class ClaimScopeSourceLock(BaseModel):
+    """Study-owner attestation over the exact V01-V08 execution bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_claim_scope_v3_source_artifact_lock"] = (
+        "openalex_claim_scope_v3_source_artifact_lock"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    api_key_used: Literal[False] = False
+    authorized_output: Literal[True] = True
+    executed_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    source_file_sha256: dict[str, str]
+    study_owner_id: str = Field(min_length=2, max_length=200)
+    authorized_at: datetime
+    note: str | None = Field(default=None, max_length=1000)
+
+    @model_validator(mode="after")
+    def _validate_frozen_identity(self) -> "ClaimScopeSourceLock":
+        if self.executed_revision != EXPECTED_EXECUTED_REVISION:
+            raise ValueError("source lock executed revision does not match")
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("source lock fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("source lock implementation identities do not match")
+        if self.source_file_sha256 != EXPECTED_SOURCE_FILE_SHA256:
+            raise ValueError("source lock does not identify the frozen v3 run")
+        if self.authorized_at.tzinfo is None:
+            raise ValueError("source lock timestamp must be timezone-aware")
+        return self
+
+
+@dataclass(frozen=True)
+class ClaimScopeReviewCandidate:
+    """One accepted v3 source identity copied into the human packet."""
+
+    case_id: str
+    provider: str
+    provider_result_index: int
+    candidate_sha256: str
+    title: str
+    url: str
+
+    @property
+    def row_id(self) -> str:
+        return (
+            f"{self.case_id}/{self.provider_result_index}/"
+            f"{self.candidate_sha256[:12]}"
+        )
+
+    @property
+    def identity_sha256(self) -> str:
+        payload = {
+            "candidate_sha256": self.candidate_sha256,
+            "case_id": self.case_id,
+            "provider": self.provider,
+            "provider_result_index": self.provider_result_index,
+            "title": self.title,
+            "url": self.url,
+        }
+        rendered = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(rendered).hexdigest()
+
+
+@dataclass(frozen=True)
+class ClaimScopeSourceSnapshot:
+    """Validated source reused unchanged at lock, packet, and result seams."""
+
+    file_hashes: dict[str, str]
+    manifest: ClaimScopeManifestArtifact
+    execution: ClaimScopeExecutionArtifact
+    candidates: tuple[ClaimScopeReviewCandidate, ...]
+    baseline_contexts: tuple[dict[str, Any], ...]
+    candidate_contexts: tuple[dict[str, Any], ...]
+
+
+def _candidate_from_row(row: Mapping[str, str]) -> ClaimScopeReviewCandidate:
+    try:
+        provider_result_index = int(row.get("provider_result_index", "").strip())
+    except ValueError as exc:
+        raise ClaimScopeReviewError(
+            "provider_result_index must be an integer"
+        ) from exc
+    candidate = ClaimScopeReviewCandidate(
+        case_id=row.get("case_id", "").strip(),
+        provider=row.get("provider", "").strip(),
+        provider_result_index=provider_result_index,
+        candidate_sha256=row.get("candidate_sha256", "").strip(),
+        title=row.get("title", "").strip(),
+        url=row.get("url", "").strip(),
+    )
+    if candidate.case_id not in CASE_IDS or candidate.provider != "openalex":
+        raise ClaimScopeReviewError(
+            f"unexpected case/provider identity: {candidate.case_id}/{candidate.provider}"
+        )
+    if not 0 <= candidate.provider_result_index <= 7:
+        raise ClaimScopeReviewError(
+            f"{candidate.case_id}: provider_result_index is outside the frozen page"
+        )
+    if (
+        len(candidate.candidate_sha256) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in candidate.candidate_sha256
+        )
+    ):
+        raise ClaimScopeReviewError(
+            f"{candidate.case_id}: candidate SHA-256 is invalid"
+        )
+    if not candidate.title or not candidate.url.startswith("https://openalex.org/W"):
+        raise ClaimScopeReviewError(
+            f"{candidate.case_id}: accepted source identity is incomplete"
+        )
+    return candidate
+
+
+def _validate_artifact_index(
+    source_dir: Path,
+    file_hashes: Mapping[str, str],
+) -> None:
+    index = _read_json_object(source_dir / "artifact-index.json")
+    expected = {
+        "schema_version": 1,
+        "mode": "openalex_claim_scope_v3_artifact_index",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "source_file_sha256": {
+            name: file_hashes[name] for name in _AGGREGATE_SOURCE_FILES
+        },
+    }
+    if index != expected:
+        raise ClaimScopeReviewError(
+            "artifact index does not match aggregate claim-scope bytes"
+        )
+
+
+def _validate_complete_execution(
+    manifest: ClaimScopeManifestArtifact,
+    execution: ClaimScopeExecutionArtifact,
+) -> None:
+    if execution.overall_state != "completed":
+        raise ClaimScopeReviewError(
+            "only the completed eight-case v3 run may be source-locked"
+        )
+    if (
+        execution.request_count != 8
+        or execution.attempted_case_count != 8
+        or execution.successful_case_count != 8
+    ):
+        raise ClaimScopeReviewError(
+            "claim-scope source execution must contain eight successful requests"
+        )
+    if (
+        execution.provider_summary.stopped_reason != "completed"
+        or execution.provider_summary.cost_state != "known"
+    ):
+        raise ClaimScopeReviewError(
+            "claim-scope provider completion or cost is not inspectable"
+        )
+    if execution.review_packet_eligibility != "eligible_for_source_lock":
+        raise ClaimScopeReviewError(
+            "the frozen mechanical gate did not authorize source locking"
+        )
+    if execution.claim_scope_accepted_case_count < ACCEPTED_CASES_MIN:
+        raise ClaimScopeReviewError(
+            "accepted-case count is below the frozen mechanical gate"
+        )
+    if (
+        manifest.fixture_sha256 != execution.fixture_sha256
+        or manifest.implementation_sha256 != execution.implementation_sha256
+        or manifest.soft_stop_usd != execution.soft_stop_usd
+        or manifest.source_value_gates != execution.source_value_gates
+    ):
+        raise ClaimScopeReviewError(
+            "execution identity does not join the persisted manifest"
+        )
+
+    expected_cases = {
+        case.spec.case_id: (
+            case.collection_sha256,
+            case.plan_sha256,
+            case.profile_sha256,
+            case.validated_plan.calls[0].idempotency_key,
+        )
+        for case in manifest.cases
+    }
+    observed_cases = {
+        case.case_id: (
+            case.collection_sha256,
+            case.plan_sha256,
+            case.profile_sha256,
+            case.idempotency_key,
+        )
+        for case in execution.cases
+    }
+    if observed_cases != expected_cases:
+        raise ClaimScopeReviewError(
+            "case executions do not join the frozen manifest"
+        )
+
+    costs: list[float] = []
+    for case in execution.cases:
+        if case.state != "completed" or case.response is None:
+            raise ClaimScopeReviewError(
+                f"{case.case_id}: case is not a completed provider observation"
+            )
+        usage = case.response.provider_usage
+        if (
+            case.response.outbound_request_count != 1
+            or usage.cost_basis != "reported_usd"
+            or usage.reported_cost_usd is None
+            or case.search_cost_usd is None
+            or usage.reported_cost_usd != case.search_cost_usd
+        ):
+            raise ClaimScopeReviewError(
+                f"{case.case_id}: request or provider accounting is invalid"
+            )
+        observed_rows = len(case.response.candidates) + len(
+            case.response.provider_rejections
+        )
+        if usage.result_count != observed_rows:
+            raise ClaimScopeReviewError(
+                f"{case.case_id}: provider row accounting is incomplete"
+            )
+        costs.append(case.search_cost_usd)
+    reported = execution.provider_summary.reported_cost_usd
+    if reported is None or abs(reported - sum(costs)) > 1e-12:
+        raise ClaimScopeReviewError(
+            "provider summary cost does not equal the eight case journals"
+        )
+
+    accepted_per_case = {
+        case.case_id: sum(
+            item.decision.action == "ACCEPT" for item in case.evaluations
+        )
+        for case in execution.cases
+    }
+    if accepted_per_case != EXPECTED_ACCEPTED_PER_CASE:
+        raise ClaimScopeReviewError(
+            "accepted candidate distribution does not match the frozen execution"
+        )
+    if sum(accepted_per_case.values()) != EXPECTED_REVIEW_ROW_COUNT:
+        raise ClaimScopeReviewError(
+            "accepted candidate denominator does not match the frozen review"
+        )
+
+
+def _validate_case_journals(
+    source_dir: Path,
+    execution: ClaimScopeExecutionArtifact,
+) -> None:
+    journal_dir = source_dir / "case-executions"
+    if not journal_dir.is_dir():
+        raise ClaimScopeReviewError("case-executions journal directory is missing")
+    observed_names = {path.name for path in journal_dir.glob("*.json")}
+    expected_names = {f"{case_id}.json" for case_id in CASE_IDS}
+    if observed_names != expected_names:
+        raise ClaimScopeReviewError(
+            "case journals do not cover V01-V08 exactly"
+        )
+    execution_by_id = {case.case_id: case for case in execution.cases}
+    for case_id in CASE_IDS:
+        journal = ClaimScopeCaseExecution.model_validate(
+            _read_json_object(journal_dir / f"{case_id}.json")
+        )
+        if journal != execution_by_id[case_id]:
+            raise ClaimScopeReviewError(
+                f"{case_id}: case journal does not match aggregate execution"
+            )
+
+
+def _baseline_contexts(
+    manifest: ClaimScopeManifestArtifact,
+) -> tuple[dict[str, Any], ...]:
+    contexts: list[dict[str, Any]] = []
+    for case in manifest.cases:
+        failure_reason = case.source_collection.failed_domains.get("academic")
+        if not failure_reason:
+            raise ClaimScopeReviewError(
+                f"{case.spec.case_id}: baseline academic gap state is missing"
+            )
+        baseline_sources: list[dict[str, str]] = []
+        for domain in ("academic", "patent", "market"):
+            for source in getattr(case.source_collection, f"{domain}_sources"):
+                projected = {
+                    "domain": domain,
+                    "source_id": source.source_id,
+                    "title": source.title,
+                    "url": str(source.url),
+                    "evidence_summary": source.evidence_summary,
+                }
+                if not all(projected.values()):
+                    raise ClaimScopeReviewError(
+                        f"{case.spec.case_id}: baseline source projection is incomplete"
+                    )
+                baseline_sources.append(projected)
+        contexts.append(
+            {
+                "case_id": case.spec.case_id,
+                "provider": "openalex",
+                "tool": "academic_search",
+                "topic": case.spec.topic,
+                "query": case.spec.query,
+                "collection_sha256": case.collection_sha256,
+                "profile_sha256": case.profile_sha256,
+                "gap_subject": "academic",
+                "gap_state": (
+                    f"academic retrieval failed: {failure_reason.strip()}"
+                ),
+                "claim_scope_profile": case.spec.profile.model_dump(mode="json"),
+                "baseline_sources": baseline_sources,
+            }
+        )
+    return tuple(contexts)
+
+
+def _candidate_contexts(
+    execution: ClaimScopeExecutionArtifact,
+) -> tuple[dict[str, Any], ...]:
+    contexts: list[dict[str, Any]] = []
+    for case in execution.cases:
+        for item in case.evaluations:
+            if item.decision.action != "ACCEPT":
+                continue
+            evidence = item.candidate.evidence
+            contexts.append(
+                {
+                    "case_id": case.case_id,
+                    "provider": "openalex",
+                    "provider_result_index": item.provider_result_index,
+                    "candidate_sha256": item.decision.candidate_sha256,
+                    "title": evidence.title,
+                    "url": str(evidence.url),
+                    "publisher": evidence.publisher,
+                    "published_date": (
+                        evidence.published_date.isoformat()
+                        if evidence.published_date is not None
+                        else None
+                    ),
+                    "doi": evidence.doi,
+                    "evidence_summary": evidence.evidence_summary,
+                    "summary_source": evidence.summary_source,
+                    "aboutness": [
+                        signal.model_dump(mode="json")
+                        for signal in item.candidate.aboutness
+                    ],
+                    "claim_scope_decision": item.decision.model_dump(mode="json"),
+                }
+            )
+    return tuple(contexts)
+
+
+def validate_finalized_source(
+    source_dir: Path,
+    *,
+    expected_hashes: Mapping[str, str] | None = None,
+) -> ClaimScopeSourceSnapshot:
+    """Validate every execution and file seam without mutating source evidence."""
+
+    if not source_dir.is_dir():
+        raise ClaimScopeReviewError(f"source directory does not exist: {source_dir}")
+    file_hashes = {name: _file_sha256(source_dir / name) for name in SOURCE_FILES}
+    if expected_hashes is not None:
+        expected = dict(expected_hashes)
+        if set(expected) != set(SOURCE_FILES):
+            raise ClaimScopeReviewError(
+                "expected hashes must identify every v3 source file"
+            )
+        if file_hashes != expected:
+            drift = {
+                name: {"expected": expected[name], "observed": file_hashes[name]}
+                for name in SOURCE_FILES
+                if file_hashes[name] != expected[name]
+            }
+            raise ClaimScopeReviewError(
+                f"source artifact identity drifted after locking: {drift}"
+            )
+    _validate_artifact_index(source_dir, file_hashes)
+
+    manifest = ClaimScopeManifestArtifact.model_validate(
+        _read_json_object(source_dir / "manifest.json")
+    )
+    execution = ClaimScopeExecutionArtifact.model_validate(
+        _read_json_object(source_dir / "execution.json")
+    )
+    _validate_complete_execution(manifest, execution)
+    _validate_case_journals(source_dir, execution)
+
+    candidate_rows = _read_csv(source_dir / "candidates.csv", _CANDIDATE_COLUMNS)
+    review_rows = _read_csv(source_dir / "review.csv", REVIEW_FIELDS)
+    expected_candidates, expected_reviews = _candidate_rows(execution.cases)
+    if candidate_rows != expected_candidates:
+        raise ClaimScopeReviewError(
+            "candidate CSV does not contain every v3 disposition exactly once"
+        )
+    if review_rows != expected_reviews:
+        raise ClaimScopeReviewError(
+            "blank review CSV does not match every v3 ACCEPT exactly"
+        )
+
+    candidates: list[ClaimScopeReviewCandidate] = []
+    seen: set[tuple[str, int, str]] = set()
+    for row in review_rows:
+        if any(row[field].strip() for field in ("relevant", "novel", "review_note")):
+            raise ClaimScopeReviewError("source review.csv is no longer blank")
+        candidate = _candidate_from_row(row)
+        key = (
+            candidate.case_id,
+            candidate.provider_result_index,
+            candidate.candidate_sha256,
+        )
+        if key in seen:
+            raise ClaimScopeReviewError(
+                f"source review rows duplicate {candidate.row_id}"
+            )
+        seen.add(key)
+        candidates.append(candidate)
+    if len(candidates) != EXPECTED_REVIEW_ROW_COUNT:
+        raise ClaimScopeReviewError(
+            "source review denominator does not match the frozen execution"
+        )
+
+    contexts = _candidate_contexts(execution)
+    context_keys = {
+        (
+            item["case_id"],
+            item["provider_result_index"],
+            item["candidate_sha256"],
+        )
+        for item in contexts
+    }
+    candidate_keys = {
+        (item.case_id, item.provider_result_index, item.candidate_sha256)
+        for item in candidates
+    }
+    if context_keys != candidate_keys:
+        raise ClaimScopeReviewError(
+            "review identities do not join accepted execution contexts"
+        )
+    return ClaimScopeSourceSnapshot(
+        file_hashes=file_hashes,
+        manifest=manifest,
+        execution=execution,
+        candidates=tuple(candidates),
+        baseline_contexts=_baseline_contexts(manifest),
+        candidate_contexts=contexts,
+    )
+
+
+def create_source_lock(
+    source_dir: Path,
+    output_path: Path,
+    *,
+    study_owner_id: str,
+    confirm_authorized_output: bool,
+    note: str | None = None,
+    authorized_at: datetime | None = None,
+) -> ClaimScopeSourceLock:
+    """Freeze inspected source bytes separately from the live output directory."""
+
+    if not confirm_authorized_output:
+        raise ClaimScopeReviewError(
+            "source locking requires explicit authorized-output confirmation"
+        )
+    if output_path.exists():
+        raise ClaimScopeReviewError(
+            f"refusing to overwrite source lock: {output_path}"
+        )
+    snapshot = validate_finalized_source(source_dir)
+    lock = ClaimScopeSourceLock(
+        executed_revision=EXPECTED_EXECUTED_REVISION,
+        fixture_sha256=EXPECTED_FIXTURE_SHA256,
+        implementation_sha256=EXPECTED_IMPLEMENTATION_SHA256,
+        source_file_sha256=snapshot.file_hashes,
+        study_owner_id=study_owner_id.strip(),
+        authorized_at=authorized_at or datetime.now(UTC),
+        note=note.strip() if note and note.strip() else None,
+    )
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ClaimScopeReviewError(
+            f"could not create source-lock parent {output_path.parent}: {exc}"
+        ) from exc
+    _write_text_new(
+        output_path,
+        json.dumps(
+            lock.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    return lock
+
+
+def _load_source_lock(path: Path) -> ClaimScopeSourceLock:
+    try:
+        return ClaimScopeSourceLock.model_validate(_read_json_object(path))
+    except ValueError as exc:
+        if isinstance(exc, ClaimScopeReviewError):
+            raise
+        raise ClaimScopeReviewError(f"source lock is invalid: {exc}") from exc
+
+
+def _packet_rows(snapshot: ClaimScopeSourceSnapshot) -> list[dict[str, Any]]:
+    context_by_key = {
+        (
+            item["case_id"],
+            item["provider_result_index"],
+            item["candidate_sha256"],
+        ): item
+        for item in snapshot.candidate_contexts
+    }
+    rows: list[dict[str, Any]] = []
+    for candidate in snapshot.candidates:
+        key = (
+            candidate.case_id,
+            candidate.provider_result_index,
+            candidate.candidate_sha256,
+        )
+        context = context_by_key[key]
+        rows.append(
+            {
+                "case_id": candidate.case_id,
+                "provider": candidate.provider,
+                "provider_result_index": candidate.provider_result_index,
+                "candidate_sha256": candidate.candidate_sha256,
+                "title": candidate.title,
+                "url": candidate.url,
+                "identity_sha256": candidate.identity_sha256,
+                "source_context": {
+                    name: value
+                    for name, value in context.items()
+                    if name
+                    not in {
+                        "case_id",
+                        "provider",
+                        "provider_result_index",
+                        "candidate_sha256",
+                        "title",
+                        "url",
+                    }
+                },
+            }
+        )
+    return rows
+
+
+def _provider_thresholds() -> dict[str, dict[str, int | float]]:
+    return {
+        "openalex": {
+            "accepted_cases_min": ACCEPTED_CASES_MIN,
+            "wrong_source_rate_max": WRONG_SOURCE_RATE_MAX,
+            "novel_relevant_cases_min": NOVEL_RELEVANT_CASES_MIN,
+            "case_count": 8,
+        }
+    }
+
+
+def _packet_readme(snapshot: ClaimScopeSourceSnapshot) -> str:
+    case_rows = "\n".join(
+        (
+            f"| {item['case_id']} | {item['topic']} | {item['query']} | "
+            f"{len(item['baseline_sources'])} |"
+        )
+        for item in snapshot.baseline_contexts
+    )
+    return f"""# OpenAlex claim-scope v3 human source-value review
+
+This packet contains the {len(snapshot.candidates)} candidates accepted by one
+exact, completed, production-disconnected V01-V08 execution. Preparing or
+summarizing it makes zero API or LLM calls.
+
+Do not edit `packet_manifest.json`. Complete only `labels.csv` and
+`reviewer_declaration.csv`. Rows may be reordered, but every identity field
+must remain unchanged. Do not send the separate source-lock file to the
+reviewer.
+
+## Case targets and frozen baselines
+
+| Case | Topic | Declared academic-gap query | Baseline sources |
+|---|---|---|---:|
+{case_rows}
+
+Read each case's full `baseline_contexts` and `claim_scope_profile` in
+`packet_manifest.json` before assigning novelty. Each candidate row also
+contains the OpenAlex abstract, metadata, provider aboutness, and the exact
+claim-scope decision provenance. These are frozen context, not proof that the
+source is correct.
+
+Attempt every candidate URL and inspect the OpenAlex work page plus accessible
+abstract or linked source content. Judge direct relevance to the declared gap,
+not broad topic overlap. Novelty means materially absent from the visible
+frozen baseline, not absent from the wider literature.
+
+## Labels
+
+- `YES/YES`: directly relevant and materially absent from the frozen baseline.
+- `YES/NO`: directly relevant but already represented in the baseline.
+- `NO/N/A`: adjacent, generic, or otherwise not directly relevant.
+- `UNVERIFIABLE/UNVERIFIABLE`: attempted, but insufficient source content was
+  inspectable.
+
+Every row requires a source-grounded `review_note`. Complete
+`reviewer_declaration.csv` after all rows. `NONE` or `LANGUAGE_ONLY`
+generative-AI use is eligible; substantive generated judgments are retained but
+excluded from the human-value result. An unreachable source is
+`UNVERIFIABLE`, never silently converted to a positive or negative judgment.
+
+The frozen gates require accepted candidates in at least six of eight cases, a
+directly irrelevant rate no greater than 5%, novel relevant candidates in at
+least six cases, every source attempted, and no substantive generative-AI
+judgment. Even a pass does not authorize production Tool Calling.
+"""
+
+
+def _packet_manifest(
+    snapshot: ClaimScopeSourceSnapshot,
+    source_lock_path: Path,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "mode": "openalex_claim_scope_v3_value_review_packet",
+        "prepared_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "row_count": len(snapshot.candidates),
+        "mechanical_result": {
+            "accepted_candidate_count": (
+                snapshot.execution.claim_scope_accepted_candidate_count
+            ),
+            "accepted_case_count": snapshot.execution.claim_scope_accepted_case_count,
+            "review_packet_eligibility": (
+                snapshot.execution.review_packet_eligibility
+            ),
+        },
+        "baseline_contexts": list(snapshot.baseline_contexts),
+        "rows": _packet_rows(snapshot),
+        "valid_label_pairs": [list(pair) for pair in sorted(VALID_LABEL_PAIRS)],
+        "provider_thresholds": _provider_thresholds(),
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def prepare_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Create a separate Schema v2 packet from source-locked exact bytes."""
+
+    if packet_dir.exists():
+        raise ClaimScopeReviewError(f"refusing to overwrite packet: {packet_dir}")
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    try:
+        packet_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise ClaimScopeReviewError(
+            f"could not create packet {packet_dir}: {exc}"
+        ) from exc
+    manifest = _packet_manifest(snapshot, source_lock_path)
+    label_rows = [
+        {
+            "case_id": candidate.case_id,
+            "provider": candidate.provider,
+            "provider_result_index": str(candidate.provider_result_index),
+            "candidate_sha256": candidate.candidate_sha256,
+            "title": candidate.title,
+            "url": candidate.url,
+            "relevant": "",
+            "novel": "",
+            "review_note": "",
+        }
+        for candidate in snapshot.candidates
+    ]
+    _write_csv_new(packet_dir / "labels.csv", REVIEW_FIELDS, label_rows)
+    _write_csv_new(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [{}],
+    )
+    _write_text_new(packet_dir / "README.md", _packet_readme(snapshot))
+    _write_text_new(
+        packet_dir / "packet_manifest.json",
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return manifest
+
+
+def _manifest_candidates(
+    manifest: dict[str, Any],
+    snapshot: ClaimScopeSourceSnapshot,
+    source_lock_path: Path,
+) -> dict[tuple[str, int, str], ClaimScopeReviewCandidate]:
+    if manifest.get("schema_version") != 2 or manifest.get("mode") != (
+        "openalex_claim_scope_v3_value_review_packet"
+    ):
+        raise ClaimScopeReviewError("packet manifest has the wrong schema or mode")
+    if (
+        manifest.get("production_connected") is not False
+        or manifest.get("report_workflow_connected") is not False
+    ):
+        raise ClaimScopeReviewError(
+            "packet manifest must remain production-disconnected"
+        )
+    if manifest.get("executed_revision") != EXPECTED_EXECUTED_REVISION:
+        raise ClaimScopeReviewError("packet executed revision drifted")
+    if manifest.get("source_lock_sha256") != _file_sha256(source_lock_path):
+        raise ClaimScopeReviewError("packet source-lock identity drifted")
+    if manifest.get("source_file_sha256") != snapshot.file_hashes:
+        raise ClaimScopeReviewError("packet source-file identities drifted")
+    if manifest.get("baseline_contexts") != list(snapshot.baseline_contexts):
+        raise ClaimScopeReviewError("packet baseline context drifted")
+    if manifest.get("provider_thresholds") != _provider_thresholds():
+        raise ClaimScopeReviewError("packet provider thresholds drifted")
+    if manifest.get("valid_label_pairs") != [
+        list(pair) for pair in sorted(VALID_LABEL_PAIRS)
+    ]:
+        raise ClaimScopeReviewError("packet label contract drifted")
+    if manifest.get("measurement_limit") != MEASUREMENT_LIMIT:
+        raise ClaimScopeReviewError("packet measurement limit drifted")
+    expected_mechanical = {
+        "accepted_candidate_count": (
+            snapshot.execution.claim_scope_accepted_candidate_count
+        ),
+        "accepted_case_count": snapshot.execution.claim_scope_accepted_case_count,
+        "review_packet_eligibility": snapshot.execution.review_packet_eligibility,
+    }
+    if manifest.get("mechanical_result") != expected_mechanical:
+        raise ClaimScopeReviewError("packet mechanical result drifted")
+    try:
+        prepared_at = datetime.fromisoformat(str(manifest["prepared_at"]))
+    except (KeyError, ValueError) as exc:
+        raise ClaimScopeReviewError(
+            "packet prepared_at is not an ISO timestamp"
+        ) from exc
+    if prepared_at.tzinfo is None:
+        raise ClaimScopeReviewError(
+            "packet prepared_at must be timezone-aware"
+        )
+
+    expected_rows = _packet_rows(snapshot)
+    if (
+        manifest.get("row_count") != len(expected_rows)
+        or manifest.get("rows") != expected_rows
+    ):
+        raise ClaimScopeReviewError(
+            "packet rows do not match source-locked candidates and context"
+        )
+    return {
+        (
+            candidate.case_id,
+            candidate.provider_result_index,
+            candidate.candidate_sha256,
+        ): candidate
+        for candidate in snapshot.candidates
+    }
+
+
+def _validated_label(
+    row: dict[str, str],
+    expected: ClaimScopeReviewCandidate,
+) -> dict[str, str] | None:
+    observed = _candidate_from_row(row)
+    if observed != expected:
+        raise ClaimScopeReviewError(
+            f"label identity drifted for {expected.row_id}"
+        )
+    values = [row[field].strip() for field in ("relevant", "novel", "review_note")]
+    if not any(values):
+        return None
+    if not all(values):
+        raise ClaimScopeReviewError(f"{expected.row_id} is partially completed")
+    relevant, novel, note = values
+    relevant = relevant.upper()
+    novel = novel.upper()
+    if (relevant, novel) not in VALID_LABEL_PAIRS:
+        raise ClaimScopeReviewError(
+            f"{expected.row_id} has invalid relevant/novel pair: "
+            f"{relevant}/{novel}"
+        )
+    if len("".join(note.split())) < 12:
+        raise ClaimScopeReviewError(
+            f"{expected.row_id} review_note is too short to ground the judgment"
+        )
+    return {
+        "case_id": expected.case_id,
+        "provider": expected.provider,
+        "provider_result_index": str(expected.provider_result_index),
+        "candidate_sha256": expected.candidate_sha256,
+        "row_id": expected.row_id,
+        "relevant": relevant,
+        "novel": novel,
+        "review_note": note,
+    }
+
+
+def _openalex_metrics(
+    snapshot: ClaimScopeSourceSnapshot,
+    completed: list[dict[str, str]],
+) -> tuple[dict[str, Any], dict[str, str], str]:
+    accepted_case_ids = sorted({item.case_id for item in snapshot.candidates})
+    wrong_source_count = sum(row["relevant"] == "NO" for row in completed)
+    denominator = len(completed)
+    wrong_source_rate = wrong_source_count / denominator if denominator else None
+    novel_case_ids = sorted(
+        {
+            row["case_id"]
+            for row in completed
+            if row["relevant"] == "YES" and row["novel"] == "YES"
+        }
+    )
+    thresholds = {
+        "accepted_cases": (
+            "pass" if len(accepted_case_ids) >= ACCEPTED_CASES_MIN else "fail"
+        ),
+        "wrong_source_rate": (
+            "pass"
+            if wrong_source_rate is not None
+            and wrong_source_rate <= WRONG_SOURCE_RATE_MAX
+            else "fail"
+        ),
+        "novel_relevant_cases": (
+            "pass"
+            if len(novel_case_ids) >= NOVEL_RELEVANT_CASES_MIN
+            else "fail"
+        ),
+    }
+    metrics = {
+        "accepted_candidate_count": len(snapshot.candidates),
+        "accepted_case_ids": accepted_case_ids,
+        "accepted_case_count": len(accepted_case_ids),
+        "wrong_source_count": wrong_source_count,
+        "wrong_source_rate": wrong_source_rate,
+        "novel_relevant_case_ids": novel_case_ids,
+        "novel_relevant_case_count": len(novel_case_ids),
+    }
+    decision = (
+        "pass" if all(value == "pass" for value in thresholds.values()) else "fail"
+    )
+    return metrics, thresholds, decision
+
+
+def summarize_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Validate source, packet, declaration, and all frozen value gates."""
+
+    if not packet_dir.is_dir():
+        raise ClaimScopeReviewError(
+            f"packet directory does not exist: {packet_dir}"
+        )
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    manifest = _read_json_object(packet_dir / "packet_manifest.json")
+    expected_candidates = _manifest_candidates(
+        manifest,
+        snapshot,
+        source_lock_path,
+    )
+
+    label_rows = _read_csv(packet_dir / "labels.csv", REVIEW_FIELDS)
+    observed_keys: list[tuple[str, int, str]] = []
+    for row in label_rows:
+        candidate = _candidate_from_row(row)
+        observed_keys.append(
+            (
+                candidate.case_id,
+                candidate.provider_result_index,
+                candidate.candidate_sha256,
+            )
+        )
+    if len(observed_keys) != len(set(observed_keys)):
+        raise ClaimScopeReviewError("labels contain duplicate candidate identities")
+    if set(observed_keys) != set(expected_candidates):
+        missing = sorted(set(expected_candidates) - set(observed_keys))
+        extra = sorted(set(observed_keys) - set(expected_candidates))
+        raise ClaimScopeReviewError(
+            f"label identities do not match packet; missing={missing}, extra={extra}"
+        )
+
+    completed: dict[tuple[str, int, str], dict[str, str]] = {}
+    incomplete_row_ids: list[str] = []
+    for row in label_rows:
+        candidate = _candidate_from_row(row)
+        key = (
+            candidate.case_id,
+            candidate.provider_result_index,
+            candidate.candidate_sha256,
+        )
+        validated = _validated_label(row, expected_candidates[key])
+        if validated is None:
+            incomplete_row_ids.append(expected_candidates[key].row_id)
+        else:
+            completed[key] = validated
+
+    declaration_rows = _read_csv(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+    )
+    if len(declaration_rows) != 1:
+        raise ClaimScopeReviewError(
+            "reviewer_declaration.csv must contain exactly one row"
+        )
+    declaration = _validated_declaration(declaration_rows[0])
+    ordered_completed = [completed[key] for key in sorted(completed)]
+    uninspectable_row_ids = [
+        row["row_id"]
+        for row in ordered_completed
+        if row["relevant"] == "UNVERIFIABLE"
+    ]
+    method_issues: list[str] = []
+    if declaration is not None:
+        if declaration["reviewed_all"] != "YES":
+            method_issues.append("reviewer_did_not_confirm_all_rows")
+        if declaration["external_sources_checked"] != "ALL_ATTEMPTED":
+            method_issues.append("not_all_external_sources_were_attempted")
+
+    if incomplete_row_ids or declaration is None:
+        protocol_status = "incomplete"
+    elif declaration["generative_ai_use"] not in ELIGIBLE_AI_USE:
+        protocol_status = "excluded_substantive_ai"
+    elif uninspectable_row_ids or method_issues:
+        protocol_status = "not_inspectable"
+    else:
+        protocol_status = "complete"
+
+    metrics: dict[str, Any] | None = None
+    threshold_results = {
+        "accepted_cases": "not_evaluated",
+        "wrong_source_rate": "not_evaluated",
+        "novel_relevant_cases": "not_evaluated",
+    }
+    decision = "not_evaluated"
+    if protocol_status == "complete":
+        metrics, threshold_results, decision = _openalex_metrics(
+            snapshot,
+            ordered_completed,
+        )
+
+    return {
+        "schema_version": 1,
+        "mode": "openalex_claim_scope_v3_value_review_result",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "packet_manifest_sha256": _file_sha256(
+            packet_dir / "packet_manifest.json"
+        ),
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "protocol_status": protocol_status,
+        "baseline_context_exposed_to_reviewer": True,
+        "decision": decision,
+        "row_count": len(expected_candidates),
+        "completed_row_count": len(completed),
+        "incomplete_row_ids": sorted(incomplete_row_ids),
+        "uninspectable_row_ids": sorted(uninspectable_row_ids),
+        "method_issues": method_issues,
+        "reviewer_declaration": declaration,
+        "observed_label_counts": (
+            {
+                "relevant": dict(
+                    sorted(
+                        Counter(
+                            row["relevant"] for row in ordered_completed
+                        ).items()
+                    )
+                ),
+                "novel": dict(
+                    sorted(
+                        Counter(row["novel"] for row in ordered_completed).items()
+                    )
+                ),
+            }
+            if not incomplete_row_ids
+            else None
+        ),
+        "provider_results": {
+            "openalex": {
+                "metrics": metrics,
+                "threshold_results": threshold_results,
+                "decision": decision,
+            }
+        },
+        "provider_thresholds": manifest["provider_thresholds"],
+        "planner_trigger_study_eligible": decision == "pass",
+        "production_connection_authorized": False,
+        "remaining_production_blockers": (
+            ["planner_trigger_precision", "disabled_path_regression", "report_value"]
+            if decision == "pass"
+            else [
+                "claim_scope_v3_source_value",
+                "planner_trigger_precision",
+                "disabled_path_regression",
+                "report_value",
+            ]
+        ),
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def write_summary(path: Path, result: dict[str, Any]) -> None:
+    """Persist one interpretation without replacing returned human evidence."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ClaimScopeReviewError(
+            f"could not create summary parent {path.parent}: {exc}"
+        ) from exc
+    _write_text_new(
+        path,
+        json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    lock = commands.add_parser("lock", help="bind the exact v3 live output")
+    lock.add_argument("source", type=Path)
+    lock.add_argument("output", type=Path)
+    lock.add_argument("--study-owner-id", required=True)
+    lock.add_argument("--confirm-authorized-output", action="store_true")
+    lock.add_argument("--note")
+
+    prepare = commands.add_parser("prepare", help="create a blank Schema v2 packet")
+    prepare.add_argument("source", type=Path)
+    prepare.add_argument("source_lock", type=Path)
+    prepare.add_argument("packet", type=Path)
+
+    summarize = commands.add_parser(
+        "summarize",
+        help="validate returned labels and write one result",
+    )
+    summarize.add_argument("source", type=Path)
+    summarize.add_argument("source_lock", type=Path)
+    summarize.add_argument("packet", type=Path)
+    summarize.add_argument("output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "lock":
+        result = create_source_lock(
+            args.source,
+            args.output,
+            study_owner_id=args.study_owner_id,
+            confirm_authorized_output=args.confirm_authorized_output,
+            note=args.note,
+        )
+    elif args.command == "prepare":
+        result = prepare_packet(args.source, args.source_lock, args.packet)
+    else:
+        result = summarize_packet(args.source, args.source_lock, args.packet)
+        write_summary(args.output, result)
+    print(_stdout_json(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_claim_scope_review.py
+++ b/tests/test_openalex_claim_scope_review.py
@@ -1,0 +1,485 @@
+"""Zero-network source-lock and Schema v2 tests for claim-scope v3."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import openalex_claim_scope_review as claim_review
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate, ToolProviderUsage
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_claim_scope_live import execute_live_study
+from openalex_claim_scope_review import (
+    DECLARATION_FIELDS,
+    REVIEW_FIELDS,
+    ClaimScopeReviewError,
+    create_source_lock,
+    prepare_packet,
+    summarize_packet,
+)
+from openalex_claim_scope_unseen import PreparedClaimScopeCase, load_frozen_cases
+
+
+def _candidate(
+    case: PreparedClaimScopeCase,
+    *,
+    accepted: bool,
+) -> OpenAlexClaimScopeCandidate:
+    """Build one deterministic candidate without importing test-only helpers."""
+
+    required = [
+        group.text_phrases[0] for group in case.spec.profile.required_groups
+    ]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups[
+            : case.spec.profile.minimum_supporting_groups
+        ]
+    ]
+    included_required = required if accepted else []
+    title = (
+        f"{' '.join(included_required)} controlled study"
+        if accepted
+        else "Broad adjacent application review"
+    )
+    summary = (
+        f"{' '.join(included_required + supporting)}. The study reports "
+        f"direct comparative evidence for {case.spec.query}."
+        if accepted
+        else (
+            f"{' '.join(supporting)}. This broad review intentionally omits "
+            "every required concept from the frozen profile."
+        )
+    )
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=title,
+            url=f"https://openalex.org/W{case.spec.case_id[1:]}00000001",
+            publisher="OpenAlex zero-network claim-scope review fixture",
+            evidence_summary=summary,
+            summary_source="abstract",
+            provider_result_index=0,
+        ),
+        aboutness=(),
+    )
+
+
+class ReviewFactory:
+    """Return one accepted or abstained source for each frozen case."""
+
+    def __init__(self, *, accepted: bool = True) -> None:
+        self.accepted = accepted
+        _, _, cases = load_frozen_cases()
+        self.case_by_key = {
+            case.plan.calls[0].idempotency_key: case for case in cases
+        }
+
+    def __call__(self):
+        def run(call: ValidatedGapCall) -> OpenAlexClaimScopeAdapterResponse:
+            case = self.case_by_key[call.idempotency_key]
+            candidate = _candidate(case, accepted=self.accepted)
+            request_id = f"client-openalex-review-{case.spec.case_id.casefold()}"
+            usage = ToolProviderUsage(
+                provider="openalex",
+                request_id=request_id,
+                request_id_source="client_generated",
+                result_count=1,
+                cost_basis="reported_usd",
+                reported_cost_usd=0.001,
+            )
+            return OpenAlexClaimScopeAdapterResponse(
+                idempotency_key=call.idempotency_key,
+                candidates=(candidate,),
+                search_cost_usd=0.001,
+                provider_request_id=request_id,
+                provider_usage=usage,
+            )
+
+        return run
+
+
+def _source(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    accepted: bool = True,
+) -> Path:
+    """Materialize a complete offline execution and bind test-local hashes."""
+
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+    source = tmp_path / "claim-scope-source"
+    execute_live_study(
+        output_dir=source,
+        soft_stop_usd=0.01,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=ReviewFactory(accepted=accepted),
+    )
+    hashes = {
+        name: hashlib.sha256((source / name).read_bytes()).hexdigest()
+        for name in claim_review.SOURCE_FILES
+    }
+    monkeypatch.setattr(claim_review, "EXPECTED_SOURCE_FILE_SHA256", hashes)
+    if accepted:
+        monkeypatch.setattr(
+            claim_review,
+            "EXPECTED_ACCEPTED_PER_CASE",
+            {case_id: 1 for case_id in claim_review.CASE_IDS},
+        )
+        monkeypatch.setattr(claim_review, "EXPECTED_REVIEW_ROW_COUNT", 8)
+    return source
+
+
+def _lock(source: Path, tmp_path: Path) -> Path:
+    source_lock = tmp_path / "private" / "source-lock.json"
+    create_source_lock(
+        source,
+        source_lock,
+        study_owner_id="offline-claim-scope-owner",
+        confirm_authorized_output=True,
+        authorized_at=datetime(2026, 8, 27, 11, 0, tzinfo=UTC),
+    )
+    return source_lock
+
+
+def _write_csv(
+    path: Path,
+    fields: tuple[str, ...],
+    rows: list[dict[str, str]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="raise")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _complete_declaration(
+    packet: Path,
+    *,
+    ai_use: str = "NONE",
+    external_sources_checked: str = "ALL_ATTEMPTED",
+    reviewed_all: str = "YES",
+) -> None:
+    _write_csv(
+        packet / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [
+            {
+                "reviewer_id": "human-reviewer-v3",
+                "reviewed_all": reviewed_all,
+                "generative_ai_use": ai_use,
+                "external_sources_checked": external_sources_checked,
+                "elapsed_minutes": "70",
+                "expertise": "academic evidence synthesis",
+                "completed_date": "2026-08-27",
+                "limitations": (
+                    "Novelty is relative to the visible frozen baseline only."
+                ),
+            }
+        ],
+    )
+
+
+def _complete_labels(
+    packet: Path,
+    *,
+    pairs_by_case: dict[str, tuple[str, str]] | None = None,
+) -> None:
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    for row in rows:
+        relevant, novel = (pairs_by_case or {}).get(
+            row["case_id"],
+            ("YES", "YES"),
+        )
+        row["relevant"] = relevant
+        row["novel"] = novel
+        row["review_note"] = (
+            "The opened source directly addresses the declared academic gap, "
+            "and its contribution was compared with the visible frozen baseline."
+        )
+    _write_csv(packet / "labels.csv", REVIEW_FIELDS, rows)
+
+
+def test_source_lock_and_packet_preserve_every_identity_and_baseline(
+    tmp_path,
+    monkeypatch,
+):
+    """The reviewer sees the exact denominator, source context, and baseline."""
+
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+
+    manifest = prepare_packet(source, source_lock, packet)
+    lock = json.loads(source_lock.read_text(encoding="utf-8"))
+
+    assert manifest["schema_version"] == 2
+    assert manifest["mode"] == "openalex_claim_scope_v3_value_review_packet"
+    assert manifest["executed_revision"] == claim_review.EXPECTED_EXECUTED_REVISION
+    assert manifest["production_connected"] is False
+    assert manifest["report_workflow_connected"] is False
+    assert len(manifest["baseline_contexts"]) == 8
+    assert len(manifest["rows"]) == 8
+    assert all(row["source_context"]["evidence_summary"] for row in manifest["rows"])
+    assert all(
+        context["claim_scope_profile"] for context in manifest["baseline_contexts"]
+    )
+    assert lock["source_file_sha256"] == claim_review.EXPECTED_SOURCE_FILE_SHA256
+    assert set(lock["source_file_sha256"]) == set(claim_review.SOURCE_FILES)
+    assert source_lock.parent != packet
+    assert (packet / "README.md").is_file()
+
+
+def test_blank_packet_is_incomplete_not_a_zero_error_pass(tmp_path, monkeypatch):
+    """No labels must remain visibly unmeasured rather than become zero errors."""
+
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "incomplete"
+    assert result["decision"] == "not_evaluated"
+    assert result["completed_row_count"] == 0
+    assert result["provider_results"]["openalex"]["metrics"] is None
+    assert result["planner_trigger_study_eligible"] is False
+    assert result["production_connection_authorized"] is False
+
+
+def test_complete_human_review_applies_all_frozen_value_gates(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(packet)
+    _complete_declaration(packet)
+
+    result = summarize_packet(source, source_lock, packet)
+    provider = result["provider_results"]["openalex"]
+
+    assert result["protocol_status"] == "complete"
+    assert result["decision"] == "pass"
+    assert provider["metrics"]["accepted_candidate_count"] == 8
+    assert provider["metrics"]["accepted_case_count"] == 8
+    assert provider["metrics"]["wrong_source_rate"] == 0.0
+    assert provider["metrics"]["novel_relevant_case_count"] == 8
+    assert all(
+        value == "pass" for value in provider["threshold_results"].values()
+    )
+    assert result["planner_trigger_study_eligible"] is True
+    assert result["production_connection_authorized"] is False
+
+
+def test_one_wrong_source_fails_the_precision_first_gate(tmp_path, monkeypatch):
+    """One false positive out of eight exceeds the frozen five-percent ceiling."""
+
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(packet, pairs_by_case={"V01": ("NO", "N/A")})
+    _complete_declaration(packet)
+
+    result = summarize_packet(source, source_lock, packet)
+    provider = result["provider_results"]["openalex"]
+
+    assert result["decision"] == "fail"
+    assert provider["metrics"]["wrong_source_count"] == 1
+    assert provider["metrics"]["wrong_source_rate"] == pytest.approx(0.125)
+    assert provider["threshold_results"]["wrong_source_rate"] == "fail"
+
+
+def test_fewer_than_six_novel_cases_fails_without_rewriting_labels(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(
+        packet,
+        pairs_by_case={
+            "V01": ("YES", "NO"),
+            "V02": ("YES", "NO"),
+            "V03": ("YES", "NO"),
+        },
+    )
+    _complete_declaration(packet)
+
+    result = summarize_packet(source, source_lock, packet)
+    provider = result["provider_results"]["openalex"]
+
+    assert result["decision"] == "fail"
+    assert provider["metrics"]["novel_relevant_case_count"] == 5
+    assert provider["threshold_results"]["novel_relevant_cases"] == "fail"
+
+
+def test_substantive_ai_review_is_retained_but_excluded(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(packet)
+    _complete_declaration(packet, ai_use="SOME_SUBSTANTIVE")
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "excluded_substantive_ai"
+    assert result["decision"] == "not_evaluated"
+    assert result["completed_row_count"] == 8
+    assert result["observed_label_counts"] is not None
+    assert result["provider_results"]["openalex"]["metrics"] is None
+
+
+@pytest.mark.parametrize(
+    ("external", "reviewed_all"),
+    [("SOME", "YES"), ("ALL_ATTEMPTED", "NO")],
+)
+def test_method_declaration_failure_is_not_a_pass(
+    tmp_path,
+    monkeypatch,
+    external,
+    reviewed_all,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(packet)
+    _complete_declaration(
+        packet,
+        external_sources_checked=external,
+        reviewed_all=reviewed_all,
+    )
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "not_inspectable"
+    assert result["decision"] == "not_evaluated"
+    assert result["method_issues"]
+
+
+def test_unverifiable_source_keeps_the_result_not_inspectable(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    _complete_labels(
+        packet,
+        pairs_by_case={"V01": ("UNVERIFIABLE", "UNVERIFIABLE")},
+    )
+    _complete_declaration(packet)
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "not_inspectable"
+    assert result["decision"] == "not_evaluated"
+    assert result["uninspectable_row_ids"]
+
+
+def test_source_lock_requires_explicit_owner_confirmation(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+
+    with pytest.raises(ClaimScopeReviewError, match="explicit"):
+        create_source_lock(
+            source,
+            tmp_path / "source-lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=False,
+        )
+
+
+def test_mechanical_failure_cannot_be_source_locked(tmp_path, monkeypatch):
+    """A complete provider run is still ineligible when no case has an ACCEPT."""
+
+    source = _source(tmp_path, monkeypatch, accepted=False)
+
+    with pytest.raises(ClaimScopeReviewError, match="mechanical gate"):
+        create_source_lock(
+            source,
+            tmp_path / "source-lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=True,
+        )
+
+
+def test_source_drift_after_lock_blocks_packet_preparation(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    journal = source / "case-executions" / "V01.json"
+    journal.write_text(
+        journal.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ClaimScopeReviewError, match="identity drifted"):
+        prepare_packet(source, source_lock, tmp_path / "packet")
+
+
+def test_case_journal_drift_blocks_source_lock(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    journal = source / "case-executions" / "V01.json"
+    payload = json.loads(journal.read_text(encoding="utf-8"))
+    payload["latency_ms"] += 1.0
+    journal.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ClaimScopeReviewError, match="journal does not match"):
+        create_source_lock(
+            source,
+            tmp_path / "source-lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=True,
+        )
+
+
+def test_packet_baseline_drift_blocks_summary(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["baseline_contexts"][0]["gap_state"] = "silently changed"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ClaimScopeReviewError, match="baseline context drifted"):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_label_identity_drift_blocks_summary(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    prepare_packet(source, source_lock, packet)
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    rows[0]["candidate_sha256"] = "0" * 64
+    _write_csv(packet / "labels.csv", REVIEW_FIELDS, rows)
+
+    with pytest.raises(ClaimScopeReviewError, match="identities do not match"):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_production_worker_stays_disconnected_from_review_and_live_paths():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
+
+    assert "openalex_claim_scope_review" not in worker
+    assert "openalex_claim_scope_live" not in worker


### PR DESCRIPTION
Records the authorized V01-V08 anonymous OpenAlex observation: 8/8 one-request cases, USD 0.008 provider-reported usage, 64 rows, 13 ACCEPT / 51 ABSTAIN, and 7/8 mechanical coverage. Adds an exact source-lock and Schema v2 review boundary so source truth remains not_evaluated until an eligible human return. The review path remains disconnected from pipeline_worker and production. Verification: 1,663 tests plus 609 subtests, 87.43% coverage, latest Ruff clean, narrow Pylint 10/10, and a re-injected valid-JSON byte-drift defect caught at the source-lock seam.