### PR TITLE
Record the failed claim-scope v3 human value gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,9 +351,17 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   separate source-lock and Schema v2 review boundary now exposes every frozen
   baseline, profile, source abstract, aboutness signal and exact decision
   provenance without importing production code. Its 16/16 focused seams pass,
-  including a re-injected valid-JSON byte-drift defect. No eligible human source
-  review has returned, so precision, source value and report value remain
-  `not_evaluated`. Do not connect or advertise v3 as completed Tool Calling.
+  including a re-injected valid-JSON byte-drift defect. One eligible human
+  source review later completed 13/13 rows, declared no substantive generative
+  AI use, and attempted every source. Twelve candidates were directly relevant
+  and baseline-novel; one V08 row was directly irrelevant because its
+  graphene/cellulose/melamine construction was outside the declared
+  biomass-aerogel scope. Accepted-case and novel-relevant coverage both passed
+  at 7/8, but the 1/13 wrong-source rate was 7.69%, above the frozen 5% maximum.
+  The strict result is therefore `complete / fail`, and planner-trigger study
+  eligibility remains false. The returned date `2026/8/27` was normalized to
+  ISO `2026-08-27` only after preserving the raw declaration privately. Do not
+  tune on or rerun V01-V08, connect v3, or advertise completed Tool Calling.
   Keep `pipeline_worker.py` disconnected from the executor, adapters, live
   runner and review module.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -381,7 +389,8 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md`, plus
   `docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md`,
   `docs/results-2026-08-27-openalex-claim-scope-v3-live.md`, and
-  `docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md`.
+  `docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md`,
+  plus `docs/results-2026-08-27-openalex-claim-scope-v3-review.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -583,13 +583,19 @@ in 7/8 cases. The exact manifest, aggregate, artifact index and eight journals
 passed mechanical validation. This demonstrates bounded provider compatibility
 and accounting, not source truth. A separate 16-test source-lock and Schema v2
 review boundary exposes every frozen baseline, profile, source abstract,
-aboutness signal and exact decision provenance. No eligible human review has
-returned, so precision and source value remain `not_evaluated`, and production
+aboutness signal and exact decision provenance. One eligible human review later
+completed all 13 rows, attempted every source and declared no substantive
+generative-AI use. Twelve candidates were directly relevant and
+baseline-novel; one V08 candidate was outside the declared biomass-aerogel
+scope. Accepted-case and novel-relevant coverage both passed at 7/8, but the
+1/13 wrong-source rate was 7.69%, above the frozen 5% maximum. The strict result
+is `complete / fail`: planner-trigger study eligibility is false and production
 remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-claim-scope-v3.md),
 [candidate implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md),
 [live-harness implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md),
 [live result](docs/results-2026-08-27-openalex-claim-scope-v3-live.md), and
