### PR TITLE
Add a role-structured OpenAlex scope-link v4 preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1663 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1678 tests (609 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -152,6 +152,8 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         conjunctive ACCEPT/ABSTAIN source gate; experimental only
   openalex_claim_scope.py
                         provider-assisted source gate; experimental only
+  openalex_scope_link.py
+                        role-structured same-segment gate; experimental only
   tools/evidence_search.py
                         one-request read-only adapter response contract
   tools/anonymous_openalex_search.py
@@ -167,7 +169,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  90 test modules plus conftest, organised by subject
+tests/                  92 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -205,6 +207,8 @@ openalex_claim_scope_live.py
                         write-once V01-V08 runner; CLI defaults to dry-run
 openalex_claim_scope_review.py
                         exact-run source lock plus Schema v2 human review
+openalex_scope_link_unseen.py
+                        frozen W01-W08 scope-link preflight; zero-network only
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -362,8 +366,21 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   eligibility remains false. The returned date `2026/8/27` was normalized to
   ISO `2026-08-27` only after preserving the raw declaration privately. Do not
   tune on or rerun V01-V08, connect v3, or advertise completed Tool Calling.
-  Keep `pipeline_worker.py` disconnected from the executor, adapters, live
-  runner and review module.
+  A separately pre-registered scope-link v4 candidate now addresses that
+  failure class without moving the provider threshold: required technology
+  concepts, source-text-only scope concepts and source-text-only supporting
+  concepts have distinct roles, and at least one exact required/scope pair
+  must occur in the same title or abstract sentence. Provider metadata may
+  still bridge at most one required group but cannot establish scope, support
+  or a relation. The raw-byte-locked W01-W08 preflight expands eight unique
+  collection/plan/profile/idempotency identities with zero sockets. Its 15/15
+  focused seams pass; combining the whole abstract into one relation segment
+  was re-injected and made the cross-sentence test fail before restoration.
+  No W01-W08 provider request or source review has occurred, so provider
+  compatibility, coverage, wrong-source rate and source value are all
+  `not_evaluated`. A live runner is not implemented or authorized. Keep
+  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4
+  candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,
   `docs/errata-2026-08-25-evidence-gap-phase3-fixture-identity.md`,
@@ -390,7 +407,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-claim-scope-v3-live-implementation.md`,
   `docs/results-2026-08-27-openalex-claim-scope-v3-live.md`, and
   `docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md`,
-  plus `docs/results-2026-08-27-openalex-claim-scope-v3-review.md`.
+  plus `docs/results-2026-08-27-openalex-claim-scope-v3-review.md`, and
+  `docs/prereg-2026-08-27-openalex-scope-link-v4.md` plus
+  `docs/results-2026-08-27-openalex-scope-link-v4-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -597,6 +597,22 @@ remains disconnected. See the [v3 protocol](docs/prereg-2026-08-27-openalex-clai
 [review-boundary implementation result](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md),
 plus the [human source-value result](docs/results-2026-08-27-openalex-claim-scope-v3-review.md).
 
+The failed v3 row showed that a generic process/performance match could still
+substitute for a topic-defining material, route or operating context. A
+separately pre-registered **scope-link v4** candidate therefore assigns those
+concepts an independent source-text-only role and requires an exact required
+concept and scope concept in the same title or abstract sentence. Provider
+topics/keywords may bridge at most one required group but cannot establish
+scope, support or the relation itself. The raw-byte-locked W01-W08 preflight
+expands eight distinct collection/plan/profile/idempotency identities with zero
+network calls; 15/15 focused tests pass, including a re-injected whole-abstract
+defect that makes the cross-sentence seam fail. The complete test directory now
+passes **1,678 tests plus 609 subtests**. No W01-W08 provider request has been
+made, no live runner is implemented or authorized, and source value remains
+`not_evaluated`; production is still disconnected. See the
+[v4 protocol](docs/prereg-2026-08-27-openalex-scope-link-v4.md) and
+[zero-network implementation result](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md).
+
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
 zero-network census of **95 historical runs** found only **3 in-scope rows over
@@ -1693,6 +1709,21 @@ collection/plan/profile/幂等身份，16/16 个聚焦测试通过；临时注�
 [真实运行结果](docs/results-2026-08-27-openalex-claim-scope-v3-live.md)与
 [评审边界实现结果](docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md)，以及
 [人工来源价值结果](docs/results-2026-08-27-openalex-claim-scope-v3-review.md)。
+
+v3 的错误条目表明，通用的过程/性能命中仍可能替代
+主题定义中的材料、路线或运行语境。项目因此另行预注册了
+**scope-link v4** 候选：它将这些概念设为独立的“仅来源文本”
+角色，并要求至少一组精确的 required/scope 概念同时出现在同一
+标题或同一摘要句中。供应商 topics/keywords 最多只能补足一个
+required 概念，不能建立 scope、support 或它们的关系。
+原始字节锁定的 W01-W08 预检在零网络下展开 8 组唯一的
+collection/plan/profile/幂等身份，15/15 个聚焦测试通过；临时将整段
+摘要当成一句后，跨句接缝测试会准确失败。当前完整测试目录为
+**1,678 项测试与 609 个 subtests**。W01-W08 尚未请求供应商，
+live runner 未实现也未授权，来源价值仍为 `not_evaluated`，
+生产路径保持断开。详见
+[v4 协议](docs/prereg-2026-08-27-openalex-scope-link-v4.md)与
+[零网络实现结果](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-27-openalex-scope-link-v4.md
+++ b/docs/prereg-2026-08-27-openalex-scope-link-v4.md
@@ -1,0 +1,155 @@
+# Pre-registration: OpenAlex scope-link candidate v4
+
+**Frozen:** 2026-08-27, after the completed claim-scope v3 review but before
+implementing this candidate, calculating any v4 decision, or requesting an
+OpenAlex response for W01-W08.
+
+**Challenge fixture:**
+`tests/fixtures/openalex_scope_link_v4_challenge.json`
+
+**Raw fixture SHA-256:**
+`f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3`
+
+**Production connection authorized:** no
+
+**Live provider requests authorized:** no. Any live execution requires a
+separate authorization naming a merged revision, request cap and soft stop.
+
+## Why another representation is needed
+
+Claim-scope v3 completed one eligible human review over 13 accepted sources.
+Twelve were directly relevant and baseline-novel; one was directly irrelevant.
+The resulting 7.69% wrong-source rate exceeded the frozen 5% maximum even
+though accepted-case and novel-relevant coverage both passed at 7/8.
+
+This is not evidence that the provider-score floor should move. The failed
+source satisfied the two required process/application groups and enough
+optional supporting groups while omitting the topic-defining material scope.
+The representation allowed a generic performance group to substitute for a
+named material, route or operating context. Raising an additive count would
+not express that relationship and would be post-result threshold tuning.
+
+V01-V08 are sealed failure evidence. Their rows and labels may explain the
+failure class, but they may not be replayed to select phrases, thresholds or
+profiles for v4, and they may not be rerun and described as unseen validation.
+The v4 fixture instead freezes eight different topics. A repository search of
+the parent `main` revision found none of the eight exact topic strings before
+the fixture was added.
+
+## Frozen scope-link rule
+
+The candidate is a deterministic, role-structured source gate. It does not use
+an embedding model or an LLM relevance judge: neither has a calibrated
+precision boundary in this project, and either would make the decisive source
+admission less inspectable while adding a paid or heavyweight dependency.
+"Scope link" here means an explicit relation between code-owned concept roles,
+not a claim of general semantic understanding.
+
+Each profile contains three disjoint kinds of concept group:
+
+1. **required groups** describe the central technology and result. Exact title
+   or abstract text may satisfy them; an OpenAlex topic or keyword with score
+   at least `0.55` may bridge at most one;
+2. **scope groups** describe the topic-defining material, route, platform or
+   operating context. They can be satisfied only by exact source text; and
+3. **supporting groups** describe measurements, mechanisms or secondary
+   context. They can be satisfied only by exact source text.
+
+Matching uses Unicode NFKC normalization, case folding and complete token
+sequences. One normalized phrase may not belong to two independent groups.
+Provider metadata cannot satisfy scope or supporting groups.
+
+A candidate is `ACCEPT` only when all of the following hold:
+
+1. every required group matches through text or the bounded provider channel;
+2. at least the profile's frozen number of required groups matches exact text;
+3. no more than the frozen number of required groups is provider-only;
+4. at least the frozen number of scope groups and supporting groups matches
+   exact source text;
+5. at least the frozen number of scope groups is **linked** to an exact
+   required group in the same title or the same abstract sentence; and
+6. the title contains at least the frozen number of exact required-or-scope
+   group anchors.
+
+Otherwise the action is `ABSTAIN` with explicit reasons. There is no `DROP`,
+profile relaxation, model fallback, source-page fetch or second request. Every
+link must expose the field, sentence index, required group, scope group and the
+exact phrases that established it. Candidate identity binds the evidence text
+and all provider aboutness metadata; profile identity binds every phrase and
+threshold.
+
+## Frozen request contract
+
+A future run may reuse the existing production-disconnected OpenAlex response
+contract, but not its v3 decision:
+
+- one anonymous Works request per attempted case;
+- `search=<frozen query>`;
+- `filter=has_abstract:true`;
+- `per-page=8`;
+- selected fields include the evidence fields, `topics` and `keywords`;
+- no API key, redirect, internal retry, enrichment fetch or model call; and
+- every provider row becomes a candidate or an explicit provider rejection,
+  with complete row indices and provider-reported USD accounting.
+
+The v4 preflight must import neither the adapter nor a transport. A later live
+runner must freeze the adapter, method, fixture and runner bytes before output
+reservation or adapter construction.
+
+## Unseen W01-W08 challenge
+
+| ID | Frozen topic |
+|---|---|
+| W01 | Agricultural-waste hard-carbon anodes for sodium-ion grid batteries |
+| W02 | Continuous-flow cell-free enzymatic synthesis of rare HMOs |
+| W03 | Plasma-assisted ammonia cracking with earth-abundant catalysts |
+| W04 | Scaffold-free acoustic bioprinting of vascularized organoids |
+| W05 | Copper-free electrochemical nitrate-to-ammonia conversion in wastewater |
+| W06 | Marine-degradable PHA barrier coatings for paper food packaging |
+| W07 | Event-camera robotic soft-fruit harvesting with tactile grippers |
+| W08 | Bioleaching recovery of rare earths from coal fly ash |
+
+The fixture freezes case order, queries, result limits, all concept roles,
+thresholds, the request contract and value gates. A preflight must produce
+eight distinct collection, plan, profile and idempotency identities while
+opening zero sockets.
+
+## Source-value gates
+
+The thresholds remain unchanged rather than being weakened after v3:
+
+1. at least one accepted candidate in at least 6/8 cases;
+2. at least one relevant and baseline-novel candidate in at least 6/8 cases;
+3. no more than 5% directly irrelevant accepted candidates;
+4. every attempted source reviewed; and
+5. no substantive generative AI producing the human judgments.
+
+A mechanically completed run with fewer than six accepted cases stops before
+human review because no labels can rescue its all-gates result. Missing source
+truth remains `not_evaluated`, never zero error.
+
+## Implementation and falsification requirements
+
+Before any provider request:
+
+- validate the raw fixture hash before JSON parsing or case expansion;
+- fail closed on duplicate roles, duplicate normalized phrases and impossible
+  thresholds;
+- expose exact group and sentence-link provenance after serialization;
+- prove provider-only scope cannot authorize a source;
+- prove concepts in different abstract sentences do not create a false link;
+- assert that all v4 modules remain absent from `pipeline_worker.py`;
+- re-inject a missing-scope-link defect and confirm the seam test turns red;
+- run the complete zero-network suite, latest Ruff and narrow Pylint; and
+- record implementation results without claiming source value.
+
+## Explicit non-claims
+
+Dry-run success would establish only deterministic identities and the intended
+contract. Even a later source-value pass would not establish OpenAlex-wide
+precision or recall, literature-wide novelty, source truth beyond the review,
+planner-trigger precision, report improvement, decision correctness, adoption,
+ROI, latency, an SLO, autonomous tool choice or production Tool Calling.
+
+`pipeline_worker.py` must remain disconnected from the v4 gate, preflight,
+adapter, any future live runner and any review module.

--- a/docs/results-2026-08-27-openalex-scope-link-v4-implementation.md
+++ b/docs/results-2026-08-27-openalex-scope-link-v4-implementation.md
@@ -1,0 +1,104 @@
+# Result: OpenAlex scope-link candidate v4 implementation
+
+**Date:** 2026-08-27
+
+**Protocol:**
+`docs/prereg-2026-08-27-openalex-scope-link-v4.md`
+
+**Frozen fixture:**
+`tests/fixtures/openalex_scope_link_v4_challenge.json`
+
+**Raw fixture SHA-256:**
+`f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3`
+
+**Live provider requests made:** 0
+
+**Provider cost:** USD 0
+
+**Production connection:** false
+
+## Outcome
+
+The role-structured v4 candidate and its zero-network W01-W08 preflight are
+implemented. The preflight expanded eight distinct collection, plan, profile
+and idempotency identities while reporting both
+`real_network_calls_performed=false` and
+`live_provider_requests_authorized=false`.
+
+This is an implementation result, not a source-value result. No OpenAlex row
+has been requested for W01-W08, no candidate has received a relevance or
+novelty label, and the frozen source-value gates remain unmeasured.
+
+## What changed
+
+`src/academic_agent/openalex_scope_link.py` separates each profile into three
+roles:
+
+- required groups for the central technology and result;
+- source-text-only scope groups for the defining material, route, platform or
+  operating context; and
+- source-text-only supporting groups for measurements and secondary context.
+
+A source can be `ACCEPT` only when an exact required concept and an exact scope
+concept occur in the same title or the same abstract sentence. OpenAlex topics
+or keywords with a score of at least `0.55` may bridge at most one required
+group, but they cannot satisfy scope, support or relation evidence. Every
+accepted relation serializes its field, sentence index, group IDs and exact
+phrases. The only negative action is `ABSTAIN`; there is no production drop,
+profile relaxation, model fallback or source-page fetch.
+
+`openalex_scope_link_unseen.py` validates the fixture's raw bytes before JSON
+parsing or case expansion. It then derives deterministic source collections,
+explicit academic gap signals, one-call validated plans, profile hashes and
+idempotency keys without importing an adapter, transport or execution kernel.
+
+## Verification
+
+The focused v4 subset passed **15/15** tests. It covers:
+
+- same-title relation evidence reaching the serialized decision boundary;
+- cross-sentence co-occurrence producing `ABSTAIN` rather than a false link;
+- one bounded provider bridge for a required group;
+- provider metadata being unable to satisfy a scope group;
+- provider-score, missing-scope and impossible-threshold failures;
+- candidate and profile identity sensitivity;
+- raw fixture, case-order, request-contract and role drift; and
+- continued absence from `pipeline_worker.py`.
+
+On a clean detached worktree, the exact project command passed **1,678 tests,
+one skipped test and 609 subtests**. Latest Ruff passed, and the project's
+narrow Pylint configuration reported 10.00/10. The test process used a
+worktree-local `TEMP`/`TMP` directory because this Windows host denies fixture
+creation under its global pytest temp root; no test was ignored or relaxed.
+
+## Defect re-injection
+
+The abstract relation scan was temporarily changed from sentence-level
+segments to one whole-abstract segment. The focused seam then failed because
+`agricultural_waste` was incorrectly reported as linked even though the hard-
+carbon statement and waste statement occurred in different sentences. After
+restoring sentence segmentation, the focused subset returned to 15/15.
+
+This demonstrates that the new test detects the original representation risk;
+it is not merely asserting that a link-shaped field exists.
+
+## Decision
+
+Implementation and zero-network preflight: **pass**.
+
+Source value and production eligibility: **not evaluated**.
+
+W01-W08 may proceed only through a separately authorized live runner that
+locks the merged revision and implementation bytes before any request. The
+unchanged gates remain at least 6/8 accepted cases, at least 6/8 cases with a
+relevant baseline-novel source, no more than 5% directly irrelevant accepted
+sources, complete attempted-source review, and no substantive generative AI
+producing the judgments.
+
+## Non-claims
+
+This result does not establish provider compatibility for v4, source truth,
+precision, recall, novel-evidence yield, planner-trigger precision, report
+improvement, decision correctness, adoption, ROI, latency, an SLO, autonomous
+tool choice or production Tool Calling. The v4 gate and preflight remain
+disconnected from `pipeline_worker.py`.

--- a/openalex_scope_link_unseen.py
+++ b/openalex_scope_link_unseen.py
@@ -1,0 +1,326 @@
+"""Zero-network preflight for the frozen OpenAlex scope-link v4 challenge.
+
+W01-W08 were authored after the claim-scope v3 human review but before any
+provider response for these topics.  This module locks the fixture bytes,
+expands deterministic source collections and one-call plans, and exposes the
+identities a separately authorized live runner would need.  It imports no
+provider adapter or transport, so this preflight cannot spend an OpenAlex
+budget or alter a production report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_scope_link import OpenAlexScopeLinkProfile
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = (
+    _ROOT / "tests/fixtures/openalex_scope_link_v4_challenge.json"
+)
+EXPECTED_FIXTURE_SHA256 = (
+    "f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3"
+)
+_CASE_ORDER = tuple(f"W{index:02d}" for index in range(1, 9))
+_COLLECTED_AT = datetime(2026, 8, 27, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 8, 27)
+
+
+class OpenAlexScopeLinkPreflightError(ValueError):
+    """Raised before case expansion when the frozen challenge drifts."""
+
+
+class ScopeLinkRequestContract(BaseModel):
+    """Provider request shape frozen without constructing a transport."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    result_limit: Literal[8] = 8
+    filter: Literal["has_abstract:true"] = "has_abstract:true"
+    aboutness_fields: tuple[Literal["topics", "keywords"], ...] = (
+        "topics",
+        "keywords",
+    )
+    redirects: Literal[False] = False
+    internal_retries: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_aboutness_order(self) -> "ScopeLinkRequestContract":
+        if self.aboutness_fields != ("topics", "keywords"):
+            raise ValueError("aboutness fields must remain topics then keywords")
+        return self
+
+
+class ScopeLinkDevelopmentObservation(BaseModel):
+    """Closed v3 result; retained as history, never as v4 tuning labels."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_document: Literal[
+        "docs/results-2026-08-27-openalex-claim-scope-v3-review.md"
+    ]
+    reviewed_candidate_count: Literal[13] = 13
+    relevant_candidate_count: Literal[12] = 12
+    wrong_source_count: Literal[1] = 1
+    wrong_source_rate: Literal[0.07692307692307693] = 0.07692307692307693
+    accepted_case_count: Literal[7] = 7
+    novel_relevant_case_count: Literal[7] = 7
+    source_truth_state: Literal["complete_fail"] = "complete_fail"
+    reuse_for_v4_tuning: Literal[False] = False
+
+
+class ScopeLinkSourceValueGates(BaseModel):
+    """Human-review gates that a future live result cannot rewrite."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    accepted_case_count_min: Literal[6] = 6
+    novel_relevant_case_count_min: Literal[6] = 6
+    wrong_source_rate_max: Literal[0.05] = 0.05
+    all_attempted_sources_reviewed: Literal[True] = True
+    substantive_generative_ai_allowed: Literal[False] = False
+
+
+class ScopeLinkCaseSpec(BaseModel):
+    """One unseen query and its role-structured authorization profile."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^W0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    query: str = Field(min_length=20, max_length=500)
+    result_limit: Literal[8] = 8
+    profile: OpenAlexScopeLinkProfile
+
+
+class ScopeLinkChallengeManifest(BaseModel):
+    """Complete byte-frozen v4 preflight input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_scope_link_v4_unseen_challenge"]
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    maximum_live_requests: Literal[8] = 8
+    request_contract: ScopeLinkRequestContract
+    development_observation: ScopeLinkDevelopmentObservation
+    challenge_cases: tuple[ScopeLinkCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+    source_value_gates: ScopeLinkSourceValueGates
+
+    @model_validator(mode="after")
+    def _validate_case_order(self) -> "ScopeLinkChallengeManifest":
+        observed = tuple(case.case_id for case in self.challenge_cases)
+        if observed != _CASE_ORDER:
+            raise ValueError("scope-link cases must remain ordered W01 through W08")
+        if any(
+            case.result_limit != self.request_contract.result_limit
+            for case in self.challenge_cases
+        ):
+            raise ValueError("case result limits drifted from the request contract")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedScopeLinkCase:
+    """Expanded deterministic identity for a later separately locked runner."""
+
+    spec: ScopeLinkCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+    profile_sha256: str
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _seed_source(spec: ScopeLinkCaseSpec) -> EvidenceSource:
+    """Create valid context without pretending a provider result exists."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen scope-link baseline context",
+        url=(
+            "https://doi.org/10.5555/"
+            f"openalex-scope-link-v4.{spec.case_id.casefold()}"
+        ),
+        publisher="Frozen Scope-link v4 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider row and does not satisfy the explicit "
+            "academic retrieval gap used by this disconnected study."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(spec: ScopeLinkCaseSpec) -> PreparedScopeLinkCase:
+    """Expand one recipe without network, clocks, randomness or model calls."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen scope-link v4 retrieval challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexScopeLinkPreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen unseen case authorizes one read-only academic "
+                "request for its explicit evidence gap."
+            ),
+            calls=(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=spec.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=spec.result_limit,
+                ),
+            ),
+        ),
+    )
+    return PreparedScopeLinkCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+        profile_sha256=spec.profile.sha256(),
+    )
+
+
+def load_frozen_cases(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    ScopeLinkChallengeManifest,
+    tuple[PreparedScopeLinkCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding any case."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexScopeLinkPreflightError(
+            "scope-link v4 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = ScopeLinkChallengeManifest.model_validate_json(raw)
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(build_case(spec) for spec in manifest.challenge_cases),
+    )
+
+
+def dry_run(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose complete frozen identities while opening zero sockets."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    return {
+        "mode": "openalex_scope_link_v4_unseen_dry_run",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "real_network_calls_performed": False,
+        "live_provider_requests_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_request_count": manifest.maximum_live_requests,
+        "request_contract": manifest.request_contract.model_dump(mode="json"),
+        "development_observation": manifest.development_observation.model_dump(
+            mode="json"
+        ),
+        "source_value_gates": manifest.source_value_gates.model_dump(mode="json"),
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+                "profile_sha256": case.profile_sha256,
+                "idempotency_key": case.plan.calls[0].idempotency_key,
+                "result_limit": case.plan.calls[0].result_limit,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE_PATH)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(json.dumps(dry_run(args.fixture), ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/openalex_scope_link.py
+++ b/src/academic_agent/openalex_scope_link.py
@@ -1,0 +1,456 @@
+"""Role-structured scope-link gate for disconnected OpenAlex studies.
+
+Claim-scope v3 could accept a paper after its core process and application
+matched together with generic performance evidence while a topic-defining
+material or operating context was absent.  Moving the same numeric threshold
+would not express that defect.  This candidate gives those differentiators an
+independent role and requires source-text evidence that links one to an exact
+core concept inside the same title or abstract sentence.
+
+OpenAlex topics and keywords may still bridge at most one required concept,
+but they can never satisfy a scope group, a supporting group, or a scope link.
+The only negative action is ABSTAIN.  This module is experimental and is not
+imported by the production worker.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from academic_agent.openalex_claim_scope import (
+    OpenAlexClaimScopeCandidate,
+    ProviderAboutnessMatch,
+)
+from academic_agent.openalex_precision import _contains_phrase, _phrase_key, _tokens
+
+
+ScopeLinkAction = Literal["ACCEPT", "ABSTAIN"]
+ScopeLinkRole = Literal["required", "scope", "supporting"]
+ScopeLinkField = Literal["title", "abstract_sentence"]
+ScopeLinkAbstentionReason = Literal[
+    "missing_required_groups",
+    "insufficient_exact_required_groups",
+    "too_many_provider_only_required_groups",
+    "insufficient_scope_groups",
+    "missing_scope_link",
+    "insufficient_supporting_groups",
+    "missing_title_anchor",
+]
+
+_GROUP_ID_PATTERN = r"^[a-z][a-z0-9_]{2,63}$"
+# Sentence splitting is deliberately conservative.  A false split can only
+# remove a link and produce ABSTAIN; joining clauses across punctuation would
+# invent a relationship and is the higher-risk error for a precision gate.
+_SENTENCE_BOUNDARY = re.compile(r"(?:[.!?;]+|\r?\n+)\s*")
+
+
+def _validate_unique_phrases(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(_phrase_key(value) for value in values)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("concept group contains duplicate normalized phrases")
+    return values
+
+
+class ScopeLinkRequiredGroup(BaseModel):
+    """Core concept with exact-text and bounded provider vocabularies."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group_id: str = Field(pattern=_GROUP_ID_PATTERN)
+    text_phrases: tuple[str, ...] = Field(min_length=1, max_length=8)
+    provider_terms: tuple[str, ...] = Field(min_length=1, max_length=8)
+
+    _validate_text = field_validator("text_phrases")(_validate_unique_phrases)
+    _validate_provider = field_validator("provider_terms")(
+        _validate_unique_phrases
+    )
+
+
+class ScopeLinkTextGroup(BaseModel):
+    """Scope or supporting concept that must occur in source text."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group_id: str = Field(pattern=_GROUP_ID_PATTERN)
+    text_phrases: tuple[str, ...] = Field(min_length=1, max_length=8)
+
+    _validate_text = field_validator("text_phrases")(_validate_unique_phrases)
+
+
+class OpenAlexScopeLinkProfile(BaseModel):
+    """Frozen authorization rule for one role-structured academic query."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_groups: tuple[ScopeLinkRequiredGroup, ...] = Field(
+        min_length=2,
+        max_length=4,
+    )
+    scope_groups: tuple[ScopeLinkTextGroup, ...] = Field(
+        min_length=1,
+        max_length=4,
+    )
+    supporting_groups: tuple[ScopeLinkTextGroup, ...] = Field(
+        min_length=2,
+        max_length=8,
+    )
+    minimum_exact_required_groups: int = Field(ge=1, le=4)
+    maximum_provider_only_required_groups: int = Field(ge=0, le=1)
+    minimum_scope_groups: int = Field(ge=1, le=4)
+    minimum_linked_scope_groups: int = Field(ge=1, le=4)
+    minimum_supporting_groups: int = Field(ge=1, le=8)
+    minimum_title_anchor_groups: int = Field(ge=1, le=8)
+    provider_score_floor: float = Field(
+        ge=0.5,
+        le=1.0,
+        allow_inf_nan=False,
+    )
+
+    @model_validator(mode="after")
+    def _validate_independent_roles(self) -> "OpenAlexScopeLinkProfile":
+        groups = (*self.required_groups, *self.scope_groups, *self.supporting_groups)
+        group_ids = tuple(group.group_id for group in groups)
+        if len(group_ids) != len(set(group_ids)):
+            raise ValueError("scope-link concept group IDs must be unique")
+
+        # A single text hit must not count as two independent roles.  This is
+        # especially important at the required/scope boundary: allowing the
+        # same phrase on both sides would manufacture the relation v4 exists
+        # to measure.
+        text_owners: dict[str, str] = {}
+        for group in groups:
+            for phrase in group.text_phrases:
+                key = _phrase_key(phrase)
+                previous = text_owners.get(key)
+                if previous is not None:
+                    raise ValueError(
+                        "normalized text phrase appears in multiple groups: "
+                        f"{key!r} in {previous!r} and {group.group_id!r}"
+                    )
+                text_owners[key] = group.group_id
+
+        provider_owners: dict[str, str] = {}
+        for group in self.required_groups:
+            for term in group.provider_terms:
+                key = _phrase_key(term)
+                previous = provider_owners.get(key)
+                if previous is not None:
+                    raise ValueError(
+                        "normalized provider term appears in multiple required "
+                        f"groups: {key!r} in {previous!r} and {group.group_id!r}"
+                    )
+                provider_owners[key] = group.group_id
+
+        if self.minimum_exact_required_groups > len(self.required_groups):
+            raise ValueError(
+                "minimum_exact_required_groups exceeds the required-group count"
+            )
+        if self.maximum_provider_only_required_groups >= len(
+            self.required_groups
+        ):
+            raise ValueError(
+                "provider-only allowance must leave at least one required text group"
+            )
+        if self.minimum_scope_groups > len(self.scope_groups):
+            raise ValueError("minimum_scope_groups exceeds the scope-group count")
+        if self.minimum_linked_scope_groups > len(self.scope_groups):
+            raise ValueError(
+                "minimum_linked_scope_groups exceeds the scope-group count"
+            )
+        if self.minimum_supporting_groups > len(self.supporting_groups):
+            raise ValueError(
+                "minimum_supporting_groups exceeds the supporting-group count"
+            )
+        if self.minimum_title_anchor_groups > (
+            len(self.required_groups) + len(self.scope_groups)
+        ):
+            raise ValueError(
+                "minimum_title_anchor_groups exceeds required plus scope groups"
+            )
+        return self
+
+    def sha256(self) -> str:
+        """Bind all role assignments, phrases and thresholds."""
+
+        payload = self.model_dump_json(exclude_none=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class ScopeLinkGroupMatch(BaseModel):
+    """Channel-level provenance for one concept role."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    group_id: str
+    role: ScopeLinkRole
+    exact_title_phrases: tuple[str, ...]
+    exact_summary_phrases: tuple[str, ...]
+    provider_aboutness: tuple[ProviderAboutnessMatch, ...]
+
+    @property
+    def exact_text_matched(self) -> bool:
+        return bool(self.exact_title_phrases or self.exact_summary_phrases)
+
+    @property
+    def matched(self) -> bool:
+        return bool(self.exact_text_matched or self.provider_aboutness)
+
+
+class ScopeLinkEvidence(BaseModel):
+    """One inspectable same-segment relation between required and scope roles."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_group_id: str
+    scope_group_id: str
+    field: ScopeLinkField
+    sentence_index: int = Field(ge=0)
+    required_phrases: tuple[str, ...] = Field(min_length=1)
+    scope_phrases: tuple[str, ...] = Field(min_length=1)
+
+
+class OpenAlexScopeLinkDecision(BaseModel):
+    """One label-blind ACCEPT/ABSTAIN decision with relation provenance."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    action: ScopeLinkAction
+    candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    required_matches: tuple[ScopeLinkGroupMatch, ...]
+    scope_matches: tuple[ScopeLinkGroupMatch, ...]
+    supporting_matches: tuple[ScopeLinkGroupMatch, ...]
+    missing_required_groups: tuple[str, ...]
+    exact_required_groups: tuple[str, ...]
+    provider_only_required_groups: tuple[str, ...]
+    exact_scope_groups: tuple[str, ...]
+    linked_scope_groups: tuple[str, ...]
+    title_anchor_groups: tuple[str, ...]
+    link_evidence: tuple[ScopeLinkEvidence, ...]
+    abstention_reasons: tuple[ScopeLinkAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_action_shape(self) -> "OpenAlexScopeLinkDecision":
+        if self.action == "ACCEPT":
+            if self.missing_required_groups or self.abstention_reasons:
+                raise ValueError("ACCEPT cannot carry missing groups or reasons")
+        elif not self.abstention_reasons:
+            raise ValueError("ABSTAIN requires at least one explicit reason")
+        return self
+
+
+def _matching_phrases(
+    field_tokens: tuple[str, ...],
+    phrases: tuple[str, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        phrase
+        for phrase in phrases
+        if _contains_phrase(field_tokens, _tokens(phrase))
+    )
+
+
+def _provider_matches(
+    group: ScopeLinkRequiredGroup,
+    candidate: OpenAlexClaimScopeCandidate,
+    *,
+    provider_score_floor: float,
+) -> tuple[ProviderAboutnessMatch, ...]:
+    matches: list[ProviderAboutnessMatch] = []
+    for signal in candidate.aboutness:
+        if signal.score < provider_score_floor:
+            continue
+        signal_tokens = _tokens(signal.display_name)
+        for term in group.provider_terms:
+            if _contains_phrase(signal_tokens, _tokens(term)):
+                matches.append(
+                    ProviderAboutnessMatch(
+                        kind=signal.kind,
+                        provider_id=signal.provider_id,
+                        display_name=signal.display_name,
+                        score=signal.score,
+                        matched_term=term,
+                    )
+                )
+                break
+    return tuple(matches)
+
+
+def _group_match(
+    group: ScopeLinkRequiredGroup | ScopeLinkTextGroup,
+    role: ScopeLinkRole,
+    candidate: OpenAlexClaimScopeCandidate,
+    *,
+    provider_score_floor: float,
+) -> ScopeLinkGroupMatch:
+    title_tokens = _tokens(candidate.evidence.title)
+    summary_tokens = _tokens(candidate.evidence.evidence_summary)
+    provider_aboutness: tuple[ProviderAboutnessMatch, ...] = ()
+    if isinstance(group, ScopeLinkRequiredGroup):
+        provider_aboutness = _provider_matches(
+            group,
+            candidate,
+            provider_score_floor=provider_score_floor,
+        )
+    return ScopeLinkGroupMatch(
+        group_id=group.group_id,
+        role=role,
+        exact_title_phrases=_matching_phrases(
+            title_tokens,
+            group.text_phrases,
+        ),
+        exact_summary_phrases=_matching_phrases(
+            summary_tokens,
+            group.text_phrases,
+        ),
+        provider_aboutness=provider_aboutness,
+    )
+
+
+def _summary_sentences(value: str) -> tuple[tuple[str, ...], ...]:
+    """Tokenize non-empty abstract sentences in their original order."""
+
+    return tuple(
+        tokens
+        for segment in _SENTENCE_BOUNDARY.split(value)
+        if (tokens := _tokens(segment))
+    )
+
+
+def _link_evidence(
+    candidate: OpenAlexClaimScopeCandidate,
+    profile: OpenAlexScopeLinkProfile,
+) -> tuple[ScopeLinkEvidence, ...]:
+    segments: tuple[tuple[ScopeLinkField, int, tuple[str, ...]], ...] = (
+        ("title", 0, _tokens(candidate.evidence.title)),
+        *tuple(
+            ("abstract_sentence", index, tokens)
+            for index, tokens in enumerate(
+                _summary_sentences(candidate.evidence.evidence_summary)
+            )
+        ),
+    )
+    links: list[ScopeLinkEvidence] = []
+    for field, sentence_index, tokens in segments:
+        required_hits = tuple(
+            (group.group_id, _matching_phrases(tokens, group.text_phrases))
+            for group in profile.required_groups
+        )
+        scope_hits = tuple(
+            (group.group_id, _matching_phrases(tokens, group.text_phrases))
+            for group in profile.scope_groups
+        )
+        for required_group_id, required_phrases in required_hits:
+            if not required_phrases:
+                continue
+            for scope_group_id, scope_phrases in scope_hits:
+                if not scope_phrases:
+                    continue
+                links.append(
+                    ScopeLinkEvidence(
+                        required_group_id=required_group_id,
+                        scope_group_id=scope_group_id,
+                        field=field,
+                        sentence_index=sentence_index,
+                        required_phrases=required_phrases,
+                        scope_phrases=scope_phrases,
+                    )
+                )
+    return tuple(links)
+
+
+def evaluate_openalex_scope_link(
+    candidate: OpenAlexClaimScopeCandidate,
+    profile: OpenAlexScopeLinkProfile,
+) -> OpenAlexScopeLinkDecision:
+    """Apply the frozen role and same-segment contract without a label."""
+
+    required = tuple(
+        _group_match(
+            group,
+            "required",
+            candidate,
+            provider_score_floor=profile.provider_score_floor,
+        )
+        for group in profile.required_groups
+    )
+    scope = tuple(
+        _group_match(
+            group,
+            "scope",
+            candidate,
+            provider_score_floor=profile.provider_score_floor,
+        )
+        for group in profile.scope_groups
+    )
+    supporting = tuple(
+        _group_match(
+            group,
+            "supporting",
+            candidate,
+            provider_score_floor=profile.provider_score_floor,
+        )
+        for group in profile.supporting_groups
+    )
+    links = _link_evidence(candidate, profile)
+
+    missing_required = tuple(item.group_id for item in required if not item.matched)
+    exact_required = tuple(
+        item.group_id for item in required if item.exact_text_matched
+    )
+    provider_only_required = tuple(
+        item.group_id
+        for item in required
+        if item.provider_aboutness and not item.exact_text_matched
+    )
+    exact_scope = tuple(item.group_id for item in scope if item.exact_text_matched)
+    linked_scope = tuple(
+        item.group_id
+        for item in scope
+        if any(link.scope_group_id == item.group_id for link in links)
+    )
+    title_anchors = tuple(
+        item.group_id
+        for item in (*required, *scope)
+        if item.exact_title_phrases
+    )
+    matched_supporting_count = sum(
+        item.exact_text_matched for item in supporting
+    )
+
+    reasons: list[ScopeLinkAbstentionReason] = []
+    if missing_required:
+        reasons.append("missing_required_groups")
+    if len(exact_required) < profile.minimum_exact_required_groups:
+        reasons.append("insufficient_exact_required_groups")
+    if len(provider_only_required) > profile.maximum_provider_only_required_groups:
+        reasons.append("too_many_provider_only_required_groups")
+    if len(exact_scope) < profile.minimum_scope_groups:
+        reasons.append("insufficient_scope_groups")
+    if len(linked_scope) < profile.minimum_linked_scope_groups:
+        reasons.append("missing_scope_link")
+    if matched_supporting_count < profile.minimum_supporting_groups:
+        reasons.append("insufficient_supporting_groups")
+    if len(title_anchors) < profile.minimum_title_anchor_groups:
+        reasons.append("missing_title_anchor")
+
+    return OpenAlexScopeLinkDecision(
+        action="ABSTAIN" if reasons else "ACCEPT",
+        candidate_sha256=candidate.sha256(),
+        profile_sha256=profile.sha256(),
+        required_matches=required,
+        scope_matches=scope,
+        supporting_matches=supporting,
+        missing_required_groups=missing_required,
+        exact_required_groups=exact_required,
+        provider_only_required_groups=provider_only_required,
+        exact_scope_groups=exact_scope,
+        linked_scope_groups=linked_scope,
+        title_anchor_groups=title_anchors,
+        link_evidence=links,
+        abstention_reasons=tuple(reasons),
+    )

--- a/tests/fixtures/openalex_scope_link_v4_challenge.json
+++ b/tests/fixtures/openalex_scope_link_v4_challenge.json
@@ -1,0 +1,434 @@
+{
+  "schema_version": 1,
+  "mode": "openalex_scope_link_v4_unseen_challenge",
+  "production_connected": false,
+  "report_workflow_connected": false,
+  "maximum_live_requests": 8,
+  "request_contract": {
+    "result_limit": 8,
+    "filter": "has_abstract:true",
+    "aboutness_fields": ["topics", "keywords"],
+    "redirects": false,
+    "internal_retries": false
+  },
+  "development_observation": {
+    "source_document": "docs/results-2026-08-27-openalex-claim-scope-v3-review.md",
+    "reviewed_candidate_count": 13,
+    "relevant_candidate_count": 12,
+    "wrong_source_count": 1,
+    "wrong_source_rate": 0.07692307692307693,
+    "accepted_case_count": 7,
+    "novel_relevant_case_count": 7,
+    "source_truth_state": "complete_fail",
+    "reuse_for_v4_tuning": false
+  },
+  "challenge_cases": [
+    {
+      "case_id": "W01",
+      "topic": "Sodium-ion batteries using agricultural-waste hard-carbon anodes for stationary grid storage",
+      "query": "sodium ion battery hard carbon agricultural waste anode grid storage cycling capacity",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "sodium_ion_battery",
+            "text_phrases": ["sodium ion battery", "sodium ion batteries"],
+            "provider_terms": ["sodium ion batteries", "sodium battery"]
+          },
+          {
+            "group_id": "hard_carbon_anode",
+            "text_phrases": ["hard carbon anode", "hard carbon anodes"],
+            "provider_terms": ["hard carbon anodes", "hard carbon"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "agricultural_waste",
+            "text_phrases": ["agricultural waste", "crop residue", "rice husk", "corn cob", "waste biomass"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "electrochemical_performance",
+            "text_phrases": ["specific capacity", "cycling stability", "coulombic efficiency", "cycle life"]
+          },
+          {
+            "group_id": "carbon_structure",
+            "text_phrases": ["porous carbon", "carbonization temperature", "pore structure", "graphitic structure"]
+          },
+          {
+            "group_id": "stationary_storage",
+            "text_phrases": ["stationary storage", "grid storage", "energy storage system"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W02",
+      "topic": "Continuous-flow enzymatic synthesis of rare human-milk oligosaccharides using cell-free multi-enzyme cascades",
+      "query": "continuous flow enzymatic synthesis human milk oligosaccharide cell free enzyme cascade",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "human_milk_oligosaccharide",
+            "text_phrases": ["human milk oligosaccharide", "human milk oligosaccharides", "hmo"],
+            "provider_terms": ["human milk oligosaccharides", "milk oligosaccharides"]
+          },
+          {
+            "group_id": "enzymatic_synthesis",
+            "text_phrases": ["enzymatic synthesis", "biocatalytic synthesis", "enzyme catalyzed synthesis"],
+            "provider_terms": ["enzymatic synthesis", "biocatalysis"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "continuous_flow",
+            "text_phrases": ["continuous flow", "flow reactor", "flow biocatalysis"]
+          },
+          {
+            "group_id": "cell_free_cascade",
+            "text_phrases": ["cell free", "multi enzyme cascade", "enzyme cascade"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "rare_product",
+            "text_phrases": ["fucosylated oligosaccharide", "sialylated oligosaccharide", "rare oligosaccharide"]
+          },
+          {
+            "group_id": "process_performance",
+            "text_phrases": ["space time yield", "productivity", "conversion yield", "residence time"]
+          },
+          {
+            "group_id": "enzyme_immobilization",
+            "text_phrases": ["immobilized enzyme", "enzyme immobilization"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W03",
+      "topic": "Low-temperature plasma-assisted ammonia cracking for hydrogen release using earth-abundant catalysts",
+      "query": "plasma assisted ammonia cracking hydrogen earth abundant catalyst low temperature",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "ammonia_cracking",
+            "text_phrases": ["ammonia cracking", "ammonia decomposition"],
+            "provider_terms": ["ammonia decomposition", "ammonia cracking"]
+          },
+          {
+            "group_id": "hydrogen_release",
+            "text_phrases": ["hydrogen release", "hydrogen production", "hydrogen generation"],
+            "provider_terms": ["hydrogen production", "hydrogen generation"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "plasma_assistance",
+            "text_phrases": ["plasma assisted", "non thermal plasma", "plasma catalysis", "plasma driven"]
+          },
+          {
+            "group_id": "earth_abundant_catalyst",
+            "text_phrases": ["earth abundant catalyst", "non noble catalyst", "base metal catalyst", "iron catalyst", "nickel catalyst"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "low_temperature",
+            "text_phrases": ["low temperature", "mild temperature", "room temperature"]
+          },
+          {
+            "group_id": "conversion_performance",
+            "text_phrases": ["ammonia conversion", "hydrogen yield", "energy efficiency"]
+          },
+          {
+            "group_id": "catalyst_stability",
+            "text_phrases": ["catalyst stability", "long term stability", "cycling stability"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W04",
+      "topic": "Scaffold-free acoustic bioprinting of vascularized organoids using multicellular spheroids",
+      "query": "acoustic bioprinting vascularized organoid scaffold free multicellular spheroid",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "acoustic_bioprinting",
+            "text_phrases": ["acoustic bioprinting", "acoustic printing", "acoustic assembly"],
+            "provider_terms": ["acoustic bioprinting", "acoustic manipulation"]
+          },
+          {
+            "group_id": "vascular_organoid",
+            "text_phrases": ["vascularized organoid", "vascular organoid", "organoid vascularization", "vascularized tissue"],
+            "provider_terms": ["organoid vascularization", "vascularized organoids"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "scaffold_free",
+            "text_phrases": ["scaffold free", "without scaffold", "scaffoldless"]
+          },
+          {
+            "group_id": "cell_spheroid",
+            "text_phrases": ["cell spheroid", "cell spheroids", "multicellular spheroid"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "cell_viability",
+            "text_phrases": ["cell viability", "viability", "cell survival"]
+          },
+          {
+            "group_id": "vascular_perfusion",
+            "text_phrases": ["perfusion", "microvasculature", "vascular network"]
+          },
+          {
+            "group_id": "spatial_positioning",
+            "text_phrases": ["cell positioning", "spatial patterning", "droplet placement"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W05",
+      "topic": "Electrochemical nitrate reduction to ammonia in wastewater using copper-free catalysts",
+      "query": "electrochemical nitrate reduction ammonia wastewater copper free catalyst",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "nitrate_reduction",
+            "text_phrases": ["nitrate reduction", "electrochemical nitrate reduction", "nitrate electroreduction"],
+            "provider_terms": ["nitrate reduction", "electrocatalytic nitrate reduction"]
+          },
+          {
+            "group_id": "ammonia_product",
+            "text_phrases": ["ammonia production", "ammonia synthesis", "nh3 production"],
+            "provider_terms": ["ammonia production", "electrochemical ammonia synthesis"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "wastewater_context",
+            "text_phrases": ["wastewater", "waste water", "nitrate contaminated water", "sewage"]
+          },
+          {
+            "group_id": "copper_free_catalyst",
+            "text_phrases": ["copper free catalyst", "non copper catalyst", "copper-free electrocatalyst"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "product_selectivity",
+            "text_phrases": ["faradaic efficiency", "ammonia selectivity", "nh3 selectivity"]
+          },
+          {
+            "group_id": "production_rate",
+            "text_phrases": ["current density", "production rate", "yield rate"]
+          },
+          {
+            "group_id": "electrolysis_durability",
+            "text_phrases": ["stability test", "long term electrolysis", "durability"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W06",
+      "topic": "Marine-degradable polyhydroxyalkanoate barrier coatings for paper-based food packaging",
+      "query": "polyhydroxyalkanoate barrier coating paper food packaging marine biodegradable",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "pha_material",
+            "text_phrases": ["polyhydroxyalkanoate", "polyhydroxyalkanoates", "pha biopolymer"],
+            "provider_terms": ["polyhydroxyalkanoates", "biopolymer"]
+          },
+          {
+            "group_id": "barrier_coating",
+            "text_phrases": ["barrier coating", "coated paper", "paper coating"],
+            "provider_terms": ["barrier coatings", "paper coating"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "marine_degradation",
+            "text_phrases": ["marine biodegradable", "marine degradation", "seawater biodegradation", "ocean degradable"]
+          },
+          {
+            "group_id": "paper_food_packaging",
+            "text_phrases": ["paper food packaging", "food packaging paper", "paperboard packaging"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "moisture_barrier",
+            "text_phrases": ["water vapor barrier", "moisture barrier", "water resistance"]
+          },
+          {
+            "group_id": "oxygen_barrier",
+            "text_phrases": ["oxygen barrier", "gas barrier", "oxygen permeability"]
+          },
+          {
+            "group_id": "food_safety",
+            "text_phrases": ["food contact", "migration test", "compostability"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W07",
+      "topic": "Event-camera-guided robotic harvesting of soft fruit with tactile grippers",
+      "query": "event camera robotic harvesting soft fruit tactile gripper damage",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "robotic_harvesting",
+            "text_phrases": ["robotic harvesting", "robot harvest", "harvesting robot", "fruit picking robot"],
+            "provider_terms": ["robotic harvesting", "agricultural robots"]
+          },
+          {
+            "group_id": "soft_fruit",
+            "text_phrases": ["soft fruit", "strawberry", "raspberry", "tomato harvesting"],
+            "provider_terms": ["soft fruit harvesting", "fruit harvesting"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "event_camera",
+            "text_phrases": ["event camera", "event based vision", "neuromorphic vision"]
+          },
+          {
+            "group_id": "tactile_gripper",
+            "text_phrases": ["tactile gripper", "tactile sensing", "force sensing gripper", "soft gripper"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "fruit_damage",
+            "text_phrases": ["fruit damage", "bruise", "grasp damage", "damage rate"]
+          },
+          {
+            "group_id": "target_localization",
+            "text_phrases": ["fruit detection", "pose estimation", "target localization"]
+          },
+          {
+            "group_id": "field_performance",
+            "text_phrases": ["field trial", "orchard", "greenhouse", "harvest success rate"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    },
+    {
+      "case_id": "W08",
+      "topic": "Bioleaching-based selective recovery of rare-earth elements from coal fly ash",
+      "query": "bioleaching rare earth recovery coal fly ash selective extraction",
+      "result_limit": 8,
+      "profile": {
+        "required_groups": [
+          {
+            "group_id": "rare_earth_recovery",
+            "text_phrases": ["rare earth recovery", "rare earth element recovery", "recover rare earth", "rare earth extraction"],
+            "provider_terms": ["rare earth element recovery", "rare earth extraction"]
+          },
+          {
+            "group_id": "coal_fly_ash",
+            "text_phrases": ["coal fly ash", "fly ash", "coal ash"],
+            "provider_terms": ["coal fly ash", "fly ash"]
+          }
+        ],
+        "scope_groups": [
+          {
+            "group_id": "bioleaching_route",
+            "text_phrases": ["bioleaching", "microbial leaching", "biological leaching"]
+          }
+        ],
+        "supporting_groups": [
+          {
+            "group_id": "microorganism",
+            "text_phrases": ["acidithiobacillus", "fungal leaching", "bacteria", "microorganism"]
+          },
+          {
+            "group_id": "selective_extraction",
+            "text_phrases": ["selective recovery", "leaching efficiency", "extraction yield"]
+          },
+          {
+            "group_id": "downstream_separation",
+            "text_phrases": ["solvent extraction", "precipitation", "ion exchange"]
+          }
+        ],
+        "minimum_exact_required_groups": 1,
+        "maximum_provider_only_required_groups": 1,
+        "minimum_scope_groups": 1,
+        "minimum_linked_scope_groups": 1,
+        "minimum_supporting_groups": 1,
+        "minimum_title_anchor_groups": 1,
+        "provider_score_floor": 0.55
+      }
+    }
+  ],
+  "source_value_gates": {
+    "accepted_case_count_min": 6,
+    "novel_relevant_case_count_min": 6,
+    "wrong_source_rate_max": 0.05,
+    "all_attempted_sources_reviewed": true,
+    "substantive_generative_ai_allowed": false
+  }
+}

--- a/tests/test_openalex_scope_link.py
+++ b/tests/test_openalex_scope_link.py
@@ -1,0 +1,275 @@
+"""Zero-network tests for the role-structured OpenAlex scope-link gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from academic_agent.openalex_claim_scope import (
+    OpenAlexAboutnessSignal,
+    OpenAlexClaimScopeCandidate,
+)
+from academic_agent.openalex_scope_link import (
+    OpenAlexScopeLinkProfile,
+    evaluate_openalex_scope_link,
+)
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _profile() -> OpenAlexScopeLinkProfile:
+    return OpenAlexScopeLinkProfile.model_validate(
+        {
+            "required_groups": [
+                {
+                    "group_id": "sodium_ion_battery",
+                    "text_phrases": [
+                        "sodium ion battery",
+                        "sodium ion batteries",
+                    ],
+                    "provider_terms": [
+                        "sodium ion batteries",
+                        "sodium battery",
+                    ],
+                },
+                {
+                    "group_id": "hard_carbon_anode",
+                    "text_phrases": [
+                        "hard carbon anode",
+                        "hard carbon anodes",
+                    ],
+                    "provider_terms": ["hard carbon anodes", "hard carbon"],
+                },
+            ],
+            "scope_groups": [
+                {
+                    "group_id": "agricultural_waste",
+                    "text_phrases": [
+                        "agricultural waste",
+                        "crop residue",
+                        "rice husk",
+                    ],
+                }
+            ],
+            "supporting_groups": [
+                {
+                    "group_id": "electrochemical_performance",
+                    "text_phrases": [
+                        "specific capacity",
+                        "cycling stability",
+                    ],
+                },
+                {
+                    "group_id": "stationary_storage",
+                    "text_phrases": ["stationary storage", "grid storage"],
+                },
+            ],
+            "minimum_exact_required_groups": 1,
+            "maximum_provider_only_required_groups": 1,
+            "minimum_scope_groups": 1,
+            "minimum_linked_scope_groups": 1,
+            "minimum_supporting_groups": 1,
+            "minimum_title_anchor_groups": 1,
+            "provider_score_floor": 0.55,
+        }
+    )
+
+
+def _candidate(
+    *,
+    title: str = (
+        "Agricultural-waste hard-carbon anodes for sodium-ion batteries"
+    ),
+    summary: str = (
+        "The electrodes retained high specific capacity during repeated cycles."
+    ),
+    aboutness: tuple[OpenAlexAboutnessSignal, ...] = (),
+) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=title,
+            url="https://openalex.org/W4400000001",
+            publisher="Frozen Test Journal",
+            evidence_summary=summary,
+            summary_source="abstract",
+            provider_result_index=0,
+        ),
+        aboutness=aboutness,
+    )
+
+
+def _signal(
+    display_name: str,
+    *,
+    score: float = 0.9,
+    suffix: str = "K1",
+) -> OpenAlexAboutnessSignal:
+    return OpenAlexAboutnessSignal(
+        kind="keyword",
+        provider_id=f"https://openalex.org/{suffix}",
+        display_name=display_name,
+        score=score,
+    )
+
+
+def test_same_title_scope_link_accepts_and_reaches_serialized_boundary():
+    decision = evaluate_openalex_scope_link(_candidate(), _profile())
+
+    assert decision.action == "ACCEPT"
+    assert decision.exact_required_groups == (
+        "sodium_ion_battery",
+        "hard_carbon_anode",
+    )
+    assert decision.exact_scope_groups == ("agricultural_waste",)
+    assert decision.linked_scope_groups == ("agricultural_waste",)
+    assert decision.abstention_reasons == ()
+
+    payload = decision.model_dump(mode="json")
+    assert payload["action"] == "ACCEPT"
+    assert payload["linked_scope_groups"] == ["agricultural_waste"]
+    assert {
+        (
+            item["required_group_id"],
+            item["scope_group_id"],
+            item["field"],
+            item["sentence_index"],
+        )
+        for item in payload["link_evidence"]
+    } == {
+        (
+            "sodium_ion_battery",
+            "agricultural_waste",
+            "title",
+            0,
+        ),
+        (
+            "hard_carbon_anode",
+            "agricultural_waste",
+            "title",
+            0,
+        ),
+    }
+
+
+def test_cross_sentence_cooccurrence_abstains_instead_of_inventing_a_link():
+    candidate = _candidate(
+        title="Hard-carbon anodes for sodium-ion batteries",
+        summary=(
+            "The hard carbon anode delivered high specific capacity. "
+            "Agricultural waste was used as the precursor."
+        ),
+    )
+
+    decision = evaluate_openalex_scope_link(candidate, _profile())
+
+    assert decision.exact_scope_groups == ("agricultural_waste",)
+    assert decision.linked_scope_groups == ()
+    assert decision.link_evidence == ()
+    assert decision.action == "ABSTAIN"
+    assert decision.abstention_reasons == ("missing_scope_link",)
+
+
+def test_provider_aboutness_may_bridge_one_required_but_not_scope():
+    candidate = _candidate(
+        title="Agricultural-waste hard-carbon anode with stable cycling",
+        summary="The electrode retained high specific capacity.",
+        aboutness=(_signal("Sodium ion batteries"),),
+    )
+
+    decision = evaluate_openalex_scope_link(candidate, _profile())
+
+    assert decision.action == "ACCEPT"
+    assert decision.exact_required_groups == ("hard_carbon_anode",)
+    assert decision.provider_only_required_groups == ("sodium_ion_battery",)
+    assert decision.linked_scope_groups == ("agricultural_waste",)
+
+    scope_only_provider = _candidate(
+        title="Hard-carbon anodes for sodium-ion batteries",
+        aboutness=(_signal("Agricultural waste"),),
+    )
+    scope_decision = evaluate_openalex_scope_link(
+        scope_only_provider,
+        _profile(),
+    )
+
+    assert scope_decision.exact_scope_groups == ()
+    assert scope_decision.linked_scope_groups == ()
+    assert scope_decision.action == "ABSTAIN"
+    assert "insufficient_scope_groups" in scope_decision.abstention_reasons
+    assert "missing_scope_link" in scope_decision.abstention_reasons
+
+
+def test_missing_scope_records_both_coverage_and_relation_failures():
+    candidate = _candidate(
+        title="Hard-carbon anodes for sodium-ion batteries",
+        summary="The electrodes retained high specific capacity.",
+    )
+
+    decision = evaluate_openalex_scope_link(candidate, _profile())
+
+    assert decision.action == "ABSTAIN"
+    assert decision.exact_scope_groups == ()
+    assert decision.abstention_reasons == (
+        "insufficient_scope_groups",
+        "missing_scope_link",
+    )
+
+
+def test_low_score_provider_label_does_not_satisfy_required_group():
+    candidate = _candidate(
+        title="Agricultural-waste hard-carbon anode with stable cycling",
+        aboutness=(_signal("Sodium ion batteries", score=0.54),),
+    )
+
+    decision = evaluate_openalex_scope_link(candidate, _profile())
+
+    assert decision.action == "ABSTAIN"
+    assert decision.missing_required_groups == ("sodium_ion_battery",)
+    assert decision.provider_only_required_groups == ()
+
+
+def test_candidate_identity_includes_provider_aboutness_score():
+    first = _candidate(aboutness=(_signal("Sodium ion batteries", score=0.8),))
+    second = _candidate(aboutness=(_signal("Sodium ion batteries", score=0.9),))
+
+    first_decision = evaluate_openalex_scope_link(first, _profile())
+    second_decision = evaluate_openalex_scope_link(second, _profile())
+
+    assert first_decision.candidate_sha256 != second_decision.candidate_sha256
+
+
+def test_duplicate_text_phrase_across_roles_fails_closed():
+    payload = _profile().model_dump(mode="json")
+    payload["scope_groups"][0]["text_phrases"][0] = (
+        payload["required_groups"][0]["text_phrases"][0]
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="normalized text phrase appears in multiple groups",
+    ):
+        OpenAlexScopeLinkProfile.model_validate(payload)
+
+
+def test_impossible_scope_threshold_fails_closed():
+    payload = _profile().model_dump(mode="json")
+    payload["minimum_linked_scope_groups"] = 2
+
+    with pytest.raises(
+        ValidationError,
+        match="minimum_linked_scope_groups exceeds the scope-group count",
+    ):
+        OpenAlexScopeLinkProfile.model_validate(payload)
+
+
+def test_production_worker_remains_disconnected():
+    worker = (_ROOT / "src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "openalex_scope_link" not in worker
+    assert "evaluate_openalex_scope_link" not in worker

--- a/tests/test_openalex_scope_link_unseen.py
+++ b/tests/test_openalex_scope_link_unseen.py
@@ -1,0 +1,141 @@
+"""Zero-network seams for the frozen scope-link v4 unseen preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import openalex_scope_link_unseen as unseen
+
+
+def test_dry_run_expands_the_exact_unseen_contract_without_live_authority():
+    result = unseen.dry_run()
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"W{index:02d}" for index in range(1, 9)
+    ]
+    assert len({case["collection_sha256"] for case in result["cases"]}) == 8
+    assert len({case["plan_sha256"] for case in result["cases"]}) == 8
+    assert len({case["profile_sha256"] for case in result["cases"]}) == 8
+    assert len({case["idempotency_key"] for case in result["cases"]}) == 8
+    assert {case["result_limit"] for case in result["cases"]} == {8}
+    assert result["request_contract"] == {
+        "result_limit": 8,
+        "filter": "has_abstract:true",
+        "aboutness_fields": ["topics", "keywords"],
+        "redirects": False,
+        "internal_retries": False,
+    }
+    assert result["development_observation"] == {
+        "source_document": (
+            "docs/results-2026-08-27-openalex-claim-scope-v3-review.md"
+        ),
+        "reviewed_candidate_count": 13,
+        "relevant_candidate_count": 12,
+        "wrong_source_count": 1,
+        "wrong_source_rate": pytest.approx(1 / 13),
+        "accepted_case_count": 7,
+        "novel_relevant_case_count": 7,
+        "source_truth_state": "complete_fail",
+        "reuse_for_v4_tuning": False,
+    }
+    assert result["source_value_gates"] == {
+        "accepted_case_count_min": 6,
+        "novel_relevant_case_count_min": 6,
+        "wrong_source_rate_max": 0.05,
+        "all_attempted_sources_reviewed": True,
+        "substantive_generative_ai_allowed": False,
+    }
+    assert result["maximum_request_count"] == 8
+    assert result["real_network_calls_performed"] is False
+    assert result["live_provider_requests_authorized"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    with pytest.raises(
+        unseen.OpenAlexScopeLinkPreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases(fixture)
+
+
+def test_semantic_case_order_drift_is_rejected_even_with_matching_raw_hash(
+    tmp_path,
+):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["challenge_cases"][0], payload["challenge_cases"][1] = (
+        payload["challenge_cases"][1],
+        payload["challenge_cases"][0],
+    )
+    fixture = tmp_path / "reordered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="ordered W01 through W08"):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_request_contract_cannot_silently_drop_the_abstract_filter(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["request_contract"]["filter"] = ""
+    fixture = tmp_path / "unfiltered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_profile_role_drift_changes_the_preflight_identity(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    first = payload["challenge_cases"][0]["profile"]
+    first["scope_groups"][0]["text_phrases"].append("farm residue")
+    fixture = tmp_path / "profile-drift.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    original = unseen.dry_run()
+    drifted = unseen.dry_run(
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+
+    assert drifted["cases"][0]["profile_sha256"] != (
+        original["cases"][0]["profile_sha256"]
+    )
+    assert drifted["cases"][0]["plan_sha256"] == (
+        original["cases"][0]["plan_sha256"]
+    )
+
+
+def test_preflight_source_imports_neither_provider_nor_live_runner():
+    source = Path("openalex_scope_link_unseen.py").read_text(encoding="utf-8")
+
+    assert "openalex_claim_scope_search" not in source
+    assert "anonymous_openalex_search" not in source
+    assert "execute_gap_plan" not in source
+    assert "urllib" not in source


### PR DESCRIPTION
This change tests a new method after the earlier OpenAlex candidate achieved 12/13 topical relevance but still failed the frozen 5 percent wrong-source gate. It freezes eight unseen W01-W08 cases before implementation, adds a deterministic required/scope/supporting role model, requires same-title or same-abstract-sentence provenance for required-to-scope links, and emits only ACCEPT or ABSTAIN. It also adds a zero-network identity preflight and records the implementation result. The work remains disconnected from pipeline_worker.py and production reports; it includes no live runner, provider request, paid evidence, or production-value claim. Verification: 15 focused tests passed; a cross-sentence defect was re-injected and made the seam test fail; the clean detached tree passed 1678 tests with 1 skip and 609 subtests; latest Ruff passed; narrow Pylint scored 10.00/10.