### PR TITLE
Pre-register quote-grounded evidence-set retrieval v5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,8 +418,17 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md,
   plus
   docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md.
+  A separately pre-registered quote-grounded evidence-set v5 hypothesis uses
+  that diagnostic only for development qualification. A label-blind
+  `deepseek-chat` judge must produce mechanically verified title/abstract
+  quotes in two order-reversed passes, and a deterministic set-cover step may
+  combine at most three complementary sources. W01-W08 remain consumed
+  development evidence; raw-byte-locked X01-X08 are the unseen challenge. All
+  provider rows require human review even after a mechanical failure. No v5
+  implementation, model call, OpenAlex request or production connection has
+  occurred. See docs/prereg-2026-08-29-openalex-evidence-set-v5.md.
   Keep
-  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4
+  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,

--- a/README.md
+++ b/README.md
@@ -647,6 +647,17 @@ W01-W08, establish source truth, or authorize production. See the
 and [blank-packet implementation result](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md),
 plus the [completed human diagnostic](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md).
 
+That diagnostic now supports a separately frozen **quote-grounded evidence-set
+v5** hypothesis. Instead of asking one paper to state the whole topic in one
+sentence, a label-blind DeepSeek judge must propose source roles with
+mechanically verifiable title/abstract quotes in two order-reversed passes; a
+deterministic selector may then combine at most three complementary sources.
+W01-W08 are development evidence only. X01-X08 are raw-byte-locked as the
+unseen challenge, and every provider row must receive human review even after a
+mechanical failure. No v5 implementation, model call or OpenAlex request has
+occurred, and production remains disconnected. See the
+[v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md).
+
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
 zero-network census of **95 historical runs** found only **3 in-scope rows over
@@ -1784,6 +1795,14 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 [诊断协议](docs/prereg-2026-08-29-openalex-scope-link-v4-abstention-diagnostic.md)与
 [空白评审包实现结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-implementation.md)，
 以及[已完成人工诊断结果](docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md)。
