### PR TITLE
Repair v5 judge contract after DeepSeek alias drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1748 tests (639 subtests), CI green on Linux + Windows × Python
+Current state: 1751 tests (639 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -421,8 +421,8 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   plus
   docs/results-2026-08-29-openalex-scope-link-v4-abstention-diagnostic-review.md.
   A separately pre-registered quote-grounded evidence-set v5 hypothesis uses
-  that diagnostic only for development qualification. A label-blind
-  `deepseek-chat` judge must produce mechanically verified title/abstract
+  that diagnostic only for development qualification. The originally frozen
+  label-blind `deepseek-chat` judge must produce mechanically verified source
   quotes in two order-reversed passes, and a deterministic set-cover step may
   combine at most three complementary sources. W01-W08 remain consumed
   development evidence; raw-byte-locked X01-X08 are the unseen challenge. All
@@ -440,13 +440,33 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   usage identity drift, and uninspectable cost. The runner writes its complete
   manifest before client construction, each response and usage before a later
   call, and each deterministic case decision before a later case. The focused
-  runner/adapter suite passes 15/15 tests, including a temporarily re-injected
-  manifest-order defect. The real zero-network preflight verified 8/8 cases,
-  64/64 candidate identities and 16 distinct prompt identities. No model call
-  or OpenAlex request occurred; human bytes were hashed but never parsed.
+  runner/adapter suite now passes 16/16 tests. The first authorized execution
+  on merged revision `5f6526b` made one potentially billable request and then
+  stopped without retry because the returned model identity did not equal the
+  frozen legacy alias. It is `partial / not_evaluated`: zero completed calls,
+  cases and candidate decisions; its cost is uninspectable, not zero; and no
+  raw semantic response was persisted. It made zero OpenAlex requests, parsed
+  no human labels and remained disconnected from production.
+  A separately frozen amendment now requests exact `deepseek-v4-flash` with
+  thinking explicitly disabled, keeps exact model rejection, and persists
+  only safe returned-model and usage observations when semantic output is
+  rejected. Aggregate tokens and cost are checked against the call journals;
+  one uninspectable potentially spending call makes the whole cost
+  uninspectable. Conservative V4 Flash peak rates carry their own 2026-08-30
+  basis date. The real zero-network preflight again verified 8/8 cases, 64/64
+  candidate identities, 16 prompt identities and all implementation hashes.
+  Removing `thinking.disabled` made the outbound seam test fail before the
+  correct implementation was restored. No later paid request is authorized or
+  has occurred. W01-W08 remain consumed development evidence, and this
+  transport amendment does not reopen their semantic method or gates.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
-  docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md.
+  docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
+  plus
+  docs/results-2026-08-30-openalex-evidence-set-v5-development-provider-drift.md,
+  docs/prereg-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment.md,
+  and
+  docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md.
   Keep
   `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5
   candidates, live runners and review modules.

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ before a later request. Every provider row reaches the aggregate artifact, and
 only v4 `ACCEPT` rows reach a blank human-review boundary. The combined v4
 decision, preflight and runner subset passes 32/32 tests, including a
 re-injected computed-but-undelivered relation-provenance defect. The complete
-repository now passes **1,748 tests plus 639 subtests**. A separately
+repository now passes **1,751 tests plus 639 subtests**. A separately
 authorized run on merged revision `678254d` completed all eight one-attempt
 anonymous requests for USD 0.008 of provider-reported usage. All 64 provider
 rows reached the v4 decision seam, but the method accepted zero candidates
@@ -662,14 +662,31 @@ now locks the exact packet, source lock, completed human labels and declaration
 before parsing only the label-blind packet. It derives roles mechanically from
 frozen v4 text groups, writes the manifest before client construction, and
 commits every response, usage record and case decision before later paid work.
-Its strict one-request DeepSeek adapter and runner pass 15/15 focused tests. A
-real zero-network preflight verified 8/8 cases, 64/64 candidates and 16 unique
-prompt identities. The full suite passes **1,748 tests plus 639 subtests**. No
-model call, OpenAlex request, human-label parse or production connection has
-occurred. See the
+Its strict one-request DeepSeek adapter and runner now pass 16/16 focused tests.
+The first separately authorized development execution on merged revision
+`5f6526b` made one potentially billable request and stopped without retry when
+the provider-returned model identity did not equal the frozen legacy
+`deepseek-chat` alias. The strict result is `partial / not_evaluated`: zero
+calls completed, zero cases or candidate decisions completed, cost is
+`uninspectable` rather than zero, no raw semantic response was retained, and
+no OpenAlex request, human-label parse or production connection occurred.
+
+A separately frozen provider-contract amendment now requests exact
+`deepseek-v4-flash` with thinking explicitly disabled, preserves exact identity
+rejection, and carries safe failed-call usage through the write-once journal
+and aggregate execution boundary without carrying semantic output. It uses
+DeepSeek's dated peak V4 Flash rates so the fixed soft stop is conservative.
+The updated real zero-network preflight again verified 8/8 cases, 64/64
+candidates and 16 unique prompt identities; the complete suite passes **1,751
+tests plus 639 subtests**. Removing the disabled-thinking field made the
+outbound seam test fail before the correct implementation was restored. No
+later paid request is authorized or has occurred. See the
 [v5 pre-registration](docs/prereg-2026-08-29-openalex-evidence-set-v5.md),
 [kernel result](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md),
-and [development-runner result](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md).
+[development-runner result](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md),
+[first provider-stop result](docs/results-2026-08-30-openalex-evidence-set-v5-development-provider-drift.md),
+[provider-contract amendment](docs/prereg-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment.md),
+and [amendment implementation result](docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md).
 
 The canary's garbled FDA PDF title was measured before any recovery rule was
 written. The original 30-run benchmark had a zero denominator; a wider
@@ -1781,7 +1798,7 @@ runner 已实现：它在构造适配器前记录冻结方法与自身观测哈�
 下一次请求前先提交当前单请求 case journal。每一条供应商返回行都会到达
 聚合产物，只有 v4 `ACCEPT` 行会进入空白人工评审边界。v4 决策、预检与
 runner 组合测试为 32/32；临时移除内部已算出的 relation provenance 后，
-客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,748 项测试与 639 个
+客户端 CSV 接缝测试会准确失败。当前全仓通过 **1,751 项测试与 639 个
 subtests**。随后在合并版本 `678254d` 上单独授权的真实实验完成了 8 次匿名、
 不重试的顺序请求，供应商记账成本为 0.008 美元。64 条供应商候选全部到达
 v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结的 6/8 门槛。
@@ -1820,13 +1837,26 @@ v4 决策接缝，但该方法接受 0 条、覆盖 0/8 个案例，低于冻结
 已完成人工标签和声明，只解析标签盲化的来源包；角色描述由冻结的 v4 文本组机械
 生成。严格的单请求 DeepSeek 适配器不重定向、不重试，并拒绝模型身份、usage 或
 费用不可检查的结果。runner 会在构造客户端前写 manifest，在后续付费调用前写入
-当前响应和 usage，并在下一案例前写入完整确定性决策。适配器与 runner 的 15/15
-项定向测试全绿；真实零网络预检验证了 8/8 案例、64/64 候选和 16 个唯一 prompt
-身份。当前全仓通过 **1,748 项测试与 639 个 subtests**。尚未发生模型调用、
-OpenAlex 请求、人工标签解析或生产接入。详见
+当前响应和 usage，并在下一案例前写入完整确定性决策。适配器与 runner 的定向
+测试在修订后为 16/16。首次另行授权的开发执行在合并版本 `5f6526b` 上只
+发出 1 个可能计费的请求；供应商返回身份与冻结的旧 `deepseek-chat` 别名不一致，
+严格适配器因此不重试并立即停止。结论是 `partial / not_evaluated`：完成 0 次调用、
+0 个案例和 0 条候选决策，费用为 `uninspectable` 而不是零，且没有保留原始语义
+响应、发起 OpenAlex 请求、解析人工标签或接入生产。
+
+另行冻结的供应商契约修订现在精确请求 `deepseek-v4-flash` 并显式关闭 thinking，
+继续拒绝任何返回身份漂移；失败响应只允许安全的模型名与 usage 穿过 write-once
+journal 和聚合执行接缝，不允许语义内容穿过。固定预算按带日期的 V4 Flash 峰值
+费率保守估算。更新后的真实零网络预检再次验证 8/8 案例、64/64 候选和 16 个
+prompt 身份；当前全仓通过 **1,751 项测试与 639 个 subtests**。临时移除
+`thinking.disabled` 后，出站接缝测试会准确失败，随后已恢复正确实现。尚未授权或
+执行后续付费请求。详见
 [v5 预注册协议](docs/prereg-2026-08-29-openalex-evidence-set-v5.md)、
 [内核实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md)和
-[开发 runner 实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md)。
+[开发 runner 实现结果](docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md)，
+以及[首次供应商停止结果](docs/results-2026-08-30-openalex-evidence-set-v5-development-provider-drift.md)、
+[供应商契约修订](docs/prereg-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment.md)和
+[修订实现结果](docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md)。
 
 针对该 canary 中出现的 FDA PDF 标题乱码，项目先计量、再冻结规则。原 30 次
 benchmark 的分母为 0；扩展到 **95 次历史运行**后，也只找到 **3 条范围内记录、

--- a/docs/prereg-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment.md
+++ b/docs/prereg-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment.md
@@ -1,0 +1,91 @@
+# Pre-registration amendment: evidence-set v5 DeepSeek V4 provider contract
+
+Date: 2026-08-30
+
+Status: frozen after the first provider-identity stop and before any later
+model request. This document does not reopen or reinterpret that run.
+
+## Reason for the amendment
+
+The original v5 protocol froze `deepseek-chat` as a non-thinking judge. The
+first authorized development request stopped because the returned model
+identity did not equal that legacy alias. Official provider documentation now
+names `deepseek-v4-flash` and `deepseek-v4-pro`, states that V4 thinking is
+enabled by default, and documents retirement of the old alias.
+
+This amendment changes only the provider transport contract needed to preserve
+the original intended non-thinking Flash judge. It does not change the
+semantic prompt, candidate order, quote verifier, deterministic selector,
+W01-W08 inputs, development gates, X01-X08 unseen gates or production
+disconnection.
+
+## Frozen amended request contract
+
+Every later v5 judge request must:
+
+1. use `POST https://api.deepseek.com/chat/completions`;
+2. request exactly `deepseek-v4-flash`;
+3. include `thinking={"type":"disabled"}`;
+4. retain JSON Object mode, temperature 0, non-streaming behavior and the
+   existing per-pass token limit;
+5. accept only the exact returned model identity `deepseek-v4-flash`;
+6. make one HTTP request with no redirect, retry, repair, fallback or model
+   substitution; and
+7. keep credentials outside every request identity and persisted artifact.
+
+An alias, dated suffix, provider fallback or prefix match is a terminal
+identity failure. Exactness is intentional: billing compatibility is not
+semantic-method compatibility.
+
+## Accounting amendment
+
+The local table uses DeepSeek's published **peak** V4 Flash rates as the
+conservative fixed-budget basis:
+
+- cache-miss input: USD 0.44 per million tokens;
+- cache-hit input: USD 0.014 per million tokens; and
+- output: USD 1.32 per million tokens.
+
+The basis is dated 2026-08-30 independently of the older shared price census.
+An environment override remains possible for normal application accounting,
+but the frozen v5 adapter deliberately ignores it. This prevents an unrecorded
+deployment variable from changing the pre-registered experiment budget.
+
+After a parseable provider envelope, safe model and usage metadata must be
+validated before semantic output is admitted. If identity then fails, the call
+journal may retain only the returned model identity and validated token/cost
+observation. It must not retain response content. Aggregate execution totals
+must include that safe failed-call usage. If any potentially spending call has
+no inspectable cost, the whole execution cost remains `uninspectable`, never
+zero or a partial total.
+
+## Historical and future-run boundaries
+
+- The 2026-08-30 legacy-alias run remains `partial / not_evaluated`.
+- Its unpersisted provider content and usage cannot be reconstructed.
+- W01-W08 remain consumed development cases; this transport correction does
+  not permit prompt or decision-rule tuning on them.
+- No paid request is authorized by this amendment or by its implementation.
+- A future run requires fresh authorization naming the merged Git revision,
+  call ceiling, soft stop and credential/provider boundary.
+- No automatic retry of the historical run is permitted.
+
+## Required zero-network evidence before another authorization
+
+1. outbound-body test proves the exact V4 model and disabled-thinking field;
+2. exact identity mismatch remains terminal after one transport call;
+3. a mismatch journal preserves safe usage through `execution.json` but no
+   semantic response content;
+4. missing usage or price stays visibly uninspectable;
+5. the provider rates, date and OpenAI-shaped cache arithmetic are tested;
+6. the disabled-thinking defect is temporarily re-injected and makes the
+   outbound seam test fail;
+7. the frozen source and implementation hashes pass the real dry-run; and
+8. full zero-network tests, latest Ruff and narrow Pylint are green.
+
+## Sources
+
+- DeepSeek, [Change Log](https://api-docs.deepseek.com/updates/)
+- DeepSeek, [Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion/)
+- DeepSeek, [Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/)
+- DeepSeek, [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/)

--- a/docs/results-2026-08-30-openalex-evidence-set-v5-development-provider-drift.md
+++ b/docs/results-2026-08-30-openalex-evidence-set-v5-development-provider-drift.md
@@ -1,0 +1,73 @@
+# Result: evidence-set v5 development run stopped on provider model drift
+
+Date: 2026-08-30
+
+## Strict outcome
+
+The first authorized W01-W08 development execution is **partial / not_evaluated**.
+It is not a failed relevance result and it is not evidence for or against the
+v5 semantic hypothesis. The first and only potentially billable request was
+rejected by the adapter because the provider-returned model identity did not
+exactly equal the frozen requested identity, `deepseek-chat`.
+
+The process then stopped without retrying. It made zero OpenAlex requests,
+completed zero model calls, completed zero cases, persisted zero candidate
+decisions, did not parse the private human labels, and remained disconnected
+from production, the report workflow and the planner trigger.
+
+## Authorized boundary actually used
+
+- merged revision: `5f6526b40731a005c5c0c397c8813264c0a9c908`;
+- frozen public W01-W08 packet and existing private-artifact hashes;
+- DeepSeek only, at most 16 sequential calls;
+- local soft stop: USD 0.10;
+- no retry, recovery, OpenAlex request or supplementary retrieval; and
+- production/report/planner connection: false.
+
+The output directory was
+`outputs/openalex-evidence-set-v5-development-5f6526b-20260830`. It remains a
+local ignored run artifact rather than a source-controlled fixture. The four
+indexed artifact hashes were independently recomputed after the stop:
+
+| Artifact | SHA-256 |
+|---|---|
+| `manifest.json` | `5ba62876abf90049fdc4638290e77723868b4c09be775cd37d09d8fca25799aa` |
+| `execution.json` | `99917697e021e453724389411a18673057aa3818b5a6ff8281f7b07f9b946214` |
+| `candidate-decisions.json` | `37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570` |
+| `judge-calls/W01-pass-1.json` | `65d3e252d73a4ccf9f937c3c4e307ad6a408c3e6258d13b21d6a46d840b94e76` |
+
+## Why the cost is not zero
+
+The request reached the provider and may have spent money. The historical
+adapter checked model identity before converting the returned usage counters
+to the durable journal. It also lacked a price row for the returned V4 family.
+Consequently the artifact correctly reports `cost_state=uninspectable` and
+`cost_usd=null`; zero would be an unsupported claim.
+
+No raw semantic response was persisted or inspected after the identity
+failure. This matters because a partial output from a consumed development
+case must not become an informal tuning signal.
+
+## Root cause and disposition
+
+The frozen protocol named a legacy provider alias. DeepSeek's official V4
+change log announced that `deepseek-chat` would be discontinued after
+2026-07-24 and that callers should explicitly request `deepseek-v4-flash` or
+`deepseek-v4-pro`. Current Chat Completions documentation also defaults V4 to
+thinking mode unless the request explicitly disables it.
+
+The strict identity check therefore did its job: it prevented a provider-side
+model change from silently altering a pre-registered judge. Loosening the
+check, accepting a prefix, or immediately retrying would have changed the
+method after seeing an outcome. The original run remains sealed as
+`not_evaluated`.
+
+Any future request requires the separate provider-contract amendment, a merged
+implementation revision, and fresh explicit paid-run authorization.
+
+## Sources
+
+- DeepSeek, [Change Log](https://api-docs.deepseek.com/updates/)
+- DeepSeek, [Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion/)
+- DeepSeek, [Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/)
+- DeepSeek, [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/)

--- a/docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md
+++ b/docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md
@@ -1,0 +1,92 @@
+# Result: evidence-set v5 DeepSeek V4 provider-contract amendment
+
+Date: 2026-08-30
+
+## Outcome
+
+The post-stop provider amendment is implemented and passes its zero-network
+qualification. It authorizes no paid rerun and keeps the v5 runner disconnected
+from production, reports, planner triggers and OpenAlex.
+
+The historical `deepseek-chat` execution remains sealed as
+`partial / not_evaluated`. This implementation does not edit those artifacts,
+infer the missing returned-model string, reconstruct unpersisted usage, or
+convert an unknown cost to zero.
+
+## Implemented contract
+
+- the adapter requests exactly `deepseek-v4-flash`;
+- every body explicitly sends `thinking={"type":"disabled"}` to preserve the
+  original non-thinking method;
+- exact returned-model equality remains mandatory, including rejection of a
+  dated suffix;
+- no redirect, retry, repair, fallback or semantic-output persistence is added;
+- a parseable failed response may expose only its safe returned-model identity
+  and validated usage observation to the runner;
+- failed-call usage reaches both the write-once call journal and aggregate
+  `execution.json` totals;
+- a potentially spending request without inspectable usage keeps the complete
+  execution cost `uninspectable`; and
+- the conservative local V4 Flash price row uses the official peak rates with
+  its own 2026-08-30 basis date, without restamping older price rows. The
+  experimental adapter ignores the general-purpose environment price override
+  so an unrecorded deployment variable cannot change the frozen budget.
+
+Manifest and execution artifacts use schema version 2 so a future consumer can
+distinguish the amended accounting contract from the historical version-1
+stop artifact.
+
+## Tests and defect reinjection
+
+The adapter/runner subset passed:
+
+```text
+16 passed in 2.33s
+```
+
+The combined adapter, runner and shared-accounting subset passed:
+
+```text
+46 passed, 8 subtests passed in 2.09s
+```
+
+The complete zero-network suite passed:
+
+```text
+1751 passed, 639 subtests passed in 32.98s
+```
+
+Two seam defects were then re-injected independently. After removing the
+`thinking.disabled` field, the outbound transport-seam test failed with a
+`KeyError: 'thinking'`, proving that the new test observes the actual serialized
+request rather than only the request model. The same patch was reversed and
+the correct implementation restored. Re-enabling the general environment price
+override inside the frozen adapter made the same seam test observe
+`env LLM_PRICE_PER_MTOK` instead of the built-in peak basis and fail. That
+patch was also reversed. These failures prove both controls are asserted at
+the serialized/provider-accounting boundary rather than as unused fields.
+
+The real default dry-run subsequently verified 8/8 W cases, 64/64 candidate
+identities, 16 unique prompt identities, the four opaque source-artifact hashes
+and all six behavior-bearing dependency hashes. It explicitly reported zero
+network calls, zero model calls, no private-label parsing and no production
+connection.
+
+## Frozen implementation identities
+
+| Dependency | SHA-256 |
+|---|---|
+| `deepseek_evidence_judge.py` | `fa912d12a74c273857b363979e841298a9ca94e8599cc7dd31b4b33a47cecc8f` |
+| `token_usage.py` | `b2a8cb6df7e6b40efc0b354965c83a205b18297002010299c9aedd0bc56a1e13` |
+
+The runner records its own observed hash in each manifest rather than embedding
+a recursive expected digest. The future authorization must name the merged Git
+revision that contains this implementation.
+
+## Next gate
+
+No further provider request occurred during this repair. A later W01-W08
+development execution requires fresh explicit authorization with a merged
+revision, model-call ceiling and soft stop. Completing that execution would
+still establish only development qualification; it would not validate v5 or
+connect Tool Calling to production.

--- a/openalex_evidence_set_development.py
+++ b/openalex_evidence_set_development.py
@@ -42,6 +42,7 @@ from academic_agent.tools.deepseek_evidence_judge import (
     DeepSeekJudgeAdapterError,
     DeepSeekJudgeRequest,
     DeepSeekJudgeResponse,
+    DeepSeekJudgeUsageObservation,
     prompt_sha256,
 )
 from academic_agent.tools.evidence_search import ToolEvidenceCandidate
@@ -104,7 +105,7 @@ _IMPLEMENTATION_PATHS = {
 # merged Git revision, while this map locks every behavior-bearing dependency.
 EXPECTED_IMPLEMENTATION_SHA256 = {
     "deepseek_evidence_judge.py": (
-        "2228d4933df066d9ced0dd4b067a85f7377ad5456f33b52005f7a996bc4cbd50"
+        "fa912d12a74c273857b363979e841298a9ca94e8599cc7dd31b4b33a47cecc8f"
     ),
     "evidence_search.py": (
         "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
@@ -119,7 +120,7 @@ EXPECTED_IMPLEMENTATION_SHA256 = {
         "1e3c0b15c9608cf83b414ee52ac2da7540728149970fa45ab9e6306773ef4749"
     ),
     "token_usage.py": (
-        "81d7fab7d2c9258e8d56fddacff114c2c06585530d2591d004cf3bb19d78defd"
+        "b2a8cb6df7e6b40efc0b354965c83a205b18297002010299c9aedd0bc56a1e13"
     ),
 }
 
@@ -247,7 +248,7 @@ class DevelopmentManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     mode: Literal["openalex_evidence_set_v5_development_manifest"] = (
         "openalex_evidence_set_v5_development_manifest"
     )
@@ -264,7 +265,7 @@ class DevelopmentManifest(BaseModel):
     selection_contract: EvidenceSetSelectionContract
     selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
     requested_provider: Literal["deepseek"] = "deepseek"
-    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    requested_model: Literal["deepseek-v4-flash"] = "deepseek-v4-flash"
     api_base: Literal["https://api.deepseek.com"] = "https://api.deepseek.com"
     maximum_model_call_count: Literal[16] = 16
     soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
@@ -310,6 +311,8 @@ class JudgeCallJournal(BaseModel):
     state: CallState
     request: DeepSeekJudgeRequest
     response: DeepSeekJudgeResponse | None = None
+    observed_returned_model: str | None = Field(default=None, max_length=200)
+    observed_usage: DeepSeekJudgeUsageObservation | None = None
     failure_type: str | None = Field(default=None, max_length=100)
     failure_detail: str | None = Field(default=None, max_length=500)
     failure_retryable: bool | None = None
@@ -322,11 +325,23 @@ class JudgeCallJournal(BaseModel):
             self.failure_detail,
             self.failure_retryable,
         )
+        observations = (self.observed_returned_model, self.observed_usage)
         if self.state == "completed":
-            if self.response is None or any(value is not None for value in failures):
+            if (
+                self.response is None
+                or any(value is not None for value in failures)
+                or any(value is not None for value in observations)
+                or not self.request_may_have_spent
+            ):
                 raise ValueError("completed call requires only a response")
         elif self.response is not None or any(value is None for value in failures):
             raise ValueError("failed call requires only failure metadata")
+        if self.observed_usage is not None and self.observed_returned_model is None:
+            raise ValueError("observed usage requires a returned model identity")
+        if not self.request_may_have_spent and any(
+            value is not None for value in observations
+        ):
+            raise ValueError("a non-spending failure cannot carry provider usage")
         if self.request.trace_id != (
             f"openalex-v5-{self.case_id.casefold()}-pass-{self.pass_number}"
         ):
@@ -334,12 +349,22 @@ class JudgeCallJournal(BaseModel):
         return self
 
 
+def _journal_usage(
+    call: JudgeCallJournal,
+) -> DeepSeekJudgeUsageObservation | None:
+    """Return measured usage regardless of semantic-output admissibility."""
+
+    if call.response is not None:
+        return call.response.usage
+    return call.observed_usage
+
+
 class DevelopmentExecution(BaseModel):
     """Final mechanical artifact; human-value gates remain unevaluated."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     mode: Literal["openalex_evidence_set_v5_development_execution"] = (
         "openalex_evidence_set_v5_development_execution"
     )
@@ -388,6 +413,46 @@ class DevelopmentExecution(BaseModel):
         )
         if self.persisted_candidate_decision_count != candidate_count:
             raise ValueError("candidate decision count drifted from case audits")
+        measured = tuple(
+            usage for call in self.calls if (usage := _journal_usage(call)) is not None
+        )
+        observed_tokens = (
+            sum(usage.prompt_tokens for usage in measured),
+            sum(usage.cached_prompt_tokens for usage in measured),
+            sum(usage.completion_tokens for usage in measured),
+            sum(usage.total_tokens for usage in measured),
+        )
+        if observed_tokens != (
+            self.prompt_tokens,
+            self.cached_prompt_tokens,
+            self.completion_tokens,
+            self.total_tokens,
+        ):
+            raise ValueError("aggregate token usage drifted from call journals")
+        cost_known = all(
+            not call.request_may_have_spent
+            or (
+                (usage := _journal_usage(call)) is not None
+                and usage.cost_usd is not None
+            )
+            for call in self.calls
+        )
+        expected_cost = (
+            sum(usage.cost_usd for usage in measured if usage.cost_usd is not None)
+            if cost_known
+            else None
+        )
+        if (self.cost_state == "known") != cost_known:
+            raise ValueError("aggregate cost state drifted from call journals")
+        if cost_known:
+            if self.cost_usd is None or not math.isclose(
+                self.cost_usd,
+                expected_cost or 0.0,
+                abs_tol=1e-12,
+            ):
+                raise ValueError("aggregate cost drifted from call journals")
+        elif self.cost_usd is not None:
+            raise ValueError("uninspectable cost cannot carry a dollar total")
         if self.disposition_agreement_denominator:
             expected = (
                 self.disposition_agreement_numerator
@@ -802,12 +867,16 @@ def _failed_journal(
     failure_detail: str,
     failure_retryable: bool,
     request_may_have_spent: bool,
+    observed_returned_model: str | None = None,
+    observed_usage: DeepSeekJudgeUsageObservation | None = None,
 ) -> JudgeCallJournal:
     return JudgeCallJournal(
         case_id=case_id,
         pass_number=int(request.trace_id[-1]),
         state="failed",
         request=request,
+        observed_returned_model=observed_returned_model,
+        observed_usage=observed_usage,
         failure_type=failure_type,
         failure_detail=failure_detail[:500],
         failure_retryable=failure_retryable,
@@ -879,9 +948,19 @@ def _execution_artifact(
         for call in calls
         if call.state == "completed" and call.response is not None
     )
-    cost_known = len(completed_responses) == len(calls)
+    measured = tuple(
+        usage for call in calls if (usage := _journal_usage(call)) is not None
+    )
+    cost_known = all(
+        not call.request_may_have_spent
+        or (
+            (usage := _journal_usage(call)) is not None
+            and usage.cost_usd is not None
+        )
+        for call in calls
+    )
     cost = (
-        sum(response.usage.cost_usd for response in completed_responses)
+        sum(usage.cost_usd for usage in measured if usage.cost_usd is not None)
         if cost_known
         else None
     )
@@ -902,18 +981,10 @@ def _execution_artifact(
         completed_model_call_count=len(completed_responses),
         completed_case_count=len(decisions),
         persisted_candidate_decision_count=candidate_count,
-        prompt_tokens=sum(
-            response.usage.prompt_tokens for response in completed_responses
-        ),
-        cached_prompt_tokens=sum(
-            response.usage.cached_prompt_tokens for response in completed_responses
-        ),
-        completion_tokens=sum(
-            response.usage.completion_tokens for response in completed_responses
-        ),
-        total_tokens=sum(
-            response.usage.total_tokens for response in completed_responses
-        ),
+        prompt_tokens=sum(usage.prompt_tokens for usage in measured),
+        cached_prompt_tokens=sum(usage.cached_prompt_tokens for usage in measured),
+        completion_tokens=sum(usage.completion_tokens for usage in measured),
+        total_tokens=sum(usage.total_tokens for usage in measured),
         cost_usd=cost,
         cost_state="known" if cost_known else "uninspectable",
         disposition_agreement_numerator=numerator,
@@ -1045,6 +1116,8 @@ def execute_development_study(
                     failure_detail=str(exc),
                     failure_retryable=exc.retryable,
                     request_may_have_spent=exc.request_may_have_spent,
+                    observed_returned_model=exc.observed_returned_model,
+                    observed_usage=exc.observed_usage,
                 )
                 stop_reason = "adapter_failed"
             except ValidationError as exc:
@@ -1069,6 +1142,8 @@ def execute_development_study(
                         ),
                         failure_retryable=False,
                         request_may_have_spent=True,
+                        observed_returned_model=response.returned_model,
+                        observed_usage=response.usage,
                     )
                     stop_reason = "response_identity_mismatch"
                 else:

--- a/src/academic_agent/token_usage.py
+++ b/src/academic_agent/token_usage.py
@@ -40,14 +40,19 @@ from typing import Any
 #
 # NOT AUTHORITATIVE. Provider prices change, and a stale entry here reports a
 # confident wrong number rather than failing — the exact failure mode this
-# module exists to avoid. So every estimate is stamped with PRICES_AS_OF, and
-# LLM_PRICE_PER_MTOK overrides the table without a code change. Verify against
-# the provider's pricing page before quoting a figure from this project.
+# module exists to avoid. Most estimates are stamped with PRICES_AS_OF; models
+# added after that shared census carry their own date rather than falsely
+# restamping every older row. LLM_PRICE_PER_MTOK overrides the table without a
+# code change. Verify against the provider's pricing page before quoting a
+# figure from this project.
 PRICES_AS_OF = "2026-05"
 
 _PRICING: dict[str, tuple[float, float, float]] = {
     "deepseek-chat":      (0.27, 0.07, 1.10),
     "deepseek-reasoner":  (0.55, 0.14, 2.19),
+    # DeepSeek V4 pricing varies by time. Use published peak rates so a fixed
+    # soft stop never understates a request made during the expensive window.
+    "deepseek-v4-flash":  (0.44, 0.014, 1.32),
     "gpt-4o":             (2.50, 1.25, 10.00),
     "gpt-4o-mini":        (0.15, 0.075, 0.60),
     "gpt-4.1":            (2.00, 0.50, 8.00),
@@ -55,6 +60,10 @@ _PRICING: dict[str, tuple[float, float, float]] = {
     "claude-opus-4":      (15.00, 1.50, 75.00),
     "claude-sonnet-4":    (3.00, 0.30, 15.00),
     "claude-haiku-4":     (0.80, 0.08, 4.00),
+}
+
+_PRICING_BASIS_OVERRIDES = {
+    "deepseek-v4-flash": "built-in DeepSeek peak table (as of 2026-08-30)",
 }
 
 # Anthropic bills a cache *write* above the normal input rate. Cache reads are
@@ -107,23 +116,36 @@ def _price_from_env() -> _Price | None:
     return _Price(input_, cached, output, "env LLM_PRICE_PER_MTOK")
 
 
-def price_for(model: str) -> _Price | None:
+def price_for(
+    model: str,
+    *,
+    allow_env_override: bool = True,
+) -> _Price | None:
     """Rates for `model`, or None when the model is not priced.
 
     None is a real answer here, not an error: it makes the caller report
     tokens without a dollar figure instead of inventing one.
     """
-    env = _price_from_env()
-    if env is not None:
-        return env
+    if allow_env_override:
+        env = _price_from_env()
+        if env is not None:
+            return env
     name = _normalize_model(model)
     if name in _PRICING:
-        return _Price(*_PRICING[name], basis=f"built-in table (as of {PRICES_AS_OF})")
+        basis = _PRICING_BASIS_OVERRIDES.get(
+            name,
+            f"built-in table (as of {PRICES_AS_OF})",
+        )
+        return _Price(*_PRICING[name], basis=basis)
     # Longest prefix wins so "claude-sonnet-4-20250514" prefers the
     # "claude-sonnet-4" row over a hypothetical shorter "claude" one.
     for key in sorted(_PRICING, key=len, reverse=True):
         if name.startswith(key):
-            return _Price(*_PRICING[key], basis=f"built-in table (as of {PRICES_AS_OF})")
+            basis = _PRICING_BASIS_OVERRIDES.get(
+                key,
+                f"built-in table (as of {PRICES_AS_OF})",
+            )
+            return _Price(*_PRICING[key], basis=basis)
     return None
 
 
@@ -218,9 +240,15 @@ class RunUsage:
         return data
 
 
-def cost_for(model: str, metrics: Any, *, llm: Any = None) -> float | None:
+def cost_for(
+    model: str,
+    metrics: Any,
+    *,
+    llm: Any = None,
+    allow_env_override: bool = True,
+) -> float | None:
     """USD for one agent's usage, or None when the model has no price."""
-    price = price_for(model)
+    price = price_for(model, allow_env_override=allow_env_override)
     if price is None:
         return None
 

--- a/src/academic_agent/tools/deepseek_evidence_judge.py
+++ b/src/academic_agent/tools/deepseek_evidence_judge.py
@@ -31,7 +31,7 @@ from academic_agent.token_usage import cost_for, price_for
 DEEPSEEK_CHAT_COMPLETIONS_ENDPOINT = (
     "https://api.deepseek.com/chat/completions"
 )
-REQUESTED_MODEL = "deepseek-chat"
+REQUESTED_MODEL = "deepseek-v4-flash"
 _MAX_RESPONSE_BYTES = 1_000_000
 _SHA256_PATTERN = r"^[0-9a-f]{64}$"
 
@@ -46,11 +46,18 @@ class DeepSeekJudgeAdapterError(RuntimeError):
         failure_type: str,
         retryable: bool,
         request_may_have_spent: bool,
+        observed_returned_model: str | None = None,
+        observed_usage: DeepSeekJudgeUsageObservation | None = None,
     ) -> None:
         super().__init__(message)
         self.failure_type = failure_type
         self.retryable = retryable
         self.request_may_have_spent = request_may_have_spent
+        # A terminal identity failure must not retain semantic output, but the
+        # provider's non-secret model and usage fields are still needed to
+        # distinguish an unknown bill from a measured failed request.
+        self.observed_returned_model = observed_returned_model
+        self.observed_usage = observed_usage
 
 
 class DeepSeekJudgeRequest(BaseModel):
@@ -59,7 +66,7 @@ class DeepSeekJudgeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     trace_id: str = Field(pattern=r"^openalex-v5-w0[1-8]-pass-[12]$")
-    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
+    requested_model: Literal["deepseek-v4-flash"] = "deepseek-v4-flash"
     system_prompt: str = Field(min_length=20, max_length=20_000)
     user_prompt: str = Field(min_length=20, max_length=250_000)
     batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
@@ -92,6 +99,11 @@ class DeepSeekJudgeRequest(BaseModel):
                 "response_format": {"type": "json_object"},
                 "stream": False,
                 "temperature": self.temperature,
+                # DeepSeek V4 enables thinking by default.  The original
+                # frozen `deepseek-chat` contract meant non-thinking mode, so
+                # this explicit toggle preserves that method after the legacy
+                # alias was retired instead of silently changing the judge.
+                "thinking": {"type": "disabled"},
             },
             ensure_ascii=True,
             separators=(",", ":"),
@@ -99,8 +111,8 @@ class DeepSeekJudgeRequest(BaseModel):
         ).encode("utf-8")
 
 
-class DeepSeekJudgeUsage(BaseModel):
-    """Provider usage and locally reproducible cost for one request."""
+class DeepSeekJudgeUsageObservation(BaseModel):
+    """Safe provider accounting retained even when semantic output is rejected."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -108,16 +120,25 @@ class DeepSeekJudgeUsage(BaseModel):
     cached_prompt_tokens: int = Field(ge=0)
     completion_tokens: int = Field(ge=0)
     total_tokens: int = Field(ge=0)
-    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
-    cost_basis: str = Field(min_length=5, max_length=300)
+    cost_usd: float | None = Field(default=None, ge=0.0, allow_inf_nan=False)
+    cost_basis: str | None = Field(default=None, min_length=5, max_length=300)
 
     @model_validator(mode="after")
-    def _validate_token_accounting(self) -> "DeepSeekJudgeUsage":
+    def _validate_token_accounting(self) -> "DeepSeekJudgeUsageObservation":
         if self.cached_prompt_tokens > self.prompt_tokens:
             raise ValueError("cached tokens cannot exceed prompt tokens")
         if self.total_tokens != self.prompt_tokens + self.completion_tokens:
             raise ValueError("total tokens do not match prompt plus completion")
+        if (self.cost_usd is None) != (self.cost_basis is None):
+            raise ValueError("cost and cost basis must be known or unknown together")
         return self
+
+
+class DeepSeekJudgeUsage(DeepSeekJudgeUsageObservation):
+    """Provider usage with the locally reproducible cost required for success."""
+
+    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+    cost_basis: str = Field(min_length=5, max_length=300)
 
 
 class DeepSeekJudgeResponse(BaseModel):
@@ -129,8 +150,8 @@ class DeepSeekJudgeResponse(BaseModel):
     request_sha256: str = Field(pattern=_SHA256_PATTERN)
     batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
     prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
-    requested_model: Literal["deepseek-chat"] = "deepseek-chat"
-    returned_model: Literal["deepseek-chat"]
+    requested_model: Literal["deepseek-v4-flash"] = "deepseek-v4-flash"
+    returned_model: Literal["deepseek-v4-flash"]
     provider_response_id: str = Field(min_length=3, max_length=300)
     provider_request_id: str | None = Field(default=None, max_length=300)
     finish_reason: str = Field(min_length=1, max_length=100)
@@ -270,6 +291,39 @@ def _safe_validation_detail(exc: ValidationError) -> str:
     return "; ".join(details)[:500] or "provider response schema invalid"
 
 
+def _usage_observation(envelope: _ProviderEnvelope) -> DeepSeekJudgeUsageObservation:
+    """Validate provider counters before deciding whether output is admissible."""
+
+    metrics = SimpleNamespace(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
+        cache_creation_tokens=0,
+        completion_tokens=envelope.usage.completion_tokens,
+    )
+    # General application accounting intentionally supports an environment
+    # price override. This pre-registered study does not: an unrecorded deploy
+    # variable must not change a frozen soft-stop calculation. The token-usage
+    # implementation hash and dated built-in basis are both in the manifest.
+    price = price_for(envelope.model, allow_env_override=False)
+    cost = (
+        cost_for(
+            envelope.model,
+            metrics,
+            allow_env_override=False,
+        )
+        if price is not None
+        else None
+    )
+    return DeepSeekJudgeUsageObservation(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
+        completion_tokens=envelope.usage.completion_tokens,
+        total_tokens=envelope.usage.total_tokens,
+        cost_usd=cost,
+        cost_basis=price.basis if price is not None else None,
+    )
+
+
 class DeepSeekEvidenceJudgeAdapter:
     """Perform exactly one fixed-model JSON request with strict accounting."""
 
@@ -349,36 +403,38 @@ class DeepSeekEvidenceJudgeAdapter:
                 request_may_have_spent=True,
             ) from exc
 
+        try:
+            observed_usage = _usage_observation(envelope)
+        except ValidationError as exc:
+            raise DeepSeekJudgeAdapterError(
+                "DeepSeek usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+            ) from exc
+
         if envelope.model != request.requested_model:
             raise DeepSeekJudgeAdapterError(
                 "DeepSeek returned a model identity inconsistent with the request",
                 failure_type="provider_model_identity_mismatch",
                 retryable=False,
                 request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
             )
-        metrics = SimpleNamespace(
-            prompt_tokens=envelope.usage.prompt_tokens,
-            cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
-            cache_creation_tokens=0,
-            completion_tokens=envelope.usage.completion_tokens,
-        )
-        cost = cost_for(envelope.model, metrics)
-        price = price_for(envelope.model)
-        if cost is None or price is None:
+        if observed_usage.cost_usd is None or observed_usage.cost_basis is None:
             raise DeepSeekJudgeAdapterError(
                 "DeepSeek token cost is not inspectable for the returned model",
                 failure_type="provider_cost_uninspectable",
                 retryable=False,
                 request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
             )
         try:
-            usage = DeepSeekJudgeUsage(
-                prompt_tokens=envelope.usage.prompt_tokens,
-                cached_prompt_tokens=envelope.usage.prompt_cache_hit_tokens,
-                completion_tokens=envelope.usage.completion_tokens,
-                total_tokens=envelope.usage.total_tokens,
-                cost_usd=cost,
-                cost_basis=price.basis,
+            usage = DeepSeekJudgeUsage.model_validate(
+                observed_usage.model_dump(mode="python")
             )
         except ValidationError as exc:
             raise DeepSeekJudgeAdapterError(
@@ -386,6 +442,7 @@ class DeepSeekEvidenceJudgeAdapter:
                 failure_type="provider_usage_invalid",
                 retryable=False,
                 request_may_have_spent=True,
+                observed_returned_model=envelope.model,
             ) from exc
         choice = envelope.choices[0]
         return DeepSeekJudgeResponse(

--- a/tests/test_deepseek_evidence_judge.py
+++ b/tests/test_deepseek_evidence_judge.py
@@ -30,7 +30,7 @@ def _request() -> DeepSeekJudgeRequest:
     )
 
 
-def _provider_body(*, model: str = "deepseek-chat") -> bytes:
+def _provider_body(*, model: str = "deepseek-v4-flash") -> bytes:
     return json.dumps(
         {
             "id": "response-123",
@@ -65,7 +65,9 @@ class RecordingTransport:
         )
 
 
-def test_adapter_sends_one_fixed_endpoint_request_without_leaking_key():
+def test_adapter_sends_one_fixed_endpoint_request_without_leaking_key(monkeypatch):
+    # Production may override prices; this frozen experiment must not.
+    monkeypatch.setenv("LLM_PRICE_PER_MTOK", "99:99:99")
     transport = RecordingTransport()
     adapter = DeepSeekEvidenceJudgeAdapter(
         api_key="secret-deepseek-key",
@@ -82,21 +84,26 @@ def test_adapter_sends_one_fixed_endpoint_request_without_leaking_key():
     assert call["headers"]["Authorization"] == "Bearer secret-deepseek-key"
     assert b"secret-deepseek-key" not in call["body"]
     payload = json.loads(call["body"])
-    assert payload["model"] == "deepseek-chat"
+    assert payload["model"] == "deepseek-v4-flash"
+    assert payload["thinking"] == {"type": "disabled"}
     assert payload["temperature"] == 0.0
     assert payload["stream"] is False
     assert payload["response_format"] == {"type": "json_object"}
-    assert response.returned_model == "deepseek-chat"
+    assert response.returned_model == "deepseek-v4-flash"
     assert response.provider_request_id == "provider-request-456"
     assert response.latency_ms == pytest.approx(250.0)
     assert response.usage.cached_prompt_tokens == 20
     assert response.usage.cost_usd > 0
-    assert "built-in table" in response.usage.cost_basis
+    assert "built-in" in response.usage.cost_basis
+    assert "peak" in response.usage.cost_basis
+    assert "env" not in response.usage.cost_basis
     assert response.request_sha256 == hashlib.sha256(call["body"]).hexdigest()
 
 
 def test_model_identity_mismatch_is_terminal_and_never_retried():
-    transport = RecordingTransport(_provider_body(model="deepseek-reasoner"))
+    transport = RecordingTransport(
+        _provider_body(model="deepseek-v4-flash-0731")
+    )
     adapter = DeepSeekEvidenceJudgeAdapter(
         api_key="secret",
         transport=transport,
@@ -111,6 +118,12 @@ def test_model_identity_mismatch_is_terminal_and_never_retried():
     assert caught.value.failure_type == "provider_model_identity_mismatch"
     assert caught.value.retryable is False
     assert caught.value.request_may_have_spent is True
+    assert caught.value.observed_returned_model == "deepseek-v4-flash-0731"
+    assert caught.value.observed_usage.prompt_tokens == 100
+    assert caught.value.observed_usage.cost_usd is not None
+    # A failed identity check may retain accounting, never the provider's
+    # semantic content that could be used to tune a consumed experiment.
+    assert not hasattr(caught.value, "raw_content")
     assert len(transport.calls) == 1
 
 

--- a/tests/test_openalex_evidence_set_development.py
+++ b/tests/test_openalex_evidence_set_development.py
@@ -15,6 +15,7 @@ from academic_agent.tools.deepseek_evidence_judge import (
     DeepSeekJudgeRequest,
     DeepSeekJudgeResponse,
     DeepSeekJudgeUsage,
+    DeepSeekJudgeUsageObservation,
 )
 
 
@@ -167,8 +168,8 @@ def _response(
         request_sha256=hashlib.sha256(request.body()).hexdigest(),
         batch_input_sha256=request.batch_input_sha256,
         prompt_sha256=prompt_sha256 or request.prompt_sha256,
-        requested_model="deepseek-chat",
-        returned_model="deepseek-chat",
+        requested_model="deepseek-v4-flash",
+        returned_model="deepseek-v4-flash",
         provider_response_id=f"response-{request.trace_id}",
         provider_request_id=f"request-{request.trace_id}",
         finish_reason="stop",
@@ -267,6 +268,7 @@ def test_full_execution_persists_each_call_and_case_before_the_next(tmp_path):
 
     assert factory.call_count == 1
     assert len(adapter.requests) == 16
+    assert result.schema_version == 2
     assert result.overall_state == "completed"
     assert result.stop_reason == "completed"
     assert result.attempted_model_call_count == 16
@@ -292,6 +294,8 @@ def test_manifest_and_model_boundary_exclude_baseline_urls_and_human_bytes(tmp_p
     assert "DO_NOT_SEND_REVIEWER_DECLARATION" not in manifest
     assert "openalex.org" not in manifest
     parsed = json.loads(manifest)
+    assert parsed["schema_version"] == 2
+    assert parsed["requested_model"] == "deepseek-v4-flash"
     for case in parsed["cases"]:
         first = case["first_request"]["user_prompt"]
         second = case["second_request"]["user_prompt"]
@@ -373,13 +377,18 @@ def test_response_identity_drift_is_persisted_and_no_retry_occurs(tmp_path):
 
     assert adapter.call_count == 1
     assert result.stop_reason == "response_identity_mismatch"
-    assert result.cost_state == "uninspectable"
+    assert result.cost_state == "known"
+    assert result.cost_usd == pytest.approx(0.001)
+    assert result.total_tokens == 12
     journal = json.loads(
         (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
     )
     assert journal["state"] == "failed"
     assert journal["failure_type"] == "adapter_response_identity_mismatch"
     assert "prompt_sha256" in journal["failure_detail"]
+    assert journal["observed_returned_model"] == "deepseek-v4-flash"
+    assert journal["observed_usage"]["cost_usd"] == pytest.approx(0.001)
+    assert "raw_content" not in journal
 
 
 class FailureAdapter:
@@ -413,9 +422,59 @@ def test_adapter_failure_is_one_attempt_and_not_a_silent_pass(tmp_path):
     assert adapter.call_count == 1
     assert result.stop_reason == "adapter_failed"
     assert result.completed_model_call_count == 0
+    assert result.cost_state == "uninspectable"
     assert result.disposition_agreement is None
     assert result.mechanical_agreement_gate_passed is None
     assert result.development_gate_state == "not_evaluated"
+
+
+class MeteredIdentityFailureAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        del request
+        self.call_count += 1
+        raise DeepSeekJudgeAdapterError(
+            "provider returned a different canonical model",
+            failure_type="provider_model_identity_mismatch",
+            retryable=False,
+            request_may_have_spent=True,
+            observed_returned_model="deepseek-v4-flash-0731",
+            observed_usage=DeepSeekJudgeUsageObservation(
+                prompt_tokens=100,
+                cached_prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=110,
+                cost_usd=0.002,
+                cost_basis="frozen test price basis",
+            ),
+        )
+
+
+def test_failed_identity_call_preserves_safe_usage_at_execution_boundary(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    output = tmp_path / "result"
+    adapter = MeteredIdentityFailureAdapter()
+
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **_common(bundle),
+    )
+
+    assert adapter.call_count == 1
+    assert result.completed_model_call_count == 0
+    assert result.total_tokens == 110
+    assert result.cost_state == "known"
+    assert result.cost_usd == pytest.approx(0.002)
+    serialized = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert serialized["total_tokens"] == 110
+    assert serialized["cost_usd"] == pytest.approx(0.002)
+    assert serialized["calls"][0]["observed_usage"]["prompt_tokens"] == 100
+    assert "raw_content" not in serialized["calls"][0]
 
 
 def test_existing_output_and_missing_budget_acknowledgement_fail_closed(tmp_path):

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -92,6 +92,31 @@ class PricingLookupTests(TestCase):
         with _clean_env():
             self.assertIn(PRICES_AS_OF, price_for("deepseek-chat").basis)
 
+    def test_deepseek_v4_flash_uses_conservative_peak_rates_and_own_date(self):
+        """A later row must not falsely refresh every older provider price."""
+        with _clean_env():
+            price = price_for("deepseek-v4-flash")
+        self.assertEqual(
+            (price.input, price.cached, price.output),
+            (0.44, 0.014, 1.32),
+        )
+        self.assertIn("peak", price.basis)
+        self.assertIn("2026-08-30", price.basis)
+        self.assertNotIn(PRICES_AS_OF, price.basis)
+
+    def test_deepseek_v4_flash_cost_uses_openai_cache_shape(self):
+        """Cached input is a subset of prompt input for DeepSeek's API."""
+        with _clean_env():
+            cost = cost_for(
+                "deepseek-v4-flash",
+                _Metrics(
+                    prompt=1_000_000,
+                    cached=250_000,
+                    completion=100_000,
+                ),
+            )
+        self.assertAlmostEqual(cost, 0.4655, places=6)
+
     def test_env_override_wins_over_the_table(self):
         with mock.patch.dict(os.environ, {"LLM_PRICE_PER_MTOK": "1.0:2.0"}):
             price = price_for("deepseek-chat")


### PR DESCRIPTION
## Summary

- preserve the first paid development attempt as partial / not_evaluated after strict model-identity rejection
- amend the disconnected v5 transport contract to request exact deepseek-v4-flash with thinking disabled
- persist safe usage for rejected responses without persisting semantic output, and aggregate failed-call accounting at the execution seam
- add conservative dated V4 Flash peak pricing while preventing deployment price overrides from changing the frozen study
- document the provider stop, pre-registration amendment, implementation evidence, and updated project state

## Verification

- 1751 passed, 639 subtests passed
- adapter/runner: 16 passed
- adapter/runner/accounting: 46 passed, 8 subtests passed
- latest Ruff: passed
- narrow CI Pylint: passed
- real default v5 dry-run: 8/8 cases, 64/64 candidates, 16 prompt identities, zero network/model calls
- defect reinjection: missing thinking control and environment-price leakage each made the outbound seam test fail

## Boundaries

No paid retry occurred. OpenAlex, production reports, and planner triggers remain disconnected. Any later W01-W08 execution requires fresh authorization on a merged revision.