-[review-boundary implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md).
+[review-boundary implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md),
+plus the [human source-value result](docs/results-2026-08-27-openalex-claim-scope-v3-review.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1675,13 +1681,18 @@ collection/plan/profile/幂等身份，16/16 个聚焦测试通过；临时注�
 一条候选；manifest、汇总、artifact index 与 8 份案例 journal 的精确字节均通过机械
 校验。这只能证明冻结 harness 的供应商兼容性与有界记账，不能证明来源真实或相关。
 另一套包含 16 个聚焦测试的 source-lock 与 Schema v2 评审边界现已实现，会向评审者
-展示每个冻结基线、profile、来源摘要、aboutness 信号与精确决策依据。目前尚无合格的
-人工来源评审返回，因此精度和来源价值仍为 `not_evaluated`，生产路径保持断开。详见
+展示每个冻结基线、profile、来源摘要、aboutness 信号与精确决策依据。随后一名合格的
+人工评审者完成 13/13 行、逐条尝试来源并声明没有生成式 AI 代做实质判断：12 条为
+`YES/YES`，1 条 V08 候选因材料实际是石墨烯/纤维素纳米晶/三聚氰胺体系而不属于
+声明的生物质气凝胶范围，标为 `NO/N/A`。候选案例覆盖和基线外相关证据覆盖均为
+7/8，通过冻结 6/8 门槛；但错源率为 1/13，即 7.69%，超过冻结 5% 上限。因此正式
+结论为 `complete / fail`，Planner 触发实验资格仍为 false，生产路径保持断开。详见
 [v3 协议](docs/prereg-2026-08-27-openalex-claim-scope-v3.md)、
 [候选实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-implementation.md)、
 [live harness 实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md)、
 [真实运行结果](docs/results-2026-08-27-openalex-claim-scope-v3-live.md)与
-[评审边界实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md)。
+[评审边界实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md)，以及
+[人工来源价值结果](docs/results-2026-08-27-openalex-claim-scope-v3-review.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-27-openalex-claim-scope-v3-review.md
+++ b/docs/results-2026-08-27-openalex-claim-scope-v3-review.md
@@ -1,0 +1,88 @@
+# Result: claim-scope v3 human source-value review
+
+**Reviewed:** 2026-08-27
+
+**Source execution:** `ad70d72120e86dad5d04f99cce319a61a623508e`
+
+**Decision:** `complete / fail`
+
+**Authority:** one source-locked human review over the 13 candidates from the
+single frozen V01-V08 execution. This result does not authorize production Tool
+Calling or a planner-trigger study.
+
+## Intake
+
+The strict zero-network summarizer revalidated the exact execution manifest,
+four aggregate files, artifact index, eight case journals, source lock, packet
+manifest and every candidate identity before reading labels.
+
+The returned review contained:
+
+- 13/13 completed rows and no missing or uninspectable rows;
+- `reviewed_all=YES`;
+- `generative_ai_use=NONE`;
+- `external_sources_checked=ALL_ATTEMPTED`;
+- 30 minutes of declared review time; and
+- one cross-disciplinary reviewer with no specialist adjudication or
+  independent replication.
+
+The reviewer entered `2026/8/27` for the completion date. Strict intake
+requires ISO `YYYY-MM-DD`, so the private working packet normalizes only that
+field to `2026-08-27` after preserving the returned declaration byte for
+byte. No label, note, identity or method declaration changed.
+
+Summarization made zero provider, search or model calls.
+
+## Frozen gates
+
+| Gate | Observed | Required | Result |
+|---|---:|---:|---|
+| Cases with an accepted candidate | 7/8 | at least 6/8 | pass |
+| Cases with novel relevant evidence | 7/8 | at least 6/8 | pass |
+| Directly irrelevant accepted candidates | 1/13 (7.69%) | at most 5% | **fail** |
+
+Observed labels were 12 `YES/YES` and one `NO/N/A`. The failed row was V08
+provider result 6: the inspected work used a graphene/cellulose-nanocrystal
+coating on a porous melamine-film structure, not the declared
+biomass-derived-aerogel material scope.
+
+The all-gates rule therefore returns:
+
+- `protocol_status=complete`;
+- `decision=fail`;
+- `planner_trigger_study_eligible=false`;
+- `production_connection_authorized=false`; and
+- `production_connected=false`.
+
+## Interpretation
+
+Claim-scope v3 materially improved the earlier anonymous OpenAlex experiment:
+the previous eligible review found 4/9 directly irrelevant candidates, while
+this unseen challenge found 1/13. That comparison is descriptive because the
+case sets differ. It does not relax the pre-registered precision-first gate.
+With only 13 accepted rows, one wrong source already exceeds the 5% ceiling.
+
+This is a useful negative result. The request, accounting, abstention,
+source-lock and human-review seams worked, and relevant baseline-novel evidence
+reached seven cases. The retrieval decision still did not meet the precision
+required before a downstream model may use tool results.
+
+Do not tune on or rerun V01-V08 and describe the revision as an unseen
+validation. Any next candidate must be specified before seeing labels and face
+a new byte-frozen challenge.
+
+## Limits
+
+This study measures candidate relevance and baseline-relative novelty for one
+frozen eight-case OpenAlex execution. It does not measure:
+
+- planner-trigger precision;
+- OpenAlex-wide precision or recall;
+- literature-wide novelty;
+- source-claim truth beyond the reviewer's inspection;
+- report improvement or decision correctness;
+- production reliability, adoption, ROI or commercial value; or
+- inter-rater agreement.
+
+The executor, adapter, live runner and review module remain disconnected from
+`pipeline_worker.py`.


### PR DESCRIPTION
Records the eligible 13-row source-locked review for the frozen V01-V08 OpenAlex run. Twelve candidates were directly relevant and baseline-novel, but one V08 candidate was outside the declared material scope, producing a 7.69 percent wrong-source rate against the pre-registered 5 percent maximum. The result is complete/fail, planner-trigger eligibility remains false, and all production paths remain disconnected. Updates AGENTS.md, both README languages, and adds the formal bounded result document. Verified locally with 1663 tests plus 609 subtests, latest Ruff, and the narrow Pylint gate.