+
+该诊断现已支持一项另行冻结的 **quote-grounded evidence-set v5** 假设。
+它不再要求一篇论文在同一句中完整表述整个主题，而是让标签盲化的 DeepSeek
+裁判以两次顺序相反的判断提出带标题/摘要原文片段的来源角色，再由确定性选择器
+组合至多三条互补来源。W01-W08 只能作为开发证据；X01-X08 已按原始字节锁定为
+未见挑战。即使机械门槛失败，全部供应商候选也必须进入人工评审。当前尚未实现
+v5、没有发生模型或 OpenAlex 请求，生产路径仍保持断开。详见
+[v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-29-openalex-evidence-set-v5.md
+++ b/docs/prereg-2026-08-29-openalex-evidence-set-v5.md
@@ -1,0 +1,244 @@
+# Pre-registration: OpenAlex quote-grounded evidence-set candidate v5
+
+**Frozen:** 2026-08-29, after the completed scope-link v4 abstention
+diagnostic but before implementing this candidate, calculating any v5
+decision, calling a semantic judge, or requesting an OpenAlex response for
+X01-X08.
+
+**Challenge fixture:**
+`tests/fixtures/openalex_evidence_set_v5_challenge.json`
+
+**Raw fixture SHA-256:**
+`f0c4cc86593f54a36040cf1b7d95b42207726b9323172b7dccae2df47ca5a521`
+
+**Production connection authorized:** no
+
+**Model or live provider calls authorized:** no. This document authorizes only
+the frozen hypothesis and future zero-network implementation. Any model call,
+OpenAlex request, or use of private development labels requires a separate
+authorization naming the merged revision, requested model, request limits and
+soft cost stop.
+
+## Why v5 changes the unit of evidence
+
+The prior candidates exposed two different failure classes:
+
+- precision v2 retained sources in only 3/8 unseen cases and stopped before
+  human review;
+- claim-scope v3 retained sources in 7/8 cases, but one of 13 human-reviewed
+  sources was directly irrelevant, so its 7.69% wrong-source rate exceeded the
+  frozen 5% maximum; and
+- scope-link v4 accepted zero of 64 OpenAlex rows across W01-W08. Its frozen
+  6/8 coverage gate therefore failed before source-value review.
+
+The separately pre-registered v4 diagnostic then reviewed all 64 abstentions
+without reopening that result. From title and abstract text, one eligible
+reviewer found 28 directly relevant rows and 36 retrieval-noise rows. Every
+case had at least one relevant, baseline-novel source. Five rows supported the
+target semantic link, and v4 missed four of the five. This single-reviewer,
+title/abstract-only result is diagnostic rather than source truth, but it is
+enough to reject another exact-phrase threshold edit as the next hypothesis.
+
+The decisive representation error is that v4 asked one paper to state the
+whole commercialization topic in one sentence. Literature evidence is often
+distributed: one source establishes the technology, another establishes the
+deployment scope, and a third supplies performance or risk evidence. v5
+therefore evaluates quote-grounded role contributions per source and then
+selects a bounded evidence **set**. It does not lower the v4 threshold, rescue
+v4, or treat W01-W08 as unseen validation.
+
+## Frozen hypothesis
+
+A bounded semantic judge can recover useful relation recall without silently
+authorizing unsupported evidence when all of the following are enforced:
+
+1. the judge sees only a candidate identity, title, abstract and code-owned
+   role descriptions;
+2. every asserted role carries a source-text quote that can be mechanically
+   verified;
+3. two order-reversed passes agree on `KEEP` and on the exact role IDs;
+4. disagreement, malformed output or an unverifiable quote becomes `ABSTAIN`;
+   and
+5. a deterministic set-cover step selects at most three complementary sources
+   for a case.
+
+The model is a proposal mechanism under a deterministic evidence boundary. It
+does not establish relevance, novelty or correctness; the frozen human-review
+stage remains the source-value authority.
+
+## Frozen semantic-judge contract
+
+The requested provider is DeepSeek, the requested model is `deepseek-chat`,
+and the API base is `https://api.deepseek.com`. The future runner must record
+the requested identity, provider-returned model identity, prompt hash, response
+hash, token usage, cost basis, latency and trace ID for every call. An absent or
+inconsistent returned model identity is an inspectability failure, not a pass.
+The model alias may change behind the provider endpoint; this protocol makes
+that limitation observable rather than claiming bitwise model reproducibility.
+
+Each case receives exactly two batch judgments over the same candidates:
+
+- pass one uses provider order;
+- pass two reverses provider order;
+- temperature is zero;
+- no previous decision, OpenAlex topic/keyword, provider score, v4 trace,
+  human label or human note is visible; and
+- the only candidate actions are `KEEP` and `ABSTAIN`.
+
+For every `KEEP`, the judge must return the role IDs it believes the source
+supports and one title-or-abstract quote for each role. Quote verification may
+normalize line endings and runs of Unicode whitespace only; it may not stem,
+translate, paraphrase or use provider metadata. A candidate survives only if
+both parsed passes return `KEEP`, name the same role IDs, and supply a valid
+quote for every role. Unparseable output, missing rows, duplicate candidate
+identities, pass disagreement or quote failure produces `ABSTAIN` and remains
+visible in the audit artifact.
+
+Disposition agreement is the fraction of provider candidates for which both
+passes return the same parsed action and, for `KEEP`, the same role IDs.
+Malformed, missing or quote-invalid output counts as disagreement. Two passes
+are a repeatability probe, not proof that the model is correct or independent.
+
+## Frozen evidence-set contract
+
+Candidate identities bind the raw title and abstract. A surviving candidate
+must contribute:
+
+1. at least one required role;
+2. at least one scope or supporting role; and
+3. at least one role grounded by a title quote.
+
+For each case, the deterministic selector enumerates sets of at most three
+surviving candidates. A valid set must cover every required role, at least one
+scope role and at least one supporting role. It chooses the smallest valid set,
+then the lexicographically smallest provider-index tuple, then candidate
+SHA-256. If no valid set exists, the case abstains. There is no model-selected
+tie break, profile relaxation, second query, source-page enrichment or fallback
+to v4 provider metadata.
+
+## Development qualification on consumed W01-W08
+
+W01-W08 and their labels are consumed evidence. They may be used once as a
+disclosed **development qualification** because they explain the failure class;
+they may never be described as v5 validation. The implementation must lock the
+exact public 64-row artifact and the private human-review artifact before
+opening labels. The semantic judge must run label-blind, and labels may be
+joined only after every model response and set decision has been committed.
+
+All development gates must pass before any X01-X08 provider request is eligible:
+
+1. candidate-disposition agreement is at least 90%;
+2. at least four of the five human-inferred semantic-link rows survive;
+3. at least 6/8 cases retain relevant, baseline-novel evidence;
+4. at most one selected source is directly irrelevant; and
+5. every candidate, pass, quote check and selection decision is persisted.
+
+A failure seals the v5 candidate. It may be analysed, but W01-W08 may not be
+tuned and replayed into a pass. Any successor requires a new hypothesis and a
+new challenge.
+
+## Unseen X01-X08 challenge
+
+A repository search of the parent `main` revision found none of these eight
+exact topic strings before the fixture was added. This is an exact-string
+claim, not a claim that the broad scientific domains were never discussed.
+
+| ID | Frozen topic |
+|---|---|
+| X01 | Redox-active polymer electrodes for electrochemical carbon dioxide capture from flue gas |
+| X02 | DNA-origami nanopores for single-molecule protein sensing |
+| X03 | Rare-earth-free magnetocaloric materials for hydrogen liquefaction |
+| X04 | Electrochemical ocean alkalinity enhancement for durable carbon dioxide removal |
+| X05 | Reprocessable vitrimer composites for recyclable wind-turbine blades |
+| X06 | Microbial electrosynthesis of acetate from industrial carbon dioxide emissions |
+| X07 | Chip-scale optomechanical accelerometers for inertial navigation |
+| X08 | Cold-plasma seed priming for drought-resilient cereal crops |
+
+The fixture freezes order, exact queries, role descriptions, result limits,
+request behavior, judge behavior, selection behavior and both gate sets. Once
+any X case sends a provider or model request, all eight case identities are
+consumed even if the run later fails.
+
+## Frozen provider contract
+
+A future unseen run may use the existing production-disconnected anonymous
+OpenAlex response contract, but not a v2, v3 or v4 admission decision:
+
+- one Works request per attempted case, at most eight requests total;
+- `search=<frozen query>`, `filter=has_abstract:true`, `per-page=8`;
+- topics and keywords are retained for audit but are inadmissible to v5;
+- no API key, redirect, internal retry, supplementary fetch or second query;
+- every provider row becomes a candidate or an explicit provider rejection;
+  and
+- provider row indices, request identity, latency and provider-reported usage
+  remain complete even when a later case fails.
+
+The model-call ceiling is 16: two batch calls for each of eight cases. There is
+no hidden retry or malformed-output repair call. A future authorization may set
+a lower request or cost ceiling but may not raise these limits without replacing
+this protocol.
+
+## Unseen source-value gates
+
+All gates are conjunctive:
+
+1. at least one selected source set in at least 6/8 cases;
+2. at least one relevant, baseline-novel source in at least 6/8 cases;
+3. human-confirmed set coverage in at least 6/8 cases;
+4. no more than 5% directly irrelevant selected sources;
+5. no more than 5% unsupported role assignments among selected sources;
+6. candidate-disposition agreement of at least 90%;
+7. every provider candidate reviewed and every source URL attempted; and
+8. no substantive generative AI producing the human judgments.
+
+The human packet must be label-blind: it exposes the frozen baseline, topic,
+role descriptions, title and abstract for every provider candidate, but hides
+v5 actions, quotes, selected sets and model traces until aggregation. Reviewers
+label direct relevance, baseline novelty and supported roles from the source.
+The checker then derives wrong-source rate, unsupported-role rate and set
+coverage from those labels. A source that cannot be opened remains visibly
+unverified; silence is not a pass.
+
+All provider candidates are reviewed even if the mechanical coverage gate has
+already failed. The v4 run showed that stopping at a mechanical failure leaves
+the cause unidentified. This additional diagnostic obligation does not relax
+the all-gates result or permit production connection.
+
+## Implementation and falsification requirements
+
+Before any development model call or unseen provider request:
+
+- verify the raw fixture hash before JSON parsing or case expansion;
+- validate unique case, role, query and candidate identities;
+- freeze prompt, parser, quote verifier, selector, runner and adapter hashes;
+- persist a complete manifest before constructing an OpenAlex adapter or model
+  client;
+- commit each pass response and its usage before allowing the next call;
+- preserve every provider row and every model disposition through the review
+  boundary;
+- scrub credentials and fail closed on uninspectable request or cost state;
+- prove provider metadata and prior human labels cannot reach the judge;
+- prove a computed role or selected source cannot disappear at serialization;
+- prove reversed order is actually sent on pass two;
+- prove an invented or paraphrased quote cannot authorize a role;
+- prove deterministic set-cover tie breaking and the three-source ceiling;
+- assert that production modules do not import v5 code; and
+- re-inject at least the quote-bypass and computed-but-undelivered defects and
+  confirm their seam tests turn red before restoring the implementation.
+
+The implementation phase must run the complete zero-network suite, latest Ruff
+and narrow Pylint, then record a separate result. Passing offline tests would
+establish only contract implementation, not model quality or source value.
+
+## Explicit non-claims
+
+This pre-registration does not authorize a model call, an OpenAlex request,
+private-label access, production import, report connection or planner trigger.
+Future development or unseen success would still not establish OpenAlex-wide
+precision or recall, literature-wide novelty, source truth beyond the review,
+inter-rater agreement, report improvement, decision correctness, adoption,
+ROI, latency, an SLO, autonomous tool choice or completed production Tool
+Calling.
+
+`pipeline_worker.py` must remain disconnected from the v5 judge, selector,
+preflight, adapters, runners and review modules.

--- a/tests/fixtures/openalex_evidence_set_v5_challenge.json
+++ b/tests/fixtures/openalex_evidence_set_v5_challenge.json
@@ -1,0 +1,390 @@
+{
+  "schema_version": 1,
+  "mode": "openalex_quote_grounded_evidence_set_v5_unseen_challenge",
+  "production_connected": false,
+  "report_workflow_connected": false,
+  "planner_trigger_connected": false,
+  "maximum_live_search_requests": 8,
+  "maximum_live_judge_calls": 16,
+  "request_contract": {
+    "result_limit": 8,
+    "filter": "has_abstract:true",
+    "aboutness_fields": ["topics", "keywords"],
+    "aboutness_admissible_for_selection": false,
+    "redirects": false,
+    "internal_retries": false,
+    "supplementary_fetches": false
+  },
+  "semantic_judge_contract": {
+    "provider": "deepseek",
+    "requested_model": "deepseek-chat",
+    "api_base": "https://api.deepseek.com",
+    "passes_per_case": 2,
+    "first_pass_order": "provider_order",
+    "second_pass_order": "reverse_provider_order",
+    "temperature": 0.0,
+    "allowed_candidate_fields": ["candidate_sha256", "title", "abstract"],
+    "hidden_fields": [
+      "provider_topics",
+      "provider_keywords",
+      "provider_scores",
+      "v4_action",
+      "v4_reasons",
+      "human_labels",
+      "human_notes"
+    ],
+    "candidate_dispositions": ["KEEP", "ABSTAIN"],
+    "consensus_rule": "both_passes_keep_with_same_role_ids",
+    "quote_rule": "every_role_requires_a_verbatim_title_or_abstract_span_in_both_passes",
+    "disagreement_rule": "abstain",
+    "malformed_or_unverifiable_rule": "abstain",
+    "maximum_selected_sources_per_case": 3,
+    "selection_rule": "deterministic_minimum_set_cover_then_provider_index_then_candidate_sha256"
+  },
+  "development_observation": {
+    "source_document": "docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md",
+    "case_ids": ["W01", "W02", "W03", "W04", "W05", "W06", "W07", "W08"],
+    "candidate_count": 64,
+    "direct_relevant_count": 28,
+    "retrieval_noise_count": 36,
+    "human_semantic_link_count": 5,
+    "v4_semantic_link_miss_count": 4,
+    "relevant_case_count": 8,
+    "novel_relevant_case_count": 8,
+    "reuse_for_v5_development": true,
+    "reuse_for_v5_validation": false
+  },
+  "challenge_cases": [
+    {
+      "case_id": "X01",
+      "topic": "Redox-active polymer electrodes for electrochemical carbon dioxide capture from flue gas",
+      "query": "electrochemical carbon dioxide capture redox active polymer electrode flue gas",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "electrochemical_carbon_capture",
+            "description": "reversible electrochemical capture or release of carbon dioxide"
+          },
+          {
+            "role_id": "redox_polymer_electrode",
+            "description": "a redox-active polymer electrode or polymer-bound redox carrier"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "flue_or_industrial_gas",
+            "description": "capture from flue gas or another dilute industrial carbon-dioxide stream"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "regeneration_energy",
+            "description": "energy demand, electrochemical regeneration, or release efficiency"
+          },
+          {
+            "role_id": "capture_performance",
+            "description": "carbon-dioxide capacity, selectivity, uptake rate, or separation performance"
+          },
+          {
+            "role_id": "cycling_stability",
+            "description": "repeated capture-release cycling or electrode stability"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X02",
+      "topic": "DNA-origami nanopores for single-molecule protein sensing",
+      "query": "DNA origami nanopore single molecule protein sensing",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "dna_origami_nanopore",
+            "description": "a nanopore or membrane channel constructed or positioned using DNA origami"
+          },
+          {
+            "role_id": "single_molecule_protein_sensing",
+            "description": "electrical or ionic-current sensing of individual proteins or peptides"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "protein_translocation",
+            "description": "protein or peptide capture, passage, discrimination, or translocation through the pore"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "signal_resolution",
+            "description": "current blockade, signal-to-noise ratio, event resolution, or molecular identification"
+          },
+          {
+            "role_id": "pore_assembly",
+            "description": "membrane insertion, pore assembly, structural stability, or nanostructure fabrication"
+          },
+          {
+            "role_id": "multiplexed_detection",
+            "description": "parallel, multiplexed, or high-throughput single-molecule measurement"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X03",
+      "topic": "Rare-earth-free magnetocaloric materials for hydrogen liquefaction",
+      "query": "rare earth free magnetocaloric material hydrogen liquefaction refrigeration",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "magnetocaloric_refrigeration",
+            "description": "magnetocaloric cooling or magnetic refrigeration"
+          },
+          {
+            "role_id": "hydrogen_liquefaction",
+            "description": "cooling hydrogen toward liquefaction or operation in the hydrogen-liquefaction temperature range"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "rare_earth_free_material",
+            "description": "a magnetocaloric composition that avoids rare-earth elements"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "low_temperature_performance",
+            "description": "entropy change, adiabatic temperature change, or cooling power at cryogenic temperature"
+          },
+          {
+            "role_id": "cyclic_refrigeration",
+            "description": "active magnetic regeneration, repeated thermal cycling, or refrigeration-cycle performance"
+          },
+          {
+            "role_id": "materials_engineering",
+            "description": "composition, phase transition, hysteresis, manufacturability, or material stability"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X04",
+      "topic": "Electrochemical ocean alkalinity enhancement for durable carbon dioxide removal",
+      "query": "electrochemical ocean alkalinity enhancement carbon dioxide removal seawater",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "electrochemical_alkalinity_generation",
+            "description": "electrochemical production or restoration of alkalinity"
+          },
+          {
+            "role_id": "carbon_dioxide_removal",
+            "description": "net atmospheric or dissolved carbon-dioxide removal and durable storage"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "ocean_or_seawater_context",
+            "description": "operation in seawater, brine, or an ocean-alkalinity-enhancement pathway"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "energy_intensity",
+            "description": "electrical energy use, voltage, current efficiency, or process energy balance"
+          },
+          {
+            "role_id": "marine_side_effects",
+            "description": "chlorine evolution, mineral scaling, acid handling, or marine environmental effects"
+          },
+          {
+            "role_id": "durability_or_mrv",
+            "description": "carbon permanence, air-sea equilibration, monitoring, reporting, or verification"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X05",
+      "topic": "Reprocessable vitrimer composites for recyclable wind-turbine blades",
+      "query": "vitrimer composite recyclable wind turbine blade reprocessing",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "vitrimer_composite",
+            "description": "a fibre-reinforced composite using a vitrimer or dynamic covalent polymer matrix"
+          },
+          {
+            "role_id": "wind_turbine_blade",
+            "description": "materials, structures, manufacturing, repair, or end-of-life treatment for wind-turbine blades"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "reprocess_or_recycle",
+            "description": "reprocessing, reshaping, repair, recycling, or material recovery enabled by reversible bonding"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "mechanical_retention",
+            "description": "strength, fatigue, fracture, interfacial, or mechanical-property retention"
+          },
+          {
+            "role_id": "bond_exchange",
+            "description": "dynamic bond exchange, topology rearrangement, or healing mechanism"
+          },
+          {
+            "role_id": "lifecycle_benefit",
+            "description": "reduced waste, circularity, lifecycle impact, or economic recovery"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X06",
+      "topic": "Microbial electrosynthesis of acetate from industrial carbon dioxide emissions",
+      "query": "microbial electrosynthesis acetate carbon dioxide industrial emissions gas",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "microbial_electrosynthesis",
+            "description": "microorganisms using cathodic electrons in a bioelectrochemical synthesis process"
+          },
+          {
+            "role_id": "acetate_from_carbon_dioxide",
+            "description": "conversion of carbon dioxide or bicarbonate into acetate"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "industrial_emission_stream",
+            "description": "industrial exhaust, flue gas, off-gas, or another impure carbon-dioxide feed"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "production_performance",
+            "description": "acetate titre, productivity, coulombic efficiency, or carbon conversion"
+          },
+          {
+            "role_id": "electron_transfer",
+            "description": "electron-transfer pathway, cathode interaction, hydrogen mediation, or microbial mechanism"
+          },
+          {
+            "role_id": "reactor_stability",
+            "description": "continuous operation, scale-up, gas tolerance, or long-term reactor performance"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X07",
+      "topic": "Chip-scale optomechanical accelerometers for inertial navigation",
+      "query": "chip scale optomechanical accelerometer inertial navigation",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "optomechanical_accelerometer",
+            "description": "acceleration sensing through an optical or cavity-optomechanical mechanical resonator"
+          },
+          {
+            "role_id": "inertial_navigation",
+            "description": "inertial navigation, dead reckoning, inertial measurement, or navigation-grade acceleration"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "chip_scale_integration",
+            "description": "chip-scale, integrated, microfabricated, MEMS, or photonic-platform implementation"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "noise_floor",
+            "description": "acceleration sensitivity, noise floor, resolution, or bias instability"
+          },
+          {
+            "role_id": "dynamic_range",
+            "description": "bandwidth, dynamic range, shock tolerance, or resonator response"
+          },
+          {
+            "role_id": "calibration_stability",
+            "description": "self-calibration, traceability, drift control, or long-term stability"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "X08",
+      "topic": "Cold-plasma seed priming for drought-resilient cereal crops",
+      "query": "cold plasma seed priming drought cereal crop resilience",
+      "result_limit": 8,
+      "role_profile": {
+        "required_roles": [
+          {
+            "role_id": "cold_plasma_seed_treatment",
+            "description": "non-thermal or cold-plasma exposure used to prime or treat seeds"
+          },
+          {
+            "role_id": "drought_resilience",
+            "description": "improved drought tolerance, water-stress response, or performance under water deficit"
+          }
+        ],
+        "scope_roles": [
+          {
+            "role_id": "cereal_crop",
+            "description": "wheat, rice, maize, barley, sorghum, or another cereal crop"
+          }
+        ],
+        "supporting_roles": [
+          {
+            "role_id": "germination_or_establishment",
+            "description": "germination, emergence, seedling vigour, or early establishment"
+          },
+          {
+            "role_id": "stress_physiology",
+            "description": "antioxidant response, water-use efficiency, osmotic adjustment, or drought physiology"
+          },
+          {
+            "role_id": "yield_or_field_performance",
+            "description": "field performance, biomass, grain yield, or agronomic outcome"
+          }
+        ]
+      }
+    }
+  ],
+  "collection_coverage_contract": {
+    "required_roles_covered": "all",
+    "minimum_scope_roles": 1,
+    "minimum_supporting_roles": 1,
+    "maximum_selected_sources_per_case": 3,
+    "minimum_candidate_required_roles": 1,
+    "minimum_candidate_context_roles": 1,
+    "minimum_candidate_title_anchor_roles": 1
+  },
+  "development_qualification_gates": {
+    "candidate_disposition_agreement_min": 0.9,
+    "semantic_link_rows_retained_min": 4,
+    "relevant_novel_case_count_min": 6,
+    "selected_directly_irrelevant_count_max": 1,
+    "all_decisions_persisted": true
+  },
+  "unseen_value_gates": {
+    "selected_case_count_min": 6,
+    "relevant_novel_case_count_min": 6,
+    "human_set_coverage_case_count_min": 6,
+    "selected_wrong_source_rate_max": 0.05,
+    "unsupported_selected_role_rate_max": 0.05,
+    "candidate_disposition_agreement_min": 0.9,
+    "all_provider_rows_reviewed": true,
+    "all_attempted_sources_opened": true,
+    "substantive_generative_ai_allowed": false
+  }
+}


### PR DESCRIPTION
## Summary

- freeze the quote-grounded evidence-set v5 hypothesis before implementation or paid calls
- lock eight exact-string-unseen X01-X08 topics, role profiles, request limits, judge contract, and conjunctive gates
- document W01-W08 as development-only evidence and keep all v5 modules disconnected from production
- synchronize the English and Chinese README sections plus AGENTS.md decision history

## Why

The completed v4 diagnostic found both retrieval noise and lexical relation-recall failure: 36/64 rows were noise, while v4 missed four of five human-inferred semantic links. Another exact-phrase threshold would repeat a disproven direction, and tuning on consumed W01-W08 labels would leak evaluation evidence. This protocol instead tests mechanically verified role quotes, order-reversed judge consensus, and deterministic evidence-set coverage capped at three sources.

## Boundaries

This PR performs no semantic-model call, OpenAlex request, private-label access, production import, planner trigger, or report connection. Future implementation and every paid stage require separate authorization.

## Verification

- full zero-network suite: 1712 passed and 639 subtests passed
- latest Ruff: passed
- frozen JSON structure and documented raw SHA-256 verified
- no prior exact occurrence of the eight X-topic strings outside the new fixture and protocol