### PR TITLE
Diagnose scope-link v4 abstentions without reopening validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,11 +405,19 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   cases, exposes none of the v4 action or match-provenance fields, and its blank
   summary is incomplete / not_evaluated with zero metrics. Sixteen focused
   tests pass, including a re-injected decision-field leak and a Windows GBK
-  stdout regression. No human label exists yet. This diagnostic may explain
-  the failure shape but cannot rescue v4, validate v5, reopen W01-W08, or
-  authorize production. See
+  stdout regression. One eligible human reviewer later completed 64/64 rows
+  without substantive generative-AI use or external-source checks. The strict
+  result is complete / evaluated as a diagnostic only: 28/64 rows were directly
+  relevant from the frozen title and abstract, 36/64 were retrieval noise, all
+  8/8 cases retained relevant and baseline-novel evidence, and v4 missed four
+  of five human-inferred semantic links. This identifies both retrieval noise
+  and lexical relation recall as contributors; it does not establish source
+  truth or inter-rater agreement. It cannot rescue v4, validate v5, reopen
+  W01-W08, or authorize production. See
   docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md and
-  docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md.
+  docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md,
+  plus
+  docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md.
   Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4
   candidates, live runners and review modules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1695 tests (609 subtests), CI green on Linux + Windows × Python
