### PR TITLE
Add a label-blind v5 development runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1733 tests (639 subtests), CI green on Linux + Windows × Python
+Current state: 1748 tests (639 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -431,10 +431,22 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   focused tests. They mechanically verify both passes' quotes, fail closed on
   disagreement or malformed rows, select at most three sources, and validate
   that every computed role reaches the serialized audit boundary. Both
-  protocol-mandated defects were re-injected and caught. No model call,
-  OpenAlex request, private-label access or production connection has occurred.
-  See docs/prereg-2026-08-29-openalex-evidence-set-v5.md and
-  docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md.
+  protocol-mandated defects were re-injected and caught.
+  A production-disconnected W01-W08 development runner now locks the exact
+  source packet, source lock, completed human labels and reviewer declaration
+  before parsing only the label-blind packet. Role descriptions are derived
+  mechanically from the earlier frozen v4 source-text groups, not from labels.
+  Its strict one-request DeepSeek adapter rejects redirects, retries, model or
+  usage identity drift, and uninspectable cost. The runner writes its complete
+  manifest before client construction, each response and usage before a later
+  call, and each deterministic case decision before a later case. The focused
+  runner/adapter suite passes 15/15 tests, including a temporarily re-injected
+  manifest-order defect. The real zero-network preflight verified 8/8 cases,
+  64/64 candidate identities and 16 distinct prompt identities. No model call
+  or OpenAlex request occurred; human bytes were hashed but never parsed.
+  See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
+  docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
+  docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md.
   Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5
   candidates, live runners and review modules.

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ before a later request. Every provider row reaches the aggregate artifact, and
 only v4 `ACCEPT` rows reach a blank human-review boundary. The combined v4
 decision, preflight and runner subset passes 32/32 tests, including a
 re-injected computed-but-undelivered relation-provenance defect. The complete
-repository now passes **1,733 tests plus 639 subtests**. A separately
+repository now passes **1,748 tests plus 639 subtests**. A separately
 authorized run on merged revision `678254d` completed all eight one-attempt
 anonymous requests for USD 0.008 of provider-reported usage. All 64 provider
 rows reached the v4 decision seam, but the method accepted zero candidates
@@ -654,14 +654,22 @@ mechanically verifiable title/abstract quotes in two order-reversed passes; a
 deterministic selector may then combine at most three complementary sources.
 W01-W08 are development evidence only. X01-X08 are raw-byte-locked as the
 unseen challenge, and every provider row must receive human review even after a
-mechanical failure. The zero-network v5 kernel and unseen preflight now pass
-21/21 focused tests: model inputs exclude provider and label metadata, quotes
-are verified against source text in both passes, and a validated final seam
-prevents computed roles from disappearing during serialization. The full suite
-passes **1,733 tests plus 639 subtests**. No model call, OpenAlex request,
-private-label access or production connection has occurred. See the
-[v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md) and
-[implementation result](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md).
+mechanical failure. The zero-network v5 kernel and unseen preflight pass 21/21
+focused tests: model inputs exclude provider and label metadata, quotes are
+verified in both passes, and the final seam prevents computed roles from
+disappearing during serialization. A production-disconnected W01-W08 runner
+now locks the exact packet, source lock, completed human labels and declaration
+before parsing only the label-blind packet. It derives roles mechanically from
+frozen v4 text groups, writes the manifest before client construction, and
+commits every response, usage record and case decision before later paid work.
+Its strict one-request DeepSeek adapter and runner pass 15/15 focused tests. A
+real zero-network preflight verified 8/8 cases, 64/64 candidates and 16 unique
+prompt identities. The full suite passes **1,748 tests plus 639 subtests**. No
+model call, OpenAlex request, human-label parse or production connection has
+occurred. See the
+[v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md),
+[kernel result](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md),
+and [development-runner result](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1773,7 +1781,7 @@ runner 已实现：它在构造适配器前记录冻结方法与自身观测哈�
 下一次请求前先提交当前单请求 case journal。每一条供应商返回行都会到达
 聚合产物，只有 v4 `ACCEPT` 行会进入空白人工评审边界。v4 决策、预检与
 runner 组合测试为 32/32；临时移除内部已算出的 relation provenance 后，
-客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,733 项测试与 639 个
+客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,748 项测试与 639 个
 subtests**。随后在合并版本 `678254d` 上单独授权的真实实验完成了 8 次匿名、
 不重试的顺序请求，供应商记账成本为 0.008 美元。64 条供应商候选全部到达
 v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结的 6/8 门槛。
@@ -1806,12 +1814,19 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 裁判以两次顺序相反的判断提出带标题/摘要原文片段的来源角色，再由确定性选择器
 组合至多三条互补来源。W01-W08 只能作为开发证据；X01-X08 已按原始字节锁定为
 未见挑战。即使机械门槛失败，全部供应商候选也必须进入人工评审。v5 零网络
-执行内核与未见预检现已通过 21/21 项定向测试：模型输入排除供应商元数据和人工
-标签，两次判断中的原文片段都必须机械验证，最终 Pydantic 接缝会阻止已计算的
-role 在序列化时丢失。当前全仓通过 **1,733 项测试与 639 个 subtests**。尚未发生
-模型调用、OpenAlex 请求、私有标签读取或生产接入。详见
-[v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)和
-[实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md)。
+执行内核与未见预检通过 21/21 项定向测试：模型输入排除供应商元数据和人工标签，
+两次判断中的原文片段都必须机械验证，最终 Pydantic 接缝会阻止已计算的 role 在
+序列化时丢失。另一个生产隔离的 W01-W08 runner 会先锁定来源包、source lock、
+已完成人工标签和声明，只解析标签盲化的来源包；角色描述由冻结的 v4 文本组机械
+生成。严格的单请求 DeepSeek 适配器不重定向、不重试，并拒绝模型身份、usage 或
+费用不可检查的结果。runner 会在构造客户端前写 manifest，在后续付费调用前写入
+当前响应和 usage，并在下一案例前写入完整确定性决策。适配器与 runner 的 15/15
+项定向测试全绿；真实零网络预检验证了 8/8 案例、64/64 候选和 16 个唯一 prompt
+身份。当前全仓通过 **1,748 项测试与 639 个 subtests**。尚未发生模型调用、
+OpenAlex 请求、人工标签解析或生产接入。详见
+[v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)、
+[内核实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md)和
+[开发 runner 实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md
+++ b/docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md
@@ -1,0 +1,151 @@
+# Result: evidence-set v5 label-blind development runner
+
+**Date:** 2026-08-29
+
+**Result state:** zero-network runner implementation complete; W01-W08 model
+quality and all human-label-dependent development gates remain `not_evaluated`.
+
+## Outcome
+
+The production-disconnected W01-W08 development runner now implements the paid
+call boundary required by the frozen
+[v5 protocol](prereg-2026-08-29-openalex-evidence-set-v5.md). It locks the
+exact 64-row public title/abstract packet, source lock, completed human labels,
+and reviewer declaration before any case expansion. The label and declaration
+bytes are hashed but never decoded or parsed. Only the already label-blind
+packet is parsed.
+
+The runner derives W01-W08 role descriptions mechanically from the previously
+frozen v4 source-text concept groups. It does not hand-author roles from the
+completed labels. Each judge input contains only candidate SHA-256, title,
+abstract, topic, and code-owned role descriptions. Baseline text, URL, DOI,
+publisher, OpenAlex metadata, v4 decisions, human labels, and reviewer notes
+cannot cross the model boundary.
+
+No DeepSeek call, OpenAlex request, private-label parse, production import,
+report connection, or planner trigger occurred in this implementation phase.
+
+## Paid-call boundary
+
+`src/academic_agent/tools/deepseek_evidence_judge.py` adds a strict
+OpenAI-shaped DeepSeek adapter with these properties:
+
+- fixed `https://api.deepseek.com/chat/completions` endpoint and
+  `deepseek-chat` model;
+- temperature zero and JSON-object response mode;
+- exactly one transport invocation per adapter call;
+- no redirect, retry, repair, fallback, streaming, or model switching;
+- absent or inconsistent provider model identity is terminal;
+- absent or inconsistent token accounting is terminal rather than zero cost;
+- cached prompt tokens use the repository's existing provider-aware pricing;
+- request body hash, prompt hash, provider IDs, token usage, cost basis,
+  latency, and trace ID reach the response contract; and
+- credentials exist only in the outbound authorization header and cannot
+  enter request identities, model prompts, errors, or artifacts.
+
+`openalex_evidence_set_development.py` adds the write-once study runner:
+
+1. verify every source and implementation byte identity;
+2. reserve a new output directory;
+3. write the complete manifest before constructing a model client;
+4. perform at most 16 calls under an explicit USD soft stop;
+5. write each pass response and usage before permitting the next call;
+6. after both passes, write the complete deterministic case decision before
+   permitting the next case; and
+7. write execution, all-candidate decisions, and a hashed artifact index.
+
+Malformed judge JSON is not repaired. It remains a completed, billed call and
+the existing kernel converts the case to explicit abstention. Transport,
+identity, usage, or cost failures stop the study without retry. A partial run
+cannot report label-join readiness, and zero checked candidates cannot report
+a passing agreement rate.
+
+## Real zero-network preflight
+
+The default CLI path was executed against the real local W01-W08 packet. It
+verified:
+
+- 8/8 ordered cases and 64/64 ordered candidate identities;
+- 16 distinct model inputs and 16 distinct prompt identities;
+- source lock SHA-256
+  `8a9747f4240fc7c529d8d8f2a737fb21b502579ad2f69c19587bf093cabba7af`;
+- packet SHA-256
+  `68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616`;
+- labels SHA-256
+  `45d12929290de9482dfcd89af61fc6e5ea74b6e63c0eec9f686f4fa0aa11d3ad`;
+- declaration SHA-256
+  `eb17b0ae23599575afcd9a68ad6a6d64644d4c0001fd10cdabb853a3f3ee1a31`;
+- v4 fixture SHA-256
+  `f4267c6a79c0bb8a685664de5086e4cfff59ebac1b352cbb56c2277957a55cc3`;
+- strict adapter SHA-256
+  `2228d4933df066d9ced0dd4b067a85f7377ad5456f33b52005f7a996bc4cbd50`;
+- `real_network_calls_performed=false` and
+  `real_model_calls_performed=false`; and
+- `private_label_bytes_hashed=true` with
+  `private_label_content_parsed=false`.
+
+The runner records its observed self-hash instead of embedding it in itself,
+which would create a recursive identity. Every other behavior-bearing
+dependency is checked against an expected SHA-256 before output reservation.
+A future paid authorization must name the merged Git revision, which binds the
+runner's observed bytes as well.
+
+## Verification
+
+Focused zero-network tests after the final accounting hardening:
+
+```text
+15 passed in 1.99s
+```
+
+The first complete-suite run, before adding the final token-total seam test,
+reported:
+
+```text
+1747 passed, 639 subtests passed in 29.68s
+```
+
+After the final token-total seam test and documentation sync, the complete
+zero-network suite reported:
+
+```text
+1748 passed, 639 subtests passed in 30.09s
+```
+
+`uv run --with ruff ruff check .` passed with the CI-equivalent latest Ruff.
+The narrow `E0701` Pylint check rated the two new runtime modules 10.00/10.
+
+No warning ignore, relaxed assertion, skipped test, or network-dependent test
+was added.
+
+## Defect re-injection
+
+The manifest write was temporarily moved after adapter construction. The
+client-boundary test failed because its injected factory observed that
+`manifest.json` did not exist. After restoring the correct order, the same
+test passed. This proves the test observes the durable pre-call boundary rather
+than merely checking a manifest field after execution.
+
+The earlier v5 kernel phase separately re-injected quote bypass and
+computed-but-undelivered role defects. Those tests remain green and are not
+replaced by this runner-order check.
+
+## What remains unobserved
+
+This result establishes implementation and zero-network preflight only. It
+does not establish:
+
+- DeepSeek JSON validity, order robustness, semantic accuracy, token use,
+  latency, or cost on W01-W08;
+- any of the five frozen development gates;
+- whether X01-X08 may be requested;
+- OpenAlex source truth, report improvement, planner precision, user value,
+  or production Tool Calling; or
+- production reliability, adoption, ROI, or an SLO.
+
+The next eligible action is a separately authorized run naming the merged
+revision, `deepseek-chat`, at most 16 sequential model calls, zero OpenAlex
+requests, and an explicit soft USD stop. Only after all responses and decisions
+are durably committed may a separate checker parse the locked human labels.
+A failed development gate seals v5; W01-W08 may not be tuned and replayed into
+a pass.

--- a/openalex_evidence_set_development.py
+++ b/openalex_evidence_set_development.py
@@ -1,0 +1,1157 @@
+"""Label-blind W01-W08 development runner for evidence-set v5.
+
+This runner consumes the frozen public title/abstract packet but never parses
+its completed human labels.  It hashes those private artifacts only so a
+later, separate unblinding step can prove which bytes were withheld.  The
+semantic judge sees candidate identity, title, abstract, and mechanically
+derived code-owned role descriptions.  Every paid response is written before
+another request is allowed, and every completed two-pass case decision is
+written before the next case begins.
+
+The module is intentionally disconnected from the production worker.  Its
+default CLI path is a zero-network preflight; model calls require an explicit
+flag, a bounded soft stop, and budget acknowledgement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetCaseAudit,
+    EvidenceSetRoleProfile,
+    EvidenceSetRoleSpec,
+    EvidenceSetSelectionContract,
+    JudgeBatchInput,
+    build_judge_inputs,
+    evaluate_evidence_set_case,
+)
+from academic_agent.tools.deepseek_evidence_judge import (
+    DeepSeekEvidenceJudgeAdapter,
+    DeepSeekJudgeAdapterError,
+    DeepSeekJudgeRequest,
+    DeepSeekJudgeResponse,
+    prompt_sha256,
+)
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+from openalex_scope_link_unseen import (
+    DEFAULT_FIXTURE_PATH as DEFAULT_V4_FIXTURE_PATH,
+    EXPECTED_FIXTURE_SHA256 as EXPECTED_V4_FIXTURE_SHA256,
+    PreparedScopeLinkCase,
+    load_frozen_cases as load_v4_frozen_cases,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_DIAGNOSTIC_DIR = (
+    _ROOT
+    / "outputs"
+    / "2026-08-29-openalex-scope-link-v4-abstention-diagnostic"
+)
+DEFAULT_SOURCE_LOCK_PATH = _DIAGNOSTIC_DIR / "source-lock.json"
+DEFAULT_PACKET_PATH = _DIAGNOSTIC_DIR / "packet" / "packet_manifest.json"
+DEFAULT_LABELS_PATH = _DIAGNOSTIC_DIR / "packet" / "labels.csv"
+DEFAULT_DECLARATION_PATH = (
+    _DIAGNOSTIC_DIR / "packet" / "reviewer_declaration.csv"
+)
+EXPECTED_SOURCE_SHA256 = {
+    "source-lock.json": (
+        "8a9747f4240fc7c529d8d8f2a737fb21b502579ad2f69c19587bf093cabba7af"
+    ),
+    "packet_manifest.json": (
+        "68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616"
+    ),
+    "labels.csv": (
+        "45d12929290de9482dfcd89af61fc6e5ea74b6e63c0eec9f686f4fa0aa11d3ad"
+    ),
+    "reviewer_declaration.csv": (
+        "eb17b0ae23599575afcd9a68ad6a6d64644d4c0001fd10cdabb853a3f3ee1a31"
+    ),
+}
+MAXIMUM_MODEL_CALL_COUNT = 16
+MAXIMUM_SOFT_STOP_USD = 0.20
+_CASE_ORDER = tuple(f"W{index:02d}" for index in range(1, 9))
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+_RUNNER_PATH = Path(__file__).resolve()
+_IMPLEMENTATION_PATHS = {
+    "deepseek_evidence_judge.py": (
+        _ROOT / "src/academic_agent/tools/deepseek_evidence_judge.py"
+    ),
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_evidence_set.py": (
+        _ROOT / "src/academic_agent/openalex_evidence_set.py"
+    ),
+    "openalex_scope_link.py": (
+        _ROOT / "src/academic_agent/openalex_scope_link.py"
+    ),
+    "openalex_scope_link_unseen.py": _ROOT / "openalex_scope_link_unseen.py",
+    "token_usage.py": _ROOT / "src/academic_agent/token_usage.py",
+}
+# These identities are filled from committed implementation bytes.  The runner
+# itself is recorded as an observed hash because embedding its own expected
+# digest would create a recursive identity.  A future authorization names the
+# merged Git revision, while this map locks every behavior-bearing dependency.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "deepseek_evidence_judge.py": (
+        "2228d4933df066d9ced0dd4b067a85f7377ad5456f33b52005f7a996bc4cbd50"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_evidence_set.py": (
+        "413bf6cea1c555c75bd80aaadae720cbf00886974acfdd443643f6a2f75e992c"
+    ),
+    "openalex_scope_link.py": (
+        "abfb9a6b6af1691411f4ad3689b0f5052c42dfeddfdc30cb2e9e21c7d0ff2667"
+    ),
+    "openalex_scope_link_unseen.py": (
+        "1e3c0b15c9608cf83b414ee52ac2da7540728149970fa45ab9e6306773ef4749"
+    ),
+    "token_usage.py": (
+        "81d7fab7d2c9258e8d56fddacff114c2c06585530d2591d004cf3bb19d78defd"
+    ),
+}
+
+_SYSTEM_PROMPT = """You are a bounded academic-evidence classification component.
+You do not decide commercial viability, novelty, or truth. For each supplied
+candidate, return KEEP only for roles directly supported by an exact quote
+from that candidate's title or abstract. Otherwise return ABSTAIN. Do not use
+outside knowledge, infer missing facts, paraphrase quotes, omit candidates, or
+change candidate order. Return one JSON object and no surrounding prose."""
+
+
+class EvidenceSetDevelopmentError(ValueError):
+    """Raised before a model call when a frozen development boundary drifts."""
+
+
+class DevelopmentPacketRow(BaseModel):
+    """One label-blind row from the frozen 64-candidate packet."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    baseline_sources_json: str = Field(min_length=2, max_length=20_000)
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    case_id: str = Field(pattern=r"^W0[1-8]$")
+    declared_gap: str = Field(min_length=10, max_length=1_000)
+    doi: str | None = Field(default=None, max_length=500)
+    evidence_summary: str = Field(min_length=1, max_length=8_000)
+    identity_sha256: str = Field(pattern=_SHA256_PATTERN)
+    provider: Literal["openalex"] = "openalex"
+    provider_result_index: int = Field(ge=0, le=7)
+    published_date: str | None = Field(default=None, max_length=40)
+    publisher: str = Field(min_length=1, max_length=600)
+    query: str = Field(min_length=20, max_length=500)
+    summary_source: Literal["abstract"] = "abstract"
+    title: str = Field(min_length=5, max_length=600)
+    topic: str = Field(min_length=20, max_length=300)
+    url: str = Field(min_length=10, max_length=2_000)
+
+
+class DevelopmentPacket(BaseModel):
+    """Exact public packet schema, including no completed human labels."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_count: Literal[8] = 8
+    diagnostic_only: Literal[True] = True
+    executed_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    measurement_limit: str = Field(min_length=20, max_length=2_000)
+    mode: Literal["openalex_scope_link_v4_candidate_diagnostic_packet"]
+    prepared_at: str = Field(min_length=10, max_length=80)
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    row_count: Literal[64] = 64
+    rows: tuple[DevelopmentPacketRow, ...] = Field(min_length=64, max_length=64)
+    schema_version: Literal[1] = 1
+    source_file_sha256: dict[str, str]
+    source_lock_sha256: str = Field(pattern=_SHA256_PATTERN)
+    valid_label_combinations: tuple[tuple[str, ...], ...] = Field(
+        min_length=1,
+        max_length=20,
+    )
+
+    @model_validator(mode="after")
+    def _validate_complete_rows(self) -> "DevelopmentPacket":
+        case_ids = tuple(row.case_id for row in self.rows)
+        expected = tuple(case_id for case_id in _CASE_ORDER for _ in range(8))
+        if case_ids != expected:
+            raise ValueError("packet rows must remain W01-W08 with eight rows each")
+        for case_id in _CASE_ORDER:
+            indices = tuple(
+                row.provider_result_index
+                for row in self.rows
+                if row.case_id == case_id
+            )
+            if indices != tuple(range(8)):
+                raise ValueError(f"{case_id}: provider row order drifted")
+        candidate_ids = tuple(row.candidate_sha256 for row in self.rows)
+        identity_ids = tuple(row.identity_sha256 for row in self.rows)
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("packet candidate identities must be unique")
+        if len(identity_ids) != len(set(identity_ids)):
+            raise ValueError("packet row identities must be unique")
+        return self
+
+
+@dataclass(frozen=True)
+class LockedEvidenceSetCandidate:
+    """Packet projection retaining the original candidate SHA verbatim."""
+
+    candidate_sha256: str
+    evidence: ToolEvidenceCandidate
+
+    def sha256(self) -> str:
+        return self.candidate_sha256
+
+
+@dataclass(frozen=True)
+class PreparedDevelopmentCase:
+    """One frozen W-case with two label-blind request identities."""
+
+    source_case: PreparedScopeLinkCase
+    profile: EvidenceSetRoleProfile
+    candidates: tuple[LockedEvidenceSetCandidate, ...]
+    first_input: JudgeBatchInput
+    second_input: JudgeBatchInput
+    first_request: DeepSeekJudgeRequest
+    second_request: DeepSeekJudgeRequest
+
+
+class FrozenDevelopmentCase(BaseModel):
+    """Everything the manifest commits before constructing a model client."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^W0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    query: str = Field(min_length=20, max_length=500)
+    profile: EvidenceSetRoleProfile
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    first_request: DeepSeekJudgeRequest
+    second_request: DeepSeekJudgeRequest
+
+
+class DevelopmentManifest(BaseModel):
+    """Durable method and authorization identity written before any call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_evidence_set_v5_development_manifest"] = (
+        "openalex_evidence_set_v5_development_manifest"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    openalex_requests_authorized: Literal[False] = False
+    private_label_bytes_hashed: Literal[True] = True
+    private_label_content_parsed: Literal[False] = False
+    source_sha256: dict[str, str]
+    v4_fixture_sha256: str = Field(pattern=_SHA256_PATTERN)
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=_SHA256_PATTERN)
+    selection_contract: EvidenceSetSelectionContract
+    selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    requested_provider: Literal["deepseek"] = "deepseek"
+    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    api_base: Literal["https://api.deepseek.com"] = "https://api.deepseek.com"
+    maximum_model_call_count: Literal[16] = 16
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    cases: tuple[FrozenDevelopmentCase, ...] = Field(min_length=8, max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_case_contract(self) -> "DevelopmentManifest":
+        if tuple(case.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("development manifest cases must remain W01-W08")
+        for case in self.cases:
+            if case.profile.sha256() != case.profile_sha256:
+                raise ValueError(f"{case.case_id}: profile identity drifted")
+            if case.first_request.trace_id != (
+                f"openalex-v5-{case.case_id.casefold()}-pass-1"
+            ):
+                raise ValueError(f"{case.case_id}: first trace identity drifted")
+            if case.second_request.trace_id != (
+                f"openalex-v5-{case.case_id.casefold()}-pass-2"
+            ):
+                raise ValueError(f"{case.case_id}: second trace identity drifted")
+        if self.selection_contract.sha256() != self.selection_contract_sha256:
+            raise ValueError("selection contract identity drifted")
+        return self
+
+
+CallState = Literal["completed", "failed"]
+StopReason = Literal[
+    "completed",
+    "soft_stop",
+    "adapter_failed",
+    "response_invalid",
+    "response_identity_mismatch",
+]
+
+
+class JudgeCallJournal(BaseModel):
+    """Write-once result for one attempted and potentially billed call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^W0[1-8]$")
+    pass_number: Literal[1, 2]
+    state: CallState
+    request: DeepSeekJudgeRequest
+    response: DeepSeekJudgeResponse | None = None
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    request_may_have_spent: bool
+
+    @model_validator(mode="after")
+    def _validate_state_shape(self) -> "JudgeCallJournal":
+        failures = (
+            self.failure_type,
+            self.failure_detail,
+            self.failure_retryable,
+        )
+        if self.state == "completed":
+            if self.response is None or any(value is not None for value in failures):
+                raise ValueError("completed call requires only a response")
+        elif self.response is not None or any(value is None for value in failures):
+            raise ValueError("failed call requires only failure metadata")
+        if self.request.trace_id != (
+            f"openalex-v5-{self.case_id.casefold()}-pass-{self.pass_number}"
+        ):
+            raise ValueError("journal trace ID drifted from case and pass")
+        return self
+
+
+class DevelopmentExecution(BaseModel):
+    """Final mechanical artifact; human-value gates remain unevaluated."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_evidence_set_v5_development_execution"] = (
+        "openalex_evidence_set_v5_development_execution"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    openalex_request_count: Literal[0] = 0
+    private_label_content_parsed: Literal[False] = False
+    manifest_sha256: str = Field(pattern=_SHA256_PATTERN)
+    overall_state: Literal["completed", "partial"]
+    stop_reason: StopReason
+    attempted_model_call_count: int = Field(ge=0, le=16)
+    completed_model_call_count: int = Field(ge=0, le=16)
+    completed_case_count: int = Field(ge=0, le=8)
+    persisted_candidate_decision_count: int = Field(ge=0, le=64)
+    prompt_tokens: int = Field(ge=0)
+    cached_prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    cost_usd: float | None = Field(default=None, ge=0.0, allow_inf_nan=False)
+    cost_state: Literal["known", "uninspectable"]
+    disposition_agreement_numerator: int = Field(ge=0, le=64)
+    disposition_agreement_denominator: int = Field(ge=0, le=64)
+    disposition_agreement: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+    )
+    mechanical_agreement_gate_passed: bool | None
+    all_decisions_persisted: bool
+    development_gate_state: Literal["ready_for_label_join", "not_evaluated"]
+    calls: tuple[JudgeCallJournal, ...] = Field(max_length=16)
+    case_decisions: tuple[EvidenceSetCaseAudit, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_complete_execution(self) -> "DevelopmentExecution":
+        if self.attempted_model_call_count != len(self.calls):
+            raise ValueError("attempted call count drifted from journals")
+        completed_calls = sum(call.state == "completed" for call in self.calls)
+        if self.completed_model_call_count != completed_calls:
+            raise ValueError("completed call count drifted from journals")
+        if self.completed_case_count != len(self.case_decisions):
+            raise ValueError("completed case count drifted from decisions")
+        candidate_count = sum(
+            len(case.candidate_decisions) for case in self.case_decisions
+        )
+        if self.persisted_candidate_decision_count != candidate_count:
+            raise ValueError("candidate decision count drifted from case audits")
+        if self.disposition_agreement_denominator:
+            expected = (
+                self.disposition_agreement_numerator
+                / self.disposition_agreement_denominator
+            )
+            if self.disposition_agreement is None or not math.isclose(
+                self.disposition_agreement,
+                expected,
+                abs_tol=1e-12,
+            ):
+                raise ValueError("aggregate disposition agreement drifted")
+        elif self.disposition_agreement is not None:
+            raise ValueError("zero checked candidates cannot report agreement")
+        ready = (
+            self.overall_state == "completed"
+            and self.completed_model_call_count == 16
+            and self.completed_case_count == 8
+            and self.persisted_candidate_decision_count == 64
+            and self.all_decisions_persisted
+        )
+        if (self.development_gate_state == "ready_for_label_join") != ready:
+            raise ValueError("label-join state does not match persisted completion")
+        return self
+
+
+class JudgeAdapter(Protocol):
+    def __call__(self, request: DeepSeekJudgeRequest) -> DeepSeekJudgeResponse: ...
+
+
+AdapterFactory = Callable[[], JudgeAdapter]
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _json_text(value: BaseModel | dict[str, Any] | list[Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise EvidenceSetDevelopmentError(
+            f"could not create write-once artifact {path}: {exc}"
+        ) from exc
+
+
+def _safe_validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "response validation failed"
+
+
+def _load_locked_packet(
+    *,
+    source_lock_path: Path,
+    packet_path: Path,
+    labels_path: Path,
+    declaration_path: Path,
+    expected_source_sha256: Mapping[str, str],
+) -> tuple[dict[str, str], DevelopmentPacket]:
+    """Hash all artifacts, then parse only the label-blind packet bytes."""
+
+    paths = {
+        "source-lock.json": source_lock_path,
+        "packet_manifest.json": packet_path,
+        "labels.csv": labels_path,
+        "reviewer_declaration.csv": declaration_path,
+    }
+    if set(paths) != set(expected_source_sha256):
+        raise EvidenceSetDevelopmentError("source lock names are inconsistent")
+    raw_by_name = {name: path.read_bytes() for name, path in paths.items()}
+    observed = {
+        name: _sha256_bytes(raw) for name, raw in raw_by_name.items()
+    }
+    if observed != dict(expected_source_sha256):
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if expected_source_sha256.get(name) != digest
+        )
+        raise EvidenceSetDevelopmentError(
+            "development source identity drifted: " + ", ".join(changed)
+        )
+    # Deliberately parse only this byte string.  The completed labels and
+    # declaration have been hashed above but remain opaque until a separate
+    # post-response authorization and checker open them.
+    packet = DevelopmentPacket.model_validate_json(
+        raw_by_name["packet_manifest.json"]
+    )
+    if packet.source_lock_sha256 != observed["source-lock.json"]:
+        raise EvidenceSetDevelopmentError(
+            "packet source-lock identity does not match the locked bytes"
+        )
+    return observed, packet
+
+
+def _role_description(group_id: str, phrases: tuple[str, ...]) -> str:
+    """Project a frozen text vocabulary without consulting human labels."""
+
+    concept = group_id.replace("_", " ")
+    examples = ", ".join(phrases)
+    return (
+        f"Evidence that the source directly addresses {concept}; the frozen "
+        f"source-text vocabulary includes: {examples}."
+    )
+
+
+def _development_profile(case: PreparedScopeLinkCase) -> EvidenceSetRoleProfile:
+    source = case.spec.profile
+    return EvidenceSetRoleProfile(
+        required_roles=tuple(
+            EvidenceSetRoleSpec(
+                role_id=group.group_id,
+                description=_role_description(group.group_id, group.text_phrases),
+            )
+            for group in source.required_groups
+        ),
+        scope_roles=tuple(
+            EvidenceSetRoleSpec(
+                role_id=group.group_id,
+                description=_role_description(group.group_id, group.text_phrases),
+            )
+            for group in source.scope_groups
+        ),
+        supporting_roles=tuple(
+            EvidenceSetRoleSpec(
+                role_id=group.group_id,
+                description=_role_description(group.group_id, group.text_phrases),
+            )
+            for group in source.supporting_groups
+        ),
+    )
+
+
+def _selection_contract() -> EvidenceSetSelectionContract:
+    return EvidenceSetSelectionContract(
+        required_roles_covered="all",
+        minimum_scope_roles=1,
+        minimum_supporting_roles=1,
+        maximum_selected_sources_per_case=3,
+        minimum_candidate_required_roles=1,
+        minimum_candidate_context_roles=1,
+        minimum_candidate_title_anchor_roles=1,
+    )
+
+
+def _locked_candidate(row: DevelopmentPacketRow) -> LockedEvidenceSetCandidate:
+    return LockedEvidenceSetCandidate(
+        candidate_sha256=row.candidate_sha256,
+        evidence=ToolEvidenceCandidate(
+            title=row.title,
+            url=row.url,
+            doi=row.doi,
+            publisher=row.publisher,
+            evidence_summary=row.evidence_summary,
+            summary_source="abstract",
+            provider_result_index=row.provider_result_index,
+        ),
+    )
+
+
+def _user_prompt(batch: JudgeBatchInput) -> str:
+    response_shape = {
+        "candidate_order": ["candidate_sha256 in exact input order"],
+        "case_id": batch.case_id,
+        "decisions": [
+            {
+                "action": "KEEP or ABSTAIN",
+                "candidate_sha256": "candidate identity",
+                "role_quotes": [
+                    {
+                        "field": "title or abstract",
+                        "quote": "exact source-text span",
+                        "role_id": "one supplied role ID",
+                    }
+                ],
+            }
+        ],
+    }
+    return (
+        "Evaluate every candidate against the supplied roles. KEEP requires at "
+        "least one role quote; ABSTAIN requires an empty role_quotes array. "
+        "The decisions array and candidate_order must contain every candidate "
+        "once and in exact input order. Return only strict JSON with this "
+        "shape:\n"
+        + json.dumps(response_shape, ensure_ascii=True, sort_keys=True)
+        + "\nINPUT:\n"
+        + batch.model_dump_json(exclude_none=False)
+    )
+
+
+def _judge_request(batch: JudgeBatchInput) -> DeepSeekJudgeRequest:
+    user_prompt = _user_prompt(batch)
+    return DeepSeekJudgeRequest(
+        trace_id=(
+            f"openalex-v5-{batch.case_id.casefold()}-pass-{batch.pass_number}"
+        ),
+        system_prompt=_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        batch_input_sha256=batch.sha256(),
+        prompt_sha256=prompt_sha256(_SYSTEM_PROMPT, user_prompt),
+    )
+
+
+def _prepare_cases(
+    packet: DevelopmentPacket,
+    v4_cases: tuple[PreparedScopeLinkCase, ...],
+) -> tuple[PreparedDevelopmentCase, ...]:
+    rows_by_case: defaultdict[str, list[DevelopmentPacketRow]] = defaultdict(list)
+    for row in packet.rows:
+        rows_by_case[row.case_id].append(row)
+    prepared: list[PreparedDevelopmentCase] = []
+    for case in v4_cases:
+        rows = tuple(rows_by_case[case.spec.case_id])
+        if any(row.topic != case.spec.topic for row in rows):
+            raise EvidenceSetDevelopmentError(
+                f"{case.spec.case_id}: packet topic drifted from frozen v4 case"
+            )
+        if any(row.query != case.spec.query for row in rows):
+            raise EvidenceSetDevelopmentError(
+                f"{case.spec.case_id}: packet query drifted from frozen v4 case"
+            )
+        profile = _development_profile(case)
+        candidates = tuple(_locked_candidate(row) for row in rows)
+        kernel_candidates = cast(
+            tuple[OpenAlexClaimScopeCandidate, ...],
+            candidates,
+        )
+        first_input, second_input = build_judge_inputs(
+            case_id=case.spec.case_id,
+            topic=case.spec.topic,
+            profile=profile,
+            candidates=kernel_candidates,
+        )
+        prepared.append(
+            PreparedDevelopmentCase(
+                source_case=case,
+                profile=profile,
+                candidates=candidates,
+                first_input=first_input,
+                second_input=second_input,
+                first_request=_judge_request(first_input),
+                second_request=_judge_request(second_input),
+            )
+        )
+    return tuple(prepared)
+
+
+def verify_frozen_implementation(
+    expected: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Reject dependency drift before output reservation or client creation."""
+
+    expected_hashes = dict(expected or EXPECTED_IMPLEMENTATION_SHA256)
+    if set(_IMPLEMENTATION_PATHS) != set(expected_hashes):
+        raise EvidenceSetDevelopmentError(
+            "development implementation lock names are inconsistent"
+        )
+    observed = {
+        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+    if observed != expected_hashes:
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if expected_hashes.get(name) != digest
+        )
+        raise EvidenceSetDevelopmentError(
+            "development implementation identity drifted: " + ", ".join(changed)
+        )
+    return observed
+
+
+def _load_prepared_study(
+    *,
+    source_lock_path: Path,
+    packet_path: Path,
+    labels_path: Path,
+    declaration_path: Path,
+    v4_fixture_path: Path,
+    expected_source_sha256: Mapping[str, str],
+    expected_v4_fixture_sha256: str,
+) -> tuple[
+    dict[str, str],
+    str,
+    tuple[PreparedDevelopmentCase, ...],
+]:
+    source_sha256, packet = _load_locked_packet(
+        source_lock_path=source_lock_path,
+        packet_path=packet_path,
+        labels_path=labels_path,
+        declaration_path=declaration_path,
+        expected_source_sha256=expected_source_sha256,
+    )
+    fixture_sha256, _, v4_cases = load_v4_frozen_cases(
+        v4_fixture_path,
+        expected_fixture_sha256=expected_v4_fixture_sha256,
+    )
+    return source_sha256, fixture_sha256, _prepare_cases(packet, v4_cases)
+
+
+def _manifest(
+    *,
+    source_sha256: dict[str, str],
+    v4_fixture_sha256: str,
+    implementation_sha256: dict[str, str],
+    runner_sha256: str,
+    cases: tuple[PreparedDevelopmentCase, ...],
+    soft_stop_usd: float,
+) -> DevelopmentManifest:
+    selection = _selection_contract()
+    return DevelopmentManifest(
+        source_sha256=source_sha256,
+        v4_fixture_sha256=v4_fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        selection_contract=selection,
+        selection_contract_sha256=selection.sha256(),
+        soft_stop_usd=soft_stop_usd,
+        cases=tuple(
+            FrozenDevelopmentCase(
+                case_id=case.source_case.spec.case_id,
+                topic=case.source_case.spec.topic,
+                query=case.source_case.spec.query,
+                profile=case.profile,
+                profile_sha256=case.profile.sha256(),
+                first_request=case.first_request,
+                second_request=case.second_request,
+            )
+            for case in cases
+        ),
+    )
+
+
+def protocol_dry_run(
+    *,
+    source_lock_path: Path = DEFAULT_SOURCE_LOCK_PATH,
+    packet_path: Path = DEFAULT_PACKET_PATH,
+    labels_path: Path = DEFAULT_LABELS_PATH,
+    declaration_path: Path = DEFAULT_DECLARATION_PATH,
+    v4_fixture_path: Path = DEFAULT_V4_FIXTURE_PATH,
+    expected_source_sha256: Mapping[str, str] = EXPECTED_SOURCE_SHA256,
+    expected_v4_fixture_sha256: str = EXPECTED_V4_FIXTURE_SHA256,
+    expected_implementation_sha256: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Verify all bytes and prompts while constructing no model client."""
+
+    source_sha256, fixture_sha256, cases = _load_prepared_study(
+        source_lock_path=source_lock_path,
+        packet_path=packet_path,
+        labels_path=labels_path,
+        declaration_path=declaration_path,
+        v4_fixture_path=v4_fixture_path,
+        expected_source_sha256=expected_source_sha256,
+        expected_v4_fixture_sha256=expected_v4_fixture_sha256,
+    )
+    implementation = verify_frozen_implementation(
+        expected_implementation_sha256
+    )
+    return {
+        "mode": "openalex_evidence_set_v5_development_dry_run",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "private_label_bytes_hashed": True,
+        "private_label_content_parsed": False,
+        "source_sha256": source_sha256,
+        "v4_fixture_sha256": fixture_sha256,
+        "implementation_sha256": implementation,
+        "runner_sha256": _file_sha256(_RUNNER_PATH),
+        "case_count": len(cases),
+        "candidate_count": sum(len(case.candidates) for case in cases),
+        "maximum_model_call_count": MAXIMUM_MODEL_CALL_COUNT,
+        "cases": [
+            {
+                "case_id": case.source_case.spec.case_id,
+                "candidate_count": len(case.candidates),
+                "profile_sha256": case.profile.sha256(),
+                "first_input_sha256": case.first_input.sha256(),
+                "second_input_sha256": case.second_input.sha256(),
+                "first_prompt_sha256": case.first_request.prompt_sha256,
+                "second_prompt_sha256": case.second_request.prompt_sha256,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _failed_journal(
+    case_id: str,
+    request: DeepSeekJudgeRequest,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool,
+    request_may_have_spent: bool,
+) -> JudgeCallJournal:
+    return JudgeCallJournal(
+        case_id=case_id,
+        pass_number=int(request.trace_id[-1]),
+        state="failed",
+        request=request,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        request_may_have_spent=request_may_have_spent,
+    )
+
+
+def _validate_response_identity(
+    request: DeepSeekJudgeRequest,
+    response: DeepSeekJudgeResponse,
+) -> str | None:
+    expected = {
+        "trace_id": request.trace_id,
+        "batch_input_sha256": request.batch_input_sha256,
+        "prompt_sha256": request.prompt_sha256,
+        "requested_model": request.requested_model,
+    }
+    observed = {
+        "trace_id": response.trace_id,
+        "batch_input_sha256": response.batch_input_sha256,
+        "prompt_sha256": response.prompt_sha256,
+        "requested_model": response.requested_model,
+    }
+    changed = sorted(key for key in expected if expected[key] != observed[key])
+    return ", ".join(changed) if changed else None
+
+
+def _write_call_journal(output_dir: Path, journal: JudgeCallJournal) -> None:
+    journal_dir = output_dir / "judge-calls"
+    journal_dir.mkdir(exist_ok=True)
+    filename = f"{journal.case_id}-pass-{journal.pass_number}.json"
+    _write_new(journal_dir / filename, _json_text(journal))
+
+
+def _write_case_decision(output_dir: Path, decision: EvidenceSetCaseAudit) -> None:
+    decision_dir = output_dir / "case-decisions"
+    decision_dir.mkdir(exist_ok=True)
+    _write_new(decision_dir / f"{decision.case_id}.json", _json_text(decision))
+
+
+def _evaluate_case(
+    case: PreparedDevelopmentCase,
+    first_raw: str,
+    second_raw: str,
+) -> EvidenceSetCaseAudit:
+    return evaluate_evidence_set_case(
+        case_id=case.source_case.spec.case_id,
+        topic=case.source_case.spec.topic,
+        profile=case.profile,
+        selection_contract=_selection_contract(),
+        candidates=cast(
+            tuple[OpenAlexClaimScopeCandidate, ...],
+            case.candidates,
+        ),
+        first_raw_response=first_raw,
+        second_raw_response=second_raw,
+    )
+
+
+def _execution_artifact(
+    *,
+    manifest_sha256: str,
+    stop_reason: StopReason,
+    calls: list[JudgeCallJournal],
+    decisions: list[EvidenceSetCaseAudit],
+) -> DevelopmentExecution:
+    completed_responses = tuple(
+        call.response
+        for call in calls
+        if call.state == "completed" and call.response is not None
+    )
+    cost_known = len(completed_responses) == len(calls)
+    cost = (
+        sum(response.usage.cost_usd for response in completed_responses)
+        if cost_known
+        else None
+    )
+    numerator = sum(case.judge_agreement_numerator for case in decisions)
+    denominator = sum(case.judge_agreement_denominator for case in decisions)
+    complete = (
+        stop_reason == "completed"
+        and len(calls) == MAXIMUM_MODEL_CALL_COUNT
+        and len(decisions) == 8
+    )
+    candidate_count = sum(len(case.candidate_decisions) for case in decisions)
+    all_persisted = complete and candidate_count == 64
+    return DevelopmentExecution(
+        manifest_sha256=manifest_sha256,
+        overall_state="completed" if complete else "partial",
+        stop_reason=stop_reason,
+        attempted_model_call_count=len(calls),
+        completed_model_call_count=len(completed_responses),
+        completed_case_count=len(decisions),
+        persisted_candidate_decision_count=candidate_count,
+        prompt_tokens=sum(
+            response.usage.prompt_tokens for response in completed_responses
+        ),
+        cached_prompt_tokens=sum(
+            response.usage.cached_prompt_tokens for response in completed_responses
+        ),
+        completion_tokens=sum(
+            response.usage.completion_tokens for response in completed_responses
+        ),
+        total_tokens=sum(
+            response.usage.total_tokens for response in completed_responses
+        ),
+        cost_usd=cost,
+        cost_state="known" if cost_known else "uninspectable",
+        disposition_agreement_numerator=numerator,
+        disposition_agreement_denominator=denominator,
+        disposition_agreement=(numerator / denominator if denominator else None),
+        mechanical_agreement_gate_passed=(
+            numerator / denominator >= 0.9 if denominator else None
+        ),
+        all_decisions_persisted=all_persisted,
+        development_gate_state=(
+            "ready_for_label_join" if all_persisted else "not_evaluated"
+        ),
+        calls=tuple(calls),
+        case_decisions=tuple(decisions),
+    )
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    execution: DevelopmentExecution,
+) -> None:
+    _write_new(output_dir / "execution.json", _json_text(execution))
+    decisions_payload = [
+        decision.model_dump(mode="json") for decision in execution.case_decisions
+    ]
+    _write_new(
+        output_dir / "candidate-decisions.json",
+        _json_text(decisions_payload),
+    )
+    indexed = (
+        "manifest.json",
+        "execution.json",
+        "candidate-decisions.json",
+        *(
+            f"judge-calls/{call.case_id}-pass-{call.pass_number}.json"
+            for call in execution.calls
+        ),
+        *(f"case-decisions/{case.case_id}.json" for case in execution.case_decisions),
+    )
+    index = {
+        "mode": "openalex_evidence_set_v5_development_artifact_index",
+        "files": {
+            name: _file_sha256(output_dir / name) for name in indexed
+        },
+    }
+    _write_new(output_dir / "artifact-index.json", _json_text(index))
+
+
+def execute_development_study(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    acknowledge_model_budget: bool,
+    source_lock_path: Path = DEFAULT_SOURCE_LOCK_PATH,
+    packet_path: Path = DEFAULT_PACKET_PATH,
+    labels_path: Path = DEFAULT_LABELS_PATH,
+    declaration_path: Path = DEFAULT_DECLARATION_PATH,
+    v4_fixture_path: Path = DEFAULT_V4_FIXTURE_PATH,
+    expected_source_sha256: Mapping[str, str] = EXPECTED_SOURCE_SHA256,
+    expected_v4_fixture_sha256: str = EXPECTED_V4_FIXTURE_SHA256,
+    expected_implementation_sha256: Mapping[str, str] | None = None,
+    adapter_factory: AdapterFactory | None = None,
+) -> DevelopmentExecution:
+    """Run at most 16 label-blind calls under a write-once soft stop."""
+
+    if not 0.0 < soft_stop_usd <= MAXIMUM_SOFT_STOP_USD:
+        raise EvidenceSetDevelopmentError(
+            "v5 soft stop must be greater than zero and at most USD 0.20"
+        )
+    if not acknowledge_model_budget:
+        raise EvidenceSetDevelopmentError(
+            "v5 execution requires explicit model-budget acknowledgement"
+        )
+    if output_dir.exists():
+        raise FileExistsError(f"v5 development output already exists: {output_dir}")
+
+    source_sha256, fixture_sha256, cases = _load_prepared_study(
+        source_lock_path=source_lock_path,
+        packet_path=packet_path,
+        labels_path=labels_path,
+        declaration_path=declaration_path,
+        v4_fixture_path=v4_fixture_path,
+        expected_source_sha256=expected_source_sha256,
+        expected_v4_fixture_sha256=expected_v4_fixture_sha256,
+    )
+    implementation = verify_frozen_implementation(
+        expected_implementation_sha256
+    )
+    runner_sha256 = _file_sha256(_RUNNER_PATH)
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest(
+        source_sha256=source_sha256,
+        v4_fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation,
+        runner_sha256=runner_sha256,
+        cases=cases,
+        soft_stop_usd=soft_stop_usd,
+    )
+    manifest_text = _json_text(manifest)
+    _write_new(output_dir / "manifest.json", manifest_text)
+
+    # This must remain after the manifest write.  Constructing the default
+    # adapter resolves a real credential; a future refactor may perform other
+    # paid-capable setup there.  The durable method boundary comes first.
+    adapter = (
+        adapter_factory()
+        if adapter_factory is not None
+        else DeepSeekEvidenceJudgeAdapter()
+    )
+    calls: list[JudgeCallJournal] = []
+    decisions: list[EvidenceSetCaseAudit] = []
+    known_cost = 0.0
+    stop_reason: StopReason = "completed"
+
+    for case in cases:
+        raw_responses: list[str] = []
+        for request in (case.first_request, case.second_request):
+            if known_cost + 1e-12 >= soft_stop_usd:
+                stop_reason = "soft_stop"
+                break
+            try:
+                raw_response = adapter(request)
+                response = DeepSeekJudgeResponse.model_validate(raw_response)
+            except DeepSeekJudgeAdapterError as exc:
+                journal = _failed_journal(
+                    case.source_case.spec.case_id,
+                    request,
+                    failure_type=exc.failure_type,
+                    failure_detail=str(exc),
+                    failure_retryable=exc.retryable,
+                    request_may_have_spent=exc.request_may_have_spent,
+                )
+                stop_reason = "adapter_failed"
+            except ValidationError as exc:
+                journal = _failed_journal(
+                    case.source_case.spec.case_id,
+                    request,
+                    failure_type="adapter_response_invalid",
+                    failure_detail=_safe_validation_detail(exc),
+                    failure_retryable=False,
+                    request_may_have_spent=True,
+                )
+                stop_reason = "response_invalid"
+            else:
+                identity_drift = _validate_response_identity(request, response)
+                if identity_drift:
+                    journal = _failed_journal(
+                        case.source_case.spec.case_id,
+                        request,
+                        failure_type="adapter_response_identity_mismatch",
+                        failure_detail=(
+                            "response identity drifted: " + identity_drift
+                        ),
+                        failure_retryable=False,
+                        request_may_have_spent=True,
+                    )
+                    stop_reason = "response_identity_mismatch"
+                else:
+                    journal = JudgeCallJournal(
+                        case_id=case.source_case.spec.case_id,
+                        pass_number=int(request.trace_id[-1]),
+                        state="completed",
+                        request=request,
+                        response=response,
+                        request_may_have_spent=True,
+                    )
+                    raw_responses.append(response.raw_content)
+
+            # The spent request, response/usage, and terminal disposition are
+            # durable before the loop can consider a second paid call.
+            _write_call_journal(output_dir, journal)
+            calls.append(journal)
+            if journal.state != "completed":
+                break
+            known_cost += journal.response.usage.cost_usd
+
+        if len(raw_responses) == 2:
+            decision = _evaluate_case(case, *raw_responses)
+            _write_case_decision(output_dir, decision)
+            decisions.append(decision)
+        if stop_reason != "completed":
+            break
+
+    execution = _execution_artifact(
+        manifest_sha256=_sha256_bytes(manifest_text.encode("utf-8")),
+        stop_reason=stop_reason,
+        calls=calls,
+        decisions=decisions,
+    )
+    _write_final_artifacts(output_dir, execution)
+    return execution
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    parser.add_argument("--acknowledge-model-budget", action="store_true")
+    parser.add_argument("--source-lock", type=Path, default=DEFAULT_SOURCE_LOCK_PATH)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET_PATH)
+    parser.add_argument("--labels", type=Path, default=DEFAULT_LABELS_PATH)
+    parser.add_argument(
+        "--declaration",
+        type=Path,
+        default=DEFAULT_DECLARATION_PATH,
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    common = {
+        "source_lock_path": args.source_lock,
+        "packet_path": args.packet,
+        "labels_path": args.labels,
+        "declaration_path": args.declaration,
+    }
+    if args.execute_live:
+        if args.output_dir is None or args.soft_stop_usd is None:
+            raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
+        result = execute_development_study(
+            output_dir=args.output_dir,
+            soft_stop_usd=args.soft_stop_usd,
+            acknowledge_model_budget=args.acknowledge_model_budget,
+            **common,
+        )
+    else:
+        result = protocol_dry_run(**common)
+    print(_stdout_json(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/tools/deepseek_evidence_judge.py
+++ b/src/academic_agent/tools/deepseek_evidence_judge.py
@@ -1,0 +1,408 @@
+"""Strict one-request DeepSeek adapter for the disconnected v5 study.
+
+The semantic model is only a proposal mechanism.  This adapter therefore
+owns no retry, repair, fallback, streaming, redirect, or model-selection
+logic.  One invocation is one potentially billable HTTP request, and a
+response is usable only when model identity, token usage, and local pricing
+are all inspectable.  The development runner persists that response before
+it permits another call.
+
+Nothing in the production worker imports this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Literal, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.token_usage import cost_for, price_for
+
+
+DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT = (
+    "https://api.deepseek.com/chat/completions"
+)
+REQUESTED_MODEL = "deepseek-chat"
+_MAX_RESPONSE_BYTES = 1_000_000
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class DeepSeekJudgeAdapterError(RuntimeError):
+    """A safe, classified failure from one model request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_type: str,
+        retryable: bool,
+        request_may_have_spent: bool,
+    ) -> None:
+        super().__init__(message)
+        self.failure_type = failure_type
+        self.retryable = retryable
+        self.request_may_have_spent = request_may_have_spent
+
+
+class DeepSeekJudgeRequest(BaseModel):
+    """Credential-free request identity passed across the paid-call seam."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    trace_id: str = Field(pattern=r"^openalex-v5-w0[1-8]-pass-[12]$")
+    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    system_prompt: str = Field(min_length=20, max_length=20_000)
+    user_prompt: str = Field(min_length=20, max_length=250_000)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    temperature: Literal[0.0] = 0.0
+    max_tokens: int = Field(default=8_000, ge=500, le=12_000)
+
+    @model_validator(mode="after")
+    def _validate_prompt_identity(self) -> "DeepSeekJudgeRequest":
+        payload = {
+            "system": self.system_prompt,
+            "user": self.user_prompt,
+        }
+        observed = _sha256_json(payload)
+        if observed != self.prompt_sha256:
+            raise ValueError("prompt SHA-256 does not match the request text")
+        return self
+
+    def body(self) -> bytes:
+        """Return the exact OpenAI-shaped body, excluding every credential."""
+
+        return json.dumps(
+            {
+                "max_tokens": self.max_tokens,
+                "messages": [
+                    {"content": self.system_prompt, "role": "system"},
+                    {"content": self.user_prompt, "role": "user"},
+                ],
+                "model": self.requested_model,
+                "response_format": {"type": "json_object"},
+                "stream": False,
+                "temperature": self.temperature,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+class DeepSeekJudgeUsage(BaseModel):
+    """Provider usage and locally reproducible cost for one request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    cached_prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+    cost_basis: str = Field(min_length=5, max_length=300)
+
+    @model_validator(mode="after")
+    def _validate_token_accounting(self) -> "DeepSeekJudgeUsage":
+        if self.cached_prompt_tokens > self.prompt_tokens:
+            raise ValueError("cached tokens cannot exceed prompt tokens")
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            raise ValueError("total tokens do not match prompt plus completion")
+        return self
+
+
+class DeepSeekJudgeResponse(BaseModel):
+    """Complete inspectable result from exactly one model request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    trace_id: str = Field(pattern=r"^openalex-v5-w0[1-8]-pass-[12]$")
+    request_sha256: str = Field(pattern=_SHA256_PATTERN)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    returned_model: Literal["deepseek-chat"]
+    provider_response_id: str = Field(min_length=3, max_length=300)
+    provider_request_id: str | None = Field(default=None, max_length=300)
+    finish_reason: str = Field(min_length=1, max_length=100)
+    raw_content: str = Field(min_length=1, max_length=200_000)
+    raw_content_sha256: str = Field(pattern=_SHA256_PATTERN)
+    usage: DeepSeekJudgeUsage
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_content_identity(self) -> "DeepSeekJudgeResponse":
+        if _sha256_text(self.raw_content) != self.raw_content_sha256:
+            raise ValueError("raw model content SHA-256 does not match")
+        return self
+
+
+@dataclass(frozen=True)
+class JudgeTransportResponse:
+    """Raw body plus response headers from one transport invocation."""
+
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class DeepSeekOneRequestTransport(Protocol):
+    """Injected seam whose one invocation equals one outbound request."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> JudgeTransportResponse: ...
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects so one adapter call cannot become two requests."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _UrllibOneRequestTransport:
+    """Default transport with no redirect and no retry behavior."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> JudgeTransportResponse:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method="POST",
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            response_headers = {
+                str(key): str(value) for key, value in response.headers.items()
+            }
+            return JudgeTransportResponse(
+                body=response.read(_MAX_RESPONSE_BYTES + 1),
+                headers=response_headers,
+            )
+
+
+class _ProviderMessage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    content: str = Field(min_length=1, max_length=200_000)
+
+
+class _ProviderChoice(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    finish_reason: str = Field(min_length=1, max_length=100)
+    message: _ProviderMessage
+
+
+class _ProviderUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    prompt_cache_hit_tokens: int = Field(default=0, ge=0)
+
+
+class _ProviderEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str = Field(min_length=3, max_length=300)
+    model: str = Field(min_length=3, max_length=200)
+    choices: tuple[_ProviderChoice, ...] = Field(min_length=1, max_length=1)
+    usage: _ProviderUsage
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return _sha256_text(canonical)
+
+
+def prompt_sha256(system_prompt: str, user_prompt: str) -> str:
+    """Bind both messages without depending on provider wire formatting."""
+
+    return _sha256_json({"system": system_prompt, "user": user_prompt})
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str | None:
+    expected = name.casefold()
+    return next(
+        (value for key, value in headers.items() if key.casefold() == expected),
+        None,
+    )
+
+
+def _safe_validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "provider response schema invalid"
+
+
+class DeepSeekEvidenceJudgeAdapter:
+    """Perform exactly one fixed-model JSON request with strict accounting."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 60.0,
+        transport: DeepSeekOneRequestTransport | None = None,
+        monotonic_clock=None,  # noqa: ANN001
+    ) -> None:
+        resolved_key = (api_key or os.getenv("DEEPSEEK_API_KEY") or "").strip()
+        if not resolved_key:
+            raise ValueError("DEEPSEEK_API_KEY is required for the v5 judge")
+        if not 0 < timeout <= 120:
+            raise ValueError("timeout must be greater than zero and at most 120 seconds")
+        self._api_key = resolved_key
+        self._timeout = timeout
+        self._transport = transport or _UrllibOneRequestTransport()
+        self._clock = monotonic_clock or time.perf_counter
+
+    def __call__(self, request: DeepSeekJudgeRequest) -> DeepSeekJudgeResponse:
+        """Send one request; all failures are terminal for the study runner."""
+
+        body = request.body()
+        request_sha256 = hashlib.sha256(body).hexdigest()
+        started_at = self._clock()
+        try:
+            transport_response = self._transport(
+                endpoint=DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT,
+                body=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "AcademicAgentEvidenceSetV5/1.0",
+                    "X-Client-Request-ID": request.trace_id,
+                },
+                timeout=self._timeout,
+            )
+        except HTTPError as exc:
+            is_redirect = 300 <= exc.code < 400
+            raise DeepSeekJudgeAdapterError(
+                f"DeepSeek HTTP {exc.code}",
+                failure_type=("provider_redirect" if is_redirect else "provider_http"),
+                retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
+                request_may_have_spent=not is_redirect,
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise DeepSeekJudgeAdapterError(
+                f"DeepSeek transport failed: {type(exc).__name__}",
+                failure_type="provider_transport",
+                retryable=True,
+                request_may_have_spent=True,
+            ) from exc
+        latency_ms = max((self._clock() - started_at) * 1000.0, 0.0)
+
+        if len(transport_response.body) > _MAX_RESPONSE_BYTES:
+            raise DeepSeekJudgeAdapterError(
+                "DeepSeek response exceeded the byte limit",
+                failure_type="provider_response_too_large",
+                retryable=False,
+                request_may_have_spent=True,
+            )
+        try:
+            decoded = json.loads(transport_response.body.decode("utf-8"))
+            envelope = _ProviderEnvelope.model_validate(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            detail = (
+                _safe_validation_detail(exc)
+                if isinstance(exc, ValidationError)
+                else type(exc).__name__
+            )
+            raise DeepSeekJudgeAdapterError(
+                f"DeepSeek response failed schema validation: {detail}",
+                failure_type="provider_response_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+            ) from exc
+
+        if envelope.model != request.requested_model:
+            raise DeepSeekJudgeAdapterError(
+                "DeepSeek returned a model identity inconsistent with the request",
+                failure_type="provider_model_identity_mismatch",
+                retryable=False,
+                request_may_have_spent=True,
+            )
+        metrics = SimpleNamespace(
+            prompt_tokens=envelope.usage.prompt_tokens,
+            cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
+            cache_creation_tokens=0,
+            completion_tokens=envelope.usage.completion_tokens,
+        )
+        cost = cost_for(envelope.model, metrics)
+        price = price_for(envelope.model)
+        if cost is None or price is None:
+            raise DeepSeekJudgeAdapterError(
+                "DeepSeek token cost is not inspectable for the returned model",
+                failure_type="provider_cost_uninspectable",
+                retryable=False,
+                request_may_have_spent=True,
+            )
+        try:
+            usage = DeepSeekJudgeUsage(
+                prompt_tokens=envelope.usage.prompt_tokens,
+                cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
+                completion_tokens=envelope.usage.completion_tokens,
+                total_tokens=envelope.usage.total_tokens,
+                cost_usd=cost,
+                cost_basis=price.basis,
+            )
+        except ValidationError as exc:
+            raise DeepSeekJudgeAdapterError(
+                "DeepSeek usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+            ) from exc
+        choice = envelope.choices[0]
+        return DeepSeekJudgeResponse(
+            trace_id=request.trace_id,
+            request_sha256=request_sha256,
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model=envelope.model,
+            provider_response_id=envelope.id,
+            provider_request_id=(
+                _header_value(transport_response.headers, "x-request-id")
+                or _header_value(transport_response.headers, "x-ds-request-id")
+            ),
+            finish_reason=choice.finish_reason,
+            raw_content=choice.message.content,
+            raw_content_sha256=_sha256_text(choice.message.content),
+            usage=usage,
+            latency_ms=latency_ms,
+        )

--- a/tests/test_deepseek_evidence_judge.py
+++ b/tests/test_deepseek_evidence_judge.py
@@ -1,0 +1,196 @@
+"""Zero-network transport and accounting seams for the v5 judge adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from academic_agent.tools.deepseek_evidence_judge import (
+    DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT,
+    DeepSeekEvidenceJudgeAdapter,
+    DeepSeekJudgeAdapterError,
+    DeepSeekJudgeRequest,
+    JudgeTransportResponse,
+    prompt_sha256,
+)
+
+
+def _request() -> DeepSeekJudgeRequest:
+    system = "Classify supplied evidence and return only strict JSON."
+    user = "Evaluate all candidates and preserve their exact order in JSON."
+    return DeepSeekJudgeRequest(
+        trace_id="openalex-v5-w01-pass-1",
+        system_prompt=system,
+        user_prompt=user,
+        batch_input_sha256="1" * 64,
+        prompt_sha256=prompt_sha256(system, user),
+    )
+
+
+def _provider_body(*, model: str = "deepseek-chat") -> bytes:
+    return json.dumps(
+        {
+            "id": "response-123",
+            "model": model,
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"content": '{"case_id":"W01"}'},
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "prompt_cache_hit_tokens": 20,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class RecordingTransport:
+    def __init__(self, body: bytes | None = None) -> None:
+        self.body = body or _provider_body()
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.calls.append(kwargs)
+        return JudgeTransportResponse(
+            body=self.body,
+            headers={"X-Request-ID": "provider-request-456"},
+        )
+
+
+def test_adapter_sends_one_fixed_endpoint_request_without_leaking_key():
+    transport = RecordingTransport()
+    adapter = DeepSeekEvidenceJudgeAdapter(
+        api_key="secret-deepseek-key",
+        transport=transport,
+        monotonic_clock=iter((1.0, 1.25)).__next__,
+    )
+
+    response = adapter(_request())
+
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call["endpoint"] == DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT
+    assert call["timeout"] == 60.0
+    assert call["headers"]["Authorization"] == "Bearer secret-deepseek-key"
+    assert b"secret-deepseek-key" not in call["body"]
+    payload = json.loads(call["body"])
+    assert payload["model"] == "deepseek-chat"
+    assert payload["temperature"] == 0.0
+    assert payload["stream"] is False
+    assert payload["response_format"] == {"type": "json_object"}
+    assert response.returned_model == "deepseek-chat"
+    assert response.provider_request_id == "provider-request-456"
+    assert response.latency_ms == pytest.approx(250.0)
+    assert response.usage.cached_prompt_tokens == 20
+    assert response.usage.cost_usd > 0
+    assert "built-in table" in response.usage.cost_basis
+    assert response.request_sha256 == hashlib.sha256(call["body"]).hexdigest()
+
+
+def test_model_identity_mismatch_is_terminal_and_never_retried():
+    transport = RecordingTransport(_provider_body(model="deepseek-reasoner"))
+    adapter = DeepSeekEvidenceJudgeAdapter(
+        api_key="secret",
+        transport=transport,
+    )
+
+    with pytest.raises(
+        DeepSeekJudgeAdapterError,
+        match="model identity inconsistent",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_model_identity_mismatch"
+    assert caught.value.retryable is False
+    assert caught.value.request_may_have_spent is True
+    assert len(transport.calls) == 1
+
+
+class RedirectTransport:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.call_count += 1
+        raise HTTPError(
+            kwargs["endpoint"],
+            302,
+            "redirect",
+            {},
+            None,
+        )
+
+
+def test_redirect_is_a_single_terminal_attempt_with_no_secret_in_error():
+    transport = RedirectTransport()
+    adapter = DeepSeekEvidenceJudgeAdapter(
+        api_key="do-not-persist-this-key",
+        transport=transport,
+    )
+
+    with pytest.raises(DeepSeekJudgeAdapterError) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_redirect"
+    assert caught.value.request_may_have_spent is False
+    assert "do-not-persist-this-key" not in str(caught.value)
+    assert transport.call_count == 1
+
+
+def test_missing_usage_is_uninspectable_instead_of_zero_cost():
+    payload = json.loads(_provider_body())
+    del payload["usage"]
+    transport = RecordingTransport(json.dumps(payload).encode("utf-8"))
+    adapter = DeepSeekEvidenceJudgeAdapter(
+        api_key="secret",
+        transport=transport,
+    )
+
+    with pytest.raises(
+        DeepSeekJudgeAdapterError,
+        match="schema validation",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_response_invalid"
+    assert len(transport.calls) == 1
+
+
+def test_inconsistent_token_totals_are_uninspectable_and_not_retried():
+    payload = json.loads(_provider_body())
+    payload["usage"]["total_tokens"] = 999
+    transport = RecordingTransport(json.dumps(payload).encode("utf-8"))
+    adapter = DeepSeekEvidenceJudgeAdapter(
+        api_key="secret",
+        transport=transport,
+    )
+
+    with pytest.raises(
+        DeepSeekJudgeAdapterError,
+        match="usage accounting",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_usage_invalid"
+    assert caught.value.retryable is False
+    assert caught.value.request_may_have_spent is True
+    assert len(transport.calls) == 1
+
+
+def test_request_rejects_a_prompt_hash_that_does_not_bind_both_messages():
+    with pytest.raises(ValueError, match="prompt SHA-256"):
+        DeepSeekJudgeRequest(
+            trace_id="openalex-v5-w01-pass-1",
+            system_prompt="A sufficiently long system classification instruction.",
+            user_prompt="A sufficiently long user evidence classification request.",
+            batch_input_sha256="2" * 64,
+            prompt_sha256="3" * 64,
+        )

--- a/tests/test_openalex_evidence_set_development.py
+++ b/tests/test_openalex_evidence_set_development.py
@@ -1,0 +1,455 @@
+"""Zero-network seams for the label-blind v5 development runner."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import openalex_evidence_set_development as development
+from academic_agent.tools.deepseek_evidence_judge import (
+    DeepSeekJudgeAdapterError,
+    DeepSeekJudgeRequest,
+    DeepSeekJudgeResponse,
+    DeepSeekJudgeUsage,
+)
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_V4_FIXTURE = _ROOT / "tests/fixtures/openalex_scope_link_v4_challenge.json"
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+@dataclass(frozen=True)
+class SourceBundle:
+    source_lock: Path
+    packet: Path
+    labels: Path
+    declaration: Path
+    hashes: dict[str, str]
+
+
+def _source_bundle(tmp_path: Path) -> SourceBundle:
+    fixture = json.loads(_V4_FIXTURE.read_text(encoding="utf-8"))
+    source_lock = tmp_path / "source-lock.json"
+    source_lock.write_bytes(b'{"frozen":true}\n')
+    rows = []
+    for case in fixture["challenge_cases"]:
+        role_phrases = [
+            group["text_phrases"][0]
+            for key in ("required_groups", "scope_groups", "supporting_groups")
+            for group in case["profile"][key]
+        ]
+        for index in range(8):
+            identity = hashlib.sha256(
+                f"{case['case_id']}-identity-{index}".encode()
+            ).hexdigest()
+            candidate = hashlib.sha256(
+                f"{case['case_id']}-candidate-{index}".encode()
+            ).hexdigest()
+            rows.append(
+                {
+                    "baseline_sources_json": (
+                        '[{"evidence_summary":"DO_NOT_SEND_BASELINE"}]'
+                    ),
+                    "candidate_sha256": candidate,
+                    "case_id": case["case_id"],
+                    "declared_gap": "frozen academic evidence retrieval gap",
+                    "doi": f"10.1000/{case['case_id'].casefold()}.{index}",
+                    "evidence_summary": (
+                        "The source discusses " + ", ".join(role_phrases) + "."
+                    ),
+                    "identity_sha256": identity,
+                    "provider": "openalex",
+                    "provider_result_index": index,
+                    "published_date": "2026-08-29",
+                    "publisher": "Frozen Test Journal",
+                    "query": case["query"],
+                    "summary_source": "abstract",
+                    "title": f"{case['topic']} candidate {index}",
+                    "topic": case["topic"],
+                    "url": f"https://openalex.org/W{case['case_id'][1:]}{index}",
+                }
+            )
+    packet_payload = {
+        "case_count": 8,
+        "diagnostic_only": True,
+        "executed_revision": "1" * 40,
+        "measurement_limit": (
+            "Synthetic zero-network packet for runner boundary tests only."
+        ),
+        "mode": "openalex_scope_link_v4_candidate_diagnostic_packet",
+        "prepared_at": "2026-08-29T00:00:00+00:00",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "row_count": 64,
+        "rows": rows,
+        "schema_version": 1,
+        "source_file_sha256": {"execution.json": "2" * 64},
+        "source_lock_sha256": _sha256(source_lock.read_bytes()),
+        "valid_label_combinations": [["YES", "YES", "YES", "YES"]],
+    }
+    packet = tmp_path / "packet_manifest.json"
+    packet.write_text(
+        json.dumps(packet_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    # Invalid UTF-8 makes accidental text parsing fail immediately.  A valid
+    # dry-run proves these bytes are hashed but never decoded or interpreted.
+    labels = tmp_path / "labels.csv"
+    labels.write_bytes(b"\xff\xfeDO_NOT_SEND_HUMAN_LABEL")
+    declaration = tmp_path / "reviewer_declaration.csv"
+    declaration.write_bytes(b"\xff\xfeDO_NOT_SEND_REVIEWER_DECLARATION")
+    hashes = {
+        "source-lock.json": _sha256(source_lock.read_bytes()),
+        "packet_manifest.json": _sha256(packet.read_bytes()),
+        "labels.csv": _sha256(labels.read_bytes()),
+        "reviewer_declaration.csv": _sha256(declaration.read_bytes()),
+    }
+    return SourceBundle(source_lock, packet, labels, declaration, hashes)
+
+
+def _implementation_hashes() -> dict[str, str]:
+    return {
+        name: development._file_sha256(path)  # noqa: SLF001
+        for name, path in development._IMPLEMENTATION_PATHS.items()  # noqa: SLF001
+    }
+
+
+def _common(bundle: SourceBundle) -> dict[str, object]:
+    return {
+        "source_lock_path": bundle.source_lock,
+        "packet_path": bundle.packet,
+        "labels_path": bundle.labels,
+        "declaration_path": bundle.declaration,
+        "v4_fixture_path": _V4_FIXTURE,
+        "expected_source_sha256": bundle.hashes,
+        "expected_v4_fixture_sha256": development.EXPECTED_V4_FIXTURE_SHA256,
+        "expected_implementation_sha256": _implementation_hashes(),
+    }
+
+
+def _abstain_content(request: DeepSeekJudgeRequest) -> str:
+    batch = json.loads(request.user_prompt.split("\nINPUT:\n", 1)[1])
+    order = [item["candidate_sha256"] for item in batch["candidates"]]
+    return json.dumps(
+        {
+            "case_id": batch["case_id"],
+            "candidate_order": order,
+            "decisions": [
+                {
+                    "candidate_sha256": candidate_sha256,
+                    "action": "ABSTAIN",
+                    "role_quotes": [],
+                }
+                for candidate_sha256 in order
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+
+def _response(
+    request: DeepSeekJudgeRequest,
+    *,
+    cost_usd: float = 0.001,
+    prompt_sha256: str | None = None,
+) -> DeepSeekJudgeResponse:
+    content = _abstain_content(request)
+    return DeepSeekJudgeResponse(
+        trace_id=request.trace_id,
+        request_sha256=hashlib.sha256(request.body()).hexdigest(),
+        batch_input_sha256=request.batch_input_sha256,
+        prompt_sha256=prompt_sha256 or request.prompt_sha256,
+        requested_model="deepseek-chat",
+        returned_model="deepseek-chat",
+        provider_response_id=f"response-{request.trace_id}",
+        provider_request_id=f"request-{request.trace_id}",
+        finish_reason="stop",
+        raw_content=content,
+        raw_content_sha256=hashlib.sha256(content.encode()).hexdigest(),
+        usage=DeepSeekJudgeUsage(
+            prompt_tokens=10,
+            cached_prompt_tokens=0,
+            completion_tokens=2,
+            total_tokens=12,
+            cost_usd=cost_usd,
+            cost_basis="frozen test price basis",
+        ),
+        latency_ms=10.0,
+    )
+
+
+class OrderedAdapter:
+    def __init__(self, output_dir: Path, *, cost_usd: float = 0.001) -> None:
+        self.output_dir = output_dir
+        self.cost_usd = cost_usd
+        self.requests: list[DeepSeekJudgeRequest] = []
+
+    def __call__(self, request: DeepSeekJudgeRequest) -> DeepSeekJudgeResponse:
+        call_index = len(self.requests)
+        if call_index:
+            previous_case = f"W{((call_index - 1) // 2) + 1:02d}"
+            previous_pass = ((call_index - 1) % 2) + 1
+            previous = (
+                self.output_dir
+                / "judge-calls"
+                / f"{previous_case}-pass-{previous_pass}.json"
+            )
+            assert previous.is_file()
+        if call_index and call_index % 2 == 0:
+            prior_case = f"W{call_index // 2:02d}"
+            assert (
+                self.output_dir / "case-decisions" / f"{prior_case}.json"
+            ).is_file()
+        self.requests.append(request)
+        return _response(request, cost_usd=self.cost_usd)
+
+
+class ManifestFirstFactory:
+    def __init__(self, output_dir: Path, adapter: OrderedAdapter) -> None:
+        self.output_dir = output_dir
+        self.adapter = adapter
+        self.call_count = 0
+
+    def __call__(self) -> OrderedAdapter:
+        self.call_count += 1
+        assert (self.output_dir / "manifest.json").is_file()
+        return self.adapter
+
+
+def _execute(
+    tmp_path: Path,
+    bundle: SourceBundle,
+    *,
+    soft_stop_usd: float = 0.05,
+    cost_usd: float = 0.001,
+):
+    output = tmp_path / "result"
+    adapter = OrderedAdapter(output, cost_usd=cost_usd)
+    factory = ManifestFirstFactory(output, adapter)
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=soft_stop_usd,
+        acknowledge_model_budget=True,
+        adapter_factory=factory,
+        **_common(bundle),
+    )
+    return output, adapter, factory, result
+
+
+def test_dry_run_hashes_opaque_labels_and_builds_16_label_blind_prompts(tmp_path):
+    bundle = _source_bundle(tmp_path)
+
+    result = development.protocol_dry_run(**_common(bundle))
+
+    assert result["case_count"] == 8
+    assert result["candidate_count"] == 64
+    assert result["maximum_model_call_count"] == 16
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["private_label_bytes_hashed"] is True
+    assert result["private_label_content_parsed"] is False
+    assert len({case["first_prompt_sha256"] for case in result["cases"]}) == 8
+    assert len({case["second_prompt_sha256"] for case in result["cases"]}) == 8
+
+
+def test_full_execution_persists_each_call_and_case_before_the_next(tmp_path):
+    bundle = _source_bundle(tmp_path)
+
+    output, adapter, factory, result = _execute(tmp_path, bundle)
+
+    assert factory.call_count == 1
+    assert len(adapter.requests) == 16
+    assert result.overall_state == "completed"
+    assert result.stop_reason == "completed"
+    assert result.attempted_model_call_count == 16
+    assert result.completed_case_count == 8
+    assert result.persisted_candidate_decision_count == 64
+    assert result.disposition_agreement == 1.0
+    assert result.mechanical_agreement_gate_passed is True
+    assert result.development_gate_state == "ready_for_label_join"
+    assert result.cost_usd == pytest.approx(0.016)
+    assert len(tuple((output / "judge-calls").glob("*.json"))) == 16
+    assert len(tuple((output / "case-decisions").glob("*.json"))) == 8
+    assert (output / "artifact-index.json").is_file()
+
+
+def test_manifest_and_model_boundary_exclude_baseline_urls_and_human_bytes(tmp_path):
+    bundle = _source_bundle(tmp_path)
+
+    output, _, _, _ = _execute(tmp_path, bundle)
+
+    manifest = (output / "manifest.json").read_text(encoding="utf-8")
+    assert "DO_NOT_SEND_BASELINE" not in manifest
+    assert "DO_NOT_SEND_HUMAN_LABEL" not in manifest
+    assert "DO_NOT_SEND_REVIEWER_DECLARATION" not in manifest
+    assert "openalex.org" not in manifest
+    parsed = json.loads(manifest)
+    for case in parsed["cases"]:
+        first = case["first_request"]["user_prompt"]
+        second = case["second_request"]["user_prompt"]
+        first_batch = json.loads(first.split("\nINPUT:\n", 1)[1])
+        second_batch = json.loads(second.split("\nINPUT:\n", 1)[1])
+        assert list(first_batch["candidates"]) == list(
+            reversed(second_batch["candidates"])
+        )
+        for candidate in first_batch["candidates"]:
+            assert set(candidate) == {"candidate_sha256", "title", "abstract"}
+
+
+def test_source_drift_stops_before_output_or_adapter_construction(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    bundle.packet.write_text("{}", encoding="utf-8")
+    factory_calls = 0
+
+    def factory():  # noqa: ANN202
+        nonlocal factory_calls
+        factory_calls += 1
+        raise AssertionError("adapter must not be constructed")
+
+    with pytest.raises(
+        development.EvidenceSetDevelopmentError,
+        match="source identity drifted",
+    ):
+        development.execute_development_study(
+            output_dir=tmp_path / "result",
+            soft_stop_usd=0.05,
+            acknowledge_model_budget=True,
+            adapter_factory=factory,
+            **_common(bundle),
+        )
+
+    assert factory_calls == 0
+    assert not (tmp_path / "result").exists()
+
+
+def test_soft_stop_commits_in_flight_call_and_starts_no_second_call(tmp_path):
+    bundle = _source_bundle(tmp_path)
+
+    output, adapter, _, result = _execute(
+        tmp_path,
+        bundle,
+        soft_stop_usd=0.0005,
+        cost_usd=0.001,
+    )
+
+    assert len(adapter.requests) == 1
+    assert result.overall_state == "partial"
+    assert result.stop_reason == "soft_stop"
+    assert result.attempted_model_call_count == 1
+    assert result.completed_case_count == 0
+    assert result.development_gate_state == "not_evaluated"
+    assert (output / "judge-calls/W01-pass-1.json").is_file()
+
+
+class IdentityDriftAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request: DeepSeekJudgeRequest) -> DeepSeekJudgeResponse:
+        self.call_count += 1
+        return _response(request, prompt_sha256="f" * 64)
+
+
+def test_response_identity_drift_is_persisted_and_no_retry_occurs(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    output = tmp_path / "result"
+    adapter = IdentityDriftAdapter()
+
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **_common(bundle),
+    )
+
+    assert adapter.call_count == 1
+    assert result.stop_reason == "response_identity_mismatch"
+    assert result.cost_state == "uninspectable"
+    journal = json.loads(
+        (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
+    )
+    assert journal["state"] == "failed"
+    assert journal["failure_type"] == "adapter_response_identity_mismatch"
+    assert "prompt_sha256" in journal["failure_detail"]
+
+
+class FailureAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        del request
+        self.call_count += 1
+        raise DeepSeekJudgeAdapterError(
+            "provider transport failed",
+            failure_type="provider_transport",
+            retryable=True,
+            request_may_have_spent=True,
+        )
+
+
+def test_adapter_failure_is_one_attempt_and_not_a_silent_pass(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    output = tmp_path / "result"
+    adapter = FailureAdapter()
+
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **_common(bundle),
+    )
+
+    assert adapter.call_count == 1
+    assert result.stop_reason == "adapter_failed"
+    assert result.completed_model_call_count == 0
+    assert result.disposition_agreement is None
+    assert result.mechanical_agreement_gate_passed is None
+    assert result.development_gate_state == "not_evaluated"
+
+
+def test_existing_output_and_missing_budget_acknowledgement_fail_closed(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    output = tmp_path / "result"
+    output.mkdir()
+
+    with pytest.raises(FileExistsError):
+        development.execute_development_study(
+            output_dir=output,
+            soft_stop_usd=0.05,
+            acknowledge_model_budget=True,
+            adapter_factory=lambda: FailureAdapter(),
+            **_common(bundle),
+        )
+
+    with pytest.raises(
+        development.EvidenceSetDevelopmentError,
+        match="budget acknowledgement",
+    ):
+        development.execute_development_study(
+            output_dir=tmp_path / "other",
+            soft_stop_usd=0.05,
+            acknowledge_model_budget=False,
+            adapter_factory=lambda: FailureAdapter(),
+            **_common(bundle),
+        )
+
+
+def test_production_worker_remains_disconnected_from_runner_and_adapter():
+    worker = (_ROOT / "src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "openalex_evidence_set_development" not in worker
+    assert "deepseek_evidence_judge" not in worker
+    assert "DeepSeekEvidenceJudgeAdapter" not in worker


### PR DESCRIPTION
Implements the pre-registered W01-W08 evidence-set v5 development boundary without connecting it to production. The change adds a strict one-request DeepSeek adapter, source and implementation identity locks, label-opacity guarantees, durable manifest and per-call write ordering, explicit usage and cost accounting, and fail-closed partial states. Human label and reviewer declaration bytes are hashed but never parsed. Verification: real zero-network preflight checked 8/8 cases, 64/64 candidates, and 16 distinct prompt identities; 15 focused tests passed; the complete suite passed 1,748 tests plus 639 subtests; latest Ruff passed; narrow E0701 Pylint scored 10.00/10. The manifest-order defect was re-injected and made the client-boundary test fail before restoration. No model call, OpenAlex request, label join, production import, report connection, or planner trigger is authorized by this PR.