### PR TITLE
Fix Qwen score rationales at the delivery seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1768 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1771 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -242,11 +242,20 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   sentinels, so CrewAI's import-time dotenv load cannot restore operator keys.
   A real CrewAI request-body seam confirms that `enable_thinking=false`
   reaches OpenAI SDK `extra_body`; putting it at top level was re-injected and
-  made the test fail. This is zero-network implementation evidence only: no
-  paid Qwen request has executed, so live compatibility, report quality,
-  latency and realised cost remain unobserved. The frozen DeepSeek evidence-set
-  v5 provider contract is unchanged. See
-  `docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md`.
+  made the test fail. One authorized single-topic paid canary later completed
+  on merged revision `ff8732d`: all recorded role identities were exactly
+  `qwen3.5-plus`; seven requests used 79,261 tokens with a conservative USD
+  0.075657 estimate, all three retrieval domains retained 8 sources, and no
+  retrieval domain failed. That observes one live transport/accounting path,
+  not general report quality, stable latency/cost or DeepSeek equivalence.
+  The run exposed two Qwen-specific internal-x10 score phrases at the client
+  prose seam. Narrow normalization now covers only bounded rating forms and
+  preserves percentages and counts; removing it made both regression tests
+  fail before restoration. A separate invented-threshold and citation-
+  entailment finding remains open and was not folded into this regex fix.
+  The frozen DeepSeek evidence-set v5 provider contract is unchanged. See
+  `docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md` and
+  `docs/results-2026-08-30-qwen35-plus-first-paid-canary.md`.
 - Evidence-gap Tool Calling now has a phase-2 execution kernel and a phase-3
   production-disconnected Tavily adapter; the production workflow is still
   phase-1 zero-call shadow mode. The phase-2 frozen 14-case synthetic

--- a/README.md
+++ b/README.md
@@ -769,11 +769,21 @@ structured-output contract. DashScope's nested cached-token usage reaches the
 existing ledger unchanged, and the built-in estimate uses the highest
 published China/global context tier so budget stops remain conservative.
 