+Current state: 1712 tests (639 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -211,6 +211,8 @@ openalex_scope_link_unseen.py
                         frozen W01-W08 scope-link preflight; zero-network only
 openalex_scope_link_live.py
                         write-once W01-W08 runner; CLI defaults to dry-run
+openalex_scope_link_abstention_review.py
+                        post-outcome W01-W08 label-blind diagnostic; zero-network
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -396,7 +398,19 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `not_evaluated`. Sixty-three decisions record `missing_scope_link`, which is
   a deterministic trace observation rather than a source-relevance label.
   W01-W08 are now consumed evaluation cases: do not tune on them, rerun them
-  and call the result validation, or connect v4. Keep
+  and call the result validation, or connect v4.
+  A separately pre-registered post-outcome diagnostic now locks the exact 64
+  abstentions and emits a label-blind packet containing only the frozen
+  baseline context and source text. The real packet has 64/64 rows across 8/8
+  cases, exposes none of the v4 action or match-provenance fields, and its blank
+  summary is incomplete / not_evaluated with zero metrics. Sixteen focused
+  tests pass, including a re-injected decision-field leak and a Windows GBK
+  stdout regression. No human label exists yet. This diagnostic may explain
+  the failure shape but cannot rescue v4, validate v5, reopen W01-W08, or
+  authorize production. See
+  docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md and
+  docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md.
+  Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,

--- a/README.md
+++ b/README.md
@@ -633,13 +633,19 @@ rule that was too strict, a separate post-outcome diagnostic was pre-registered
 without reopening the v4 result. It locks all 64 abstentions, exposes the
 frozen baseline plus title/abstract text in a label-blind packet, and withholds
 the v4 action, reasons and match provenance until summary. The real 64-row
-packet spans 8/8 cases and its untouched summary is
-**incomplete / not_evaluated** with zero calculated metrics. Sixteen focused
-tests include a re-injected decision leak and a Windows legacy-console output
-failure. No human labels exist yet: this work cannot rescue v4, validate a
-successor on W01-W08, or authorize production. See the
+packet spans 8/8 cases. One eligible human reviewer later completed 64/64 rows
+without substantive generative-AI use or external-source checks, producing
+**complete / evaluated** as a diagnostic only. From the frozen titles and
+abstracts, 28/64 rows were directly relevant and 36/64 were retrieval noise;
+all 8 cases retained at least one relevant, baseline-novel source. The reviewer
+inferred the target semantic link in five rows, and v4 missed four of those
+five. Sixteen focused tests include a re-injected decision leak and a Windows
+legacy-console output failure. This title/abstract-only, single-reviewer result
+explains the failure shape but cannot rescue v4, validate a successor on
+W01-W08, establish source truth, or authorize production. See the
 [diagnostic protocol](docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md)
-and [blank-packet implementation result](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md).
+and [blank-packet implementation result](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md),
+plus the [completed human diagnostic](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1767,12 +1773,17 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 由于机械失败本身无法区分“来源无关”和“规则过严”，项目在不重开 v4 结论的
 前提下另行预注册了事后诊断。它锁定全部 64 条 abstention，只在盲评包中展示
 冻结基线以及标题/摘要文本，并将 v4 动作、原因和匹配来源隐藏到汇总阶段。
-真实评审包覆盖 8/8 个案例、共 64 行；未填写时明确返回
-**incomplete / not_evaluated**，不计算任何指标。16 个聚焦测试覆盖了临时回注的
-决策字段泄露和 Windows 旧编码终端输出失败。目前尚无人工标签，因此该诊断不能
-挽救 v4、不能在 W01-W08 上验证后继方法，也不能授权生产接入。详见
+真实评审包覆盖 8/8 个案例、共 64 行。随后一名合格人工评审者在未使用实质性
+生成式 AI、未检查外部来源的条件下完成 64/64 行，严格汇总状态为仅诊断用途的
+**complete / evaluated**。基于冻结标题和摘要，28/64 行被判断为直接相关，36/64
+行为检索噪声；8/8 个案例均至少保留一条相关且相对冻结基线有新增信息的来源。
+评审者在 5 行中能够推断目标语义关系，而 v4 漏掉其中 4 行。16 个聚焦测试覆盖了
+临时回注的决策字段泄露和 Windows 旧编码终端输出失败。该单评审者、仅标题摘要的
+结果可以解释失败形态，但不能挽救 v4、不能在 W01-W08 上验证后继方法、不能建立
+来源真值，也不能授权生产接入。详见
 [诊断协议](docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md)与
-[空白评审包实现结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md)。
+[空白评审包实现结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md)，
+以及[已完成人工诊断结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ before a later request. Every provider row reaches the aggregate artifact, and
 only v4 `ACCEPT` rows reach a blank human-review boundary. The combined v4
 decision, preflight and runner subset passes 32/32 tests, including a
 re-injected computed-but-undelivered relation-provenance defect. The complete
-repository now passes **1,695 tests plus 609 subtests**. A separately
+repository now passes **1,712 tests plus 639 subtests**. A separately
 authorized run on merged revision `678254d` completed all eight one-attempt
 anonymous requests for USD 0.008 of provider-reported usage. All 64 provider
 rows reached the v4 decision seam, but the method accepted zero candidates
@@ -627,6 +627,19 @@ See the
 plus the [live-runner protocol](docs/prereg-2026-08-28-openalex-scope-link-v4-live.md)
 and [live-runner implementation result](docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md),
 and the [frozen live result](docs/results-2026-08-29-openalex-scope-link-v4-live.md).
+
+Because the mechanical failure could not distinguish irrelevant sources from a
+rule that was too strict, a separate post-outcome diagnostic was pre-registered
+without reopening the v4 result. It locks all 64 abstentions, exposes the
+frozen baseline plus title/abstract text in a label-blind packet, and withholds
+the v4 action, reasons and match provenance until summary. The real 64-row
+packet spans 8/8 cases and its untouched summary is
+**incomplete / not_evaluated** with zero calculated metrics. Sixteen focused
+tests include a re-injected decision leak and a Windows legacy-console output
+failure. No human labels exist yet: this work cannot rescue v4, validate a
+successor on W01-W08, or authorize production. See the
+[diagnostic protocol](docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md)
+and [blank-packet implementation result](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1738,7 +1751,7 @@ runner 已实现：它在构造适配器前记录冻结方法与自身观测哈�
 下一次请求前先提交当前单请求 case journal。每一条供应商返回行都会到达
 聚合产物，只有 v4 `ACCEPT` 行会进入空白人工评审边界。v4 决策、预检与
 runner 组合测试为 32/32；临时移除内部已算出的 relation provenance 后，
-客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,695 项测试与 609 个
+客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,712 项测试与 639 个
 subtests**。随后在合并版本 `678254d` 上单独授权的真实实验完成了 8 次匿名、
 不重试的顺序请求，供应商记账成本为 0.008 美元。64 条供应商候选全部到达
 v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结的 6/8 门槛。
@@ -1750,6 +1763,16 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 以及 [live runner 协议](docs/prereg-2026-08-28-openalex-scope-link-v4-live.md)与
 [live runner 实现结果](docs/results-2026-08-28-openalex-scope-link-v4-live-implementation.md)，
 以及[冻结真实实验结果](docs/results-2026-08-29-openalex-scope-link-v4-live.md)。
+
+由于机械失败本身无法区分“来源无关”和“规则过严”，项目在不重开 v4 结论的
+前提下另行预注册了事后诊断。它锁定全部 64 条 abstention，只在盲评包中展示
+冻结基线以及标题/摘要文本，并将 v4 动作、原因和匹配来源隐藏到汇总阶段。
+真实评审包覆盖 8/8 个案例、共 64 行；未填写时明确返回
+**incomplete / not_evaluated**，不计算任何指标。16 个聚焦测试覆盖了临时回注的
+决策字段泄露和 Windows 旧编码终端输出失败。目前尚无人工标签，因此该诊断不能
+挽救 v4、不能在 W01-W08 上验证后继方法，也不能授权生产接入。详见
+[诊断协议](docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md)与
+[空白评审包实现结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md
+++ b/docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md
@@ -1,0 +1,178 @@
+# Pre-registration: OpenAlex scope-link v4 abstention diagnostic
+
+**Frozen:** 2026-08-29, after the W01-W08 live result was observed and
+recorded, but before implementing this diagnostic packet or obtaining any
+human labels for the 64 abstained candidates.
+
+**Parent execution protocol:**
+`docs/prereg-2026-08-28-openalex-scope-link-v4-live.md`
+
+**Observed execution result:**
+`docs/results-2026-08-29-openalex-scope-link-v4-live.md`
+
+**Executed revision:**
+`678254d66c599402811d04f9b2b91ff6977ac089`
+
+**Production connection authorized:** no
+
+## Status of this document
+
+This is a post-outcome diagnostic pre-registration, not a retrospective change
+to the W01-W08 value study. The original study failed its frozen mechanical
+coverage gate at 0/8 accepted cases and remains `source_value=not_evaluated`.
+Nothing in this diagnostic can rescue that result, authorize production, or
+turn W01-W08 into an unseen validation set again.
+
+The only still-unobserved quantity frozen here is the human interpretation of
+the title and abstract text for every candidate that v4 abstained from.
+
+## Observed facts available before human labels
+
+The exact completed run contains eight candidates for each of W01-W08, for 64
+candidate decisions in total. All 64 decisions are `ABSTAIN` and 63 include
+`missing_scope_link`. Across the persisted decision traces:
+
+- 33 candidates contain at least one exact required-group match;
+- 8 contain at least one exact scope-group match;
+- 20 contain at least one exact supporting-group match; and
+- 1 contains a linked scope group but fails another frozen requirement.
+
+These are deterministic trace counts. They do not say whether a paper is
+relevant, whether a semantic relationship exists, or whether the abstract is
+sufficient for a human judgment.
+
+## Question
+
+Does the 0/8 result primarily reflect:
+
+1. OpenAlex retrieval noise;
+2. relevant but target-relation-missing papers;
+3. a semantic relationship present in the frozen text but missed by the exact
+   same-segment rule; or
+4. title/abstract evidence that is insufficient for classification?
+
+## Frozen population and source identity
+
+The diagnostic includes all 64 candidate evaluations. There is no sampling,
+ranking, top-k selection, provider request, enrichment fetch, retry, redirect,
+model call, or supplementary search.
+
+The implementation must lock and revalidate all of these source files:
+
+- `manifest.json`;
+- `execution.json`;
+- `candidates.csv`;
+- the intentionally header-only `review.csv`;
+- `artifact-index.json`; and
+- `case-executions/W01.json` through `W08.json`.
+
+The source lock must bind the exact file hashes recorded by the completed live
+result. Packet preparation and result summarization must repeat that validation
+and reject any drift.
+
+## Label-blind packet boundary
+
+The reviewer receives the frozen topic, baseline source context, candidate
+title, abstract, publisher, publication date, DOI and URL. The editable label
+file and reviewer-facing context must not expose:
+
+- `ACCEPT` or `ABSTAIN`;
+- abstention reasons;
+- required, scope or supporting match provenance;
+- same-segment link evidence;
+- profile thresholds; or
+- provider aboutness scores.
+
+Those values remain in the source-locked execution and are joined only after
+labels are returned. This blinding prevents `missing_scope_link` from telling
+the reviewer what conclusion the diagnostic expects.
+
+## Frozen labels
+
+Every row requires five completed fields:
+
+1. `direct_relevance`: `YES`, `NO`, or `UNVERIFIABLE`;
+2. `semantic_scope_link`: `YES`, `NO`, `N/A`, or `UNVERIFIABLE`;
+3. `baseline_novelty`: `YES`, `NO`, `N/A`, or `UNVERIFIABLE`;
+4. `abstract_sufficient`: `YES` or `NO`; and
+5. a source-grounded `review_note`.
+
+The only valid combinations are:
+
+- directly relevant `YES`, semantic link `YES` or `NO`, baseline novelty
+  `YES` or `NO`, and abstract sufficient `YES`;
+- directly relevant `NO`, semantic link `N/A`, baseline novelty `N/A`, and
+  abstract sufficient `YES`; or
+- `UNVERIFIABLE / UNVERIFIABLE / UNVERIFIABLE / NO`.
+
+The reviewer judges only the frozen title and abstract against the visible
+topic and baseline. Opening external URLs is optional and must be declared,
+because this diagnostic measures the method's treatment of the text it
+actually received rather than source truth beyond that text.
+
+## Reviewer eligibility
+
+The declaration records reviewer ID, complete-row confirmation, generative-AI
+use, external-source checking, elapsed minutes, expertise, date and
+limitations. `NONE` and `LANGUAGE_ONLY` are the only eligible generative-AI
+states. A substantive AI declaration is retained but yields
+`excluded_substantive_ai / not_evaluated`. Missing rows, a missing declaration,
+or failure to confirm all rows cannot appear as a completed diagnostic.
+
+`UNVERIFIABLE` is a valid observation and remains in the denominator; it is
+never silently converted into a negative label.
+
+## Frozen descriptive metrics
+
+For an eligible complete return, the summarizer reports:
+
+- relevant, irrelevant and unverifiable candidate counts;
+- relevant-case and baseline-novel relevant-case coverage;
+- semantic-link-present count;
+- the count and rate of human semantic links paired with v4
+  `missing_scope_link`;
+- retrieval-noise and frozen-text-insufficiency rates;
+- attribution counts by case; and
+- the original v4 reason distribution.
+
+The post-label attribution categories are:
+
+- `semantic_relation_missed_by_v4`: relevant and human-linked, while v4
+  recorded `missing_scope_link`;
+- `other_gate_rejection_of_relevant_source`: relevant but not in the first
+  category;
+- `retrieval_noise`: directly irrelevant; and
+- `frozen_text_insufficient`: unverifiable from the frozen text.
+
+No pass/fail threshold is attached to these metrics. Their only purpose is to
+choose a new hypothesis family. If a future v5 is built, it must be evaluated
+on a newly frozen unseen challenge; W01-W08 may be development evidence only.
+
+## Required zero-network verification
+
+Tests must prove that:
+
+- only the exact completed 64-row mechanical-failure execution can be locked;
+- every source and case-journal byte is revalidated at lock, packet and summary
+  boundaries;
+- all 64 candidate identities and all eight baseline contexts reach the packet;
+- editable and reviewer-facing packet content contains no v4 decision signal;
+- blank rows are `incomplete`, never a zero-error result;
+- identity drift, partial labels and invalid label combinations are rejected;
+- substantive generated judgments remain retained but not evaluated;
+- complete eligible labels join the hidden decision trace only at summary;
+- the output always preserves `original_source_value_state=not_evaluated` and
+  `production_connected=false`; and
+- `pipeline_worker.py` imports none of the diagnostic, v4 method, runner or
+  adapter modules.
+
+After the focused tests pass, deliberately leak one v4 decision field into the
+reviewer label boundary and confirm the packet-blinding seam test fails. Restore
+the correct boundary before the full suite.
+
+## Explicit non-claims
+
+This diagnostic cannot establish provider-wide precision or recall, source
+truth, planner-trigger precision, report improvement, user value, adoption,
+ROI, an SLO, autonomous tool choice, or production Tool Calling. It cannot
+change the already failed v4 source-value result.

--- a/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md
+++ b/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md
@@ -1,0 +1,144 @@
+# Result: scope-link v4 post-outcome abstention diagnostic
+
+**Implemented:** 2026-08-29
+
+**Authority:** zero-network diagnostic implementation and blank packet
+preparation only. This result cannot repair the failed v4 mechanical gate,
+establish source truth, validate a future method, authorize another provider
+run, or connect Tool Calling to production.
+
+## Why this diagnostic exists
+
+The frozen W01-W08 live study delivered all 64 provider candidates to the v4
+decision seam but accepted none. Sixty-three rows recorded
+**missing_scope_link**. That trace proves how the exact same-segment rule
+behaved; it does not say whether a source was irrelevant, whether its abstract
+was insufficient, or whether a human could infer the required relationship
+without the literal lexical link.
+
+The original protocol correctly stopped before source-value review because
+0/8 cases missed the frozen 6/8 coverage gate. The diagnostic was therefore
+pre-registered after observing the failure and is kept in a separate result
+lineage. W01-W08 remain consumed cases. Human labels collected here can explain
+the failure shape but cannot turn these cases into unseen validation.
+
+## Frozen boundary
+
+The root-level diagnostic utility provides three offline operations:
+
+1. **lock** revalidates the executed revision, fixture, nine implementation
+   hashes, four aggregate files, artifact index and eight case journals;
+2. **prepare** emits all 64 rows across W01-W08 into a label-blind packet that
+   exposes the frozen topic, query, gap, baseline context, title and abstract;
+3. **summarize** revalidates every source and packet identity before joining the
+   hidden v4 trace to completed human labels.
+
+The reviewer labels direct topic relevance, whether a human can infer the
+required technology/scope relationship, novelty against the exposed baseline,
+and whether the abstract is sufficient to judge. The packet hides the v4
+action, abstention reasons, concept profile, provider aboutness, match
+provenance and link evidence. Those fields appear only after a complete,
+eligible return reaches the summarizer.
+
+Review states remain explicit:
+
+- blank or partial labels are **incomplete / not_evaluated**;
+- substantive generated judgments are
+  **excluded_substantive_ai / not_evaluated**;
+- inaccessible or unattempted sources are
+  **not_inspectable / not_evaluated**;
+- only a complete eligible human return produces descriptive diagnostic
+  metrics.
+
+No diagnostic state authorizes v5 or production connection.
+
+## Pre-label census
+
+The deterministic trace over all 64 rows contains:
+
+| Observation | Count |
+|---|---:|
+| missing_scope_link | 63 |
+| missing_required_groups | 54 |
+| insufficient_scope_groups | 56 |
+| insufficient_supporting_groups | 44 |
+| insufficient_exact_required_groups | 31 |
+| missing_title_anchor | 34 |
+| Any exact scope match present | 8 |
+| Any exact required match present | 33 |
+| Any supporting match present | 20 |
+| Any linked required/scope segment present | 1 |
+
+These are rule traces, not relevance labels. In particular, the one linked row
+still abstained for other requirements, and the other 63 rows are not thereby
+proven wrong or useful.
+
+## Real blank packet
+
+The exact finalized source directory from revision
+**678254d66c599402811d04f9b2b91ff6977ac089** passed the source lock. The lock
+contains 13 complete SHA-256 identities and has file hash **8a9747f4...**; the
+64-row packet manifest has hash **68e15abd...**. All eight cases contribute
+exactly eight rows. A byte search over the real packet found none of the v4
+action, abstention-reason, link-evidence, or match-provenance fields.
+
+Summarizing the untouched packet returned:
+
+- completed rows: 0;
+- protocol status: **incomplete**;
+- diagnostic state: **not_evaluated**;
+- all 64 row identities listed as incomplete;
+- metrics: null;
+- v5 validation authorized: false;
+- both production and report-workflow connections false.
+
+No human judgment has been supplied, so this implementation adds no
+source-value result.
+
+## Defects found at the seams
+
+The first real source-lock attempt stopped before packet creation because the
+new, uncommitted diagnostic constant had lost one hexadecimal character while
+copying the artifact-index digest. Exact-map comparison alone would not explain
+that class of transcription error, so the lock now independently requires
+every source digest to be 64 lowercase hexadecimal characters. The published
+live-result document and immutable artifact already contained the correct
+digest; neither was changed.
+
+The first real packet preparation then committed all packet files but failed
+while echoing the result because Windows GBK stdout could not encode a Unicode
+minus sign from a source title. CLI JSON now writes UTF-8 bytes at the stdout
+boundary, while text-only test doubles retain their normal path. A regression
+test recreates the legacy-encoded console rather than removing the source
+character.
+
+Full-suite validation also showed that a used workspace could collect ignored
+repository snapshots under outputs and .claude/worktrees as duplicate test
+modules. Pytest now excludes those generated evidence/tool boundaries without
+skipping or weakening any canonical test under tests.
+
+## Verification
+
+Sixteen focused zero-network tests cover source identity, complete SHA-256
+representation, all 64 rows, eight-case coverage, decision blinding, blank and
+ineligible states, label combinations, source and packet drift, exact hidden
+trace joins, production disconnection, and the Windows UTF-8 stdout boundary.
+
+The decision-leak defect was re-injected by temporarily adding the v4 action to
+every reviewer row. The packet-boundary test failed before a packet could be
+emitted and named the leaked field. Restoring the correct row projection made
+the same test and the full focused module pass.
+
+The complete zero-network suite passes **1,712 tests plus 639 subtests** with a
+project-local pytest temporary directory; latest Ruff and the CI-scope Pylint
+checks also pass. The project-local temporary directory is necessary only
+because this Windows account has a pre-existing inaccessible pytest directory
+under the user temp path; it changes no collected test or assertion.
+
+## Next decision
+
+One eligible human reviewer may now label the 64-row packet. The result must be
+reported as post-outcome failure analysis. It may justify designing a different
+method on newly frozen cases, but it must not be used to tune v4 on W01-W08,
+claim v4 source precision, rerun W01-W08 as validation, or advertise completed
+production Tool Calling.

--- a/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md
+++ b/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md
@@ -135,10 +135,20 @@ checks also pass. The project-local temporary directory is necessary only
 because this Windows account has a pre-existing inaccessible pytest directory
 under the user temp path; it changes no collected test or assertion.
 
-## Next decision
+## Next decision at implementation time
 
 One eligible human reviewer may now label the 64-row packet. The result must be
 reported as post-outcome failure analysis. It may justify designing a different
 method on newly frozen cases, but it must not be used to tune v4 on W01-W08,
 claim v4 source precision, rerun W01-W08 as validation, or advertise completed
 production Tool Calling.
+
+## Human-review follow-up
+
+An eligible human return later completed all 64 rows and passed the strict
+source and packet locks. The diagnostic is now **complete / evaluated**: 28
+rows were directly relevant from the frozen text, 36 were retrieval noise, and
+four of five human-inferred semantic links were missed by v4. No external
+sources were checked, so this is title/abstract interpretation rather than
+source-truth validation. See the
+[completed diagnostic result](results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md).

--- a/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md
+++ b/docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md
@@ -1,0 +1,126 @@
+# Result: scope-link v4 abstention diagnostic human review
+
+**Completed:** 2026-08-29
+
+**Status:** `complete / evaluated` as a post-outcome diagnostic only.
+
+**Authority:** descriptive human interpretation of the 64 frozen W01-W08
+titles and abstracts. This result cannot repair the failed v4 gate, establish
+source truth, validate a successor, authorize another provider run, or connect
+Tool Calling to production.
+
+## Why this is a separate result
+
+The live v4 study accepted zero candidates and therefore stopped before its
+planned source-value review. That mechanical failure did not distinguish
+irrelevant retrievals from useful sources rejected by an overly literal rule.
+The project consequently pre-registered a label-blind, post-outcome diagnostic
+over every abstained candidate. W01-W08 were already consumed before this
+review began and remain unavailable as unseen validation data.
+
+The diagnostic locked the exact live revision
+`678254d66c599402811d04f9b2b91ff6977ac089`, source lock
+`8a9747f4240fc7c529d8d8f2a737fb21b502579ad2f69c19587bf093cabba7af`,
+and packet manifest
+`68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616`.
+The reviewer saw the frozen topic, gap, baseline context, title and abstract,
+but not the v4 action, rejection reasons, concept profile, match provenance or
+link evidence.
+
+## Eligible return
+
+One anonymous human reviewer completed all 64 rows in 30 minutes and declared:
+
+- all rows reviewed: `YES`;
+- substantive generative-AI use: `NONE`;
+- external sources checked: `NONE`;
+- expertise: academic literature relevance assessment;
+- limitation: judgments used only the frozen titles and abstracts.
+
+The returned declaration encoded the external-source answer as `0`, while its
+plain-language limitation independently stated that no external sources were
+checked. With the project owner's explicit confirmation, only that field was
+normalized to the schema value `NONE`. The byte-exact returned files were
+preserved in the private audit archive before normalization; no substantive
+label, note, identity, duration or limitation was changed.
+
+The strict zero-network summarizer revalidated the source lock, packet
+manifest and every row identity before producing `complete / evaluated` with
+no method issue and no incomplete row.
+
+## Aggregate result
+
+| Measure | Result |
+|---|---:|
+| Completed rows | 64 / 64 |
+| Directly relevant from frozen text | 28 / 64 (43.75%) |
+| Directly irrelevant / retrieval noise | 36 / 64 (56.25%) |
+| Unverifiable from frozen text | 0 / 64 |
+| Cases with at least one relevant source | 8 / 8 |
+| Cases with at least one relevant, baseline-novel source | 8 / 8 |
+| Rows where the reviewer inferred the required semantic link | 5 |
+| Human semantic links missed by v4 | 4 / 5 (80.0%) |
+
+The hidden-trace attribution joined after review was:
+
+| Attribution | Rows |
+|---|---:|
+| Retrieval noise | 36 |
+| Semantic relation missed by v4 | 4 |
+| Relevant source rejected by another v4 gate | 24 |
+
+The 24 rows in the final category are relevant-source rejections, not
+additional semantic-link misses. Only five rows received a positive human
+semantic-link label, and four of those five were missed by the exact
+same-segment rule.
+
+## Case-level census
+
+| Case | Relevant | Retrieval noise | Semantic-link miss | Other relevant-source rejection |
+|---|---:|---:|---:|---:|
+| W01 | 7 | 1 | 2 | 5 |
+| W02 | 1 | 7 | 0 | 1 |
+| W03 | 1 | 7 | 0 | 1 |
+| W04 | 1 | 7 | 0 | 1 |
+| W05 | 8 | 0 | 1 | 7 |
+| W06 | 3 | 5 | 0 | 3 |
+| W07 | 5 | 3 | 0 | 5 |
+| W08 | 2 | 6 | 1 | 1 |
+
+## Interpretation
+
+The zero-acceptance outcome had two observable contributors:
+
+1. the generic OpenAlex candidate query returned substantial retrieval noise;
+2. among the small set of rows where a human inferred the target relationship,
+   the exact same-segment lexical rule missed most links.
+
+All eight cases nevertheless contained at least one source the reviewer judged
+both directly relevant and novel relative to the displayed frozen baseline.
+The live failure therefore cannot be explained solely as an absence of useful
+candidate evidence.
+
+These observations explain the failure shape; they do not estimate provider
+recall, source truth, report improvement, user value or production reliability.
+Because no external page was checked, every judgment is limited to the supplied
+title and abstract. One reviewer also provides no inter-rater agreement.
+
+## Decision
+
+Scope-link v4 remains failed and disconnected. The diagnostic does not reopen
+its frozen gate and does not authorize v5 validation or production Tool
+Calling. A successor may be designed only as a new hypothesis with newly
+frozen, unseen cases. It should address retrieval precision and relation recall
+as separate failure surfaces rather than tuning against W01-W08.
+
+## Verification
+
+The completed return passed the strict zero-network summarizer and all 16
+focused diagnostic seam tests. The implementation continues to expose
+`production_connected=false`, `report_workflow_connected=false`, and
+`v5_validation_authorized=false`.
+
+See the
+[pre-registration](prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md),
+[blank-packet implementation result](results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md),
+and [original live result](results-2026-08-29-openalex-scope-link-v4-live.md).

--- a/openalex_scope_link_abstention_review.py
+++ b/openalex_scope_link_abstention_review.py
@@ -1,0 +1,1218 @@
+"""Diagnose the frozen scope-link v4 abstentions without changing their result.
+
+The W01-W08 live study failed before its registered source-value review could
+begin.  This module creates a separate, explicitly post-outcome diagnostic over
+the title and abstract text already on disk.  Reviewers never see the v4 action,
+reasons, match provenance, profile, or provider aboutness.  Those hidden traces
+are joined only after labels return, so the packet can distinguish retrieval
+noise from semantic relationships missed by the exact same-segment rule.
+
+This is deliberately a root-level experimental utility.  It opens no socket,
+invokes no model, registers no evidence, and is never imported by the
+production report worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from evidence_gap_phase4_review import (
+    DECLARATION_FIELDS,
+    ELIGIBLE_AI_USE,
+    Phase4ReviewError as ScopeLinkDiagnosticError,
+    _file_sha256,
+    _read_csv,
+    _read_json_object,
+    _validated_declaration,
+    _write_csv_new,
+    _write_text_new,
+)
+from openalex_scope_link_live import (
+    EXPECTED_IMPLEMENTATION_SHA256,
+    ScopeLinkCaseExecution,
+    ScopeLinkExecutionArtifact,
+    ScopeLinkManifestArtifact,
+    _AGGREGATE_SOURCE_FILES,
+    _CANDIDATE_COLUMNS,
+    _REVIEW_COLUMNS,
+    _candidate_rows,
+)
+from openalex_scope_link_unseen import EXPECTED_FIXTURE_SHA256
+
+
+EXPECTED_EXECUTED_REVISION = "678254d66c599402811d04f9b2b91ff6977ac089"
+EXPECTED_SOURCE_FILE_SHA256 = {
+    "manifest.json": (
+        "3ea66fdb806efe049cba09b582a8dd99daf5a500c584dbce401b22d413ea630b"
+    ),
+    "execution.json": (
+        "aff3b692783c695647dede20b5aafbb9a6a5b96baf58b205349ca0cb691eff87"
+    ),
+    "candidates.csv": (
+        "7e3ae36d1efb02132de241d47bd685117ae4c1c5478d25adeaeeb88498bbcaf3"
+    ),
+    "review.csv": (
+        "6c89b81c657dc0cfd3c3853c738d132e244f91a54f0ec67aa61853ea08243148"
+    ),
+    "artifact-index.json": (
+        "2bc4cd8a7d6719c3799521ea0866530be0331bfb233a6af61c261ef69d67c445"
+    ),
+    "case-executions/W01.json": (
+        "27eac645e068eb064b1fa3e2d775996d707d0830b2e1437ab3ccd369eb14f411"
+    ),
+    "case-executions/W02.json": (
+        "6576026b30a12e2c93e9c893b322e7bdd0b0ae7a8d96c00bbb3d8a7680bb085c"
+    ),
+    "case-executions/W03.json": (
+        "042f6047ed075c5b76a7d4d75aaba1a65ca08f4a15385391e24c83e620f284a5"
+    ),
+    "case-executions/W04.json": (
+        "d230e72c3017ca9781e73e658a4e90160ce182786a7dae0d7c17379e0272ab95"
+    ),
+    "case-executions/W05.json": (
+        "e72d37f606be6b150aca371546deb64767d4027617717ccb46782b418bc9fa9d"
+    ),
+    "case-executions/W06.json": (
+        "3c6e6ff6a799bd25039d46dd5c2d2e1e5fa8709138e1e3b61e974b4baa08f913"
+    ),
+    "case-executions/W07.json": (
+        "41705e6da987a8d040e03ec4aa28703c3f7e1483f38476bb1d8da605089e3509"
+    ),
+    "case-executions/W08.json": (
+        "f34ec5f2f72956e34ae4d0e2e74f76eacaa9902b1e6731fd77efecb3f4c71e1b"
+    ),
+}
+CASE_IDS = tuple(f"W{index:02d}" for index in range(1, 9))
+SOURCE_FILES = (
+    *_AGGREGATE_SOURCE_FILES,
+    "artifact-index.json",
+    *(f"case-executions/{case_id}.json" for case_id in CASE_IDS),
+)
+EXPECTED_ABSTAINED_PER_CASE = {case_id: 8 for case_id in CASE_IDS}
+EXPECTED_CANDIDATE_COUNT = 64
+EXPECTED_MISSING_SCOPE_LINK_COUNT = 63
+
+# The long immutable context columns are intentional.  A separate context file
+# is easier to read but creates a second join that a reviewer can accidentally
+# break.  Keeping context and labels on one row makes the returned boundary
+# self-contained while the candidate SHA still binds the original provider
+# object byte-for-byte.
+CONTEXT_FIELDS = (
+    "case_id",
+    "provider",
+    "provider_result_index",
+    "candidate_sha256",
+    "topic",
+    "query",
+    "declared_gap",
+    "baseline_sources_json",
+    "title",
+    "url",
+    "publisher",
+    "published_date",
+    "doi",
+    "evidence_summary",
+    "summary_source",
+)
+LABEL_VALUE_FIELDS = (
+    "direct_relevance",
+    "semantic_scope_link",
+    "baseline_novelty",
+    "abstract_sufficient",
+    "review_note",
+)
+LABEL_FIELDS = (*CONTEXT_FIELDS, *LABEL_VALUE_FIELDS)
+VALID_LABEL_COMBINATIONS = {
+    ("YES", semantic_link, novelty, "YES")
+    for semantic_link in ("YES", "NO")
+    for novelty in ("YES", "NO")
+} | {
+    ("NO", "N/A", "N/A", "YES"),
+    ("UNVERIFIABLE", "UNVERIFIABLE", "UNVERIFIABLE", "NO"),
+}
+MEASUREMENT_LIMIT = (
+    "This post-outcome diagnostic measures human interpretation of the frozen "
+    "title and abstract text for all 64 W01-W08 candidates. It cannot change "
+    "the failed v4 result, establish source truth, validate v5, or authorize "
+    "production Tool Calling."
+)
+_FORBIDDEN_REVIEWER_KEYS = {
+    "scope_link_action",
+    "abstention_reasons",
+    "missing_required_groups",
+    "exact_required_groups",
+    "provider_only_required_groups",
+    "exact_scope_groups",
+    "linked_scope_groups",
+    "title_anchor_groups",
+    "required_match_provenance",
+    "scope_match_provenance",
+    "supporting_match_provenance",
+    "link_evidence",
+    "aboutness",
+    "claim_scope_profile",
+}
+
+
+class ScopeLinkAbstentionDiagnosticLock(BaseModel):
+    """Owner attestation over the exact mechanical-failure execution bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_scope_link_v4_abstention_diagnostic_lock"] = (
+        "openalex_scope_link_v4_abstention_diagnostic_lock"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    diagnostic_only: Literal[True] = True
+    original_source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    authorized_output: Literal[True] = True
+    executed_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    source_file_sha256: dict[str, str]
+    study_owner_id: str = Field(min_length=2, max_length=200)
+    authorized_at: datetime
+    note: str | None = Field(default=None, max_length=1000)
+
+    @model_validator(mode="after")
+    def _validate_frozen_identity(self) -> "ScopeLinkAbstentionDiagnosticLock":
+        # Exact-map equality alone does not prove that a manually transcribed
+        # digest is a complete SHA-256 value: the expected map can contain the
+        # same truncated value. Validate the representation independently so a
+        # prose-to-code transcription error fails before a packet is emitted.
+        if any(
+            len(value) != 64
+            or any(character not in "0123456789abcdef" for character in value)
+            for value in self.source_file_sha256.values()
+        ):
+            raise ValueError(
+                "diagnostic lock source hashes must be complete lowercase SHA-256 values"
+            )
+        if self.executed_revision != EXPECTED_EXECUTED_REVISION:
+            raise ValueError("diagnostic lock executed revision does not match")
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("diagnostic lock fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("diagnostic lock implementation identities do not match")
+        if self.source_file_sha256 != EXPECTED_SOURCE_FILE_SHA256:
+            raise ValueError("diagnostic lock does not identify the frozen v4 run")
+        if self.authorized_at.tzinfo is None:
+            raise ValueError("diagnostic lock timestamp must be timezone-aware")
+        return self
+
+
+@dataclass(frozen=True)
+class ScopeLinkDiagnosticCandidate:
+    """One reviewer-visible row with no automated decision information."""
+
+    case_id: str
+    provider: str
+    provider_result_index: int
+    candidate_sha256: str
+    topic: str
+    query: str
+    declared_gap: str
+    baseline_sources_json: str
+    title: str
+    url: str
+    publisher: str
+    published_date: str
+    doi: str
+    evidence_summary: str
+    summary_source: str
+
+    @property
+    def key(self) -> tuple[str, int, str]:
+        return (
+            self.case_id,
+            self.provider_result_index,
+            self.candidate_sha256,
+        )
+
+    @property
+    def row_id(self) -> str:
+        return (
+            f"{self.case_id}/{self.provider_result_index}/"
+            f"{self.candidate_sha256[:12]}"
+        )
+
+    @property
+    def identity_sha256(self) -> str:
+        rendered = json.dumps(
+            asdict(self),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(rendered).hexdigest()
+
+
+@dataclass(frozen=True)
+class ScopeLinkDiagnosticSnapshot:
+    """Validated bytes shared unchanged by lock, packet, and summary seams."""
+
+    file_hashes: dict[str, str]
+    manifest: ScopeLinkManifestArtifact
+    execution: ScopeLinkExecutionArtifact
+    candidates: tuple[ScopeLinkDiagnosticCandidate, ...]
+    hidden_traces: dict[tuple[str, int, str], dict[str, Any]]
+
+
+def _candidate_from_mapping(
+    row: Mapping[str, Any],
+) -> ScopeLinkDiagnosticCandidate:
+    try:
+        provider_result_index = int(str(row.get("provider_result_index", "")))
+    except ValueError as exc:
+        raise ScopeLinkDiagnosticError(
+            "provider_result_index must be an integer"
+        ) from exc
+    values = {
+        field: str(row.get(field, ""))
+        for field in CONTEXT_FIELDS
+        if field != "provider_result_index"
+    }
+    candidate = ScopeLinkDiagnosticCandidate(
+        provider_result_index=provider_result_index,
+        **values,
+    )
+    if candidate.case_id not in CASE_IDS or candidate.provider != "openalex":
+        raise ScopeLinkDiagnosticError(
+            f"unexpected diagnostic identity: {candidate.case_id}/{candidate.provider}"
+        )
+    if not 0 <= candidate.provider_result_index <= 7:
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: provider index is outside the frozen page"
+        )
+    if (
+        len(candidate.candidate_sha256) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in candidate.candidate_sha256
+        )
+    ):
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: candidate SHA-256 is invalid"
+        )
+    required_text = (
+        candidate.topic,
+        candidate.query,
+        candidate.declared_gap,
+        candidate.baseline_sources_json,
+        candidate.title,
+        candidate.url,
+        candidate.publisher,
+        candidate.evidence_summary,
+        candidate.summary_source,
+    )
+    if not all(required_text):
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: reviewer context is incomplete"
+        )
+    if not candidate.url.startswith("https://openalex.org/W"):
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: candidate URL is not an OpenAlex work"
+        )
+    try:
+        baseline_sources = json.loads(candidate.baseline_sources_json)
+    except json.JSONDecodeError as exc:
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: baseline source context is invalid JSON"
+        ) from exc
+    if not isinstance(baseline_sources, list) or not baseline_sources:
+        raise ScopeLinkDiagnosticError(
+            f"{candidate.case_id}: baseline source context is empty"
+        )
+    return candidate
+
+
+def _validate_artifact_index(
+    source_dir: Path,
+    file_hashes: Mapping[str, str],
+) -> None:
+    index = _read_json_object(source_dir / "artifact-index.json")
+    expected = {
+        "schema_version": 1,
+        "mode": "openalex_scope_link_v4_artifact_index",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "source_file_sha256": {
+            name: file_hashes[name] for name in _AGGREGATE_SOURCE_FILES
+        },
+    }
+    if index != expected:
+        raise ScopeLinkDiagnosticError(
+            "artifact index does not match aggregate scope-link bytes"
+        )
+
+
+def _validate_complete_mechanical_failure(
+    manifest: ScopeLinkManifestArtifact,
+    execution: ScopeLinkExecutionArtifact,
+) -> None:
+    if execution.overall_state != "completed":
+        raise ScopeLinkDiagnosticError(
+            "only the completed W01-W08 execution may be diagnosed"
+        )
+    if (
+        execution.request_count != 8
+        or execution.attempted_case_count != 8
+        or execution.successful_case_count != 8
+    ):
+        raise ScopeLinkDiagnosticError(
+            "diagnostic source must contain eight successful requests"
+        )
+    if (
+        execution.provider_summary.stopped_reason != "completed"
+        or execution.provider_summary.cost_state != "known"
+    ):
+        raise ScopeLinkDiagnosticError(
+            "provider completion or cost is not inspectable"
+        )
+    if (
+        execution.review_packet_eligibility != "mechanical_gate_failed"
+        or execution.scope_link_accepted_candidate_count != 0
+        or execution.scope_link_abstained_candidate_count
+        != EXPECTED_CANDIDATE_COUNT
+        or execution.scope_link_accepted_case_count != 0
+        or execution.source_value_state != "not_evaluated"
+    ):
+        raise ScopeLinkDiagnosticError(
+            "source is not the frozen 64-row mechanical coverage failure"
+        )
+    if (
+        manifest.fixture_sha256 != execution.fixture_sha256
+        or manifest.implementation_sha256 != execution.implementation_sha256
+        or manifest.runner_sha256 != execution.runner_sha256
+        or manifest.soft_stop_usd != execution.soft_stop_usd
+        or manifest.source_value_gates != execution.source_value_gates
+    ):
+        raise ScopeLinkDiagnosticError(
+            "execution identity does not join the persisted manifest"
+        )
+
+    expected_cases = {
+        case.spec.case_id: (
+            case.collection_sha256,
+            case.plan_sha256,
+            case.profile_sha256,
+            case.validated_plan.calls[0].idempotency_key,
+        )
+        for case in manifest.cases
+    }
+    observed_cases = {
+        case.case_id: (
+            case.collection_sha256,
+            case.plan_sha256,
+            case.profile_sha256,
+            case.idempotency_key,
+        )
+        for case in execution.cases
+    }
+    if observed_cases != expected_cases:
+        raise ScopeLinkDiagnosticError(
+            "case executions do not join the frozen manifest"
+        )
+
+    abstained_per_case: dict[str, int] = {}
+    missing_scope_link_count = 0
+    costs: list[float] = []
+    for case in execution.cases:
+        if case.state != "completed" or case.response is None:
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: case is not a completed provider observation"
+            )
+        usage = case.response.provider_usage
+        if (
+            case.response.outbound_request_count != 1
+            or usage.cost_basis != "reported_usd"
+            or usage.reported_cost_usd is None
+            or case.search_cost_usd is None
+            or usage.reported_cost_usd != case.search_cost_usd
+        ):
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: request or cost accounting is invalid"
+            )
+        if len(case.response.candidates) != 8 or case.response.provider_rejections:
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: provider row denominator is not the frozen page"
+            )
+        if usage.result_count != 8 or len(case.evaluations) != 8:
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: candidate accounting is incomplete"
+            )
+        if any(item.decision.action != "ABSTAIN" for item in case.evaluations):
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: diagnostic source contains an accepted candidate"
+            )
+        if any(
+            item.candidate.evidence.summary_source != "abstract"
+            for item in case.evaluations
+        ):
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: frozen-text diagnostic requires abstracts"
+            )
+        abstained_per_case[case.case_id] = len(case.evaluations)
+        missing_scope_link_count += sum(
+            "missing_scope_link" in item.decision.abstention_reasons
+            for item in case.evaluations
+        )
+        costs.append(case.search_cost_usd)
+    if abstained_per_case != EXPECTED_ABSTAINED_PER_CASE:
+        raise ScopeLinkDiagnosticError(
+            "abstained candidate distribution does not match the frozen run"
+        )
+    if missing_scope_link_count != EXPECTED_MISSING_SCOPE_LINK_COUNT:
+        raise ScopeLinkDiagnosticError(
+            "missing-scope-link denominator does not match the frozen run"
+        )
+    reported = execution.provider_summary.reported_cost_usd
+    if reported is None or abs(reported - sum(costs)) > 1e-12:
+        raise ScopeLinkDiagnosticError(
+            "provider summary cost does not equal the case journals"
+        )
+
+
+def _validate_case_journals(
+    source_dir: Path,
+    execution: ScopeLinkExecutionArtifact,
+) -> None:
+    journal_dir = source_dir / "case-executions"
+    if not journal_dir.is_dir():
+        raise ScopeLinkDiagnosticError("case-executions directory is missing")
+    observed_names = {path.name for path in journal_dir.glob("*.json")}
+    expected_names = {f"{case_id}.json" for case_id in CASE_IDS}
+    if observed_names != expected_names:
+        raise ScopeLinkDiagnosticError(
+            "case journals do not cover W01-W08 exactly"
+        )
+    execution_by_id = {case.case_id: case for case in execution.cases}
+    for case_id in CASE_IDS:
+        journal = ScopeLinkCaseExecution.model_validate(
+            _read_json_object(journal_dir / f"{case_id}.json")
+        )
+        if journal != execution_by_id[case_id]:
+            raise ScopeLinkDiagnosticError(
+                f"{case_id}: case journal does not match aggregate execution"
+            )
+
+
+def _baseline_sources_json(case: Any) -> str:
+    sources: list[dict[str, str]] = []
+    for domain in ("academic", "patent", "market"):
+        for source in getattr(case.source_collection, f"{domain}_sources"):
+            projection = {
+                "domain": domain,
+                "source_id": source.source_id,
+                "title": source.title,
+                "url": str(source.url),
+                "evidence_summary": source.evidence_summary,
+            }
+            if not all(projection.values()):
+                raise ScopeLinkDiagnosticError(
+                    f"{case.spec.case_id}: baseline source context is incomplete"
+                )
+            sources.append(projection)
+    if not sources:
+        raise ScopeLinkDiagnosticError(
+            f"{case.spec.case_id}: baseline source context is empty"
+        )
+    return json.dumps(
+        sources,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _project_candidates(
+    manifest: ScopeLinkManifestArtifact,
+    execution: ScopeLinkExecutionArtifact,
+) -> tuple[
+    tuple[ScopeLinkDiagnosticCandidate, ...],
+    dict[tuple[str, int, str], dict[str, Any]],
+]:
+    manifest_by_id = {case.spec.case_id: case for case in manifest.cases}
+    candidates: list[ScopeLinkDiagnosticCandidate] = []
+    traces: dict[tuple[str, int, str], dict[str, Any]] = {}
+    for case in execution.cases:
+        frozen = manifest_by_id[case.case_id]
+        failure_reason = frozen.source_collection.failed_domains.get("academic")
+        if not failure_reason:
+            raise ScopeLinkDiagnosticError(
+                f"{case.case_id}: baseline academic gap state is missing"
+            )
+        baseline_json = _baseline_sources_json(frozen)
+        for item in case.evaluations:
+            evidence = item.candidate.evidence
+            candidate = ScopeLinkDiagnosticCandidate(
+                case_id=case.case_id,
+                provider="openalex",
+                provider_result_index=item.provider_result_index,
+                candidate_sha256=item.decision.candidate_sha256,
+                topic=frozen.spec.topic,
+                query=frozen.spec.query,
+                declared_gap=f"academic retrieval failed: {failure_reason.strip()}",
+                baseline_sources_json=baseline_json,
+                title=evidence.title,
+                url=str(evidence.url),
+                publisher=evidence.publisher,
+                published_date=(
+                    evidence.published_date.isoformat()
+                    if evidence.published_date is not None
+                    else ""
+                ),
+                doi=evidence.doi or "",
+                evidence_summary=evidence.evidence_summary,
+                summary_source=evidence.summary_source,
+            )
+            if candidate.key in traces:
+                raise ScopeLinkDiagnosticError(
+                    f"duplicate candidate identity: {candidate.row_id}"
+                )
+            candidates.append(candidate)
+            traces[candidate.key] = {
+                "action": item.decision.action,
+                "abstention_reasons": list(item.decision.abstention_reasons),
+            }
+    if len(candidates) != EXPECTED_CANDIDATE_COUNT:
+        raise ScopeLinkDiagnosticError(
+            "reviewer projection does not contain all 64 candidates"
+        )
+    return tuple(candidates), traces
+
+
+def validate_finalized_source(
+    source_dir: Path,
+    *,
+    expected_hashes: Mapping[str, str] | None = None,
+) -> ScopeLinkDiagnosticSnapshot:
+    """Validate every persisted byte and project a decision-blind population."""
+
+    if not source_dir.is_dir():
+        raise ScopeLinkDiagnosticError(
+            f"source directory does not exist: {source_dir}"
+        )
+    file_hashes = {name: _file_sha256(source_dir / name) for name in SOURCE_FILES}
+    if expected_hashes is not None:
+        expected = dict(expected_hashes)
+        if set(expected) != set(SOURCE_FILES):
+            raise ScopeLinkDiagnosticError(
+                "expected hashes must identify every v4 diagnostic source file"
+            )
+        if file_hashes != expected:
+            drift = {
+                name: {"expected": expected[name], "observed": file_hashes[name]}
+                for name in SOURCE_FILES
+                if file_hashes[name] != expected[name]
+            }
+            raise ScopeLinkDiagnosticError(
+                f"source artifact identity drifted after locking: {drift}"
+            )
+    _validate_artifact_index(source_dir, file_hashes)
+
+    manifest = ScopeLinkManifestArtifact.model_validate(
+        _read_json_object(source_dir / "manifest.json")
+    )
+    execution = ScopeLinkExecutionArtifact.model_validate(
+        _read_json_object(source_dir / "execution.json")
+    )
+    _validate_complete_mechanical_failure(manifest, execution)
+    _validate_case_journals(source_dir, execution)
+
+    candidate_rows = _read_csv(source_dir / "candidates.csv", _CANDIDATE_COLUMNS)
+    review_rows = _read_csv(source_dir / "review.csv", _REVIEW_COLUMNS)
+    expected_candidates, expected_reviews = _candidate_rows(execution.cases)
+    if candidate_rows != expected_candidates:
+        raise ScopeLinkDiagnosticError(
+            "candidate CSV does not contain every v4 disposition exactly once"
+        )
+    if review_rows != expected_reviews or review_rows:
+        raise ScopeLinkDiagnosticError(
+            "the mechanical-failure review boundary must remain header-only"
+        )
+
+    candidates, traces = _project_candidates(manifest, execution)
+    return ScopeLinkDiagnosticSnapshot(
+        file_hashes=file_hashes,
+        manifest=manifest,
+        execution=execution,
+        candidates=candidates,
+        hidden_traces=traces,
+    )
+
+
+def create_source_lock(
+    source_dir: Path,
+    output_path: Path,
+    *,
+    study_owner_id: str,
+    confirm_authorized_output: bool,
+    note: str | None = None,
+    authorized_at: datetime | None = None,
+) -> ScopeLinkAbstentionDiagnosticLock:
+    """Bind the exact failed execution before a reviewer packet exists."""
+
+    if not confirm_authorized_output:
+        raise ScopeLinkDiagnosticError(
+            "diagnostic locking requires authorized-output confirmation"
+        )
+    if output_path.exists():
+        raise ScopeLinkDiagnosticError(
+            f"refusing to overwrite diagnostic lock: {output_path}"
+        )
+    snapshot = validate_finalized_source(source_dir)
+    lock = ScopeLinkAbstentionDiagnosticLock(
+        executed_revision=EXPECTED_EXECUTED_REVISION,
+        fixture_sha256=EXPECTED_FIXTURE_SHA256,
+        implementation_sha256=EXPECTED_IMPLEMENTATION_SHA256,
+        source_file_sha256=snapshot.file_hashes,
+        study_owner_id=study_owner_id.strip(),
+        authorized_at=authorized_at or datetime.now(UTC),
+        note=note.strip() if note and note.strip() else None,
+    )
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ScopeLinkDiagnosticError(
+            f"could not create diagnostic-lock parent {output_path.parent}: {exc}"
+        ) from exc
+    _write_text_new(
+        output_path,
+        json.dumps(
+            lock.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    return lock
+
+
+def _load_source_lock(path: Path) -> ScopeLinkAbstentionDiagnosticLock:
+    try:
+        return ScopeLinkAbstentionDiagnosticLock.model_validate(
+            _read_json_object(path)
+        )
+    except ValueError as exc:
+        if isinstance(exc, ScopeLinkDiagnosticError):
+            raise
+        raise ScopeLinkDiagnosticError(
+            f"diagnostic source lock is invalid: {exc}"
+        ) from exc
+
+
+def _packet_rows(
+    snapshot: ScopeLinkDiagnosticSnapshot,
+) -> list[dict[str, Any]]:
+    rows = [
+        {**asdict(candidate), "identity_sha256": candidate.identity_sha256}
+        for candidate in snapshot.candidates
+    ]
+    leaked = sorted(
+        _FORBIDDEN_REVIEWER_KEYS.intersection(
+            key for row in rows for key in row
+        )
+    )
+    if leaked:
+        raise ScopeLinkDiagnosticError(
+            f"reviewer packet leaks automated decision fields: {leaked}"
+        )
+    return rows
+
+
+def _packet_manifest(
+    snapshot: ScopeLinkDiagnosticSnapshot,
+    source_lock_path: Path,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "mode": "openalex_scope_link_v4_candidate_diagnostic_packet",
+        "prepared_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "row_count": len(snapshot.candidates),
+        "case_count": len(CASE_IDS),
+        "rows": _packet_rows(snapshot),
+        "valid_label_combinations": [
+            list(values) for values in sorted(VALID_LABEL_COMBINATIONS)
+        ],
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def _packet_readme(snapshot: ScopeLinkDiagnosticSnapshot) -> str:
+    counts = Counter(candidate.case_id for candidate in snapshot.candidates)
+    cases = "\n".join(
+        f"| {case_id} | {counts[case_id]} |" for case_id in CASE_IDS
+    )
+    return f"""# OpenAlex frozen candidate diagnostic
+
+This packet contains {len(snapshot.candidates)} title-and-abstract rows from one
+completed, production-disconnected OpenAlex execution. Preparing and
+summarizing the packet makes zero API or LLM calls.
+
+Do not edit `packet_manifest.json`. Complete only `labels.csv` and
+`reviewer_declaration.csv`. Rows may be reordered, but every context and
+identity field must remain byte-for-byte unchanged. Do not inspect the source
+execution, implementation, automated decisions, or separate source-lock file
+until after returning the labels. The packet deliberately hides those values.
+
+| Case | Candidate rows |
+|---|---:|
+{cases}
+
+Judge each candidate from its frozen topic, query, baseline context, title and
+abstract. `direct_relevance=YES` means the candidate directly addresses the
+declared topic rather than sharing a broad field. `semantic_scope_link=YES`
+means the required technology and scope are meaningfully related in the title
+or abstract, even when exact wording differs. `baseline_novelty=YES` means the
+candidate adds material evidence absent from `baseline_sources_json`.
+
+Use only one of these combinations:
+
+- `YES / YES-or-NO / YES-or-NO / YES`;
+- `NO / N/A / N/A / YES`; or
+- `UNVERIFIABLE / UNVERIFIABLE / UNVERIFIABLE / NO`.
+
+Every row requires a source-grounded `review_note`. External URLs are optional
+because this diagnostic concerns the exact frozen text seen by the method, but
+record how many you attempted in `reviewer_declaration.csv`. `NONE` or
+`LANGUAGE_ONLY` generative-AI use is eligible; substantive generated judgments
+are retained but not evaluated.
+
+This is a post-outcome diagnostic, not a source-value rerun. It cannot change
+the original study, validate a later method, or authorize production Tool
+Calling.
+"""
+
+
+def prepare_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Create a separate label-blind packet from the locked exact bytes."""
+
+    if packet_dir.exists():
+        raise ScopeLinkDiagnosticError(
+            f"refusing to overwrite diagnostic packet: {packet_dir}"
+        )
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    try:
+        packet_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise ScopeLinkDiagnosticError(
+            f"could not create diagnostic packet {packet_dir}: {exc}"
+        ) from exc
+    manifest = _packet_manifest(snapshot, source_lock_path)
+    label_rows = [
+        {
+            **asdict(candidate),
+            **{field: "" for field in LABEL_VALUE_FIELDS},
+        }
+        for candidate in snapshot.candidates
+    ]
+    _write_csv_new(packet_dir / "labels.csv", LABEL_FIELDS, label_rows)
+    _write_csv_new(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [{}],
+    )
+    _write_text_new(packet_dir / "README.md", _packet_readme(snapshot))
+    _write_text_new(
+        packet_dir / "packet_manifest.json",
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return manifest
+
+
+def _manifest_candidates(
+    manifest: dict[str, Any],
+    snapshot: ScopeLinkDiagnosticSnapshot,
+    source_lock_path: Path,
+) -> dict[tuple[str, int, str], ScopeLinkDiagnosticCandidate]:
+    expected_header = {
+        "schema_version": 1,
+        "mode": "openalex_scope_link_v4_candidate_diagnostic_packet",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "row_count": EXPECTED_CANDIDATE_COUNT,
+        "case_count": len(CASE_IDS),
+        "valid_label_combinations": [
+            list(values) for values in sorted(VALID_LABEL_COMBINATIONS)
+        ],
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+    for key, value in expected_header.items():
+        if manifest.get(key) != value:
+            raise ScopeLinkDiagnosticError(
+                f"diagnostic packet {key} drifted from the frozen contract"
+            )
+    rows = manifest.get("rows")
+    if not isinstance(rows, list) or len(rows) != EXPECTED_CANDIDATE_COUNT:
+        raise ScopeLinkDiagnosticError(
+            "diagnostic packet row denominator is not inspectable"
+        )
+    candidates: dict[tuple[str, int, str], ScopeLinkDiagnosticCandidate] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ScopeLinkDiagnosticError("diagnostic packet rows must be objects")
+        leaked = sorted(_FORBIDDEN_REVIEWER_KEYS.intersection(row))
+        if leaked:
+            raise ScopeLinkDiagnosticError(
+                f"diagnostic packet leaks automated decision fields: {leaked}"
+            )
+        candidate = _candidate_from_mapping(row)
+        if row.get("identity_sha256") != candidate.identity_sha256:
+            raise ScopeLinkDiagnosticError(
+                f"packet identity hash drifted for {candidate.row_id}"
+            )
+        if candidate.key in candidates:
+            raise ScopeLinkDiagnosticError(
+                f"packet contains duplicate identity {candidate.row_id}"
+            )
+        candidates[candidate.key] = candidate
+    expected = {candidate.key: candidate for candidate in snapshot.candidates}
+    if candidates != expected:
+        raise ScopeLinkDiagnosticError(
+            "packet candidates do not match the source-locked population"
+        )
+    return candidates
+
+
+def _validated_label(
+    row: Mapping[str, str],
+    expected: ScopeLinkDiagnosticCandidate,
+) -> dict[str, str] | None:
+    observed = _candidate_from_mapping(row)
+    if observed != expected:
+        raise ScopeLinkDiagnosticError(
+            f"label context or identity drifted for {expected.row_id}"
+        )
+    values = [row[field].strip() for field in LABEL_VALUE_FIELDS]
+    if not any(values):
+        return None
+    if not all(values):
+        raise ScopeLinkDiagnosticError(
+            f"{expected.row_id} is partially completed"
+        )
+    direct, semantic, novelty, sufficient, note = values
+    normalized = (
+        direct.upper(),
+        semantic.upper(),
+        novelty.upper(),
+        sufficient.upper(),
+    )
+    if normalized not in VALID_LABEL_COMBINATIONS:
+        raise ScopeLinkDiagnosticError(
+            f"{expected.row_id} has invalid diagnostic labels: {normalized}"
+        )
+    if len("".join(note.split())) < 12:
+        raise ScopeLinkDiagnosticError(
+            f"{expected.row_id} review_note is too short to ground the judgment"
+        )
+    return {
+        "case_id": expected.case_id,
+        "provider_result_index": str(expected.provider_result_index),
+        "candidate_sha256": expected.candidate_sha256,
+        "row_id": expected.row_id,
+        "direct_relevance": normalized[0],
+        "semantic_scope_link": normalized[1],
+        "baseline_novelty": normalized[2],
+        "abstract_sufficient": normalized[3],
+        "review_note": note,
+    }
+
+
+def _diagnostic_metrics(
+    snapshot: ScopeLinkDiagnosticSnapshot,
+    labels: list[dict[str, str]],
+) -> dict[str, Any]:
+    label_by_key = {
+        (
+            row["case_id"],
+            int(row["provider_result_index"]),
+            row["candidate_sha256"],
+        ): row
+        for row in labels
+    }
+    direct_counts: Counter[str] = Counter()
+    attribution_counts: Counter[str] = Counter()
+    reason_counts: Counter[str] = Counter()
+    relevant_cases: set[str] = set()
+    novel_relevant_cases: set[str] = set()
+    semantic_link_count = 0
+    semantic_link_miss_count = 0
+    by_case: dict[str, Counter[str]] = {
+        case_id: Counter() for case_id in CASE_IDS
+    }
+
+    for key, trace in snapshot.hidden_traces.items():
+        label = label_by_key[key]
+        direct = label["direct_relevance"]
+        semantic = label["semantic_scope_link"]
+        direct_counts[direct] += 1
+        by_case[key[0]][f"direct_{direct.casefold()}"] += 1
+        for reason in trace["abstention_reasons"]:
+            reason_counts[reason] += 1
+
+        if direct == "UNVERIFIABLE":
+            attribution = "frozen_text_insufficient"
+        elif direct == "NO":
+            attribution = "retrieval_noise"
+        else:
+            relevant_cases.add(key[0])
+            if label["baseline_novelty"] == "YES":
+                novel_relevant_cases.add(key[0])
+            if semantic == "YES":
+                semantic_link_count += 1
+            if (
+                semantic == "YES"
+                and "missing_scope_link" in trace["abstention_reasons"]
+            ):
+                semantic_link_miss_count += 1
+                attribution = "semantic_relation_missed_by_v4"
+            else:
+                attribution = "other_gate_rejection_of_relevant_source"
+        attribution_counts[attribution] += 1
+        by_case[key[0]][attribution] += 1
+
+    inspectable_count = EXPECTED_CANDIDATE_COUNT - direct_counts["UNVERIFIABLE"]
+    retrieval_noise_rate = (
+        direct_counts["NO"] / inspectable_count if inspectable_count else None
+    )
+    semantic_link_miss_rate = (
+        semantic_link_miss_count / semantic_link_count
+        if semantic_link_count
+        else None
+    )
+    return {
+        "candidate_count": EXPECTED_CANDIDATE_COUNT,
+        "inspectable_candidate_count": inspectable_count,
+        "direct_relevant_count": direct_counts["YES"],
+        "direct_irrelevant_count": direct_counts["NO"],
+        "unverifiable_count": direct_counts["UNVERIFIABLE"],
+        "relevant_case_ids": sorted(relevant_cases),
+        "relevant_case_count": len(relevant_cases),
+        "novel_relevant_case_ids": sorted(novel_relevant_cases),
+        "novel_relevant_case_count": len(novel_relevant_cases),
+        "human_semantic_link_count": semantic_link_count,
+        "semantic_link_miss_count": semantic_link_miss_count,
+        "semantic_link_miss_rate_among_human_links": semantic_link_miss_rate,
+        "retrieval_noise_rate_among_inspectable": retrieval_noise_rate,
+        "frozen_text_insufficiency_rate": (
+            direct_counts["UNVERIFIABLE"] / EXPECTED_CANDIDATE_COUNT
+        ),
+        "attribution_counts": dict(sorted(attribution_counts.items())),
+        "v4_reason_counts": dict(sorted(reason_counts.items())),
+        "by_case": {
+            case_id: dict(sorted(counts.items()))
+            for case_id, counts in by_case.items()
+        },
+    }
+
+
+def summarize_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Validate returned labels and join hidden v4 traces only at this seam."""
+
+    if not packet_dir.is_dir():
+        raise ScopeLinkDiagnosticError(
+            f"diagnostic packet directory does not exist: {packet_dir}"
+        )
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    manifest = _read_json_object(packet_dir / "packet_manifest.json")
+    expected_candidates = _manifest_candidates(
+        manifest,
+        snapshot,
+        source_lock_path,
+    )
+
+    label_rows = _read_csv(packet_dir / "labels.csv", LABEL_FIELDS)
+    observed_keys = [
+        _candidate_from_mapping(row).key for row in label_rows
+    ]
+    if len(observed_keys) != len(set(observed_keys)):
+        raise ScopeLinkDiagnosticError(
+            "diagnostic labels contain duplicate candidate identities"
+        )
+    if set(observed_keys) != set(expected_candidates):
+        missing = sorted(set(expected_candidates) - set(observed_keys))
+        extra = sorted(set(observed_keys) - set(expected_candidates))
+        raise ScopeLinkDiagnosticError(
+            f"diagnostic label identities drifted; missing={missing}, extra={extra}"
+        )
+
+    completed: dict[tuple[str, int, str], dict[str, str]] = {}
+    incomplete_row_ids: list[str] = []
+    for row in label_rows:
+        candidate = _candidate_from_mapping(row)
+        validated = _validated_label(row, expected_candidates[candidate.key])
+        if validated is None:
+            incomplete_row_ids.append(candidate.row_id)
+        else:
+            completed[candidate.key] = validated
+
+    declaration_rows = _read_csv(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+    )
+    if len(declaration_rows) != 1:
+        raise ScopeLinkDiagnosticError(
+            "reviewer_declaration.csv must contain exactly one row"
+        )
+    declaration = _validated_declaration(declaration_rows[0])
+    method_issues: list[str] = []
+    if declaration is not None and declaration["reviewed_all"] != "YES":
+        method_issues.append("reviewer_did_not_confirm_all_rows")
+
+    if incomplete_row_ids or declaration is None:
+        protocol_status = "incomplete"
+    elif declaration["generative_ai_use"] not in ELIGIBLE_AI_USE:
+        protocol_status = "excluded_substantive_ai"
+    elif method_issues:
+        protocol_status = "not_inspectable"
+    else:
+        protocol_status = "complete"
+
+    ordered_labels = [completed[key] for key in sorted(completed)]
+    metrics = (
+        _diagnostic_metrics(snapshot, ordered_labels)
+        if protocol_status == "complete"
+        else None
+    )
+    return {
+        "schema_version": 1,
+        "mode": "openalex_scope_link_v4_abstention_diagnostic_result",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "original_review_packet_eligibility": "mechanical_gate_failed",
+        "original_source_value_state": "not_evaluated",
+        "v5_validation_authorized": False,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "packet_manifest_sha256": _file_sha256(
+            packet_dir / "packet_manifest.json"
+        ),
+        "protocol_status": protocol_status,
+        "diagnostic_state": (
+            "evaluated" if protocol_status == "complete" else "not_evaluated"
+        ),
+        "expected_row_count": EXPECTED_CANDIDATE_COUNT,
+        "completed_row_count": len(completed),
+        "incomplete_row_ids": incomplete_row_ids,
+        "method_issues": method_issues,
+        "declaration": declaration,
+        "metrics": metrics,
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def _json_text(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _write_json_stdout(value: object) -> None:
+    """Emit UTF-8 even when the Windows text console still advertises GBK."""
+    text = _json_text(value)
+    stdout_buffer = getattr(sys.stdout, "buffer", None)
+    if stdout_buffer is None:
+        # StringIO and other test doubles intentionally expose only text I/O.
+        sys.stdout.write(text)
+        return
+    stdout_buffer.write(text.encode("utf-8"))
+    stdout_buffer.flush()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Lock, prepare, or summarize the zero-network v4 diagnostic."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    lock = commands.add_parser("lock")
+    lock.add_argument("--source-dir", type=Path, required=True)
+    lock.add_argument("--output", type=Path, required=True)
+    lock.add_argument("--study-owner-id", required=True)
+    lock.add_argument("--note")
+    lock.add_argument("--confirm-authorized-output", action="store_true")
+
+    prepare = commands.add_parser("prepare")
+    prepare.add_argument("--source-dir", type=Path, required=True)
+    prepare.add_argument("--source-lock", type=Path, required=True)
+    prepare.add_argument("--packet-dir", type=Path, required=True)
+
+    summarize = commands.add_parser("summarize")
+    summarize.add_argument("--source-dir", type=Path, required=True)
+    summarize.add_argument("--source-lock", type=Path, required=True)
+    summarize.add_argument("--packet-dir", type=Path, required=True)
+    summarize.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "lock":
+        result: object = create_source_lock(
+            args.source_dir,
+            args.output,
+            study_owner_id=args.study_owner_id,
+            confirm_authorized_output=args.confirm_authorized_output,
+            note=args.note,
+        ).model_dump(mode="json")
+    elif args.command == "prepare":
+        result = prepare_packet(
+            args.source_dir,
+            args.source_lock,
+            args.packet_dir,
+        )
+    else:
+        result = summarize_packet(
+            args.source_dir,
+            args.source_lock,
+            args.packet_dir,
+        )
+        if args.output is not None:
+            _write_text_new(args.output, _json_text(result))
+    _write_json_stdout(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ type = "crew"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+# Runtime outputs and assistant worktrees may contain byte-frozen or stale
+# repository snapshots. They are evidence/tool artifacts, not another copy of
+# the live test suite; collecting them makes identical module names shadow the
+# canonical tests after real studies have run. Excluding those ignored
+# boundaries keeps the documented command equivalent between a used workspace
+# and CI.
+norecursedirs = [".claude", ".git", ".venv", "outputs", "__pycache__"]
 # Turning UserWarning into an error is what stops a test from quietly calling a
 # real API: those paths warn and fall back rather than raising, so a leak would
 # otherwise pass. Configured here rather than on the CI command line because the

--- a/tests/test_openalex_scope_link_abstention_review.py
+++ b/tests/test_openalex_scope_link_abstention_review.py
@@ -1,0 +1,519 @@
+"""Zero-network seams for the post-outcome scope-link v4 diagnostic."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import openalex_scope_link_abstention_review as diagnostic
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate, ToolProviderUsage
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from openalex_scope_link_abstention_review import (
+    DECLARATION_FIELDS,
+    LABEL_FIELDS,
+    ScopeLinkDiagnosticError,
+    create_source_lock,
+    prepare_packet,
+    summarize_packet,
+)
+from openalex_scope_link_live import execute_live_study
+from openalex_scope_link_unseen import PreparedScopeLinkCase, load_frozen_cases
+
+
+class _LegacyEncodedStdout:
+    """Expose an ASCII text facade plus a byte buffer like Windows stdout."""
+
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, text: str) -> int:
+        text.encode("ascii")
+        return len(text)
+
+
+def _candidate(
+    case: PreparedScopeLinkCase,
+    index: int,
+) -> OpenAlexClaimScopeCandidate:
+    """Build a row that contains every concept but no same-segment relation."""
+
+    required = [
+        group.text_phrases[0] for group in case.spec.profile.required_groups
+    ]
+    scope = [group.text_phrases[0] for group in case.spec.profile.scope_groups]
+    supporting = [
+        group.text_phrases[0]
+        for group in case.spec.profile.supporting_groups[
+            : case.spec.profile.minimum_supporting_groups
+        ]
+    ]
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{' '.join(required)} controlled review {index}",
+            url=(
+                f"https://openalex.org/W{case.spec.case_id[1:]}"
+                f"{index + 1:07d}"
+            ),
+            publisher="OpenAlex zero-network abstention diagnostic fixture",
+            evidence_summary=(
+                f"{' '.join(scope)}. {' '.join(supporting)}. "
+                "Required and scope concepts remain in separate sentences."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+class DiagnosticFactory:
+    """Return eight deterministic ABSTAIN rows for every frozen case."""
+
+    def __init__(self) -> None:
+        _, _, cases = load_frozen_cases()
+        self.case_by_key = {
+            case.plan.calls[0].idempotency_key: case for case in cases
+        }
+
+    def __call__(self):
+        def run(call: ValidatedGapCall) -> OpenAlexClaimScopeAdapterResponse:
+            case = self.case_by_key[call.idempotency_key]
+            candidates = tuple(_candidate(case, index) for index in range(8))
+            request_id = (
+                f"client-openalex-diagnostic-{case.spec.case_id.casefold()}"
+            )
+            usage = ToolProviderUsage(
+                provider="openalex",
+                request_id=request_id,
+                request_id_source="client_generated",
+                result_count=8,
+                cost_basis="reported_usd",
+                reported_cost_usd=0.001,
+            )
+            return OpenAlexClaimScopeAdapterResponse(
+                idempotency_key=call.idempotency_key,
+                candidates=candidates,
+                search_cost_usd=0.001,
+                provider_request_id=request_id,
+                provider_usage=usage,
+            )
+
+        return run
+
+
+def _source(tmp_path: Path, monkeypatch) -> Path:
+    """Materialize the exact 8x8 shape and bind test-local source hashes."""
+
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+    source = tmp_path / "scope-link-v4-source"
+    execution = execute_live_study(
+        output_dir=source,
+        soft_stop_usd=0.01,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=DiagnosticFactory(),
+    )
+    assert execution.scope_link_accepted_candidate_count == 0
+    assert execution.scope_link_abstained_candidate_count == 64
+    hashes = {
+        name: hashlib.sha256((source / name).read_bytes()).hexdigest()
+        for name in diagnostic.SOURCE_FILES
+    }
+    monkeypatch.setattr(diagnostic, "EXPECTED_SOURCE_FILE_SHA256", hashes)
+    # The real execution contains one row with a link that fails another
+    # requirement.  The synthetic source isolates the link rule on all 64 rows,
+    # so its test-local frozen denominator is intentionally different.
+    monkeypatch.setattr(diagnostic, "EXPECTED_MISSING_SCOPE_LINK_COUNT", 64)
+    return source
+
+
+def _lock(source: Path, tmp_path: Path) -> Path:
+    path = tmp_path / "private" / "diagnostic-source-lock.json"
+    create_source_lock(
+        source,
+        path,
+        study_owner_id="offline-scope-link-owner",
+        confirm_authorized_output=True,
+        authorized_at=datetime(2026, 8, 29, 12, 0, tzinfo=UTC),
+    )
+    return path
+
+
+def _packet(source: Path, tmp_path: Path) -> tuple[Path, Path]:
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "reviewer-packet"
+    prepare_packet(source, source_lock, packet)
+    return source_lock, packet
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_csv(
+    path: Path,
+    fields: tuple[str, ...],
+    rows: list[dict[str, str]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="raise")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _complete_declaration(
+    packet: Path,
+    *,
+    ai_use: str = "NONE",
+    reviewed_all: str = "YES",
+    external_sources_checked: str = "NONE",
+) -> None:
+    _write_csv(
+        packet / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [
+            {
+                "reviewer_id": "human-diagnostic-reviewer",
+                "reviewed_all": reviewed_all,
+                "generative_ai_use": ai_use,
+                "external_sources_checked": external_sources_checked,
+                "elapsed_minutes": "180",
+                "expertise": "Academic evidence synthesis",
+                "completed_date": "2026-08-29",
+                "limitations": "Judged from the frozen title and abstract text.",
+            }
+        ],
+    )
+
+
+def _complete_labels(
+    packet: Path,
+    *,
+    semantic: str = "YES",
+    novelty: str = "YES",
+) -> list[dict[str, str]]:
+    rows = _read_csv(packet / "labels.csv")
+    for row in rows:
+        row.update(
+            {
+                "direct_relevance": "YES",
+                "semantic_scope_link": semantic,
+                "baseline_novelty": novelty,
+                "abstract_sufficient": "YES",
+                "review_note": (
+                    "The frozen abstract directly addresses the declared topic "
+                    "and supports this human diagnostic label."
+                ),
+            }
+        )
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    return rows
+
+
+def test_packet_preserves_all_rows_and_hides_every_v4_decision_signal(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+
+    lock_payload = json.loads(source_lock.read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (packet / "packet_manifest.json").read_text(encoding="utf-8")
+    )
+    label_text = (packet / "labels.csv").read_text(encoding="utf-8")
+    manifest_text = (packet / "packet_manifest.json").read_text(encoding="utf-8")
+    labels = _read_csv(packet / "labels.csv")
+
+    assert lock_payload["original_source_value_state"] == "not_evaluated"
+    assert lock_payload["production_connected"] is False
+    assert manifest["row_count"] == 64
+    assert len(labels) == 64
+    assert {row["case_id"] for row in labels} == set(diagnostic.CASE_IDS)
+    assert all(
+        sum(row["case_id"] == case_id for row in labels) == 8
+        for case_id in diagnostic.CASE_IDS
+    )
+    assert all(row["evidence_summary"] for row in labels)
+    assert all(row["baseline_sources_json"] for row in labels)
+    forbidden_values = (
+        "scope_link_action",
+        "abstention_reasons",
+        "missing_scope_link",
+        "link_evidence",
+        "ABSTAIN",
+    )
+    assert all(value not in label_text for value in forbidden_values)
+    assert all(value not in manifest_text for value in forbidden_values)
+
+
+def test_blank_packet_is_incomplete_not_a_zero_error_result(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "incomplete"
+    assert result["diagnostic_state"] == "not_evaluated"
+    assert result["completed_row_count"] == 0
+    assert len(result["incomplete_row_ids"]) == 64
+    assert result["metrics"] is None
+    assert result["original_source_value_state"] == "not_evaluated"
+    assert result["v5_validation_authorized"] is False
+
+
+def test_complete_labels_join_hidden_trace_only_at_summary(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    _complete_labels(packet)
+    _complete_declaration(packet, external_sources_checked="NONE")
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "complete"
+    assert result["diagnostic_state"] == "evaluated"
+    assert result["production_connected"] is False
+    assert result["completed_row_count"] == 64
+    metrics = result["metrics"]
+    assert metrics["direct_relevant_count"] == 64
+    assert metrics["human_semantic_link_count"] == 64
+    assert metrics["semantic_link_miss_count"] == 64
+    assert metrics["semantic_link_miss_rate_among_human_links"] == 1.0
+    assert metrics["v4_reason_counts"] == {"missing_scope_link": 64}
+    assert metrics["attribution_counts"] == {
+        "semantic_relation_missed_by_v4": 64
+    }
+    assert result["declaration"]["external_sources_checked"] == "NONE"
+
+
+def test_diagnostic_keeps_noise_and_unverifiable_rows_in_denominators(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _complete_labels(packet)
+    rows[0].update(
+        {
+            "direct_relevance": "NO",
+            "semantic_scope_link": "N/A",
+            "baseline_novelty": "N/A",
+            "abstract_sufficient": "YES",
+            "review_note": (
+                "The abstract shares a broad field but does not address the "
+                "declared technical topic."
+            ),
+        }
+    )
+    rows[1].update(
+        {
+            "direct_relevance": "UNVERIFIABLE",
+            "semantic_scope_link": "UNVERIFIABLE",
+            "baseline_novelty": "UNVERIFIABLE",
+            "abstract_sufficient": "NO",
+            "review_note": (
+                "The frozen abstract is insufficient to determine direct "
+                "relevance or the requested semantic relation."
+            ),
+        }
+    )
+    rows[2].update(
+        {
+            "semantic_scope_link": "NO",
+            "review_note": (
+                "The source is relevant to the field but does not connect the "
+                "required technology to the declared scope."
+            ),
+        }
+    )
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    _complete_declaration(packet)
+
+    metrics = summarize_packet(source, source_lock, packet)["metrics"]
+
+    assert metrics["candidate_count"] == 64
+    assert metrics["inspectable_candidate_count"] == 63
+    assert metrics["direct_relevant_count"] == 62
+    assert metrics["direct_irrelevant_count"] == 1
+    assert metrics["unverifiable_count"] == 1
+    assert metrics["retrieval_noise_rate_among_inspectable"] == pytest.approx(
+        1 / 63
+    )
+    assert metrics["frozen_text_insufficiency_rate"] == pytest.approx(1 / 64)
+    assert metrics["attribution_counts"]["retrieval_noise"] == 1
+    assert metrics["attribution_counts"]["frozen_text_insufficient"] == 1
+    assert (
+        metrics["attribution_counts"][
+            "other_gate_rejection_of_relevant_source"
+        ]
+        == 1
+    )
+
+
+def test_substantive_ai_review_is_retained_but_not_evaluated(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    _complete_labels(packet)
+    _complete_declaration(packet, ai_use="MOST_OR_ALL")
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "excluded_substantive_ai"
+    assert result["completed_row_count"] == 64
+    assert result["metrics"] is None
+    assert result["declaration"]["generative_ai_use"] == "MOST_OR_ALL"
+
+
+def test_source_lock_requires_explicit_owner_confirmation(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+
+    with pytest.raises(
+        ScopeLinkDiagnosticError,
+        match="authorized-output confirmation",
+    ):
+        create_source_lock(
+            source,
+            tmp_path / "lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=False,
+        )
+
+
+def test_frozen_source_identity_contains_only_complete_sha256_values():
+    """A prior prose transcription dropped one hex digit from the index hash."""
+    assert set(diagnostic.EXPECTED_SOURCE_FILE_SHA256) == set(
+        diagnostic.SOURCE_FILES
+    )
+    assert all(
+        len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+        for value in diagnostic.EXPECTED_SOURCE_FILE_SHA256.values()
+    )
+
+
+def test_json_stdout_bypasses_legacy_windows_text_encoding(monkeypatch):
+    """A real packet reached disk but GBK print failure hid CLI success."""
+    stdout = _LegacyEncodedStdout()
+    monkeypatch.setattr(diagnostic.sys, "stdout", stdout)
+
+    diagnostic._write_json_stdout({"topic": "battery−grid"})
+
+    assert '"topic": "battery−grid"' in stdout.buffer.getvalue().decode("utf-8")
+
+
+def test_source_drift_after_lock_blocks_packet_preparation(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    candidates = source / "candidates.csv"
+    candidates.write_text(
+        candidates.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ScopeLinkDiagnosticError, match="identity drifted"):
+        prepare_packet(source, source_lock, tmp_path / "packet")
+
+
+def test_case_journal_drift_blocks_source_lock(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    journal_path = source / "case-executions" / "W01.json"
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    journal["trace_id"] = "openalex-scope-link-v4-w08"
+    journal_path.write_text(
+        json.dumps(journal, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ScopeLinkDiagnosticError, match="does not match aggregate"):
+        create_source_lock(
+            source,
+            tmp_path / "lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=True,
+        )
+
+
+def test_label_context_drift_is_rejected_even_when_identity_count_matches(
+    tmp_path,
+    monkeypatch,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _complete_labels(packet)
+    rows[0]["evidence_summary"] += " altered"
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    _complete_declaration(packet)
+
+    with pytest.raises(ScopeLinkDiagnosticError, match="context or identity drifted"):
+        summarize_packet(source, source_lock, packet)
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"semantic_scope_link": ""}, "partially completed"),
+        (
+            {
+                "direct_relevance": "NO",
+                "semantic_scope_link": "YES",
+                "baseline_novelty": "N/A",
+            },
+            "invalid diagnostic labels",
+        ),
+        ({"review_note": "too short"}, "review_note is too short"),
+    ],
+)
+def test_partial_invalid_or_ungrounded_labels_are_rejected(
+    tmp_path,
+    monkeypatch,
+    updates,
+    message,
+):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _complete_labels(packet)
+    rows[0].update(updates)
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    _complete_declaration(packet)
+
+    with pytest.raises(ScopeLinkDiagnosticError, match=message):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_packet_manifest_rejects_automated_decision_leak(tmp_path, monkeypatch):
+    source = _source(tmp_path, monkeypatch)
+    source_lock, packet = _packet(source, tmp_path)
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["rows"][0]["scope_link_action"] = "ABSTAIN"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ScopeLinkDiagnosticError,
+        match="leaks automated decision fields",
+    ):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_production_worker_cannot_import_the_diagnostic():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "openalex_scope_link_abstention_review" not in worker


### PR DESCRIPTION
## Why

The frozen W01-W08 run failed its mechanical coverage gate at 0/8, but 64 deterministic ABSTAIN traces could not distinguish irrelevant retrieval from an overly strict lexical relation rule. This PR adds a separately pre-registered, post-outcome diagnostic rather than changing v4 or rerunning consumed cases.

## What

- lock the exact failed run and all 64 rows
- create a label-blind packet that hides v4 decisions and match provenance
- preserve incomplete, AI-assisted, uninspectable, and evaluated states
- emit UTF-8 CLI JSON on legacy Windows consoles
- keep generated outputs and assistant worktrees out of canonical pytest discovery
- record the completed anonymous human diagnostic and explicit non-production limitations

## Human diagnostic

One eligible anonymous human reviewer completed 64/64 rows without substantive generative-AI use or external-source checks.

- 28/64 rows were directly relevant from the frozen title and abstract
- 36/64 rows were retrieval noise
- all 8/8 cases retained relevant and baseline-novel evidence
- the reviewer inferred the target semantic link in five rows
- v4 missed four of those five semantic links

This is a single-reviewer, title/abstract-only diagnostic. Raw return files, row-level labels, and reviewer identity remain in the private audit lineage and are not published here.

## Verification

- 16 focused zero-network diagnostic tests
- decision-field leak re-injected and observed red before restoration
- 1,712 tests plus 639 subtests pass
- latest Ruff passes
- CI-scope Pylint passes

## Boundaries

The result explains the failure shape but does not establish source truth, inter-rater agreement, provider recall, report value, or production reliability. It cannot rescue v4, validate v5 on consumed W01-W08 cases, authorize another provider run, or connect Tool Calling to production.