### PR TITLE
Add the disconnected Scope-Link v4 live runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1678 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1695 tests (609 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -209,6 +209,8 @@ openalex_claim_scope_review.py
                         exact-run source lock plus Schema v2 human review
 openalex_scope_link_unseen.py
                         frozen W01-W08 scope-link preflight; zero-network only
+openalex_scope_link_live.py
+                        write-once W01-W08 runner; CLI defaults to dry-run
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -376,9 +378,18 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   collection/plan/profile/idempotency identities with zero sockets. Its 15/15
   focused seams pass; combining the whole abstract into one relation segment
   was re-injected and made the cross-sentence test fail before restoration.
+  A separately pre-registered write-once live runner now locks the fixture and
+  nine decision/transport dependency hashes before output reservation, records
+  its observed self-hash without creating a recursive lock, persists the full
+  manifest before adapter construction, and commits each one-attempt case
+  journal before a later request. Every provider candidate or rejection reaches
+  the aggregate CSV, with required/scope/support/link provenance kept distinct;
+  only ACCEPT rows reach a blank review boundary. Its 17/17 runner seams pass,
+  and dropping link evidence after a correct internal decision was re-injected
+  and made the client-boundary test fail. The combined v4 subset passes 32/32.
   No W01-W08 provider request or source review has occurred, so provider
-  compatibility, coverage, wrong-source rate and source value are all
-  `not_evaluated`. A live runner is not implemented or authorized. Keep
+  compatibility, coverage, wrong-source rate and source value remain
+  `not_evaluated`. The runner is implemented but not live-authorized. Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
@@ -409,7 +420,9 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-08-27-openalex-claim-scope-v3-review-implementation.md`,
   plus `docs/results-2026-08-27-openalex-claim-scope-v3-review.md`, and
   `docs/prereg-2026-08-27-openalex-scope-link-v4.md` plus
-  `docs/results-2026-08-27-openalex-scope-link-v4-implementation.md`.
+  `docs/results-2026-08-27-openalex-scope-link-v4-implementation.md`, plus
+  `docs/prereg-2026-08-28-openalex-scope-link-v4-live.md` and
+  `docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md`.
 - Regulator title recovery is integrated from one frozen development challenge,
   not a production-rate estimate. A zero-network census of 95 historical runs
   found only 3 in-scope rows across 2 unique ClinicalTrials.gov URLs. The

--- a/README.md
+++ b/README.md
@@ -606,12 +606,20 @@ topics/keywords may bridge at most one required group but cannot establish
 scope, support or the relation itself. The raw-byte-locked W01-W08 preflight
 expands eight distinct collection/plan/profile/idempotency identities with zero
 network calls; 15/15 focused tests pass, including a re-injected whole-abstract
-defect that makes the cross-sentence seam fail. The complete test directory now
-passes **1,678 tests plus 609 subtests**. No W01-W08 provider request has been
-made, no live runner is implemented or authorized, and source value remains
-`not_evaluated`; production is still disconnected. See the
+defect that makes the cross-sentence seam fail. A separately pre-registered
+write-once live runner now records the frozen method and its observed self-hash
+before constructing an adapter, then commits each one-request case journal
+before a later request. Every provider row reaches the aggregate artifact, and
+only v4 `ACCEPT` rows reach a blank human-review boundary. The combined v4
+decision, preflight and runner subset passes 32/32 tests, including a
+re-injected computed-but-undelivered relation-provenance defect. The complete
+repository now passes **1,695 tests plus 609 subtests**. No W01-W08 provider
+request has been made, the live runner is not authorized, and source value
+remains `not_evaluated`; production is still disconnected. See the
 [v4 protocol](docs/prereg-2026-08-27-openalex-scope-link-v4.md) and
-[zero-network implementation result](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md).
+[zero-network implementation result](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md),
+plus the [live-runner protocol](docs/prereg-2026-08-28-openalex-scope-link-v4-live.md)
+and [live-runner implementation result](docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1718,12 +1726,18 @@ v3 的错误条目表明，通用的过程/性能命中仍可能替代
 required 概念，不能建立 scope、support 或它们的关系。
 原始字节锁定的 W01-W08 预检在零网络下展开 8 组唯一的
 collection/plan/profile/幂等身份，15/15 个聚焦测试通过；临时将整段
-摘要当成一句后，跨句接缝测试会准确失败。当前完整测试目录为
-**1,678 项测试与 609 个 subtests**。W01-W08 尚未请求供应商，
-live runner 未实现也未授权，来源价值仍为 `not_evaluated`，
-生产路径保持断开。详见
+摘要当成一句后，跨句接缝测试会准确失败。另行预注册的写一次 live
+runner 已实现：它在构造适配器前记录冻结方法与自身观测哈希，并在发起
+下一次请求前先提交当前单请求 case journal。每一条供应商返回行都会到达
+聚合产物，只有 v4 `ACCEPT` 行会进入空白人工评审边界。v4 决策、预检与
+runner 组合测试为 32/32；临时移除内部已算出的 relation provenance 后，
+客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,695 项测试与 609 个
+subtests**。W01-W08 尚未请求供应商，live runner 尚未获得运行授权，
+来源价值仍为 `not_evaluated`，生产路径保持断开。详见
 [v4 协议](docs/prereg-2026-08-27-openalex-scope-link-v4.md)与
-[零网络实现结果](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md)。
+[零网络实现结果](docs/results-2026-08-27-openalex-scope-link-v4-implementation.md)，
+以及 [live runner 协议](docs/prereg-2026-08-28-openalex-scope-link-v4-live.md)与
+[live runner 实现结果](docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-28-openalex-scope-link-v4-live.md
+++ b/docs/prereg-2026-08-28-openalex-scope-link-v4-live.md
@@ -1,0 +1,171 @@
+# Pre-registration: OpenAlex scope-link v4 live harness
+
+**Frozen:** 2026-08-28, after the zero-network v4 implementation merged as
+`e9a9616e07bce1a7967888d0b8ba290237754f99`, but before implementing a v4
+live runner, constructing a provider adapter for W01-W08, or making any
+provider request for those cases.
+
+**Parent protocol:**
+`docs/prereg-2026-08-27-openalex-scope-link-v4.md`
+
+**Challenge fixture:**
+`tests/fixtures/openalex_scope_link_v4_challenge.json`
+
+**Raw fixture SHA-256:**
+`f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3`
+
+**Production connection authorized:** no
+
+**Live provider execution authorized:** no. This document authorizes only the
+implementation and zero-network verification of a disconnected runner. A real
+run requires separate owner authorization naming the merged revision, a cap of
+no more than eight requests and a provider-reported soft stop no greater than
+USD 0.01.
+
+## Question
+
+Can the frozen W01-W08 v4 method be executed through a durable, auditable
+one-request-per-case boundary without allowing code drift, retries, unknown
+cost or incomplete relation provenance to look like a successful source-value
+study?
+
+This stage does not ask whether v4 retrieves useful sources. Provider
+compatibility, accepted-case coverage, wrong-source rate, novelty and source
+value remain `not_evaluated` until a separately authorized live run and an
+eligible human review occur.
+
+## Frozen execution contract
+
+The runner must default to a zero-network dry-run. Its live path must require
+all of the following:
+
+1. an explicit `--execute-live` flag;
+2. a fresh write-once output directory;
+3. a positive provider-reported soft stop no greater than USD 0.01;
+4. acknowledgement of the anonymous OpenAlex daily budget;
+5. no configured `OPENALEX_API_KEY`; and
+6. a separately authorized merged revision.
+
+The runner may attempt W01-W08 in frozen order. Each attempted case owns
+exactly one anonymous OpenAlex Works request with `has_abstract:true`,
+`per-page=8`, topics and keywords selected, no redirect, no internal retry, no
+enrichment fetch and no model call. A provider failure, invalid response,
+identity mismatch, uninspectable cost or reached soft stop ends the run without
+starting another request.
+
+## Identity and persistence order
+
+Before reserving output or constructing a network-capable adapter, the runner
+must verify the raw fixture bytes and the committed bytes of every reused
+method and adapter dependency. The frozen dependency set is:
+
+- `domain_evidence_search.py`;
+- `evidence.py`;
+- `evidence_gap.py`;
+- `evidence_search.py`;
+- `openalex_claim_scope.py`, which defines the adapter candidate contract;
+- `openalex_claim_scope_search.py`, which defines the anonymous adapter;
+- `openalex_precision.py`, which supplies exact phrase normalization;
+- `openalex_scope_link.py`; and
+- `openalex_scope_link_unseen.py`.
+
+The runner's own observed SHA-256 must also reach the manifest and final
+execution artifact before provider work. It cannot embed an expected hash of
+its own complete bytes without a recursive identity. The separate execution
+authorization must therefore name the merged revision, while the artifact
+records the observed runner bytes for later comparison.
+
+After identity checks, ordering is fixed:
+
+1. reserve the fresh output directory;
+2. persist `manifest.json` with every expanded collection, validated plan,
+   profile, idempotency key, value gate and implementation identity;
+3. only then construct the adapter;
+4. issue at most one request for the next frozen case;
+5. persist its complete `case-executions/Wxx.json` journal before another case
+   can begin; and
+6. finish with write-once execution, candidate, blank-review and artifact-index
+   files.
+
+An interrupted prefix is inspectable history, not resumable authority. This
+experimental runner does not add retry or recovery semantics.
+
+## Frozen artifact contract
+
+Every valid provider candidate must reach the v4 decision boundary. Every
+malformed provider row must reach an indexed rejection. Candidate rows must
+preserve at least:
+
+- provider request, row, cost and trace identities;
+- `ACCEPT`, `ABSTAIN` or explicit `NOT_EVALUATED` disposition;
+- missing, exact and provider-only required groups;
+- exact and linked scope groups;
+- title anchors;
+- required, scope and supporting match provenance; and
+- every same-title or same-abstract-sentence scope link, including field,
+  sentence index, both group IDs and exact phrases.
+
+Only `ACCEPT` candidates may appear in `review.csv`, and all human label cells
+must remain blank. A completed provider run with accepted candidates in fewer
+than 6/8 cases is `mechanical_gate_failed`; six or more is only
+`eligible_for_source_lock`. Both states retain
+`human_review_state=not_prepared` and `source_value_state=not_evaluated`.
+
+## Frozen source-value gates
+
+The parent v4 gates remain unchanged:
+
+1. at least one accepted candidate in at least 6/8 cases;
+2. at least one relevant and baseline-novel candidate in at least 6/8 cases;
+3. no more than 5% directly irrelevant accepted candidates;
+4. every attempted source reviewed; and
+5. no substantive generative AI producing the human judgments.
+
+No implementation test may manufacture a source-value pass. Synthetic rows
+exercise persistence and accounting only.
+
+## Required zero-network verification
+
+Before any live authorization, tests must prove that:
+
+- the dry-run locks all eight W identities and opens zero sockets;
+- fixture or implementation drift fails before output and adapter construction;
+- `manifest.json` exists before an injected adapter factory can run;
+- each prior case journal exists before a later injected request can run;
+- exactly one request, latency and cost record reaches every attempted case;
+- provider failures, invalid accounting, unknown cost and soft stop remain
+  distinct partial states;
+- all provider rows and v4 decisions reach CSV, including complete scope-link
+  provenance;
+- only accepted rows reach the blank review boundary;
+- fewer than six accepted cases cannot be described as source value;
+- no environment secret reaches any artifact; and
+- `pipeline_worker.py` imports none of the v4 runner, preflight, method or
+  adapter modules.
+
+After the focused suite passes, remove scope-link provenance from the CSV seam
+temporarily and confirm the boundary test fails. Restore it, run the full
+zero-network suite, latest Ruff and the project's narrow Pylint checks, and
+record the result without performing a provider request.
+
+## Stop and falsification rules
+
+Implementation fails if any required identity can drift without detection, if
+an adapter can exist before the complete manifest, if a later request can begin
+before the previous journal, if a spent request lacks inspectable accounting,
+if an accepted row loses relation provenance, or if production imports any v4
+component.
+
+A later live study fails mechanically if fewer than six cases retain an
+accepted candidate. It must then stop before human review because labels cannot
+rescue the frozen all-gates rule. A mechanically eligible run still has no
+source-value result until a separate source lock and eligible human review
+apply every remaining gate.
+
+## Explicit non-claims
+
+Passing this implementation stage would not establish provider compatibility,
+source relevance, novelty, precision, recall, report improvement,
+planner-trigger precision, decision quality, adoption, ROI, an SLO, autonomous
+tool choice or production Tool Calling. `pipeline_worker.py` must remain
+disconnected.

--- a/docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md
+++ b/docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md
@@ -1,0 +1,82 @@
+# OpenAlex scope-link v4 live-runner implementation result
+
+Date: 2026-08-28
+
+Status: **implementation complete; no live provider request authorized or made**
+
+## Question
+
+Can the byte-frozen W01-W08 scope-link v4 challenge be given the same
+write-once, bounded, auditable live-execution boundary as the earlier v3 study
+without connecting the experiment to production or claiming source value?
+
+## Frozen boundary
+
+The implementation follows
+`docs/prereg-2026-08-28-openalex-scope-link-v4-live.md`. In particular:
+
+- the raw W01-W08 fixture remains locked at
+  `f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3`;
+- all decision and transport dependencies are verified before output
+  reservation or adapter construction;
+- execution is capped at eight anonymous, one-attempt requests and a USD 0.01
+  provider-reported soft stop;
+- a configured `OPENALEX_API_KEY` is refused rather than silently used;
+- production and report-workflow connections remain false; and
+- a future live execution still requires separate authorization naming the
+  merged revision and budget.
+
+The runner's observed byte hash is
+`bfd0bb7b4e668c56f3acd57a95d87a7fdedcd17699ae0b6d225dd882320de96d`.
+It is recorded in the manifest and final execution artifact instead of being
+placed in its own expected-hash table, which would create a recursive and
+therefore unsatisfiable self-hash contract.
+
+## What was implemented
+
+`openalex_scope_link_live.py` reuses the previously bounded anonymous OpenAlex
+transport but replaces the v3 decision with the frozen v4 scope-link gate. The
+complete manifest is written before a network-capable adapter can be
+constructed. Each attempted case writes its journal before any later case may
+start. Provider candidates and provider rejections both reach the aggregate
+CSV boundary.
+
+For evaluated candidates, the artifact keeps required, scope and supporting
+match provenance separately and also carries the exact same-segment
+`link_evidence`. Only `ACCEPT` rows enter the blank human-review CSV;
+`ABSTAIN` and provider-rejected rows remain inspectable in `candidates.csv`.
+No human labels, source-value result, planner decision or report claim are
+created by this runner.
+
+## Verification
+
+- 17 new live-runner tests pass.
+- The combined v4 decision, unseen preflight and live-runner subset passes
+  **32/32** zero-network tests.
+- The complete repository passes **1,695 tests plus 609 subtests**; one
+  pre-existing optional test is skipped.
+- Latest Ruff passes across the repository.
+- Narrow Pylint checks for exception ordering, unreachable code,
+  use-before-assignment and undefined variables pass for the new runner.
+- The production worker imports none of the v4 runner, preflight or decision
+  modules.
+
+The pre-registered delivery defect was re-injected by dropping
+`link_evidence` while leaving the internal v4 decision intact. The CSV-boundary
+test failed on accepted rows, proving that it checks delivery to the review
+artifact rather than merely checking an internal field. The correct mapping
+was restored and the full 32-test subset passed again.
+
+## Observed outcome and limits
+
+The live execution harness is mechanically ready and remains disconnected.
+Real network calls performed: **0**. Provider cost: **USD 0.00**. W01-W08
+provider compatibility, accepted-case coverage, wrong-source rate, novelty and
+source value all remain **`not_evaluated`**. This result must not be described
+as completed Tool Calling, production integration, provider validation or a
+quality improvement.
+
+The next admissible step is a separately authorized run on the merged revision.
+Only if all eight case journals are valid and at least six cases retain an
+`ACCEPT` candidate may a source-locked human-review packet be prepared. A live
+run alone cannot establish value.

--- a/openalex_scope_link_live.py
+++ b/openalex_scope_link_live.py
@@ -1,0 +1,1114 @@
+"""Production-disconnected live runner for the scope-link v4 challenge.
+
+The default command is a zero-network preflight.  Live execution requires an
+explicit flag, a bounded provider-reported soft stop, and acknowledgement of
+the anonymous OpenAlex daily budget.  Every frozen input is persisted before
+adapter construction, and each one-request case journal is committed before a
+later request may start.  The resulting ACCEPT rows remain unregistered review
+candidates: this module is never imported by the production report worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence_gap import (
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    source_collection_sha256,
+)
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.openalex_scope_link import (
+    OpenAlexScopeLinkDecision,
+    evaluate_openalex_scope_link,
+)
+from academic_agent.source_pipeline import SourceCollection
+from academic_agent.tools.evidence_search import ToolAdapterFailure
+from academic_agent.tools.openalex_claim_scope_search import (
+    AnonymousOpenAlexClaimScopeAdapter,
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_scope_link_unseen import (
+    EXPECTED_FIXTURE_SHA256,
+    ScopeLinkCaseSpec,
+    ScopeLinkSourceValueGates,
+    PreparedScopeLinkCase,
+    dry_run,
+    load_frozen_cases,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_RUNNER_PATH = Path(__file__).resolve()
+_IMPLEMENTATION_PATHS = {
+    "domain_evidence_search.py": (
+        _ROOT / "src/academic_agent/tools/domain_evidence_search.py"
+    ),
+    "evidence.py": _ROOT / "src/academic_agent/evidence.py",
+    "evidence_gap.py": _ROOT / "src/academic_agent/evidence_gap.py",
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_claim_scope.py": (
+        _ROOT / "src/academic_agent/openalex_claim_scope.py"
+    ),
+    "openalex_claim_scope_search.py": (
+        _ROOT / "src/academic_agent/tools/openalex_claim_scope_search.py"
+    ),
+    "openalex_precision.py": _ROOT / "src/academic_agent/openalex_precision.py",
+    "openalex_scope_link.py": _ROOT / "src/academic_agent/openalex_scope_link.py",
+    "openalex_scope_link_unseen.py": _ROOT / "openalex_scope_link_unseen.py",
+}
+# These values are populated from the merge-candidate bytes before any live
+# request.  A later code drift must create a new study rather than silently
+# changing the method under the original W01-W08 identities.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "domain_evidence_search.py": (
+        "ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab"
+    ),
+    "evidence.py": (
+        "8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5"
+    ),
+    "evidence_gap.py": (
+        "f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_claim_scope.py": (
+        "739e165838ff5042ec863c3c510311e737216e8d90804c8d3da5095acce22f16"
+    ),
+    "openalex_claim_scope_search.py": (
+        "070d07ac8c4bcaa32bfbc563513b4034162b012aea1f47ce3208ed06cb085642"
+    ),
+    "openalex_precision.py": (
+        "7c6e0f2999aae68a9caa042584c886bc5273037a2eaf2e95d80c553b7a503029"
+    ),
+    "openalex_scope_link.py": (
+        "abfb9a6b6af1691411f4ad3689b0f5052c42dfeddfdc30cb2e9e21c7d0ff2667"
+    ),
+    "openalex_scope_link_unseen.py": (
+        "1e3c0b15c9608cf83b414ee52ac2da7540728149970fa45ab9e6306773ef4749"
+    ),
+}
+MAXIMUM_REQUESTS = 8
+MAXIMUM_SOFT_STOP_USD = 0.01
+ANONYMOUS_DAILY_BUDGET_USD = 0.10
+_CASE_ORDER = tuple(f"W{index:02d}" for index in range(1, 9))
+_AGGREGATE_SOURCE_FILES = (
+    "manifest.json",
+    "execution.json",
+    "candidates.csv",
+    "review.csv",
+)
+_CANDIDATE_COLUMNS = (
+    "case_id",
+    "provider",
+    "tool",
+    "provider_request_id",
+    "provider_request_id_source",
+    "provider_cost_basis",
+    "provider_result_index",
+    "adapter_disposition",
+    "scope_link_action",
+    "abstention_reasons",
+    "missing_required_groups",
+    "exact_required_groups",
+    "provider_only_required_groups",
+    "exact_scope_groups",
+    "linked_scope_groups",
+    "title_anchor_groups",
+    "required_match_provenance",
+    "scope_match_provenance",
+    "supporting_match_provenance",
+    "link_evidence",
+    "aboutness_signal_count",
+    "candidate_sha256",
+    "profile_sha256",
+    "title",
+    "url",
+    "provider_rejection_code",
+    "rejection_detail",
+    "latency_ms",
+    "trace_id",
+)
+_REVIEW_COLUMNS = (
+    "case_id",
+    "provider",
+    "provider_result_index",
+    "candidate_sha256",
+    "title",
+    "url",
+    "relevant",
+    "novel",
+    "review_note",
+)
+
+
+ScopeLinkAdapter = Callable[
+    [ValidatedGapCall],
+    OpenAlexClaimScopeAdapterResponse | dict[str, Any],
+]
+AdapterFactory = Callable[[], ScopeLinkAdapter]
+Clock = Callable[[], float]
+StopReason = Literal[
+    "completed",
+    "soft_stop",
+    "cost_uninspectable",
+    "request_failed",
+    "accounting_invalid",
+]
+ReviewPacketEligibility = Literal[
+    "eligible_for_source_lock",
+    "mechanical_gate_failed",
+    "incomplete",
+]
+
+
+class OpenAlexScopeLinkLiveError(ValueError):
+    """Raised before provider work when a frozen live boundary fails."""
+
+
+class ScopeLinkFrozenCaseArtifact(BaseModel):
+    """Complete deterministic case input persisted before the first request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: ScopeLinkCaseSpec
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_collection: SourceCollection
+    validated_plan: ValidatedGapPlan
+
+    @model_validator(mode="after")
+    def _validate_expanded_identities(self) -> "ScopeLinkFrozenCaseArtifact":
+        if source_collection_sha256(self.source_collection) != self.collection_sha256:
+            raise ValueError("expanded source collection hash does not match")
+        plan_sha256 = _sha256_bytes(
+            self.validated_plan.model_dump_json(exclude_none=False).encode("utf-8")
+        )
+        if plan_sha256 != self.plan_sha256:
+            raise ValueError("expanded validated plan hash does not match")
+        if self.spec.profile.sha256() != self.profile_sha256:
+            raise ValueError("expanded scope-link profile hash does not match")
+        return self
+
+
+class ScopeLinkManifestArtifact(BaseModel):
+    """Write-once expansion of all frozen inputs and implementation identities."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_scope_link_v4_manifest"] = (
+        "openalex_scope_link_v4_manifest"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[8] = MAXIMUM_REQUESTS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    source_value_gates: ScopeLinkSourceValueGates
+    cases: tuple[ScopeLinkFrozenCaseArtifact, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_frozen_contract(self) -> "ScopeLinkManifestArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("manifest fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("manifest implementation identities do not match")
+        if tuple(case.spec.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("manifest cases must remain ordered W01 through W08")
+        return self
+
+
+class ScopeLinkCandidateEvaluation(BaseModel):
+    """One provider candidate joined to its label-blind v4 decision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider_result_index: int = Field(ge=0, le=7)
+    candidate: OpenAlexClaimScopeCandidate
+    decision: OpenAlexScopeLinkDecision
+
+    @model_validator(mode="after")
+    def _validate_candidate_identity(self) -> "ScopeLinkCandidateEvaluation":
+        if self.candidate.evidence.provider_result_index != self.provider_result_index:
+            raise ValueError("candidate provider index drifted from evaluation")
+        if self.candidate.sha256() != self.decision.candidate_sha256:
+            raise ValueError("scope-link decision is attached to another candidate")
+        return self
+
+
+class ScopeLinkCaseExecution(BaseModel):
+    """One request journal, including explicit failure and accounting states."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^W0[1-8]$")
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trace_id: str = Field(pattern=r"^openalex-scope-link-v4-w0[1-8]$")
+    state: Literal["completed", "failed"]
+    outbound_attempt_count: Literal[1] = 1
+    response: OpenAlexClaimScopeAdapterResponse | None = None
+    evaluations: tuple[ScopeLinkCandidateEvaluation, ...] = Field(
+        default=(),
+        max_length=8,
+    )
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    search_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    latency_ms: float = Field(
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+
+    @model_validator(mode="after")
+    def _validate_state_and_evaluations(self) -> "ScopeLinkCaseExecution":
+        if self.state == "completed":
+            if self.response is None:
+                raise ValueError("completed case requires an adapter response")
+            if any(
+                value is not None
+                for value in (
+                    self.failure_type,
+                    self.failure_detail,
+                    self.failure_retryable,
+                )
+            ):
+                raise ValueError("completed case cannot carry failure metadata")
+            if self.response.idempotency_key != self.idempotency_key:
+                raise ValueError("response idempotency identity drifted")
+            if self.response.search_cost_usd != self.search_cost_usd:
+                raise ValueError("case cost drifted from provider response")
+            expected = tuple(
+                (
+                    int(candidate.evidence.provider_result_index),
+                    candidate,
+                )
+                for candidate in self.response.candidates
+                if candidate.evidence.provider_result_index is not None
+            )
+            observed = tuple(
+                (item.provider_result_index, item.candidate)
+                for item in self.evaluations
+            )
+            if observed != expected:
+                raise ValueError("every provider candidate must reach v4 evaluation")
+            if any(
+                item.decision.profile_sha256 != self.profile_sha256
+                for item in self.evaluations
+            ):
+                raise ValueError("scope-link decision profile identity drifted")
+        else:
+            if self.failure_type is None or self.failure_detail is None:
+                raise ValueError("failed case requires explicit failure metadata")
+            if self.evaluations:
+                raise ValueError("failed case cannot imply completed evaluations")
+            if self.response is not None and (
+                self.response.search_cost_usd != self.search_cost_usd
+            ):
+                raise ValueError("failed case cost drifted from provider response")
+        return self
+
+
+class ScopeLinkProviderSummary(BaseModel):
+    """Anonymous provider accounting where no observation is not a pass."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["openalex"] = "openalex"
+    access_mode: Literal["anonymous_no_key"] = "anonymous_no_key"
+    authorized_case_count: Literal[8] = MAXIMUM_REQUESTS
+    attempted_case_count: int = Field(ge=0, le=8)
+    successful_case_count: int = Field(ge=0, le=8)
+    request_count: int = Field(ge=0, le=8)
+    cost_state: Literal["known", "uninspectable", "not_observed"]
+    reported_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    total_latency_ms: float = Field(
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    stopped_reason: StopReason
+
+    @model_validator(mode="after")
+    def _validate_accounting(self) -> "ScopeLinkProviderSummary":
+        if self.successful_case_count > self.attempted_case_count:
+            raise ValueError("successful cases cannot exceed attempted cases")
+        if self.request_count != self.attempted_case_count:
+            raise ValueError("every attempted case must own exactly one request")
+        if self.cost_state == "known" and self.reported_cost_usd is None:
+            raise ValueError("known provider cost requires a numeric total")
+        if self.cost_state != "known" and self.reported_cost_usd is not None:
+            raise ValueError("uninspectable provider cost must keep USD null")
+        completed = self.successful_case_count == MAXIMUM_REQUESTS
+        if (self.stopped_reason == "completed") != completed:
+            raise ValueError("provider completion does not match successful cases")
+        return self
+
+
+class ScopeLinkExecutionArtifact(BaseModel):
+    """Final write-once state; source value still requires eligible humans."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_scope_link_v4_execution"] = (
+        "openalex_scope_link_v4_execution"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[8] = MAXIMUM_REQUESTS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    request_count: int = Field(ge=0, le=8)
+    attempted_case_count: int = Field(ge=0, le=8)
+    successful_case_count: int = Field(ge=0, le=8)
+    overall_state: Literal["completed", "partial"]
+    scope_link_accepted_candidate_count: int = Field(ge=0, le=64)
+    scope_link_abstained_candidate_count: int = Field(ge=0, le=64)
+    scope_link_accepted_case_count: int = Field(ge=0, le=8)
+    review_packet_eligibility: ReviewPacketEligibility
+    source_lock_state: Literal["not_created"] = "not_created"
+    human_review_state: Literal["not_prepared"] = "not_prepared"
+    source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    source_value_gates: ScopeLinkSourceValueGates
+    provider_summary: ScopeLinkProviderSummary
+    cases: tuple[ScopeLinkCaseExecution, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_totals_and_states(self) -> "ScopeLinkExecutionArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("execution fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("execution implementation identities do not match")
+        case_ids = tuple(case.case_id for case in self.cases)
+        if case_ids != _CASE_ORDER[: len(case_ids)]:
+            raise ValueError("case executions must preserve the frozen prefix")
+        if len(self.cases) != self.attempted_case_count:
+            raise ValueError("attempted cases must equal persisted journals")
+        if self.request_count != sum(
+            case.outbound_attempt_count for case in self.cases
+        ):
+            raise ValueError("request count must equal journal attempt total")
+        successful = sum(case.state == "completed" for case in self.cases)
+        if successful != self.successful_case_count:
+            raise ValueError("successful cases must equal completed journals")
+        if self.provider_summary.request_count != self.request_count:
+            raise ValueError("provider request count drifted from execution")
+        if self.provider_summary.attempted_case_count != self.attempted_case_count:
+            raise ValueError("provider attempted-case count drifted")
+        if self.provider_summary.successful_case_count != self.successful_case_count:
+            raise ValueError("provider successful-case count drifted")
+        expected_latency = sum(case.latency_ms for case in self.cases)
+        if not math.isclose(
+            self.provider_summary.total_latency_ms,
+            expected_latency,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise ValueError("provider latency total drifted from case journals")
+
+        evaluations = tuple(
+            item for case in self.cases for item in case.evaluations
+        )
+        accepted = sum(item.decision.action == "ACCEPT" for item in evaluations)
+        abstained = sum(item.decision.action == "ABSTAIN" for item in evaluations)
+        accepted_cases = sum(
+            any(item.decision.action == "ACCEPT" for item in case.evaluations)
+            for case in self.cases
+        )
+        if accepted != self.scope_link_accepted_candidate_count:
+            raise ValueError("accepted-candidate count drifted")
+        if abstained != self.scope_link_abstained_candidate_count:
+            raise ValueError("abstained-candidate count drifted")
+        if accepted_cases != self.scope_link_accepted_case_count:
+            raise ValueError("accepted-case count drifted")
+
+        completed = self.successful_case_count == MAXIMUM_REQUESTS
+        if (self.overall_state == "completed") != completed:
+            raise ValueError("overall state does not match provider completion")
+        expected_eligibility: ReviewPacketEligibility
+        if not completed:
+            expected_eligibility = "incomplete"
+        elif accepted_cases < self.source_value_gates.accepted_case_count_min:
+            expected_eligibility = "mechanical_gate_failed"
+        else:
+            expected_eligibility = "eligible_for_source_lock"
+        if self.review_packet_eligibility != expected_eligibility:
+            raise ValueError("review-packet eligibility drifted from frozen gates")
+        return self
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects because one case authorizes one outbound request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _OneRequestTransport:
+    """Concrete transport with neither redirect following nor internal retry."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method=method,
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read()
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    try:
+        return _sha256_bytes(path.read_bytes())
+    except OSError as exc:
+        raise OpenAlexScopeLinkLiveError(
+            f"could not read frozen implementation file {path.name}: {exc}"
+        ) from exc
+
+
+def verify_frozen_implementation() -> dict[str, str]:
+    """Reject code drift before output reservation or adapter construction."""
+
+    if set(_IMPLEMENTATION_PATHS) != set(EXPECTED_IMPLEMENTATION_SHA256):
+        raise OpenAlexScopeLinkLiveError(
+            "scope-link implementation lock names are inconsistent"
+        )
+    observed = {
+        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+    if observed != EXPECTED_IMPLEMENTATION_SHA256:
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if EXPECTED_IMPLEMENTATION_SHA256.get(name) != digest
+        )
+        raise OpenAlexScopeLinkLiveError(
+            "scope-link implementation identity drifted: " + ", ".join(changed)
+        )
+    return observed
+
+
+def protocol_dry_run() -> dict[str, Any]:
+    """Expose fixture and implementation identities while opening zero sockets."""
+
+    result = dry_run()
+    result["implementation_sha256"] = verify_frozen_implementation()
+    result["runner_sha256"] = _file_sha256(_RUNNER_PATH)
+    return result
+
+
+def _manifest_artifact(
+    cases: tuple[PreparedScopeLinkCase, ...],
+    fixture_sha256: str,
+    implementation_sha256: dict[str, str],
+    runner_sha256: str,
+    gates: ScopeLinkSourceValueGates,
+    soft_stop_usd: float,
+) -> ScopeLinkManifestArtifact:
+    return ScopeLinkManifestArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        source_value_gates=gates,
+        cases=tuple(
+            ScopeLinkFrozenCaseArtifact(
+                spec=case.spec,
+                collection_sha256=case.collection_sha256,
+                plan_sha256=case.plan_sha256,
+                profile_sha256=case.profile_sha256,
+                source_collection=case.collection,
+                validated_plan=case.plan,
+            )
+            for case in cases
+        ),
+    )
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise OpenAlexScopeLinkLiveError(
+            f"could not create write-once artifact {path}: {exc}"
+        ) from exc
+
+
+def _json_text(value: BaseModel | dict[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _write_case_journal(
+    output_dir: Path,
+    execution: ScopeLinkCaseExecution,
+) -> None:
+    journal_dir = output_dir / "case-executions"
+    journal_dir.mkdir(exist_ok=True)
+    _write_new(journal_dir / f"{execution.case_id}.json", _json_text(execution))
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    """Describe a failed response shape without copying provider input."""
+
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "adapter response failed validation"
+
+
+def _failure_execution(
+    case: PreparedScopeLinkCase,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool | None,
+    latency_ms: float,
+    response: OpenAlexClaimScopeAdapterResponse | None = None,
+    search_cost_usd: float | None = None,
+) -> ScopeLinkCaseExecution:
+    return ScopeLinkCaseExecution(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-scope-link-v4-{case.spec.case_id.casefold()}",
+        state="failed",
+        response=response,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        search_cost_usd=search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _completed_execution(
+    case: PreparedScopeLinkCase,
+    response: OpenAlexClaimScopeAdapterResponse,
+    latency_ms: float,
+) -> ScopeLinkCaseExecution:
+    return ScopeLinkCaseExecution(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-scope-link-v4-{case.spec.case_id.casefold()}",
+        state="completed",
+        response=response,
+        evaluations=tuple(
+            ScopeLinkCandidateEvaluation(
+                provider_result_index=int(
+                    candidate.evidence.provider_result_index
+                ),
+                candidate=candidate,
+                decision=evaluate_openalex_scope_link(
+                    candidate,
+                    case.spec.profile,
+                ),
+            )
+            for candidate in response.candidates
+            if candidate.evidence.provider_result_index is not None
+        ),
+        search_cost_usd=response.search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _provider_cost(
+    executions: list[ScopeLinkCaseExecution],
+) -> tuple[Literal["known", "uninspectable", "not_observed"], float | None]:
+    if not executions:
+        return "not_observed", None
+    values = [item.search_cost_usd for item in executions]
+    if any(value is None for value in values):
+        return "uninspectable", None
+    return "known", sum(value for value in values if value is not None)
+
+
+def _elapsed_ms(clock: Clock, started_at: float) -> float:
+    """Return monotonic request latency without losing a spent-request journal."""
+
+    elapsed_ms = (clock() - started_at) * 1000.0
+    if not math.isfinite(elapsed_ms):
+        raise OpenAlexScopeLinkLiveError("request clock produced non-finite latency")
+    # perf_counter is monotonic. Clamping a custom test clock's backwards
+    # reading is safer than dropping the journal for an already-spent request.
+    return max(0.0, elapsed_ms)
+
+
+def _json_compact(value: object) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def _candidate_rows(
+    executions: tuple[ScopeLinkCaseExecution, ...],
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    rows: list[dict[str, str]] = []
+    reviews: list[dict[str, str]] = []
+    for execution in executions:
+        response = execution.response
+        if response is None:
+            continue
+        evaluations = {
+            item.provider_result_index: item for item in execution.evaluations
+        }
+        usage = response.provider_usage
+        for candidate in response.candidates:
+            index = candidate.evidence.provider_result_index
+            if index is None:
+                raise OpenAlexScopeLinkLiveError(
+                    "provider-accounted candidate lost its result index"
+                )
+            evaluation = evaluations.get(index)
+            decision = evaluation.decision if evaluation is not None else None
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "provider": "openalex",
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(index),
+                    "adapter_disposition": "candidate",
+                    "scope_link_action": (
+                        decision.action if decision is not None else "NOT_EVALUATED"
+                    ),
+                    "abstention_reasons": _json_compact(
+                        decision.abstention_reasons if decision else ()
+                    ),
+                    "missing_required_groups": _json_compact(
+                        decision.missing_required_groups if decision else ()
+                    ),
+                    "exact_required_groups": _json_compact(
+                        decision.exact_required_groups if decision else ()
+                    ),
+                    "provider_only_required_groups": _json_compact(
+                        decision.provider_only_required_groups if decision else ()
+                    ),
+                    "exact_scope_groups": _json_compact(
+                        decision.exact_scope_groups if decision else ()
+                    ),
+                    "linked_scope_groups": _json_compact(
+                        decision.linked_scope_groups if decision else ()
+                    ),
+                    "title_anchor_groups": _json_compact(
+                        decision.title_anchor_groups if decision else ()
+                    ),
+                    "required_match_provenance": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.required_matches
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "scope_match_provenance": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.scope_matches
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "supporting_match_provenance": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.supporting_matches
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "link_evidence": _json_compact(
+                        [
+                            item.model_dump(mode="json")
+                            for item in decision.link_evidence
+                        ]
+                        if decision
+                        else []
+                    ),
+                    "aboutness_signal_count": str(len(candidate.aboutness)),
+                    "candidate_sha256": (
+                        decision.candidate_sha256 if decision else candidate.sha256()
+                    ),
+                    "profile_sha256": execution.profile_sha256,
+                    "title": candidate.evidence.title,
+                    "url": candidate.evidence.url,
+                    "provider_rejection_code": "",
+                    "rejection_detail": "",
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+            if decision is not None and decision.action == "ACCEPT":
+                reviews.append(
+                    {
+                        "case_id": execution.case_id,
+                        "provider": "openalex",
+                        "provider_result_index": str(index),
+                        "candidate_sha256": decision.candidate_sha256,
+                        "title": candidate.evidence.title,
+                        "url": candidate.evidence.url,
+                        "relevant": "",
+                        "novel": "",
+                        "review_note": "",
+                    }
+                )
+        for rejection in response.provider_rejections:
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "provider": "openalex",
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(rejection.provider_result_index),
+                    "adapter_disposition": "provider_rejected",
+                    "scope_link_action": "NOT_EVALUATED",
+                    "abstention_reasons": "[]",
+                    "missing_required_groups": "[]",
+                    "exact_required_groups": "[]",
+                    "provider_only_required_groups": "[]",
+                    "exact_scope_groups": "[]",
+                    "linked_scope_groups": "[]",
+                    "title_anchor_groups": "[]",
+                    "required_match_provenance": "[]",
+                    "scope_match_provenance": "[]",
+                    "supporting_match_provenance": "[]",
+                    "link_evidence": "[]",
+                    "aboutness_signal_count": "0",
+                    "candidate_sha256": "",
+                    "profile_sha256": execution.profile_sha256,
+                    "title": rejection.title or "",
+                    "url": rejection.url or "",
+                    "provider_rejection_code": rejection.code,
+                    "rejection_detail": rejection.detail,
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+    rows.sort(key=lambda row: (row["case_id"], int(row["provider_result_index"])))
+    reviews.sort(
+        key=lambda row: (row["case_id"], int(row["provider_result_index"]))
+    )
+    return rows, reviews
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    artifact: ScopeLinkExecutionArtifact,
+) -> None:
+    rows, reviews = _candidate_rows(artifact.cases)
+    _write_new(output_dir / "execution.json", _json_text(artifact))
+    _write_new(
+        output_dir / "candidates.csv",
+        _csv_text(_CANDIDATE_COLUMNS, rows),
+    )
+    _write_new(output_dir / "review.csv", _csv_text(_REVIEW_COLUMNS, reviews))
+    file_hashes = {
+        name: _sha256_bytes((output_dir / name).read_bytes())
+        for name in _AGGREGATE_SOURCE_FILES
+    }
+    _write_new(
+        output_dir / "artifact-index.json",
+        _json_text(
+            {
+                "schema_version": 1,
+                "mode": "openalex_scope_link_v4_artifact_index",
+                "production_connected": False,
+                "report_workflow_connected": False,
+                "source_file_sha256": file_hashes,
+            }
+        ),
+    )
+
+
+def _review_packet_eligibility(
+    *,
+    successful_case_count: int,
+    accepted_case_count: int,
+    gates: ScopeLinkSourceValueGates,
+) -> ReviewPacketEligibility:
+    if successful_case_count != MAXIMUM_REQUESTS:
+        return "incomplete"
+    if accepted_case_count < gates.accepted_case_count_min:
+        return "mechanical_gate_failed"
+    return "eligible_for_source_lock"
+
+
+def execute_live_study(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    acknowledge_anonymous_daily_budget: bool,
+    adapter_factory: AdapterFactory | None = None,
+    monotonic_clock: Clock | None = None,
+) -> ScopeLinkExecutionArtifact:
+    """Run W01-W08 under a provider-reported soft stop and write-once seams."""
+
+    if not 0.0 < soft_stop_usd <= MAXIMUM_SOFT_STOP_USD:
+        raise OpenAlexScopeLinkLiveError(
+            "scope-link v4 soft stop must be greater than zero and at most USD 0.01"
+        )
+    if not acknowledge_anonymous_daily_budget:
+        raise OpenAlexScopeLinkLiveError(
+            "scope-link v4 execution requires daily-budget acknowledgement"
+        )
+    if (os.getenv("OPENALEX_API_KEY") or "").strip():
+        raise OpenAlexScopeLinkLiveError(
+            "anonymous scope-link v4 study refuses a configured OPENALEX_API_KEY"
+        )
+    if output_dir.exists():
+        raise FileExistsError(f"scope-link v4 output already exists: {output_dir}")
+
+    fixture_sha256, challenge, cases = load_frozen_cases()
+    implementation_sha256 = verify_frozen_implementation()
+    runner_sha256 = _file_sha256(_RUNNER_PATH)
+    # Reserve the path and persist the complete method before constructing a
+    # network-capable object.  This ordering is a crash/retry boundary, not a
+    # cosmetic artifact convention.
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest_artifact(
+        cases,
+        fixture_sha256,
+        implementation_sha256,
+        runner_sha256,
+        challenge.source_value_gates,
+        soft_stop_usd,
+    )
+    _write_new(output_dir / "manifest.json", _json_text(manifest))
+    adapter: ScopeLinkAdapter
+    if adapter_factory is not None:
+        adapter = adapter_factory()
+    else:
+        adapter = AnonymousOpenAlexClaimScopeAdapter(
+            transport=_OneRequestTransport()
+        )
+
+    executions: list[ScopeLinkCaseExecution] = []
+    clock = monotonic_clock or time.perf_counter
+    known_cost = 0.0
+    stopped_reason: StopReason = "completed"
+    for case in cases:
+        if known_cost + 1e-12 >= soft_stop_usd:
+            stopped_reason = "soft_stop"
+            break
+        call = case.plan.calls[0]
+        case_stop_reason: StopReason | None = None
+        started_at = clock()
+        try:
+            raw_response = adapter(call)
+        except ToolAdapterFailure as exc:
+            latency_ms = _elapsed_ms(clock, started_at)
+            execution = _failure_execution(
+                case,
+                failure_type=exc.failure_type,
+                failure_detail=str(exc),
+                failure_retryable=exc.retryable,
+                latency_ms=latency_ms,
+                search_cost_usd=exc.search_cost_usd,
+            )
+            case_stop_reason = "request_failed"
+        else:
+            latency_ms = _elapsed_ms(clock, started_at)
+            try:
+                response = OpenAlexClaimScopeAdapterResponse.model_validate(
+                    raw_response
+                )
+            except ValidationError as exc:
+                execution = _failure_execution(
+                    case,
+                    failure_type="adapter_response_invalid",
+                    failure_detail=_validation_detail(exc),
+                    failure_retryable=False,
+                    latency_ms=latency_ms,
+                )
+                case_stop_reason = "accounting_invalid"
+            else:
+                if response.idempotency_key != call.idempotency_key:
+                    execution = _failure_execution(
+                        case,
+                        failure_type="adapter_identity_mismatch",
+                        failure_detail=(
+                            "adapter response idempotency key does not match the "
+                            "authorized call"
+                        ),
+                        failure_retryable=False,
+                        latency_ms=latency_ms,
+                        response=response,
+                        search_cost_usd=response.search_cost_usd,
+                    )
+                    case_stop_reason = "accounting_invalid"
+                else:
+                    execution = _completed_execution(case, response, latency_ms)
+
+        # Commit the one-request journal before checking whether another case
+        # may run.  If the process dies after this line, the spent request and
+        # its disposition remain independently inspectable.
+        _write_case_journal(output_dir, execution)
+        executions.append(execution)
+        if execution.search_cost_usd is None:
+            stopped_reason = case_stop_reason or "cost_uninspectable"
+            break
+        known_cost += execution.search_cost_usd
+        if case_stop_reason is not None:
+            stopped_reason = case_stop_reason
+            break
+
+    cost_state, reported_cost = _provider_cost(executions)
+    successful_case_count = sum(item.state == "completed" for item in executions)
+    provider_summary = ScopeLinkProviderSummary(
+        attempted_case_count=len(executions),
+        successful_case_count=successful_case_count,
+        request_count=sum(item.outbound_attempt_count for item in executions),
+        cost_state=cost_state,
+        reported_cost_usd=reported_cost,
+        total_latency_ms=sum(item.latency_ms for item in executions),
+        stopped_reason=stopped_reason,
+    )
+    evaluations = tuple(item for case in executions for item in case.evaluations)
+    accepted_case_count = sum(
+        any(item.decision.action == "ACCEPT" for item in case.evaluations)
+        for case in executions
+    )
+    artifact = ScopeLinkExecutionArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        request_count=provider_summary.request_count,
+        attempted_case_count=provider_summary.attempted_case_count,
+        successful_case_count=provider_summary.successful_case_count,
+        overall_state=(
+            "completed" if stopped_reason == "completed" else "partial"
+        ),
+        scope_link_accepted_candidate_count=sum(
+            item.decision.action == "ACCEPT" for item in evaluations
+        ),
+        scope_link_abstained_candidate_count=sum(
+            item.decision.action == "ABSTAIN" for item in evaluations
+        ),
+        scope_link_accepted_case_count=accepted_case_count,
+        review_packet_eligibility=_review_packet_eligibility(
+            successful_case_count=successful_case_count,
+            accepted_case_count=accepted_case_count,
+            gates=challenge.source_value_gates,
+        ),
+        source_value_gates=challenge.source_value_gates,
+        provider_summary=provider_summary,
+        cases=tuple(executions),
+    )
+    _write_final_artifacts(output_dir, artifact)
+    return artifact
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    parser.add_argument(
+        "--acknowledge-anonymous-daily-budget",
+        action="store_true",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(_stdout_json(protocol_dry_run()))
+        return 0
+    if args.output_dir is None or args.soft_stop_usd is None:
+        raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
+    artifact = execute_live_study(
+        output_dir=args.output_dir,
+        soft_stop_usd=args.soft_stop_usd,
+        acknowledge_anonymous_daily_budget=(
+            args.acknowledge_anonymous_daily_budget
+        ),
+    )
+    print(_stdout_json(artifact))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_scope_link_live.py
+++ b/tests/test_openalex_scope_link_live.py
@@ -1,0 +1,478 @@
+"""Zero-network seams for the scope-link v4 live harness."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import openalex_scope_link_live as live
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_scope_link_live import (
+    OpenAlexScopeLinkLiveError,
+    execute_live_study,
+)
+from openalex_scope_link_unseen import PreparedScopeLinkCase, load_frozen_cases
+
+
+def _accepted_candidate(
+    case: PreparedScopeLinkCase,
+    index: int,
+) -> OpenAlexClaimScopeCandidate:
+    required = [
+        group.text_phrases[0] for group in case.spec.profile.required_groups
+    ]
+    scope = [group.text_phrases[0] for group in case.spec.profile.scope_groups]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups[
+            : case.spec.profile.minimum_supporting_groups
+        ]
+    ]
+    # Required and scope roles share the title segment deliberately.  The row
+    # is synthetic persistence input, not a claim about retrieval precision.
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{' '.join(required + scope)} controlled study",
+            url=f"https://openalex.org/W{case.spec.case_id[1:]}00000001",
+            publisher="OpenAlex zero-network scope-link fixture",
+            evidence_summary=(
+                f"{' '.join(required + scope)}. {' '.join(supporting)}. "
+                f"The study reports a direct measurement for {case.spec.query}."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+def _abstained_candidate(
+    case: PreparedScopeLinkCase,
+    index: int,
+) -> OpenAlexClaimScopeCandidate:
+    required = [
+        group.text_phrases[0] for group in case.spec.profile.required_groups
+    ]
+    scope = [group.text_phrases[0] for group in case.spec.profile.scope_groups]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups[
+            : case.spec.profile.minimum_supporting_groups
+        ]
+    ]
+    # All concepts are present, but the required and scope roles never share a
+    # title or abstract sentence.  This isolates the v4 relation boundary.
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{' '.join(required)} broad application review",
+            url=f"https://openalex.org/W{case.spec.case_id[1:]}00000002",
+            publisher="OpenAlex zero-network scope-link review",
+            evidence_summary=(
+                f"{' '.join(scope)}. {' '.join(supporting)}. "
+                "The required and scope concepts remain in separate segments."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+def _response(
+    case: PreparedScopeLinkCase,
+    call: ValidatedGapCall,
+    *,
+    reported_cost_usd: float,
+    include_rejection: bool,
+    only_abstained: bool,
+    identity_mismatch: bool,
+) -> OpenAlexClaimScopeAdapterResponse:
+    candidates = (
+        (_abstained_candidate(case, 0),)
+        if only_abstained
+        else (
+            _accepted_candidate(case, 0),
+            _abstained_candidate(case, 1),
+        )
+    )
+    rejection_index = len(candidates)
+    rejections = (
+        (
+            ProviderResultRejection(
+                provider_result_index=rejection_index,
+                code="provider_result_not_object",
+                detail="zero-network fixture row is not an object",
+            ),
+        )
+        if include_rejection
+        else ()
+    )
+    idempotency_key = "0" * 64 if identity_mismatch else call.idempotency_key
+    usage = ToolProviderUsage(
+        provider="openalex",
+        request_id=f"client-openalex-scope-link-{call.idempotency_key[:12]}",
+        request_id_source="client_generated",
+        result_count=len(candidates) + len(rejections),
+        cost_basis="reported_usd",
+        reported_cost_usd=reported_cost_usd,
+    )
+    return OpenAlexClaimScopeAdapterResponse(
+        idempotency_key=idempotency_key,
+        candidates=candidates,
+        provider_rejections=rejections,
+        search_cost_usd=reported_cost_usd,
+        provider_request_id=usage.request_id,
+        provider_usage=usage,
+    )
+
+
+class RecordingFactory:
+    """Injected adapter proving construction and request journal ordering."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        *,
+        reported_cost_usd: float = 0.001,
+        include_rejection: bool = False,
+        fail: bool = False,
+        invalid_response: bool = False,
+        identity_mismatch: bool = False,
+        only_abstained: bool = False,
+    ) -> None:
+        self.output_dir = output_dir
+        self.reported_cost_usd = reported_cost_usd
+        self.include_rejection = include_rejection
+        self.fail = fail
+        self.invalid_response = invalid_response
+        self.identity_mismatch = identity_mismatch
+        self.only_abstained = only_abstained
+        self.constructed = 0
+        self.calls: list[str] = []
+        _, _, cases = load_frozen_cases()
+        self.case_by_key = {
+            case.plan.calls[0].idempotency_key: case for case in cases
+        }
+
+    def __call__(self):
+        # The manifest is the durable authorization and identity boundary.  A
+        # socket-capable adapter must never exist before these bytes do.
+        assert (self.output_dir / "manifest.json").is_file()
+        self.constructed += 1
+
+        def run(call: ValidatedGapCall):
+            case = self.case_by_key[call.idempotency_key]
+            for previous_case in self.calls:
+                assert (
+                    self.output_dir
+                    / "case-executions"
+                    / f"{previous_case}.json"
+                ).is_file()
+            self.calls.append(case.spec.case_id)
+            if self.fail:
+                raise ToolAdapterFailure(
+                    "offline injected provider failure",
+                    retryable=False,
+                    failure_type="provider_authentication",
+                    search_cost_usd=None,
+                )
+            if self.invalid_response:
+                return {
+                    "tool": "academic_search",
+                    "idempotency_key": call.idempotency_key,
+                    "outbound_request_count": 1,
+                }
+            return _response(
+                case,
+                call,
+                reported_cost_usd=self.reported_cost_usd,
+                include_rejection=self.include_rejection,
+                only_abstained=self.only_abstained,
+                identity_mismatch=self.identity_mismatch,
+            )
+
+        return run
+
+
+def _run(tmp_path: Path, *, monotonic_clock=None, **factory_options):
+    output = tmp_path / "scope-link-v4"
+    factory = RecordingFactory(output, **factory_options)
+    artifact = execute_live_study(
+        output_dir=output,
+        soft_stop_usd=0.01,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=factory,
+        monotonic_clock=monotonic_clock,
+    )
+    return output, factory, artifact
+
+
+def test_protocol_dry_run_locks_eight_cases_without_live_authority():
+    result = live.protocol_dry_run()
+
+    assert result["case_count"] == 8
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"W{index:02d}" for index in range(1, 9)
+    ]
+    assert result["implementation_sha256"] == live.EXPECTED_IMPLEMENTATION_SHA256
+    assert len(result["runner_sha256"]) == 64
+    assert result["live_provider_requests_authorized"] is False
+    assert result["real_network_calls_performed"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+
+
+def test_complete_run_reaches_decision_and_artifact_seams(tmp_path):
+    output, factory, artifact = _run(tmp_path)
+
+    assert factory.constructed == 1
+    assert factory.calls == [f"W{index:02d}" for index in range(1, 9)]
+    assert artifact.overall_state == "completed"
+    assert artifact.request_count == 8
+    assert artifact.successful_case_count == 8
+    assert artifact.scope_link_accepted_candidate_count == 8
+    assert artifact.scope_link_abstained_candidate_count == 8
+    assert artifact.scope_link_accepted_case_count == 8
+    assert artifact.review_packet_eligibility == "eligible_for_source_lock"
+    assert artifact.provider_summary.reported_cost_usd == pytest.approx(0.008)
+    assert {path.name for path in (output / "case-executions").glob("*.json")} == {
+        f"W{index:02d}.json" for index in range(1, 9)
+    }
+    assert (output / "artifact-index.json").is_file()
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    execution = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert manifest["runner_sha256"] == artifact.runner_sha256
+    assert execution["runner_sha256"] == artifact.runner_sha256
+
+
+def test_request_latency_reaches_journal_csv_and_provider_summary(tmp_path):
+    ticks = iter(float(value) for value in range(16))
+    output, _, artifact = _run(
+        tmp_path,
+        monotonic_clock=lambda: next(ticks),
+    )
+
+    assert artifact.provider_summary.total_latency_ms == pytest.approx(8000.0)
+    assert {case.latency_ms for case in artifact.cases} == {1000.0}
+    first_journal = (
+        output / "case-executions" / "W01.json"
+    ).read_text(encoding="utf-8")
+    assert '"latency_ms": 1000.0' in first_journal
+    with (output / "candidates.csv").open(
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["latency_ms"] for row in rows} == {"1000.0"}
+
+
+def test_every_provider_row_and_decision_reaches_csv_boundary(tmp_path):
+    output, _, _ = _run(tmp_path, include_rejection=True)
+
+    with (output / "candidates.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    with (output / "review.csv").open(encoding="utf-8", newline="") as handle:
+        reviews = list(csv.DictReader(handle))
+
+    assert len(rows) == 24
+    assert len(reviews) == 8
+    actions = [row["scope_link_action"] for row in rows]
+    assert actions.count("ACCEPT") == 8
+    assert actions.count("ABSTAIN") == 8
+    assert actions.count("NOT_EVALUATED") == 8
+    evaluated = [
+        row
+        for row in rows
+        if row["scope_link_action"] in {"ACCEPT", "ABSTAIN"}
+    ]
+    accepted = [row for row in rows if row["scope_link_action"] == "ACCEPT"]
+    abstained = [row for row in rows if row["scope_link_action"] == "ABSTAIN"]
+    assert all(row["missing_required_groups"] == "[]" for row in abstained)
+    assert all("missing_scope_link" in row["abstention_reasons"] for row in abstained)
+    assert all(row["required_match_provenance"] != "[]" for row in evaluated)
+    assert all(row["scope_match_provenance"] != "[]" for row in evaluated)
+    assert all(row["supporting_match_provenance"] != "[]" for row in evaluated)
+    assert all(row["link_evidence"] != "[]" for row in accepted)
+    assert all(row["link_evidence"] == "[]" for row in abstained)
+    assert {row["case_id"] for row in reviews} == {
+        f"W{index:02d}" for index in range(1, 9)
+    }
+    assert all(row["candidate_sha256"] for row in reviews)
+    assert all(
+        not row["relevant"] and not row["novel"] and not row["review_note"]
+        for row in reviews
+    )
+
+
+@pytest.mark.parametrize(
+    ("soft_stop", "acknowledge"),
+    [(0.0, True), (0.0101, True), (0.01, False)],
+)
+def test_invalid_authorization_fails_before_adapter_and_output(
+    tmp_path,
+    soft_stop,
+    acknowledge,
+):
+    output = tmp_path / "forbidden"
+    factory = RecordingFactory(output)
+
+    with pytest.raises(OpenAlexScopeLinkLiveError):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=soft_stop,
+            acknowledge_anonymous_daily_budget=acknowledge,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_configured_key_fails_before_adapter_and_output(tmp_path, monkeypatch):
+    output = tmp_path / "configured-key"
+    factory = RecordingFactory(output)
+    monkeypatch.setenv("OPENALEX_API_KEY", "configured-secret")
+
+    with pytest.raises(OpenAlexScopeLinkLiveError, match="refuses"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_existing_output_fails_before_adapter_construction(tmp_path):
+    output = tmp_path / "existing"
+    output.mkdir()
+    factory = RecordingFactory(output)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+
+
+def test_implementation_hash_drift_fails_before_factory_and_output(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "hash-drift"
+    factory = RecordingFactory(output)
+    monkeypatch.setitem(
+        live.EXPECTED_IMPLEMENTATION_SHA256,
+        "openalex_scope_link.py",
+        "0" * 64,
+    )
+
+    with pytest.raises(OpenAlexScopeLinkLiveError, match="identity drifted"):
+        execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.01,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_soft_stop_commits_first_case_before_stopping(tmp_path):
+    output, factory, artifact = _run(tmp_path, reported_cost_usd=0.01)
+
+    assert factory.calls == ["W01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "soft_stop"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "case-executions" / "W01.json").is_file()
+    assert not (output / "case-executions" / "W02.json").exists()
+
+
+def test_provider_failure_remains_an_inspectable_partial_result(tmp_path):
+    output, factory, artifact = _run(tmp_path, fail=True)
+
+    assert factory.calls == ["W01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "request_failed"
+    assert artifact.provider_summary.cost_state == "uninspectable"
+    assert artifact.cases[0].failure_type == "provider_authentication"
+    assert (output / "case-executions" / "W01.json").is_file()
+
+
+def test_invalid_response_is_not_reported_as_a_provider_pass(tmp_path):
+    output, factory, artifact = _run(tmp_path, invalid_response=True)
+
+    assert factory.calls == ["W01"]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.cases[0].failure_type == "adapter_response_invalid"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "case-executions" / "W01.json").is_file()
+
+
+def test_identity_mismatch_preserves_response_but_blocks_evaluation(tmp_path):
+    output, factory, artifact = _run(tmp_path, identity_mismatch=True)
+
+    assert factory.calls == ["W01"]
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.cases[0].response is not None
+    assert artifact.cases[0].evaluations == ()
+    assert artifact.cases[0].failure_type == "adapter_identity_mismatch"
+    with (output / "candidates.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["scope_link_action"] for row in rows} == {"NOT_EVALUATED"}
+
+
+def test_completed_mechanical_failure_is_not_a_source_value_pass(tmp_path):
+    _, _, artifact = _run(tmp_path, only_abstained=True)
+
+    assert artifact.overall_state == "completed"
+    assert artifact.scope_link_accepted_case_count == 0
+    assert artifact.review_packet_eligibility == "mechanical_gate_failed"
+    assert artifact.human_review_state == "not_prepared"
+    assert artifact.source_value_state == "not_evaluated"
+
+
+def test_artifacts_expose_no_key_or_unrelated_process_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNRELATED_PROCESS_SECRET", "must-not-reach-artifacts")
+    output, _, _ = _run(tmp_path)
+
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in output.rglob("*")
+        if path.is_file()
+    )
+    assert "must-not-reach-artifacts" not in rendered
+    assert "configured-secret" not in rendered
+    assert '"api_key_used": false' in rendered
+
+
+def test_production_worker_does_not_import_scope_link_live_components():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
+
+    assert "openalex_scope_link_live" not in worker
+    assert "openalex_scope_link_unseen" not in worker
+    assert "openalex_scope_link" not in worker
+    assert "openalex_claim_scope_search" not in worker
+    assert "openalex_claim_scope" not in worker


### PR DESCRIPTION
## Why

Scope-link v4 passed its zero-network method gate but had no auditable boundary for any later authorized W01-W08 provider study. Running the provider directly would have lost the manifest-before-adapter, per-request journal, row-complete accounting, and review-provenance guarantees established by earlier experiments.

## What changed

- pre-registers the exact anonymous one-attempt W01-W08 execution and USD 0.01 soft-stop contract before implementation
- adds a production-disconnected write-once runner that records its observed self-hash and locks all decision/transport dependencies
- persists the complete manifest before adapter construction and each case journal before any later request
- carries required, scope, supporting, and same-segment link provenance to the aggregate CSV while sending only ACCEPT rows to a blank review boundary
- documents that no provider request, source review, or production authorization has occurred

## Verification

- 17/17 new runner tests
- 32/32 combined v4 decision, preflight, and runner tests
- 1,695 tests passed, 1 skipped, and 609 subtests passed in a clean detached worktree
- latest Ruff and narrow Pylint passed
- defect reinjection: dropping link_evidence only at the CSV seam made the client-boundary test fail before restoration

Production remains disconnected. This PR does not authorize or perform a live OpenAlex request.