-This is **zero-network implementation evidence only**: no paid Qwen request has
-been made, so live compatibility, report quality, latency, and realised cost
-remain unobserved. See the [implementation record](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md).
-Local verification passes **1,768 tests plus 657 subtests**, latest Ruff, the
-narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
+One operator-authorized single-topic paid canary has now completed through the
+deployed API. All recorded role model identities were `qwen3.5-plus`; the run
+used 7 provider requests, 79,261 tokens and a conservative USD 0.075657
+estimate, with 8 academic, 8 patent and 8 market sources and no failed
+retrieval domain.
+
+The canary observed live transport and accounting for one run, not general
+report quality or benchmark equivalence. It exposed two internal-x10 score
+phrases that reached report prose; the deterministic score payload remained
+correct, and the narrow narrative seam is now covered by regression tests.
+A separate invented-threshold/citation-entailment finding remains open. See
+the [implementation record](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
+and [paid canary record](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md).
+Local verification now passes **1,771 tests plus 657 subtests**, latest Ruff,
+the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
 
@@ -1946,10 +1956,18 @@ OpenAI-compatible 传输层。适配层读取官方 `DASHSCOPE_API_KEY`，默认
 Token 沿用 DashScope 的 OpenAI 兼容统计格式，成本估算采用已公布的最高
 上下文档位，避免低估预算。
 
-目前只有**零网络实现证据**，尚未执行付费 Qwen 请求，因此不能宣称已经
-验证线上兼容性、报告质量、延迟或实际成本。详见[实现记录](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)。
-本地验证通过 **1,768 项测试与 657 个 subtests**、最新版 Ruff、CI 同款窄范围
-Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
+现已完成一次经授权的单主题付费 canary。部署 API 记录的全部角色模型均为
+`qwen3.5-plus`；本次运行包含 7 次供应商请求、79,261 Tokens，保守估算
+成本为 0.075657 美元，学术、专利和市场来源各 8 条，未出现检索域失败。
+
+这只能证明一次真实运行的传输与计费兼容性，不能证明普遍报告质量或与
+冻结 DeepSeek Benchmark 等价。本次运行暴露了两处内部十倍整数分数进入
+报告叙述的问题；确定性数值本身正确，现已用窄范围边界测试覆盖。另有
+模型自创决策阈值与引用蕴含问题仍待单独处理。详见
+[实现记录](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
+和[付费 canary 记录](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md)。
+本地验证现通过 **1,771 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始
 

--- a/docs/results-2026-08-30-qwen35-plus-first-paid-canary.md
+++ b/docs/results-2026-08-30-qwen35-plus-first-paid-canary.md
@@ -1,0 +1,120 @@
+# Qwen3.5 Plus first paid canary
+
+Date: 2026-08-30
+Status: single_canary_complete / live_transport_observed / quality_not_validated
+
+## Scope
+
+This was an operator-authorized exploratory canary after the Qwen3.5 Plus
+adapter reached public main. It was one production-isolated root run, not a
+pre-registered benchmark and not evidence of general model quality.
+
+- Merged revision:
+  ff8732d604c12a01d437716aa1585eefb933f8bd.
+- Run:
+  20260830T125659Z-50c35c817187f804658dda7dcc9a894a.
+- Public record:
+  <https://academic-commercialization-agent.up.railway.app/run/20260830T125659Z-50c35c817187f804658dda7dcc9a894a>.
+- Topic: solid-state sodium-ion batteries using sulfide electrolytes for grid
+  storage commercialization.
+- Recovery: not requested.
+- Evidence-gap planner: shadow no_gap; zero tool calls.
+
+The run used the deployed service and the configured operator Qwen credential.
+It did not authorize an evidence-gap supplement, recovery child or a second
+root run.
+
+## Observations
+
+The root run completed in 306 seconds.
+
+- Academic sources: 8.
+- Patent sources: 8.
+- Market sources: 8.
+- Failed retrieval domains: none.
+- Evidence incomplete: false.
+- Provider requests: 7.
+- Tokens recorded: 79,261.
+- Conservative estimated cost: USD 0.075657.
+- Cost completeness: true.
+- Every recorded role model: exactly qwen3.5-plus.
+- Checkpoints: all seven persisted stages complete.
+- Claim grounding: 2 checked, 0 unsupported and 3 unverifiable; all three
+  unverifiable claims were in the market domain.
+- Quality review: passed.
+- Consistency screen: 0 errors and 0 warnings.
+- Trace:
+  0c8a63f9ed45872726d8ce00cd083c1b, with Phoenix delivery attempted.
+
+The reviewer role recorded two requests while every other role recorded one.
+The observable artifacts establish one extra reviewer request, but they do not
+retain enough provider detail to prove whether its exact cause was guardrail
+regeneration or another CrewAI-internal retry. This record therefore does not
+invent a root cause.
+
+## Score-rationale seam found by the canary
+
+The deterministic scoring payload was correct:
+
+- market accessibility: 2.5;
+- evidence confidence: 3.5;
+- weighted total: 50.3.
+
+However, Qwen emitted the corresponding narrative as "rated at 25" and
+"moderate (35)". These are the internal integer scores before the established
+divide-by-ten delivery scale. The formula and stored numeric fields were
+correct, but the prose that reached the report was not. This is the same class
+of seam defect the project treats as high risk: a value can be computed and
+stored correctly while a contradictory representation reaches the client.
+
+A census of 79 existing top-level score.json artifacts found no prior use of
+either exact phrase. The existing normalizer covered explicit "score is 30",
+Chinese score labels and "30/50", but not these Qwen-specific forms.
+
+The fix is deliberately narrow:
+
+- normalize a raw integer only after a score-like noun and "rated at/as";
+- normalize a parenthesized raw integer only after a score-like noun and a
+  bounded qualitative rating adjective;
+- preserve percentages, dates, unlabelled counts and candidate-source counts;
+- leave the scoring formula and evidence_confidence floor unchanged.
+
+The two exact canary phrases were added as client-boundary tests. After the fix,
+the implementation was removed once while the tests remained: both tests
+failed on the original phrases. Restoring the implementation made the whole
+score-narrative class pass again.
+
+## Separate quality finding
+
+Manual inspection also found that the report converted an orientation-mode
+statement that no owner-approved threshold existed into several apparently
+mandatory numeric decision thresholds. One citation attached to a
+sulfide-electrolyte processing claim also described an oxide-electrolyte
+source.
+
+Those are not score-scale defects and are not changed by this patch. Treating
+them as one regex problem would either miss semantic substitutions or create
+false-positive blocking on completed paid reports. They remain a separately
+scoped decision-contract and citation-entailment problem that needs its own
+measured design.
+
+## What this establishes
+
+This single canary establishes that, for this request:
+
+- the official endpoint accepted the adapter's non-thinking JSON requests;
+- CrewAI returned structured payloads through every pipeline role;
+- the exact provider model identity and usage reached accounting;
+- the run completed through the API, checkpoints and browser report seam.
+
+It does not establish:
+
+- Qwen report quality across topics, languages or decision modes;
+- equivalence to the frozen DeepSeek benchmark;
+- stable latency, retry rate, token usage or realised cost;
+- semantic correctness of every citation or recommendation;
+- production Tool Calling, which remained at zero calls.
+
+The accurate claim is therefore "one live Qwen3.5 Plus end-to-end canary
+completed and exposed a repaired narrative seam," not "Qwen is fully validated
+for production."

--- a/docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md
+++ b/docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md
@@ -109,6 +109,16 @@ a frozen topic and success criteria, a strict request limit, and a cost stop.
 Until then the accurate claim is “Qwen3.5 Plus adapter implemented and verified
 offline,” not “Qwen validated in production.”
 
+## Later live observation
+
+After this implementation-only record was written and the adapter reached
+public `main`, one separately authorized paid canary completed on revision
+`ff8732d604c12a01d437716aa1585eefb933f8bd`. That later run does not change
+the historical claims above. It adds one live compatibility observation and
+documents both a repaired score-rationale seam and separate unresolved
+semantic-quality findings. See
+[Qwen3.5 Plus first paid canary](results-2026-08-30-qwen35-plus-first-paid-canary.md).
+
 ## Official contract references
 
 - [Qwen3.5 Plus model documentation](https://www.alibabacloud.com/help/en/model-studio/qwen3-5-plus)

--- a/src/academic_agent/run_output.py
+++ b/src/academic_agent/run_output.py
@@ -1,6 +1,8 @@
 """Per-run output management for generated commercialization reports."""
 
 import json
+import math
+import re
 import secrets
 import warnings
 from collections.abc import Sequence
@@ -338,6 +340,98 @@ def save_source_collection(
     return source_path
 
 
+_SCORE_RATIONALE_FIELDS = (
+    ("trl_score", "trl_rationale"),
+    ("mrl_score", "mrl_rationale"),
+    ("patent_strength", "patent_rationale"),
+    ("market_accessibility", "market_rationale"),
+    ("evidence_confidence", "evidence_rationale"),
+)
+_SCORE_NOUNS = "score|rating|confidence|accessibility|strength|readiness"
+_RATING_ADJECTIVES = "low|weak|limited|moderate|medium|strong|high"
+
+
+def _delivered_and_raw_score_text(value: Any) -> tuple[str, str] | None:
+    """Return the client-scale value and its exact internal x10 integer."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    delivered = float(value)
+    raw = delivered * 10
+    if not math.isfinite(delivered) or not raw.is_integer() or not 0 <= raw <= 100:
+        return None
+    return f"{delivered:g}", str(int(raw))
+
+
+def _normalize_qwen_score_phrase(rationale: str, delivered_score: Any) -> str:
+    pair = _delivered_and_raw_score_text(delivered_score)
+    if pair is None:
+        return rationale
+    delivered, raw = pair
+    escaped_raw = re.escape(raw)
+    rated_pattern = re.compile(
+        rf"(?P<prefix>\b(?:{_SCORE_NOUNS})\s+"
+        rf"(?:(?:is|was|remains)\s+)?rated\s+(?:at|as)\s*)"
+        rf"{escaped_raw}(?![\d.%])"
+        rf"(?=\s*(?:[,.;:)]|$|\b(?:because|based|reflecting|given|with)\b))",
+        re.IGNORECASE,
+    )
+    parenthetical_pattern = re.compile(
+        rf"(?P<prefix>\b(?:{_SCORE_NOUNS})\s+"
+        rf"(?:is|was|remains)\s+(?:very\s+)?(?:{_RATING_ADJECTIVES})\s+\(\s*)"
+        rf"{escaped_raw}(?P<suffix>\s*\))(?!\d)",
+        re.IGNORECASE,
+    )
+    normalized = rated_pattern.sub(
+        lambda match: f"{match.group('prefix')}{delivered}", rationale
+    )
+    return parenthetical_pattern.sub(
+        lambda match: f"{match.group('prefix')}{delivered}{match.group('suffix')}",
+        normalized,
+    )
+
+
+def _normalize_delivered_score_rationales(scores_json: str) -> str:
+    """Repair only bounded raw-scale phrases at the persisted client seam.
+
+    The scoring guardrail already handles generic explicit score forms. The
+    first paid Qwen canary used two new phrases that passed that guardrail
+    while the numeric fields were correct. This second defense belongs here:
+    every fresh or restored scorer output reaches this file before API and
+    browser readers do.
+
+    Moving the rule into evidence.py would change byte-locked dependencies of
+    consumed OpenAlex experiments. Updating those historical hashes would
+    falsely rewrite their method identity, so the persistence seam is both
+    the narrowest production fix and the one that preserves experiment lineage.
+    """
+
+    try:
+        payload = json.loads(scores_json)
+    except json.JSONDecodeError:
+        # Persisting the original diagnostic payload preserves save_scores'
+        # pre-existing behavior; validation belongs to the scorer guardrail.
+        return scores_json
+    if not isinstance(payload, dict):
+        return scores_json
+
+    changed = False
+    for score_field, rationale_field in _SCORE_RATIONALE_FIELDS:
+        rationale = payload.get(rationale_field)
+        if not isinstance(rationale, str):
+            continue
+        normalized = _normalize_qwen_score_phrase(
+            rationale, payload.get(score_field)
+        )
+        if normalized != rationale:
+            payload[rationale_field] = normalized
+            changed = True
+
+    if not changed:
+        return scores_json
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def save_scores(
     scores_json: str,
     run_id: str,
@@ -348,7 +442,9 @@ def save_scores(
     run_directory = output_root / run_id
     run_directory.mkdir(parents=True, exist_ok=True)
     scores_path = run_directory / "commercialization_scores.json"
-    scores_path.write_text(scores_json, encoding="utf-8")
+    scores_path.write_text(
+        _normalize_delivered_score_rationales(scores_json), encoding="utf-8"
+    )
     return scores_path
 
 

--- a/tests/test_run_output.py
+++ b/tests/test_run_output.py
@@ -1,5 +1,6 @@
 """Tests for isolated per-run report output."""
 
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -50,6 +51,72 @@ class RunOutputTests(TestCase):
 
             self.assertEqual(path, root / "run-123" / "commercialization_scores.json")
             self.assertEqual(path.read_text(encoding="utf-8"), '{"overall_score":65}')
+
+    def test_scores_normalize_qwen_rated_at_form_at_persistence_seam(self) -> None:
+        """The first paid Qwen phrase must not reach the client score artifact."""
+        from academic_agent.run_output import save_scores
+
+        payload = {
+            "market_accessibility": 2.5,
+            "market_rationale": (
+                "Market accessibility is rated at 25, reflecting active private "
+                "investment without a verified commercial product."
+            ),
+        }
+        with TemporaryDirectory() as temporary_directory:
+            path = save_scores(
+                json.dumps(payload),
+                "run-qwen-rated",
+                output_root=Path(temporary_directory),
+            )
+
+            saved = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertIn("rated at 2.5", saved["market_rationale"])
+        self.assertNotIn("rated at 25", saved["market_rationale"])
+
+    def test_scores_normalize_qwen_parenthetical_form_at_persistence_seam(self) -> None:
+        """A qualitative score label must use the delivered decimal scale."""
+        from academic_agent.run_output import save_scores
+
+        payload = {
+            "evidence_confidence": 3.5,
+            "evidence_rationale": (
+                "Confidence is moderate (35) because the evidence domains "
+                "remain only indirectly correlated."
+            ),
+        }
+        with TemporaryDirectory() as temporary_directory:
+            path = save_scores(
+                json.dumps(payload),
+                "run-qwen-parenthetical",
+                output_root=Path(temporary_directory),
+            )
+
+            saved = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertIn("moderate (3.5)", saved["evidence_rationale"])
+        self.assertNotIn("moderate (35)", saved["evidence_rationale"])
+
+    def test_scores_leave_percentages_and_candidate_counts_unchanged(self) -> None:
+        """Precision-first normalization must not rewrite evidence quantities."""
+        from academic_agent.run_output import save_scores
+
+        rationale = "Confidence is moderate (35%) after review of 35 candidate sources."
+        payload = {
+            "evidence_confidence": 3.5,
+            "evidence_rationale": rationale,
+        }
+        with TemporaryDirectory() as temporary_directory:
+            path = save_scores(
+                json.dumps(payload),
+                "run-qwen-percentage",
+                output_root=Path(temporary_directory),
+            )
+
+            saved = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(saved["evidence_rationale"], rationale)
 
     def test_reviewer_notes_uses_run_directory(self) -> None:
         from academic_agent.run_output import save_reviewer_notes


### PR DESCRIPTION
Why
- The first paid Qwen3.5 Plus canary completed with correct numeric scores but persisted two internal-x10 values in report-facing rationale prose.
- The repair belongs at the score artifact boundary so fresh and restored runs converge without changing evidence.py or rewriting consumed OpenAlex experiment hashes.

What changed
- Normalize only bounded rated-at and qualitative-parenthetical forms using the delivered numeric field as authority.
- Preserve percentages, dates, unlabelled counts and malformed diagnostic payload behavior.
- Record the live canary facts and its explicit quality limitations in README, AGENTS and a dated result artifact.

Verification
- 1771 tests and 657 subtests passed.
- Latest Ruff passed.
- CI-equivalent narrow Pylint passed at 10.00/10.
- Chromium smoke passed with zero external and zero paid-provider requests.
- The persistence call was bypassed after the fix; both exact defect tests failed, then passed after restoration.
- Historical OpenAlex lock tests passed without changing any frozen hash.

Known separate issue
- The same canary exposed invented decision thresholds and one citation-entailment concern. This PR records but does not conflate that semantic problem with the score-scale seam.