### PR TITLE
Implement the quote-grounded evidence-set v5 kernel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1712 tests (639 subtests), CI green on Linux + Windows × Python
+Current state: 1733 tests (639 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -154,6 +154,8 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         provider-assisted source gate; experimental only
   openalex_scope_link.py
                         role-structured same-segment gate; experimental only
+  openalex_evidence_set.py
+                        quote-grounded two-pass set selector; experimental only
   tools/evidence_search.py
                         one-request read-only adapter response contract
   tools/anonymous_openalex_search.py
@@ -424,9 +426,15 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   quotes in two order-reversed passes, and a deterministic set-cover step may
   combine at most three complementary sources. W01-W08 remain consumed
   development evidence; raw-byte-locked X01-X08 are the unseen challenge. All
-  provider rows require human review even after a mechanical failure. No v5
-  implementation, model call, OpenAlex request or production connection has
-  occurred. See docs/prereg-2026-08-29-openalex-evidence-set-v5.md.
+  provider rows require human review even after a mechanical failure. The v5
+  zero-network kernel and X01-X08 preflight are implemented and pass 21/21
+  focused tests. They mechanically verify both passes' quotes, fail closed on
+  disagreement or malformed rows, select at most three sources, and validate
+  that every computed role reaches the serialized audit boundary. Both
+  protocol-mandated defects were re-injected and caught. No model call,
+  OpenAlex request, private-label access or production connection has occurred.
+  See docs/prereg-2026-08-29-openalex-evidence-set-v5.md and
+  docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md.
   Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5
   candidates, live runners and review modules.

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ before a later request. Every provider row reaches the aggregate artifact, and
 only v4 `ACCEPT` rows reach a blank human-review boundary. The combined v4
 decision, preflight and runner subset passes 32/32 tests, including a
 re-injected computed-but-undelivered relation-provenance defect. The complete
-repository now passes **1,712 tests plus 639 subtests**. A separately
+repository now passes **1,733 tests plus 639 subtests**. A separately
 authorized run on merged revision `678254d` completed all eight one-attempt
 anonymous requests for USD 0.008 of provider-reported usage. All 64 provider
 rows reached the v4 decision seam, but the method accepted zero candidates
@@ -654,9 +654,14 @@ mechanically verifiable title/abstract quotes in two order-reversed passes; a
 deterministic selector may then combine at most three complementary sources.
 W01-W08 are development evidence only. X01-X08 are raw-byte-locked as the
 unseen challenge, and every provider row must receive human review even after a
-mechanical failure. No v5 implementation, model call or OpenAlex request has
-occurred, and production remains disconnected. See the
-[v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md).
+mechanical failure. The zero-network v5 kernel and unseen preflight now pass
+21/21 focused tests: model inputs exclude provider and label metadata, quotes
+are verified against source text in both passes, and a validated final seam
+prevents computed roles from disappearing during serialization. The full suite
+passes **1,733 tests plus 639 subtests**. No model call, OpenAlex request,
+private-label access or production connection has occurred. See the
+[v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md) and
+[implementation result](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1768,7 +1773,7 @@ runner 已实现：它在构造适配器前记录冻结方法与自身观测哈�
 下一次请求前先提交当前单请求 case journal。每一条供应商返回行都会到达
 聚合产物，只有 v4 `ACCEPT` 行会进入空白人工评审边界。v4 决策、预检与
 runner 组合测试为 32/32；临时移除内部已算出的 relation provenance 后，
-客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,712 项测试与 639 个
+客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,733 项测试与 639 个
 subtests**。随后在合并版本 `678254d` 上单独授权的真实实验完成了 8 次匿名、
 不重试的顺序请求，供应商记账成本为 0.008 美元。64 条供应商候选全部到达
 v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结的 6/8 门槛。
@@ -1800,9 +1805,13 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 它不再要求一篇论文在同一句中完整表述整个主题，而是让标签盲化的 DeepSeek
 裁判以两次顺序相反的判断提出带标题/摘要原文片段的来源角色，再由确定性选择器
 组合至多三条互补来源。W01-W08 只能作为开发证据；X01-X08 已按原始字节锁定为
-未见挑战。即使机械门槛失败，全部供应商候选也必须进入人工评审。当前尚未实现
-v5、没有发生模型或 OpenAlex 请求，生产路径仍保持断开。详见
-[v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)。
+未见挑战。即使机械门槛失败，全部供应商候选也必须进入人工评审。v5 零网络
+执行内核与未见预检现已通过 21/21 项定向测试：模型输入排除供应商元数据和人工
+标签，两次判断中的原文片段都必须机械验证，最终 Pydantic 接缝会阻止已计算的
+role 在序列化时丢失。当前全仓通过 **1,733 项测试与 639 个 subtests**。尚未发生
+模型调用、OpenAlex 请求、私有标签读取或生产接入。详见
+[v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)和
+[实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md
+++ b/docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md
@@ -1,0 +1,136 @@
+# Result: OpenAlex quote-grounded evidence-set v5 kernel and unseen preflight
+
+**Date:** 2026-08-29
+
+**Result state:** zero-network kernel complete; development qualification,
+provider compatibility and source value `not_evaluated`.
+
+## Outcome
+
+The production-disconnected v5 decision kernel and raw-byte-locked X01-X08
+preflight now implement the offline portion of the frozen
+[v5 protocol](prereg-2026-08-29-openalex-evidence-set-v5.md). The model-facing
+surface contains only candidate identity, title and abstract plus code-owned
+role descriptions. It cannot receive provider topics, keywords or scores,
+prior v4 decisions, or human labels and notes.
+
+The kernel parses two order-reversed judgment passes, mechanically verifies
+every proposed title or abstract quote, requires exact agreement on `KEEP` and
+role IDs, and fails closed to `ABSTAIN` on malformed output, missing rows,
+duplicate identities, disagreement or unverifiable text. The deterministic
+selector then chooses the smallest evidence set that covers every required
+role plus the frozen scope and supporting minimums, using provider index and
+candidate SHA-256 as tie breakers and never selecting more than three sources.
+Every candidate disposition and every selected role reaches one validated case
+audit model.
+
+No semantic model was called, no OpenAlex request was made, no private label
+was opened, and no production, report or planner connection was added.
+
+## Added boundaries
+
+- `src/academic_agent/openalex_evidence_set.py`: strict Pydantic contracts,
+  model-input projection, raw-response parsing, quote verification,
+  two-pass consensus, deterministic bounded set cover and final audit seam;
+- `openalex_evidence_set_unseen.py`: raw-fixture verification before parsing,
+  X01-X08 contract expansion, deterministic collection/plan/profile/case and
+  idempotency identities, and explicit zero-authority dry-run output;
+- `tests/test_openalex_evidence_set.py`: decision, quote, ordering, selection,
+  serialization and production-disconnection seams;
+- `tests/test_openalex_evidence_set_unseen.py`: fixture, case order, hidden
+  field, identity, request-cap and import-boundary seams.
+
+The fixture remains byte-identical to the pre-registration:
+
+```text
+f0c4cc86593f54a36040cf1b7d95b42207726b9323172b7dccae2df47ca5a521
+```
+
+## Zero-network preflight
+
+The default command completed with:
+
+- 8/8 ordered X01-X08 cases;
+- eight distinct source-collection, plan, profile, case-contract and
+  idempotency identities;
+- at most eight future OpenAlex searches and sixteen future judge calls;
+- one abstract-bearing Works query contract, no redirect, internal retry or
+  supplementary fetch;
+- provider metadata retained for audit but inadmissible to the selector;
+- request contract SHA-256
+  `328a25581a874251704856289210ee8a3caedb27b462bb6e59e1743a00c9fe1c`;
+- judge contract SHA-256
+  `dc824c41409057bc7f790b9cec4c50b586e1930557b8a7a05dbc91cd057db5d5`;
+- selection contract SHA-256
+  `d9fafbe1423e4a29878a47783eabed977c6a5d9e786c8ea02857e4a277f17559`;
+- `real_network_calls_performed=false`,
+  `real_model_calls_performed=false`, `private_labels_opened=false`, and all
+  production/report/planner and live-authorization flags false.
+
+## Verification
+
+Focused zero-network tests:
+
+```text
+21 passed in 2.17s
+```
+
+Full zero-network suite:
+
+```text
+1733 passed, 639 subtests passed in 33.10s
+```
+
+Static checks:
+
+```text
+uv run --with ruff ruff check \
+  src/academic_agent/openalex_evidence_set.py \
+  openalex_evidence_set_unseen.py \
+  tests/test_openalex_evidence_set.py \
+  tests/test_openalex_evidence_set_unseen.py
+All checks passed!
+
+uv run pylint --disable=all --enable=E0701 \
+  src/academic_agent/openalex_evidence_set.py \
+  openalex_evidence_set_unseen.py
+Your code has been rated at 10.00/10
+```
+
+No warning filter, ignored warning, relaxed assertion or skipped test was
+added.
+
+## Defect re-injection
+
+Two protocol-mandated defects were introduced only long enough to run their
+exact seam test and were then reverted.
+
+1. The quote verifier was changed so a role could survive when only one of the
+   two judge-pass quotes was present in source text. The paraphrase test failed
+   because the candidate incorrectly became `KEEP` instead of `ABSTAIN`.
+2. A correctly verified supporting role was removed while constructing the
+   serialized selected-source payload. The client-boundary test failed with
+   `selected source must deliver every verified KEEP role`.
+
+After restoration, all 21 focused tests and the complete repository suite
+returned to green. These failures show that the tests observe the authorization
+and delivery seams, not only internal role fields.
+
+## What remains unobserved
+
+This result establishes the offline contracts and deterministic kernel only.
+It does not establish:
+
+- DeepSeek output validity, agreement, relevance or cost;
+- the five frozen development gates on consumed W01-W08;
+- OpenAlex compatibility or any X01-X08 provider result;
+- candidate precision, recall, source truth, novelty or set coverage;
+- report improvement, planner-trigger quality or completed Tool Calling;
+- production reliability, user value, adoption or ROI.
+
+The next eligible step is a separately authorized, label-blind W01-W08
+development qualification on the merged implementation revision. It may make
+at most sixteen `deepseek-chat` calls, must make zero OpenAlex calls, and must
+commit every raw response and deterministic decision before private labels are
+opened. A failed development gate seals v5; it does not authorize tuning and
+replay. X01-X08 and production remain out of scope until that result exists.

--- a/openalex_evidence_set_unseen.py
+++ b/openalex_evidence_set_unseen.py
@@ -1,0 +1,507 @@
+"""Zero-network preflight for the frozen OpenAlex evidence-set v5 challenge.
+
+X01-X08 were frozen after the scope-link v4 diagnostic and before v5 code,
+model responses, or OpenAlex results existed.  This module validates the raw
+fixture bytes first, expands deterministic evidence-gap identities, and exposes
+the contracts a separately authorized runner would need.  It imports neither a
+provider adapter nor a model client, so dry-run cannot spend either budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetRoleProfile,
+    EvidenceSetSelectionContract,
+)
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = (
+    _ROOT / "tests/fixtures/openalex_evidence_set_v5_challenge.json"
+)
+EXPECTED_FIXTURE_SHA256 = (
+    "f0c4cc86593f54a36040cf1b7d95b42207726b9323172b7dccae2df47ca5a521"
+)
+_CASE_ORDER = tuple(f"X{index:02d}" for index in range(1, 9))
+_DEVELOPMENT_CASE_ORDER = tuple(f"W{index:02d}" for index in range(1, 9))
+_COLLECTED_AT = datetime(2026, 8, 29, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 8, 29)
+
+
+class OpenAlexEvidenceSetPreflightError(ValueError):
+    """Raised before case expansion when the frozen v5 contract drifts."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(
+        value.model_dump_json(exclude_none=False).encode("utf-8")
+    )
+
+
+class EvidenceSetRequestContract(BaseModel):
+    """One-request OpenAlex shape frozen without constructing a transport."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    result_limit: Literal[8] = 8
+    filter: Literal["has_abstract:true"] = "has_abstract:true"
+    aboutness_fields: tuple[Literal["topics", "keywords"], ...]
+    aboutness_admissible_for_selection: Literal[False] = False
+    redirects: Literal[False] = False
+    internal_retries: Literal[False] = False
+    supplementary_fetches: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_aboutness_order(self) -> "EvidenceSetRequestContract":
+        if self.aboutness_fields != ("topics", "keywords"):
+            raise ValueError("aboutness fields must remain topics then keywords")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class EvidenceSetJudgeContract(BaseModel):
+    """Exact future model boundary frozen without importing a model SDK."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["deepseek"] = "deepseek"
+    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    api_base: Literal["https://api.deepseek.com"] = "https://api.deepseek.com"
+    passes_per_case: Literal[2] = 2
+    first_pass_order: Literal["provider_order"] = "provider_order"
+    second_pass_order: Literal["reverse_provider_order"] = "reverse_provider_order"
+    temperature: Literal[0.0] = 0.0
+    allowed_candidate_fields: tuple[str, ...]
+    hidden_fields: tuple[str, ...]
+    candidate_dispositions: tuple[str, ...]
+    consensus_rule: Literal["both_passes_keep_with_same_role_ids"]
+    quote_rule: Literal[
+        "every_role_requires_a_verbatim_title_or_abstract_span_in_both_passes"
+    ]
+    disagreement_rule: Literal["abstain"] = "abstain"
+    malformed_or_unverifiable_rule: Literal["abstain"] = "abstain"
+    maximum_selected_sources_per_case: Literal[3] = 3
+    selection_rule: Literal[
+        "deterministic_minimum_set_cover_then_provider_index_then_candidate_sha256"
+    ]
+
+    @model_validator(mode="after")
+    def _validate_exact_sequences(self) -> "EvidenceSetJudgeContract":
+        if self.allowed_candidate_fields != (
+            "candidate_sha256",
+            "title",
+            "abstract",
+        ):
+            raise ValueError("judge candidate fields drifted")
+        if self.hidden_fields != (
+            "provider_topics",
+            "provider_keywords",
+            "provider_scores",
+            "v4_action",
+            "v4_reasons",
+            "human_labels",
+            "human_notes",
+        ):
+            raise ValueError("judge hidden-field contract drifted")
+        if self.candidate_dispositions != ("KEEP", "ABSTAIN"):
+            raise ValueError("judge dispositions must remain KEEP then ABSTAIN")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class EvidenceSetDevelopmentObservation(BaseModel):
+    """Consumed v4 diagnostic evidence available only for development."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_document: Literal[
+        "docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md"
+    ]
+    case_ids: tuple[str, ...]
+    candidate_count: Literal[64] = 64
+    direct_relevant_count: Literal[28] = 28
+    retrieval_noise_count: Literal[36] = 36
+    human_semantic_link_count: Literal[5] = 5
+    v4_semantic_link_miss_count: Literal[4] = 4
+    relevant_case_count: Literal[8] = 8
+    novel_relevant_case_count: Literal[8] = 8
+    reuse_for_v5_development: Literal[True] = True
+    reuse_for_v5_validation: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_consumed_case_order(self) -> "EvidenceSetDevelopmentObservation":
+        if self.case_ids != _DEVELOPMENT_CASE_ORDER:
+            raise ValueError("development cases must remain W01 through W08")
+        return self
+
+
+class EvidenceSetDevelopmentGates(BaseModel):
+    """Label-blind qualification gates before an unseen request is eligible."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_disposition_agreement_min: Literal[0.9] = 0.9
+    semantic_link_rows_retained_min: Literal[4] = 4
+    relevant_novel_case_count_min: Literal[6] = 6
+    selected_directly_irrelevant_count_max: Literal[1] = 1
+    all_decisions_persisted: Literal[True] = True
+
+
+class EvidenceSetUnseenGates(BaseModel):
+    """Conjunctive human-value gates for a separately authorized live run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_case_count_min: Literal[6] = 6
+    relevant_novel_case_count_min: Literal[6] = 6
+    human_set_coverage_case_count_min: Literal[6] = 6
+    selected_wrong_source_rate_max: Literal[0.05] = 0.05
+    unsupported_selected_role_rate_max: Literal[0.05] = 0.05
+    candidate_disposition_agreement_min: Literal[0.9] = 0.9
+    all_provider_rows_reviewed: Literal[True] = True
+    all_attempted_sources_opened: Literal[True] = True
+    substantive_generative_ai_allowed: Literal[False] = False
+
+
+class EvidenceSetCaseSpec(BaseModel):
+    """One exact unseen query and its natural-language evidence roles."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^X0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    query: str = Field(min_length=20, max_length=500)
+    result_limit: Literal[8] = 8
+    role_profile: EvidenceSetRoleProfile
+
+
+class EvidenceSetChallengeManifest(BaseModel):
+    """Complete raw-byte-frozen v5 preflight input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_quote_grounded_evidence_set_v5_unseen_challenge"]
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    maximum_live_search_requests: Literal[8] = 8
+    maximum_live_judge_calls: Literal[16] = 16
+    request_contract: EvidenceSetRequestContract
+    semantic_judge_contract: EvidenceSetJudgeContract
+    development_observation: EvidenceSetDevelopmentObservation
+    challenge_cases: tuple[EvidenceSetCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+    collection_coverage_contract: EvidenceSetSelectionContract
+    development_qualification_gates: EvidenceSetDevelopmentGates
+    unseen_value_gates: EvidenceSetUnseenGates
+
+    @model_validator(mode="after")
+    def _validate_cross_contracts(self) -> "EvidenceSetChallengeManifest":
+        observed = tuple(case.case_id for case in self.challenge_cases)
+        if observed != _CASE_ORDER:
+            raise ValueError("evidence-set cases must remain ordered X01 through X08")
+        if any(
+            case.result_limit != self.request_contract.result_limit
+            for case in self.challenge_cases
+        ):
+            raise ValueError("case result limits drifted from the request contract")
+        if self.maximum_live_search_requests != len(self.challenge_cases):
+            raise ValueError("search request cap must remain one per case")
+        expected_judge_calls = (
+            len(self.challenge_cases) * self.semantic_judge_contract.passes_per_case
+        )
+        if self.maximum_live_judge_calls != expected_judge_calls:
+            raise ValueError("judge call cap must remain two per case")
+        if (
+            self.collection_coverage_contract.maximum_selected_sources_per_case
+            != self.semantic_judge_contract.maximum_selected_sources_per_case
+        ):
+            raise ValueError("judge and set-cover source ceilings drifted")
+        for case in self.challenge_cases:
+            if self.collection_coverage_contract.minimum_scope_roles > len(
+                case.role_profile.scope_roles
+            ):
+                raise ValueError(f"{case.case_id}: impossible scope-role threshold")
+            if self.collection_coverage_contract.minimum_supporting_roles > len(
+                case.role_profile.supporting_roles
+            ):
+                raise ValueError(
+                    f"{case.case_id}: impossible supporting-role threshold"
+                )
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedEvidenceSetCase:
+    """Deterministic identities for a future separately locked live runner."""
+
+    spec: EvidenceSetCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+    profile_sha256: str
+    case_contract_sha256: str
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _case_contract_sha256(
+    spec: EvidenceSetCaseSpec,
+    *,
+    request_contract_sha256: str,
+    judge_contract_sha256: str,
+    selection_contract_sha256: str,
+) -> str:
+    payload = {
+        "spec": spec.model_dump(mode="json"),
+        "request_contract_sha256": request_contract_sha256,
+        "judge_contract_sha256": judge_contract_sha256,
+        "selection_contract_sha256": selection_contract_sha256,
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _seed_source(spec: EvidenceSetCaseSpec) -> EvidenceSource:
+    """Create valid gap context without pretending provider evidence exists."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen evidence-set baseline context",
+        url=(
+            "https://doi.org/10.5555/"
+            f"openalex-evidence-set-v5.{spec.case_id.casefold()}"
+        ),
+        publisher="Frozen Evidence-set v5 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider row and does not satisfy the explicit "
+            "academic retrieval gap used by this disconnected study."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(
+    spec: EvidenceSetCaseSpec,
+    *,
+    request_contract_sha256: str,
+    judge_contract_sha256: str,
+    selection_contract_sha256: str,
+) -> PreparedEvidenceSetCase:
+    """Expand one X-case without network, clocks, randomness or model calls."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen evidence-set v5 retrieval challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexEvidenceSetPreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen unseen case authorizes one read-only academic "
+                "request for its explicit evidence gap."
+            ),
+            calls=(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=spec.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=spec.result_limit,
+                ),
+            ),
+        ),
+    )
+    return PreparedEvidenceSetCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+        profile_sha256=spec.role_profile.sha256(),
+        case_contract_sha256=_case_contract_sha256(
+            spec,
+            request_contract_sha256=request_contract_sha256,
+            judge_contract_sha256=judge_contract_sha256,
+            selection_contract_sha256=selection_contract_sha256,
+        ),
+    )
+
+
+def load_frozen_cases(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    EvidenceSetChallengeManifest,
+    tuple[PreparedEvidenceSetCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding any X-case."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexEvidenceSetPreflightError(
+            "evidence-set v5 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = EvidenceSetChallengeManifest.model_validate_json(raw)
+    request_sha256 = manifest.request_contract.sha256()
+    judge_sha256 = manifest.semantic_judge_contract.sha256()
+    selection_sha256 = manifest.collection_coverage_contract.sha256()
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(
+            build_case(
+                spec,
+                request_contract_sha256=request_sha256,
+                judge_contract_sha256=judge_sha256,
+                selection_contract_sha256=selection_sha256,
+            )
+            for spec in manifest.challenge_cases
+        ),
+    )
+
+
+def dry_run(
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose every frozen identity while opening zero sockets or model clients."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    return {
+        "mode": "openalex_evidence_set_v5_unseen_dry_run",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "private_labels_opened": False,
+        "live_provider_requests_authorized": False,
+        "live_model_calls_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_search_request_count": manifest.maximum_live_search_requests,
+        "maximum_judge_call_count": manifest.maximum_live_judge_calls,
+        "request_contract": manifest.request_contract.model_dump(mode="json"),
+        "semantic_judge_contract": manifest.semantic_judge_contract.model_dump(
+            mode="json"
+        ),
+        "development_observation": manifest.development_observation.model_dump(
+            mode="json"
+        ),
+        "collection_coverage_contract": (
+            manifest.collection_coverage_contract.model_dump(mode="json")
+        ),
+        "development_qualification_gates": (
+            manifest.development_qualification_gates.model_dump(mode="json")
+        ),
+        "unseen_value_gates": manifest.unseen_value_gates.model_dump(mode="json"),
+        "request_contract_sha256": manifest.request_contract.sha256(),
+        "judge_contract_sha256": manifest.semantic_judge_contract.sha256(),
+        "selection_contract_sha256": (
+            manifest.collection_coverage_contract.sha256()
+        ),
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+                "profile_sha256": case.profile_sha256,
+                "case_contract_sha256": case.case_contract_sha256,
+                "idempotency_key": case.plan.calls[0].idempotency_key,
+                "result_limit": case.plan.calls[0].result_limit,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE_PATH)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(json.dumps(dry_run(args.fixture), ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/openalex_evidence_set.py
+++ b/src/academic_agent/openalex_evidence_set.py
@@ -1,0 +1,849 @@
+"""Quote-grounded evidence-set kernel for disconnected OpenAlex studies.
+
+Scope-link v4 required one source to express the whole topic relation in one
+sentence.  The completed diagnostic found both provider noise and useful
+sources whose contribution was distributed across papers.  This candidate
+therefore treats a model as a bounded proposal mechanism: two order-reversed
+passes may assign code-owned roles only when every assignment quotes the title
+or abstract.  Deterministic code verifies those quotes, requires pass
+agreement, and chooses the smallest covering set of at most three sources.
+
+This module contains no provider client, model client, retry loop, label access
+or production import.  Malformed output and disagreement become ABSTAIN; they
+never trigger a hidden repair call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from itertools import combinations
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    model_validator,
+)
+
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+
+
+EvidenceRoleKind = Literal["required", "scope", "supporting"]
+JudgeAction = Literal["KEEP", "ABSTAIN"]
+JudgeQuoteField = Literal["title", "abstract"]
+JudgePassState = Literal["valid", "malformed", "contract_invalid"]
+EvidenceSetAction = Literal["SELECT", "ABSTAIN"]
+JudgePassErrorCode = Literal[
+    "response_too_large",
+    "schema_invalid",
+    "case_id_mismatch",
+    "candidate_order_mismatch",
+]
+CandidateAbstentionReason = Literal[
+    "judge_pass_invalid",
+    "judge_abstained",
+    "judge_action_disagreement",
+    "judge_role_disagreement",
+    "unknown_role",
+    "invalid_quote",
+    "insufficient_required_roles",
+    "insufficient_context_roles",
+    "missing_title_anchor",
+]
+CaseAbstentionReason = Literal["no_valid_candidates", "no_covering_set"]
+
+_ROLE_ID_PATTERN = r"^[a-z][a-z0-9_]{2,63}$"
+_CASE_ID_PATTERN = r"^[A-Z][0-9]{2}$"
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+_WHITESPACE = re.compile(r"\s+")
+_MAX_RAW_RESPONSE_CHARACTERS = 200_000
+
+
+class EvidenceSetContractError(ValueError):
+    """Raised when code-owned inputs cannot satisfy the frozen contract."""
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_text(value.model_dump_json(exclude_none=False))
+
+
+def _normalized_quote_text(value: str) -> str:
+    """Normalize layout only; lexical case and characters remain evidence."""
+
+    # The protocol permits line-ending and Unicode-whitespace normalization so
+    # a copied sentence is not rejected because JSON flattened its layout.  It
+    # deliberately does not case-fold, stem, translate, or normalize Unicode
+    # characters because each of those would admit a paraphrase as a quote.
+    return _WHITESPACE.sub(" ", value.replace("\r\n", "\n").replace("\r", "\n")).strip()
+
+
+class EvidenceSetRoleSpec(BaseModel):
+    """One code-owned semantic role described without lexical answer keys."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    description: str = Field(min_length=10, max_length=600)
+
+
+class EvidenceSetRoleProfile(BaseModel):
+    """Required, scope and supporting roles for one frozen research topic."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_roles: tuple[EvidenceSetRoleSpec, ...] = Field(
+        min_length=2,
+        max_length=4,
+    )
+    scope_roles: tuple[EvidenceSetRoleSpec, ...] = Field(
+        min_length=1,
+        max_length=4,
+    )
+    supporting_roles: tuple[EvidenceSetRoleSpec, ...] = Field(
+        min_length=2,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_unique_roles(self) -> "EvidenceSetRoleProfile":
+        roles = (*self.required_roles, *self.scope_roles, *self.supporting_roles)
+        role_ids = tuple(role.role_id for role in roles)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("evidence-set role IDs must be unique")
+        return self
+
+    def sha256(self) -> str:
+        """Bind every role identifier and natural-language description."""
+
+        return _model_sha256(self)
+
+    def role_kinds(self) -> dict[str, EvidenceRoleKind]:
+        """Return the code-owned role classification used after judging."""
+
+        return {
+            **{role.role_id: "required" for role in self.required_roles},
+            **{role.role_id: "scope" for role in self.scope_roles},
+            **{role.role_id: "supporting" for role in self.supporting_roles},
+        }
+
+
+class EvidenceSetSelectionContract(BaseModel):
+    """Deterministic per-source and collection coverage requirements."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required_roles_covered: Literal["all"] = "all"
+    minimum_scope_roles: int = Field(ge=1, le=4)
+    minimum_supporting_roles: int = Field(ge=1, le=8)
+    maximum_selected_sources_per_case: int = Field(ge=1, le=3)
+    minimum_candidate_required_roles: int = Field(ge=1, le=4)
+    minimum_candidate_context_roles: int = Field(ge=1, le=8)
+    minimum_candidate_title_anchor_roles: int = Field(ge=1, le=8)
+
+    def sha256(self) -> str:
+        """Bind every source-eligibility and set-cover threshold."""
+
+        return _model_sha256(self)
+
+
+class JudgeRoleInput(BaseModel):
+    """One role visible to the label-blind semantic judge."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    role_kind: EvidenceRoleKind
+    description: str = Field(min_length=10, max_length=600)
+
+
+class JudgeCandidateInput(BaseModel):
+    """The complete candidate surface allowed to cross the model boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    title: str = Field(min_length=5, max_length=600)
+    abstract: str = Field(min_length=1, max_length=8000)
+
+
+class JudgeBatchInput(BaseModel):
+    """One immutable judge request; no URL or provider metadata can enter."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=_CASE_ID_PATTERN)
+    topic: str = Field(min_length=20, max_length=300)
+    pass_number: Literal[1, 2]
+    roles: tuple[JudgeRoleInput, ...] = Field(min_length=5, max_length=16)
+    candidates: tuple[JudgeCandidateInput, ...] = Field(min_length=1, max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_unique_inputs(self) -> "JudgeBatchInput":
+        role_ids = tuple(role.role_id for role in self.roles)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("judge input role IDs must be unique")
+        candidate_ids = tuple(item.candidate_sha256 for item in self.candidates)
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("judge input candidate identities must be unique")
+        return self
+
+    def sha256(self) -> str:
+        """Bind the exact order and evidence text crossing the judge seam."""
+
+        return _model_sha256(self)
+
+
+class JudgeRoleQuote(BaseModel):
+    """One model-proposed role backed by a purported source-text quote."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    field: JudgeQuoteField
+    quote: str = Field(min_length=1, max_length=8000)
+
+
+class JudgeCandidateDecision(BaseModel):
+    """One KEEP/ABSTAIN proposal in an otherwise all-row batch response."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    action: JudgeAction
+    role_quotes: tuple[JudgeRoleQuote, ...] = Field(default=(), max_length=16)
+
+    @model_validator(mode="after")
+    def _validate_action_shape(self) -> "JudgeCandidateDecision":
+        role_ids = tuple(item.role_id for item in self.role_quotes)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("judge decision role IDs must be unique")
+        if self.action == "KEEP" and not self.role_quotes:
+            raise ValueError("KEEP requires at least one quoted role")
+        if self.action == "ABSTAIN" and self.role_quotes:
+            raise ValueError("ABSTAIN cannot carry role quotes")
+        return self
+
+
+class JudgeBatchResponse(BaseModel):
+    """Strict JSON response containing one decision for every input row."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=_CASE_ID_PATTERN)
+    candidate_order: tuple[str, ...] = Field(min_length=1, max_length=8)
+    decisions: tuple[JudgeCandidateDecision, ...] = Field(
+        min_length=1,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_complete_order(self) -> "JudgeBatchResponse":
+        if any(re.fullmatch(_SHA256_PATTERN, value) is None for value in self.candidate_order):
+            raise ValueError("candidate_order contains an invalid identity")
+        if len(self.candidate_order) != len(set(self.candidate_order)):
+            raise ValueError("candidate_order identities must be unique")
+        decision_ids = tuple(item.candidate_sha256 for item in self.decisions)
+        if decision_ids != self.candidate_order:
+            raise ValueError("decisions must cover candidate_order in exact order")
+        return self
+
+
+class JudgePassAudit(BaseModel):
+    """Parse and contract state for one raw model response."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pass_number: Literal[1, 2]
+    state: JudgePassState
+    raw_response_sha256: str = Field(pattern=_SHA256_PATTERN)
+    input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    error_code: JudgePassErrorCode | None = None
+    response: JudgeBatchResponse | None = None
+
+    @model_validator(mode="after")
+    def _validate_state_shape(self) -> "JudgePassAudit":
+        if self.state == "valid":
+            if self.response is None or self.error_code is not None:
+                raise ValueError("valid judge pass requires only a parsed response")
+        elif self.response is not None or self.error_code is None:
+            raise ValueError("invalid judge pass requires only an error code")
+        return self
+
+
+class VerifiedRoleQuote(BaseModel):
+    """A consensus role whose two independently returned quotes both verify."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    role_kind: EvidenceRoleKind
+    first_field: JudgeQuoteField
+    first_quote: str
+    second_field: JudgeQuoteField
+    second_quote: str
+
+
+class EvidenceSetCandidateAudit(BaseModel):
+    """One all-row decision after consensus, quote and contribution checks."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    provider_result_index: int = Field(ge=0)
+    action: JudgeAction
+    first_action: JudgeAction | None
+    second_action: JudgeAction | None
+    judge_agreement: bool
+    required_role_ids: tuple[str, ...]
+    scope_role_ids: tuple[str, ...]
+    supporting_role_ids: tuple[str, ...]
+    title_anchor_role_ids: tuple[str, ...]
+    verified_role_quotes: tuple[VerifiedRoleQuote, ...]
+    abstention_reasons: tuple[CandidateAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_action_shape(self) -> "EvidenceSetCandidateAudit":
+        role_ids = (
+            *self.required_role_ids,
+            *self.scope_role_ids,
+            *self.supporting_role_ids,
+        )
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("candidate role assignments must be unique")
+        verified_ids = tuple(item.role_id for item in self.verified_role_quotes)
+        if set(verified_ids) != set(role_ids):
+            raise ValueError("verified quotes must cover every assigned role")
+        if not set(self.title_anchor_role_ids).issubset(role_ids):
+            raise ValueError("title anchors must be assigned candidate roles")
+        if self.action == "KEEP" and self.abstention_reasons:
+            raise ValueError("KEEP candidate cannot carry abstention reasons")
+        if self.action == "ABSTAIN" and not self.abstention_reasons:
+            raise ValueError("ABSTAIN candidate requires an explicit reason")
+        return self
+
+
+class SelectedEvidenceSource(BaseModel):
+    """One selected source and every consensus role delivered downstream."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    provider_result_index: int = Field(ge=0)
+    role_ids: tuple[str, ...] = Field(min_length=1)
+
+
+class EvidenceSetCaseAudit(BaseModel):
+    """Complete zero-network decision at the future runner/review seam."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=_CASE_ID_PATTERN)
+    topic: str = Field(min_length=20, max_length=300)
+    action: EvidenceSetAction
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    provider_candidate_count: int = Field(ge=1, le=8)
+    first_pass: JudgePassAudit
+    second_pass: JudgePassAudit
+    candidate_decisions: tuple[EvidenceSetCandidateAudit, ...] = Field(
+        min_length=1,
+        max_length=8,
+    )
+    selected_sources: tuple[SelectedEvidenceSource, ...] = Field(max_length=3)
+    covered_required_role_ids: tuple[str, ...]
+    covered_scope_role_ids: tuple[str, ...]
+    covered_supporting_role_ids: tuple[str, ...]
+    judge_agreement_numerator: int = Field(ge=0, le=8)
+    judge_agreement_denominator: int = Field(ge=1, le=8)
+    judge_disposition_agreement: float = Field(ge=0.0, le=1.0)
+    abstention_reasons: tuple[CaseAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_complete_boundary(self) -> "EvidenceSetCaseAudit":
+        if len(self.candidate_decisions) != self.provider_candidate_count:
+            raise ValueError("every provider candidate must reach the audit boundary")
+        candidate_ids = tuple(item.candidate_sha256 for item in self.candidate_decisions)
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("candidate audit identities must be unique")
+        selected_ids = tuple(item.candidate_sha256 for item in self.selected_sources)
+        if not set(selected_ids).issubset(candidate_ids):
+            raise ValueError("selected source is missing from candidate decisions")
+        if len(selected_ids) != len(set(selected_ids)):
+            raise ValueError("selected source identities must be unique")
+        decisions_by_id = {
+            item.candidate_sha256: item for item in self.candidate_decisions
+        }
+        selected_decisions = tuple(decisions_by_id[value] for value in selected_ids)
+        for selected, decision in zip(
+            self.selected_sources,
+            selected_decisions,
+            strict=True,
+        ):
+            expected_roles = (
+                *decision.required_role_ids,
+                *decision.scope_role_ids,
+                *decision.supporting_role_ids,
+            )
+            if decision.action != "KEEP" or selected.role_ids != expected_roles:
+                raise ValueError(
+                    "selected source must deliver every verified KEEP role"
+                )
+        expected_required = {
+            role_id for item in selected_decisions for role_id in item.required_role_ids
+        }
+        expected_scope = {
+            role_id for item in selected_decisions for role_id in item.scope_role_ids
+        }
+        expected_supporting = {
+            role_id
+            for item in selected_decisions
+            for role_id in item.supporting_role_ids
+        }
+        if set(self.covered_required_role_ids) != expected_required:
+            raise ValueError("covered required roles drifted from selected sources")
+        if set(self.covered_scope_role_ids) != expected_scope:
+            raise ValueError("covered scope roles drifted from selected sources")
+        if set(self.covered_supporting_role_ids) != expected_supporting:
+            raise ValueError("covered supporting roles drifted from selected sources")
+        if self.judge_agreement_denominator != self.provider_candidate_count:
+            raise ValueError("agreement denominator must include every candidate")
+        expected_rate = self.judge_agreement_numerator / self.judge_agreement_denominator
+        if abs(self.judge_disposition_agreement - expected_rate) > 1e-12:
+            raise ValueError("judge agreement rate does not match its counts")
+        if self.action == "SELECT":
+            if not self.selected_sources or self.abstention_reasons:
+                raise ValueError("SELECT requires sources and no abstention reason")
+        elif self.selected_sources or not self.abstention_reasons:
+            raise ValueError("ABSTAIN requires no selected sources and a reason")
+        return self
+
+
+def _role_inputs(profile: EvidenceSetRoleProfile) -> tuple[JudgeRoleInput, ...]:
+    return tuple(
+        JudgeRoleInput(
+            role_id=role.role_id,
+            role_kind=kind,
+            description=role.description,
+        )
+        for kind, roles in (
+            ("required", profile.required_roles),
+            ("scope", profile.scope_roles),
+            ("supporting", profile.supporting_roles),
+        )
+        for role in roles
+    )
+
+
+def _provider_ordered_candidates(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+) -> tuple[OpenAlexClaimScopeCandidate, ...]:
+    if not candidates:
+        raise EvidenceSetContractError("at least one candidate is required")
+    if len(candidates) > 8:
+        raise EvidenceSetContractError("at most eight provider candidates are allowed")
+    indices = tuple(item.evidence.provider_result_index for item in candidates)
+    if any(index is None for index in indices):
+        raise EvidenceSetContractError("every candidate requires a provider result index")
+    if len(indices) != len(set(indices)):
+        raise EvidenceSetContractError("provider result indices must be unique")
+    identities = tuple(item.sha256() for item in candidates)
+    if len(identities) != len(set(identities)):
+        raise EvidenceSetContractError("candidate identities must be unique")
+    return tuple(
+        sorted(
+            candidates,
+            key=lambda item: (
+                item.evidence.provider_result_index,
+                item.sha256(),
+            ),
+        )
+    )
+
+
+def build_judge_inputs(
+    *,
+    case_id: str,
+    topic: str,
+    profile: EvidenceSetRoleProfile,
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+) -> tuple[JudgeBatchInput, JudgeBatchInput]:
+    """Build provider-order and reverse-order inputs with no hidden metadata."""
+
+    ordered = _provider_ordered_candidates(candidates)
+    roles = _role_inputs(profile)
+
+    def candidate_input(candidate: OpenAlexClaimScopeCandidate) -> JudgeCandidateInput:
+        return JudgeCandidateInput(
+            candidate_sha256=candidate.sha256(),
+            title=candidate.evidence.title,
+            abstract=candidate.evidence.evidence_summary,
+        )
+
+    first_candidates = tuple(candidate_input(item) for item in ordered)
+    return (
+        JudgeBatchInput(
+            case_id=case_id,
+            topic=topic,
+            pass_number=1,
+            roles=roles,
+            candidates=first_candidates,
+        ),
+        JudgeBatchInput(
+            case_id=case_id,
+            topic=topic,
+            pass_number=2,
+            roles=roles,
+            candidates=tuple(reversed(first_candidates)),
+        ),
+    )
+
+
+def parse_judge_pass(
+    raw_response: str,
+    expected_input: JudgeBatchInput,
+) -> JudgePassAudit:
+    """Parse one exact JSON response without repair, fallback or retry."""
+
+    response_sha256 = _sha256_text(raw_response)
+    if len(raw_response) > _MAX_RAW_RESPONSE_CHARACTERS:
+        return JudgePassAudit(
+            pass_number=expected_input.pass_number,
+            state="malformed",
+            raw_response_sha256=response_sha256,
+            input_sha256=expected_input.sha256(),
+            error_code="response_too_large",
+        )
+    try:
+        parsed_json = json.loads(raw_response)
+        response = JudgeBatchResponse.model_validate(parsed_json)
+    except (json.JSONDecodeError, ValidationError):
+        return JudgePassAudit(
+            pass_number=expected_input.pass_number,
+            state="malformed",
+            raw_response_sha256=response_sha256,
+            input_sha256=expected_input.sha256(),
+            error_code="schema_invalid",
+        )
+    if response.case_id != expected_input.case_id:
+        return JudgePassAudit(
+            pass_number=expected_input.pass_number,
+            state="contract_invalid",
+            raw_response_sha256=response_sha256,
+            input_sha256=expected_input.sha256(),
+            error_code="case_id_mismatch",
+        )
+    expected_order = tuple(
+        item.candidate_sha256 for item in expected_input.candidates
+    )
+    if response.candidate_order != expected_order:
+        return JudgePassAudit(
+            pass_number=expected_input.pass_number,
+            state="contract_invalid",
+            raw_response_sha256=response_sha256,
+            input_sha256=expected_input.sha256(),
+            error_code="candidate_order_mismatch",
+        )
+    return JudgePassAudit(
+        pass_number=expected_input.pass_number,
+        state="valid",
+        raw_response_sha256=response_sha256,
+        input_sha256=expected_input.sha256(),
+        response=response,
+    )
+
+
+def _quote_is_valid(
+    quote: JudgeRoleQuote,
+    candidate: OpenAlexClaimScopeCandidate,
+) -> bool:
+    source = (
+        candidate.evidence.title
+        if quote.field == "title"
+        else candidate.evidence.evidence_summary
+    )
+    normalized_quote = _normalized_quote_text(quote.quote)
+    return bool(
+        normalized_quote
+        and normalized_quote in _normalized_quote_text(source)
+    )
+
+
+def _invalid_pass_candidate(
+    candidate: OpenAlexClaimScopeCandidate,
+) -> EvidenceSetCandidateAudit:
+    return EvidenceSetCandidateAudit(
+        candidate_sha256=candidate.sha256(),
+        provider_result_index=candidate.evidence.provider_result_index,
+        action="ABSTAIN",
+        first_action=None,
+        second_action=None,
+        judge_agreement=False,
+        required_role_ids=(),
+        scope_role_ids=(),
+        supporting_role_ids=(),
+        title_anchor_role_ids=(),
+        verified_role_quotes=(),
+        abstention_reasons=("judge_pass_invalid",),
+    )
+
+
+def _candidate_audit(
+    candidate: OpenAlexClaimScopeCandidate,
+    first: JudgeCandidateDecision,
+    second: JudgeCandidateDecision,
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> EvidenceSetCandidateAudit:
+    reasons: list[CandidateAbstentionReason] = []
+    role_kinds = profile.role_kinds()
+    first_role_ids = tuple(item.role_id for item in first.role_quotes)
+    second_role_ids = tuple(item.role_id for item in second.role_quotes)
+    verified: list[VerifiedRoleQuote] = []
+    agreement = False
+
+    if first.action == second.action == "ABSTAIN":
+        agreement = True
+        reasons.append("judge_abstained")
+    elif first.action != second.action:
+        reasons.append("judge_action_disagreement")
+    elif set(first_role_ids) != set(second_role_ids):
+        reasons.append("judge_role_disagreement")
+    else:
+        first_by_role = {item.role_id: item for item in first.role_quotes}
+        second_by_role = {item.role_id: item for item in second.role_quotes}
+        unknown_roles = set(first_by_role).difference(role_kinds)
+        if unknown_roles:
+            reasons.append("unknown_role")
+        else:
+            for role_id in role_kinds:
+                if role_id not in first_by_role:
+                    continue
+                first_quote = first_by_role[role_id]
+                second_quote = second_by_role[role_id]
+                if not (
+                    _quote_is_valid(first_quote, candidate)
+                    and _quote_is_valid(second_quote, candidate)
+                ):
+                    reasons.append("invalid_quote")
+                    break
+                verified.append(
+                    VerifiedRoleQuote(
+                        role_id=role_id,
+                        role_kind=role_kinds[role_id],
+                        first_field=first_quote.field,
+                        first_quote=first_quote.quote,
+                        second_field=second_quote.field,
+                        second_quote=second_quote.quote,
+                    )
+                )
+            if not reasons:
+                agreement = True
+
+    required = tuple(
+        item.role_id for item in verified if item.role_kind == "required"
+    )
+    scope = tuple(item.role_id for item in verified if item.role_kind == "scope")
+    supporting = tuple(
+        item.role_id for item in verified if item.role_kind == "supporting"
+    )
+    title_anchors = tuple(
+        item.role_id
+        for item in verified
+        if item.first_field == item.second_field == "title"
+    )
+    if agreement and first.action == second.action == "KEEP":
+        if len(required) < contract.minimum_candidate_required_roles:
+            reasons.append("insufficient_required_roles")
+        if len(scope) + len(supporting) < contract.minimum_candidate_context_roles:
+            reasons.append("insufficient_context_roles")
+        if len(title_anchors) < contract.minimum_candidate_title_anchor_roles:
+            reasons.append("missing_title_anchor")
+
+    return EvidenceSetCandidateAudit(
+        candidate_sha256=candidate.sha256(),
+        provider_result_index=candidate.evidence.provider_result_index,
+        action="ABSTAIN" if reasons else "KEEP",
+        first_action=first.action,
+        second_action=second.action,
+        judge_agreement=agreement,
+        required_role_ids=required,
+        scope_role_ids=scope,
+        supporting_role_ids=supporting,
+        title_anchor_role_ids=title_anchors,
+        verified_role_quotes=tuple(verified),
+        abstention_reasons=tuple(reasons),
+    )
+
+
+def _selection_contract_is_possible(
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> None:
+    if contract.minimum_scope_roles > len(profile.scope_roles):
+        raise EvidenceSetContractError(
+            "minimum_scope_roles exceeds the profile scope-role count"
+        )
+    if contract.minimum_supporting_roles > len(profile.supporting_roles):
+        raise EvidenceSetContractError(
+            "minimum_supporting_roles exceeds the profile supporting-role count"
+        )
+
+
+def _covers_profile(
+    decisions: tuple[EvidenceSetCandidateAudit, ...],
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> bool:
+    required = {role_id for item in decisions for role_id in item.required_role_ids}
+    scope = {role_id for item in decisions for role_id in item.scope_role_ids}
+    supporting = {
+        role_id for item in decisions for role_id in item.supporting_role_ids
+    }
+    return (
+        required == {role.role_id for role in profile.required_roles}
+        and len(scope) >= contract.minimum_scope_roles
+        and len(supporting) >= contract.minimum_supporting_roles
+    )
+
+
+def _select_sources(
+    decisions: tuple[EvidenceSetCandidateAudit, ...],
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> tuple[EvidenceSetCandidateAudit, ...]:
+    eligible = tuple(
+        sorted(
+            (item for item in decisions if item.action == "KEEP"),
+            key=lambda item: (item.provider_result_index, item.candidate_sha256),
+        )
+    )
+    for size in range(1, contract.maximum_selected_sources_per_case + 1):
+        valid = tuple(
+            group
+            for group in combinations(eligible, size)
+            if _covers_profile(group, profile, contract)
+        )
+        if valid:
+            return min(
+                valid,
+                key=lambda group: (
+                    tuple(item.provider_result_index for item in group),
+                    tuple(item.candidate_sha256 for item in group),
+                ),
+            )
+    return ()
+
+
+def evaluate_evidence_set_case(
+    *,
+    case_id: str,
+    topic: str,
+    profile: EvidenceSetRoleProfile,
+    selection_contract: EvidenceSetSelectionContract,
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+    first_raw_response: str,
+    second_raw_response: str,
+) -> EvidenceSetCaseAudit:
+    """Evaluate two raw judge responses and emit every row at one seam."""
+
+    _selection_contract_is_possible(profile, selection_contract)
+    ordered = _provider_ordered_candidates(candidates)
+    first_input, second_input = build_judge_inputs(
+        case_id=case_id,
+        topic=topic,
+        profile=profile,
+        candidates=ordered,
+    )
+    first_pass = parse_judge_pass(first_raw_response, first_input)
+    second_pass = parse_judge_pass(second_raw_response, second_input)
+
+    if first_pass.state != "valid" or second_pass.state != "valid":
+        candidate_decisions = tuple(
+            _invalid_pass_candidate(candidate) for candidate in ordered
+        )
+    else:
+        first_by_id = {
+            item.candidate_sha256: item for item in first_pass.response.decisions
+        }
+        second_by_id = {
+            item.candidate_sha256: item for item in second_pass.response.decisions
+        }
+        candidate_decisions = tuple(
+            _candidate_audit(
+                candidate,
+                first_by_id[candidate.sha256()],
+                second_by_id[candidate.sha256()],
+                profile,
+                selection_contract,
+            )
+            for candidate in ordered
+        )
+
+    selected = _select_sources(candidate_decisions, profile, selection_contract)
+    selected_sources = tuple(
+        SelectedEvidenceSource(
+            candidate_sha256=item.candidate_sha256,
+            provider_result_index=item.provider_result_index,
+            role_ids=(
+                *item.required_role_ids,
+                *item.scope_role_ids,
+                *item.supporting_role_ids,
+            ),
+        )
+        for item in selected
+    )
+    covered_required = tuple(
+        role.role_id
+        for role in profile.required_roles
+        if any(role.role_id in item.required_role_ids for item in selected)
+    )
+    covered_scope = tuple(
+        role.role_id
+        for role in profile.scope_roles
+        if any(role.role_id in item.scope_role_ids for item in selected)
+    )
+    covered_supporting = tuple(
+        role.role_id
+        for role in profile.supporting_roles
+        if any(role.role_id in item.supporting_role_ids for item in selected)
+    )
+    agreement_numerator = sum(
+        item.judge_agreement for item in candidate_decisions
+    )
+    eligible_count = sum(item.action == "KEEP" for item in candidate_decisions)
+    abstention_reasons: tuple[CaseAbstentionReason, ...] = ()
+    if not selected:
+        abstention_reasons = (
+            "no_valid_candidates" if eligible_count == 0 else "no_covering_set",
+        )
+
+    return EvidenceSetCaseAudit(
+        case_id=case_id,
+        topic=topic,
+        action="SELECT" if selected else "ABSTAIN",
+        profile_sha256=profile.sha256(),
+        selection_contract_sha256=selection_contract.sha256(),
+        provider_candidate_count=len(ordered),
+        first_pass=first_pass,
+        second_pass=second_pass,
+        candidate_decisions=candidate_decisions,
+        selected_sources=selected_sources,
+        covered_required_role_ids=covered_required,
+        covered_scope_role_ids=covered_scope,
+        covered_supporting_role_ids=covered_supporting,
+        judge_agreement_numerator=agreement_numerator,
+        judge_agreement_denominator=len(ordered),
+        judge_disposition_agreement=agreement_numerator / len(ordered),
+        abstention_reasons=abstention_reasons,
+    )

--- a/tests/test_openalex_evidence_set.py
+++ b/tests/test_openalex_evidence_set.py
@@ -1,0 +1,593 @@
+"""Zero-network seams for the quote-grounded evidence-set v5 kernel."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from academic_agent.openalex_claim_scope import (
+    OpenAlexAboutnessSignal,
+    OpenAlexClaimScopeCandidate,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetCaseAudit,
+    EvidenceSetRoleProfile,
+    EvidenceSetSelectionContract,
+    build_judge_inputs,
+    evaluate_evidence_set_case,
+    parse_judge_pass,
+)
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_TOPIC = (
+    "Redox-active polymer electrodes for electrochemical carbon dioxide "
+    "capture from flue gas"
+)
+
+
+def _profile() -> EvidenceSetRoleProfile:
+    return EvidenceSetRoleProfile.model_validate(
+        {
+            "required_roles": [
+                {
+                    "role_id": "electrochemical_capture",
+                    "description": (
+                        "reversible electrochemical capture or release of "
+                        "carbon dioxide"
+                    ),
+                },
+                {
+                    "role_id": "redox_polymer",
+                    "description": (
+                        "a redox-active polymer electrode or polymer-bound carrier"
+                    ),
+                },
+            ],
+            "scope_roles": [
+                {
+                    "role_id": "flue_gas",
+                    "description": (
+                        "capture from flue gas or a dilute industrial gas stream"
+                    ),
+                }
+            ],
+            "supporting_roles": [
+                {
+                    "role_id": "capture_performance",
+                    "description": (
+                        "capacity, selectivity, rate, or separation performance"
+                    ),
+                },
+                {
+                    "role_id": "cycling_stability",
+                    "description": (
+                        "repeated capture-release cycling or electrode stability"
+                    ),
+                },
+            ],
+        }
+    )
+
+
+def _contract(**overrides: object) -> EvidenceSetSelectionContract:
+    payload = {
+        "required_roles_covered": "all",
+        "minimum_scope_roles": 1,
+        "minimum_supporting_roles": 1,
+        "maximum_selected_sources_per_case": 3,
+        "minimum_candidate_required_roles": 1,
+        "minimum_candidate_context_roles": 1,
+        "minimum_candidate_title_anchor_roles": 1,
+    }
+    payload.update(overrides)
+    return EvidenceSetSelectionContract.model_validate(payload)
+
+
+def _candidate(
+    index: int,
+    *,
+    title: str,
+    abstract: str,
+    aboutness: tuple[OpenAlexAboutnessSignal, ...] = (),
+) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=title,
+            url=f"https://openalex.org/W45000000{index}",
+            publisher="Frozen Test Journal",
+            evidence_summary=abstract,
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=aboutness,
+    )
+
+
+def _capture_candidate(index: int = 0) -> OpenAlexClaimScopeCandidate:
+    return _candidate(
+        index,
+        title="Electrochemical capture using a polymer electrode",
+        abstract=(
+            "The system removes carbon dioxide from flue gas with high capture "
+            "capacity."
+        ),
+    )
+
+
+def _polymer_candidate(index: int = 1) -> OpenAlexClaimScopeCandidate:
+    return _candidate(
+        index,
+        title="Redox-active polymer electrodes with stable cycling",
+        abstract=(
+            "The polymer retained activity during repeated capture and release "
+            "cycles."
+        ),
+    )
+
+
+def _assignments() -> dict[str, tuple[tuple[str, str, str], ...]]:
+    capture = _capture_candidate()
+    polymer = _polymer_candidate()
+    return {
+        capture.sha256(): (
+            (
+                "electrochemical_capture",
+                "title",
+                "Electrochemical capture",
+            ),
+            ("flue_gas", "abstract", "flue gas"),
+            (
+                "capture_performance",
+                "abstract",
+                "high capture capacity",
+            ),
+        ),
+        polymer.sha256(): (
+            ("redox_polymer", "title", "Redox-active polymer electrodes"),
+            ("cycling_stability", "title", "stable cycling"),
+        ),
+    }
+
+
+def _raw_response(
+    batch,
+    assignments: dict[str, tuple[tuple[str, str, str], ...] | None],
+) -> str:
+    decisions = []
+    for candidate in batch.candidates:
+        rows = assignments[candidate.candidate_sha256]
+        decisions.append(
+            {
+                "candidate_sha256": candidate.candidate_sha256,
+                "action": "ABSTAIN" if rows is None else "KEEP",
+                "role_quotes": []
+                if rows is None
+                else [
+                    {"role_id": role_id, "field": field, "quote": quote}
+                    for role_id, field, quote in rows
+                ],
+            }
+        )
+    return json.dumps(
+        {
+            "case_id": batch.case_id,
+            "candidate_order": [
+                item.candidate_sha256 for item in batch.candidates
+            ],
+            "decisions": decisions,
+        },
+        ensure_ascii=True,
+    )
+
+
+def _evaluate(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+    assignments: dict[str, tuple[tuple[str, str, str], ...] | None],
+    *,
+    profile: EvidenceSetRoleProfile | None = None,
+    contract: EvidenceSetSelectionContract | None = None,
+):
+    chosen_profile = profile or _profile()
+    chosen_contract = contract or _contract()
+    first, second = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=chosen_profile,
+        candidates=candidates,
+    )
+    return evaluate_evidence_set_case(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=chosen_profile,
+        selection_contract=chosen_contract,
+        candidates=candidates,
+        first_raw_response=_raw_response(first, assignments),
+        second_raw_response=_raw_response(second, assignments),
+    )
+
+
+def test_judge_inputs_reverse_order_and_expose_only_allowed_candidate_fields():
+    signal = OpenAlexAboutnessSignal(
+        kind="topic",
+        provider_id="https://openalex.org/T100",
+        display_name="Secret provider topic",
+        score=0.99,
+    )
+    first_candidate = _candidate(
+        1,
+        title="Redox-active polymer electrodes with stable cycling",
+        abstract="The polymer remained stable.",
+        aboutness=(signal,),
+    )
+    second_candidate = _capture_candidate(0)
+
+    first, second = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(first_candidate, second_candidate),
+    )
+
+    first_ids = [item.candidate_sha256 for item in first.candidates]
+    second_ids = [item.candidate_sha256 for item in second.candidates]
+    assert first_ids == [second_candidate.sha256(), first_candidate.sha256()]
+    assert second_ids == list(reversed(first_ids))
+    assert first.pass_number == 1
+    assert second.pass_number == 2
+    for candidate in first.model_dump(mode="json")["candidates"]:
+        assert set(candidate) == {"candidate_sha256", "title", "abstract"}
+    serialized = first.model_dump_json()
+    assert "openalex.org" not in serialized
+    assert "Secret provider topic" not in serialized
+    assert "provider" not in serialized
+
+
+def test_two_complementary_sources_are_selected_and_reach_json_boundary():
+    capture = _capture_candidate()
+    polymer = _polymer_candidate()
+
+    result = _evaluate((polymer, capture), _assignments())
+
+    assert result.action == "SELECT"
+    assert result.judge_disposition_agreement == 1.0
+    assert [item.provider_result_index for item in result.selected_sources] == [0, 1]
+    assert result.covered_required_role_ids == (
+        "electrochemical_capture",
+        "redox_polymer",
+    )
+    assert result.covered_scope_role_ids == ("flue_gas",)
+    assert result.covered_supporting_role_ids == (
+        "capture_performance",
+        "cycling_stability",
+    )
+
+    payload = result.model_dump(mode="json")
+    assert len(payload["candidate_decisions"]) == 2
+    assert payload["selected_sources"] == [
+        {
+            "candidate_sha256": capture.sha256(),
+            "provider_result_index": 0,
+            "role_ids": [
+                "electrochemical_capture",
+                "flue_gas",
+                "capture_performance",
+            ],
+        },
+        {
+            "candidate_sha256": polymer.sha256(),
+            "provider_result_index": 1,
+            "role_ids": [
+                "redox_polymer",
+                "cycling_stability",
+            ],
+        },
+    ]
+
+
+def test_invalid_paraphrase_abstains_and_counts_as_disagreement():
+    candidate = _capture_candidate()
+    assignments = {
+        candidate.sha256(): (
+            (
+                "electrochemical_capture",
+                "title",
+                "electric separation of carbon",
+            ),
+            ("flue_gas", "abstract", "flue gas"),
+        )
+    }
+
+    result = _evaluate((candidate,), assignments)
+
+    decision = result.candidate_decisions[0]
+    assert decision.action == "ABSTAIN"
+    assert decision.judge_agreement is False
+    assert decision.abstention_reasons == ("invalid_quote",)
+    assert result.judge_disposition_agreement == 0.0
+    assert result.action == "ABSTAIN"
+    assert result.abstention_reasons == ("no_valid_candidates",)
+
+
+def test_serialized_selected_roles_cannot_drop_a_verified_assignment():
+    result = _evaluate(
+        (_capture_candidate(), _polymer_candidate()),
+        _assignments(),
+    )
+    payload = result.model_dump(mode="json")
+    payload["selected_sources"][0]["role_ids"].pop()
+
+    with pytest.raises(
+        ValidationError,
+        match="deliver every verified KEEP role",
+    ):
+        EvidenceSetCaseAudit.model_validate(payload)
+
+
+def test_layout_only_whitespace_normalization_preserves_a_real_quote():
+    candidate = _candidate(
+        0,
+        title="Electrochemical capture using a polymer electrode",
+        abstract="Carbon dioxide was removed from\n   flue gas at high capacity.",
+    )
+    assignments = {
+        candidate.sha256(): (
+            ("electrochemical_capture", "title", "Electrochemical capture"),
+            ("flue_gas", "abstract", "from flue gas"),
+        )
+    }
+
+    result = _evaluate((candidate,), assignments)
+
+    assert result.candidate_decisions[0].judge_agreement is True
+    assert "invalid_quote" not in result.candidate_decisions[0].abstention_reasons
+
+
+def test_role_disagreement_fails_closed_without_a_repair_call():
+    candidate = _capture_candidate()
+    first, second = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(candidate,),
+    )
+    first_assignments = {
+        candidate.sha256(): (
+            ("electrochemical_capture", "title", "Electrochemical capture"),
+            ("flue_gas", "abstract", "flue gas"),
+        )
+    }
+    second_assignments = {
+        candidate.sha256(): (
+            ("electrochemical_capture", "title", "Electrochemical capture"),
+            (
+                "capture_performance",
+                "abstract",
+                "high capture capacity",
+            ),
+        )
+    }
+
+    result = evaluate_evidence_set_case(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        selection_contract=_contract(),
+        candidates=(candidate,),
+        first_raw_response=_raw_response(first, first_assignments),
+        second_raw_response=_raw_response(second, second_assignments),
+    )
+
+    assert result.candidate_decisions[0].abstention_reasons == (
+        "judge_role_disagreement",
+    )
+    assert result.first_pass.state == "valid"
+    assert result.second_pass.state == "valid"
+
+
+def test_malformed_pass_abstains_every_row_and_keeps_every_row_in_audit():
+    capture = _capture_candidate()
+    polymer = _polymer_candidate()
+    _, second = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(capture, polymer),
+    )
+
+    result = evaluate_evidence_set_case(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        selection_contract=_contract(),
+        candidates=(capture, polymer),
+        first_raw_response="not-json",
+        second_raw_response=_raw_response(second, _assignments()),
+    )
+
+    assert result.first_pass.state == "malformed"
+    assert result.first_pass.error_code == "schema_invalid"
+    assert result.provider_candidate_count == 2
+    assert len(result.candidate_decisions) == 2
+    assert {item.abstention_reasons for item in result.candidate_decisions} == {
+        ("judge_pass_invalid",)
+    }
+
+
+def test_wrong_case_or_candidate_order_is_contract_invalid():
+    candidate = _capture_candidate()
+    first, _ = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(candidate,),
+    )
+    assignments = {
+        candidate.sha256(): (
+            ("electrochemical_capture", "title", "Electrochemical capture"),
+            ("flue_gas", "abstract", "flue gas"),
+        )
+    }
+    payload = json.loads(_raw_response(first, assignments))
+    payload["case_id"] = "X02"
+
+    audit = parse_judge_pass(json.dumps(payload), first)
+
+    assert audit.state == "contract_invalid"
+    assert audit.error_code == "case_id_mismatch"
+
+
+def test_both_model_abstentions_agree_but_do_not_create_evidence():
+    candidate = _capture_candidate()
+
+    result = _evaluate((candidate,), {candidate.sha256(): None})
+
+    decision = result.candidate_decisions[0]
+    assert decision.judge_agreement is True
+    assert decision.action == "ABSTAIN"
+    assert decision.abstention_reasons == ("judge_abstained",)
+    assert result.judge_disposition_agreement == 1.0
+
+
+def test_candidate_without_consensus_title_anchor_cannot_enter_set_cover():
+    candidate = _capture_candidate()
+    first, second = build_judge_inputs(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(candidate,),
+    )
+    first_assignments = {
+        candidate.sha256(): (
+            ("electrochemical_capture", "title", "Electrochemical capture"),
+            ("flue_gas", "abstract", "flue gas"),
+        )
+    }
+    second_assignments = {
+        candidate.sha256(): (
+            (
+                "electrochemical_capture",
+                "abstract",
+                "removes carbon dioxide",
+            ),
+            ("flue_gas", "abstract", "flue gas"),
+        )
+    }
+
+    result = evaluate_evidence_set_case(
+        case_id="X01",
+        topic=_TOPIC,
+        profile=_profile(),
+        selection_contract=_contract(),
+        candidates=(candidate,),
+        first_raw_response=_raw_response(first, first_assignments),
+        second_raw_response=_raw_response(second, second_assignments),
+    )
+
+    assert result.candidate_decisions[0].abstention_reasons == (
+        "missing_title_anchor",
+    )
+
+
+def test_set_cover_prefers_lower_provider_index_after_minimum_size():
+    capture = _capture_candidate()
+    lower = _polymer_candidate(1)
+    higher = _polymer_candidate(2)
+    assignments = _assignments()
+    assignments[higher.sha256()] = assignments.pop(_polymer_candidate().sha256())
+    assignments[lower.sha256()] = (
+        ("redox_polymer", "title", "Redox-active polymer electrodes"),
+        ("cycling_stability", "title", "stable cycling"),
+    )
+
+    result = _evaluate((higher, capture, lower), assignments)
+
+    assert [item.provider_result_index for item in result.selected_sources] == [0, 1]
+    assert higher.sha256() not in {
+        item.candidate_sha256 for item in result.selected_sources
+    }
+
+
+def test_three_source_ceiling_abstains_when_four_scope_roles_are_required():
+    profile_payload = _profile().model_dump(mode="json")
+    profile_payload["required_roles"].extend(
+        [
+            {"role_id": "required_three", "description": "third required role"},
+            {"role_id": "required_four", "description": "fourth required role"},
+        ]
+    )
+    profile_payload["scope_roles"] = [
+        {"role_id": f"scope_{index}", "description": f"scope role number {index}"}
+        for index in range(1, 5)
+    ]
+    profile = EvidenceSetRoleProfile.model_validate(profile_payload)
+    candidates = tuple(
+        _candidate(
+            index,
+            title=f"Required role {index + 1} with scope role {index + 1}",
+            abstract="Supporting evidence was reported.",
+        )
+        for index in range(4)
+    )
+    required_ids = [role.role_id for role in profile.required_roles]
+    assignments = {
+        candidate.sha256(): (
+            (
+                required_ids[index],
+                "title",
+                f"Required role {index + 1}",
+            ),
+            (
+                f"scope_{index + 1}",
+                "title",
+                f"scope role {index + 1}",
+            ),
+            (
+                "capture_performance",
+                "abstract",
+                "Supporting evidence",
+            ),
+        )
+        for index, candidate in enumerate(candidates)
+    }
+
+    result = _evaluate(
+        candidates,
+        assignments,
+        profile=profile,
+        contract=_contract(minimum_scope_roles=4),
+    )
+
+    assert all(item.action == "KEEP" for item in result.candidate_decisions)
+    assert result.action == "ABSTAIN"
+    assert result.abstention_reasons == ("no_covering_set",)
+
+
+def test_duplicate_role_ids_fail_before_any_judge_input_can_be_built():
+    payload = _profile().model_dump(mode="json")
+    payload["scope_roles"][0]["role_id"] = (
+        payload["required_roles"][0]["role_id"]
+    )
+
+    with pytest.raises(ValidationError, match="role IDs must be unique"):
+        EvidenceSetRoleProfile.model_validate(payload)
+
+
+def test_production_worker_and_kernel_remain_disconnected_from_live_clients():
+    worker = (_ROOT / "src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+    kernel = (_ROOT / "src/academic_agent/openalex_evidence_set.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "openalex_evidence_set" not in worker
+    assert "evaluate_evidence_set_case" not in worker
+    assert "anonymous_openalex_search" not in kernel
+    assert "openalex_claim_scope_search" not in kernel
+    assert "litellm" not in kernel
+    assert "urllib" not in kernel

--- a/tests/test_openalex_evidence_set_unseen.py
+++ b/tests/test_openalex_evidence_set_unseen.py
@@ -1,0 +1,183 @@
+"""Zero-network seams for the frozen evidence-set v5 unseen preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import openalex_evidence_set_unseen as unseen
+
+
+def test_dry_run_expands_all_frozen_identities_without_live_authority():
+    result = unseen.dry_run()
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"X{index:02d}" for index in range(1, 9)
+    ]
+    for key in (
+        "collection_sha256",
+        "plan_sha256",
+        "profile_sha256",
+        "case_contract_sha256",
+        "idempotency_key",
+    ):
+        assert len({case[key] for case in result["cases"]}) == 8
+    assert {case["result_limit"] for case in result["cases"]} == {8}
+    assert result["maximum_search_request_count"] == 8
+    assert result["maximum_judge_call_count"] == 16
+    assert result["request_contract"] == {
+        "result_limit": 8,
+        "filter": "has_abstract:true",
+        "aboutness_fields": ["topics", "keywords"],
+        "aboutness_admissible_for_selection": False,
+        "redirects": False,
+        "internal_retries": False,
+        "supplementary_fetches": False,
+    }
+    judge = result["semantic_judge_contract"]
+    assert judge["provider"] == "deepseek"
+    assert judge["requested_model"] == "deepseek-chat"
+    assert judge["passes_per_case"] == 2
+    assert judge["temperature"] == 0.0
+    assert judge["allowed_candidate_fields"] == [
+        "candidate_sha256",
+        "title",
+        "abstract",
+    ]
+    assert judge["maximum_selected_sources_per_case"] == 3
+    assert result["development_observation"]["case_ids"] == [
+        f"W{index:02d}" for index in range(1, 9)
+    ]
+    assert result["development_observation"]["reuse_for_v5_validation"] is False
+    assert result["development_qualification_gates"] == {
+        "candidate_disposition_agreement_min": 0.9,
+        "semantic_link_rows_retained_min": 4,
+        "relevant_novel_case_count_min": 6,
+        "selected_directly_irrelevant_count_max": 1,
+        "all_decisions_persisted": True,
+    }
+    assert result["unseen_value_gates"]["selected_wrong_source_rate_max"] == 0.05
+    assert result["unseen_value_gates"]["all_provider_rows_reviewed"] is True
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["private_labels_opened"] is False
+    assert result["live_provider_requests_authorized"] is False
+    assert result["live_model_calls_authorized"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+    assert result["planner_trigger_connected"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path, monkeypatch):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    def must_not_expand(*args, **kwargs):
+        raise AssertionError("case expansion ran before the raw hash check")
+
+    monkeypatch.setattr(unseen, "build_case", must_not_expand)
+    with pytest.raises(
+        unseen.OpenAlexEvidenceSetPreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases(fixture)
+
+
+def test_case_order_drift_is_rejected_with_a_matching_test_hash(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["challenge_cases"][0], payload["challenge_cases"][1] = (
+        payload["challenge_cases"][1],
+        payload["challenge_cases"][0],
+    )
+    fixture = tmp_path / "reordered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="ordered X01 through X08"):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_hidden_field_or_judge_surface_drift_fails_closed(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["semantic_judge_contract"]["allowed_candidate_fields"].append("url")
+    fixture = tmp_path / "judge-leak.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="judge candidate fields drifted"):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_role_profile_drift_changes_only_role_bound_identities(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["challenge_cases"][0]["role_profile"]["scope_roles"][0][
+        "description"
+    ] += " under saline operating conditions"
+    fixture = tmp_path / "role-drift.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    original = unseen.dry_run()
+    drifted = unseen.dry_run(
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+
+    assert drifted["cases"][0]["profile_sha256"] != (
+        original["cases"][0]["profile_sha256"]
+    )
+    assert drifted["cases"][0]["case_contract_sha256"] != (
+        original["cases"][0]["case_contract_sha256"]
+    )
+    assert drifted["cases"][0]["plan_sha256"] == (
+        original["cases"][0]["plan_sha256"]
+    )
+
+
+def test_request_and_judge_caps_remain_one_search_and_two_passes_per_case(
+    tmp_path,
+):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["maximum_live_judge_calls"] = 17
+    fixture = tmp_path / "extra-call.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError):
+        unseen.load_frozen_cases(
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_preflight_imports_neither_provider_model_nor_execution_client():
+    source = Path("openalex_evidence_set_unseen.py").read_text(encoding="utf-8")
+
+    assert "anonymous_openalex_search" not in source
+    assert "openalex_claim_scope_search" not in source
+    assert "execute_gap_plan" not in source
+    assert "litellm" not in source
+    assert "crewai" not in source
+    assert "urllib" not in source


### PR DESCRIPTION
## Why

Scope-Link v4 demonstrated that a same-segment lexical relation can abstain on
useful literature when evidence is distributed across complementary sources.
The frozen v5 protocol therefore tests a different representation: exact,
quote-grounded per-source roles followed by deterministic bounded set cover.

## What changed

- add a production-disconnected two-pass evidence-set decision kernel;
- expose only candidate identity, title, abstract, and code-owned roles to a
  future semantic judge;
- mechanically verify every quote and fail closed on malformed, missing,
  duplicate, disagreeing, or unverifiable responses;
- select at most three complementary sources with deterministic tie breaking;
- validate that every computed role and selected source reaches the serialized
  audit seam;
- add a raw-byte-locked X01-X08 zero-network preflight and 21 focused seam
  tests;
- record both required defect re-injections and update README/AGENTS without
  claiming a model, provider, source-value, or production result.

## Verification

- `uv run pytest -q --basetemp outputs\pytest-v5-kernel-final-20260829-01`
  - `1733 passed, 639 subtests passed`
- `uv run --with ruff ruff check .`
  - passed
- narrow Pylint `E0701`
  - `10.00/10`
- `git diff --check`
  - passed
- changed-file secret scan
  - no matches

The quote-bypass defect made the paraphrase seam test fail, and dropping a
verified supporting role made the final serialized audit seam fail. Both
temporary changes were reverted before the final suite.

## Explicit boundaries

This PR makes no DeepSeek call, OpenAlex request, private-label access, planner
connection, report connection, or production import. W01-W08 development
qualification and every X01-X08/provider step still require separate explicit
authorization after this revision is merged.
