### PR TITLE
Add a strict Qwen contract for the disconnected evidence-set judge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1771 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1782 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -171,7 +171,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  92 test modules plus conftest, organised by subject
+tests/                  93 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -482,6 +482,20 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   correct implementation was restored. No later paid request is authorized or
   has occurred. W01-W08 remain consumed development evidence, and this
   transport amendment does not reopen their semantic method or gates.
+  A separately pre-registered Qwen profile is now implemented without editing
+  that historical DeepSeek contract. Its raw one-request adapter fixes exact
+  `qwen3.5-plus`, top-level `enable_thinking=false`, JSON Object mode, nested
+  cached-token accounting and the committed conservative price basis. Qwen
+  uses manifest/execution schema 3, requires an explicit provider for live
+  CLI execution, and reaches every manifest, journal and execution boundary.
+  The real zero-network preflight verified 8/8 W cases, 64/64 candidates and
+  16 prompt identities with no socket or model call. Removing the thinking
+  field and the cross-provider journal check independently made their seam
+  tests fail before restoration. No paid Qwen v5 call is authorized, and this
+  implementation does not complete or connect production Tool Calling. See
+  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`
+  and
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -782,7 +782,14 @@ correct, and the narrow narrative seam is now covered by regression tests.
 A separate invented-threshold/citation-entailment finding remains open. See
 the [implementation record](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
 and [paid canary record](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md).
-Local verification now passes **1,771 tests plus 657 subtests**, latest Ruff,
+
+Separately, the production-disconnected v5 evidence judge now has a strict
+one-request Qwen raw-HTTP profile. Its zero-network preflight verified 8 frozen
+cases, 64 candidates and 16 prompt identities; no paid v5 Qwen call has been
+authorized, and production remains in zero-call shadow mode. See the
+[pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)
+and [implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md).
+Local verification now passes **1,782 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -1966,7 +1973,13 @@ Token 沿用 DashScope 的 OpenAI 兼容统计格式，成本估算采用已公�
 模型自创决策阈值与引用蕴含问题仍待单独处理。详见
 [实现记录](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
 和[付费 canary 记录](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md)。
-本地验证现通过 **1,771 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+
+此外，生产隔离的 v5 Evidence Judge 已增加严格的 Qwen 单请求原始 HTTP
+Profile。零网络预检验证了 8 个冻结案例、64 个候选和 16 个 Prompt 身份；
+目前没有授权任何 v5 Qwen 付费调用，生产仍保持零调用 Shadow Mode。详见
+[预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)
+和[实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md)。
+本地验证现通过 **1,782 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md
+++ b/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md
@@ -1,0 +1,127 @@
+# Pre-registration amendment: evidence-set v5 Qwen provider contract
+
+Date: 2026-08-31
+
+Status: frozen before implementation and before any Qwen request for the v5
+study. This amendment authorizes no paid call and does not reinterpret the
+earlier DeepSeek provider-identity stop.
+
+## Why this amendment exists
+
+The production six-stage workflow now has a first-class Qwen3.5 Plus adapter
+and one completed live canary, while the disconnected evidence-set v5 runner
+still imports a provider-specific `deepseek-v4-flash` judge. Reusing the normal
+CrewAI adapter would be the wrong boundary: production retries selected
+transport failures, whereas one v5 judge invocation must equal exactly one
+potentially billable request with no hidden repair or fallback.
+
+This amendment adds a separate strict Qwen judge profile. It does not replace
+or edit the historical DeepSeek contract. It changes only provider transport,
+identity and accounting. The semantic prompt, two reversed-order passes,
+quote verifier, deterministic set-cover selector, W01-W08 development inputs,
+five development gates, X01-X08 unseen gates and production disconnection stay
+unchanged.
+
+## Frozen Qwen request contract
+
+Every v5 Qwen judge request must:
+
+1. use `POST https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`;
+2. authenticate only with `DASHSCOPE_API_KEY` in the outbound bearer header;
+3. request exactly `qwen3.5-plus` and accept only that exact returned model;
+4. place `enable_thinking=false` at the top level of the raw HTTP body;
+5. retain JSON Object mode, temperature 0, non-streaming behavior and the
+   existing per-pass output-token limit;
+6. contain the word `JSON` in the prompt, as already required by the frozen v5
+   system and user instructions;
+7. make exactly one HTTP request with no redirect, retry, repair, fallback,
+   model substitution or second formatting call; and
+8. keep credentials outside prompts, identities, errors and persisted
+   artifacts.
+
+The top-level thinking field is deliberate. Alibaba documents `extra_body` as
+an OpenAI SDK mechanism and explicitly says direct HTTP callers must send the
+provider field directly. Copying the production CrewAI configuration into a
+raw JSON body would therefore serialize the wrong contract.
+
+An alias, dated suffix, alternate region, operator endpoint override or prefix
+match is terminal. Exact identity is needed because a transport-compatible
+model is not automatically the frozen semantic judge.
+
+## Frozen response and accounting contract
+
+The adapter may admit semantic output only after it validates:
+
+- one response choice with non-empty content and a finish reason;
+- exact returned-model identity;
+- non-negative `prompt_tokens`, `completion_tokens` and `total_tokens` with
+  `total_tokens = prompt_tokens + completion_tokens`;
+- optional cached input only from
+  `usage.prompt_tokens_details.cached_tokens`, bounded by prompt input; and
+- a locally reproducible cost using the repository's dated, conservative
+  Qwen3.5 Plus peak-tier row with environment price overrides disabled.
+
+The built-in row intentionally remains conservative for this fixed soft-stop
+study. Changing a deployment's `LLM_PRICE_PER_MTOK` must not move an
+experiment gate without changing committed bytes.
+
+After a parseable provider envelope, a terminal identity failure may preserve
+only safe returned-model and usage observations. Semantic content must not be
+persisted. Any potentially spending call with missing or invalid usage makes
+the aggregate cost `uninspectable`, never zero or a partial known total.
+
+## Runner and artifact compatibility
+
+- The existing DeepSeek profile remains the default for historical dry-run
+  compatibility and retains manifest schema version 2.
+- Qwen uses an explicit provider selection and manifest schema version 3.
+- A live CLI execution must name its provider; provider auto-detection is not
+  allowed at an experimental paid boundary.
+- Provider, model, endpoint, request schema and the selected adapter hash must
+  reach the pre-call manifest and every call journal.
+- The complete manifest is written before credential resolution or adapter
+  construction, and each response/usage journal is durable before a later
+  call.
+- `pipeline_worker.py` must import neither provider judge nor the v5 runner.
+
+## Required zero-network evidence
+
+Before a paid Qwen development authorization:
+
+1. the exact raw body contains top-level `enable_thinking=false`, JSON Object
+   mode and `qwen3.5-plus`, with no `extra_body` wrapper;
+2. exact model drift is terminal after one request and preserves safe usage
+   without semantic content;
+3. redirect, missing usage, inconsistent totals and uninspectable cost remain
+   terminal and never trigger a retry;
+4. nested cached-token accounting and the frozen price basis are tested while
+   an environment price override is present;
+5. the Qwen provider/model/endpoint and every request identity reach the
+   manifest and journal boundary;
+6. the historical DeepSeek dry-run and its schema-2 manifest remain valid;
+7. the top-level thinking field is temporarily removed and the outbound seam
+   test fails before restoration;
+8. the complete W01-W08 Qwen dry-run verifies 8 cases, 64 candidates, 16 prompt
+   identities, all source hashes and all provider-specific implementation
+   hashes with zero sockets and zero model calls; and
+9. the full zero-network suite, latest Ruff and narrow Pylint pass.
+
+## Later paid boundary
+
+This amendment and its implementation authorize no provider request. A later
+W01-W08 development execution requires fresh authorization naming the merged
+Git revision, provider, exact model, maximum 16 sequential calls and a soft USD
+stop. W01-W08 remain consumed development evidence and can never be described
+as v5 validation. Failure of any frozen development gate seals v5; it cannot be
+tuned and replayed into a pass.
+
+Even a development pass would authorize only the separately frozen X01-X08
+unseen study. It would not authorize planner triggering, report insertion or
+production Tool Calling.
+
+## Official contract references
+
+- <https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions>
+- <https://docs.modelstudio.console.alibabacloud.com/en/model-studio/qwen-structured-output>
+- <https://www.alibabacloud.com/help/en/model-studio/qwen3-5-plus>
+- <https://www.alibabacloud.com/help/en/model-studio/model-pricing>

--- a/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md
+++ b/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md
@@ -1,0 +1,113 @@
+# Result: evidence-set v5 Qwen provider-contract implementation
+
+Date: 2026-08-31
+
+## Outcome
+
+The pre-registered Qwen3.5 Plus provider profile is implemented and passes its
+zero-network qualification. It authorizes no paid request and keeps the v5
+judge disconnected from production reports, planner triggers, OpenAlex and the
+six-stage workflow.
+
+The existing DeepSeek schema-2 profile remains available as the historical
+default. Qwen uses a separate schema-3 manifest and implementation lock rather
+than rewriting the provider identity of earlier artifacts.
+
+## Implemented contract
+
+The new strict adapter:
+
+- sends one raw HTTP request to the frozen DashScope Chat Completions endpoint;
+- requests exactly `qwen3.5-plus` and rejects aliases, suffixes and endpoint
+  overrides;
+- places `enable_thinking=false` at the top level of the direct JSON body;
+- requires JSON Object mode, temperature 0, non-streaming output and the
+  existing per-pass output ceiling;
+- performs no redirect, retry, repair, fallback or model substitution;
+- reads cached input only from
+  `usage.prompt_tokens_details.cached_tokens`;
+- validates prompt, completion and total-token arithmetic before admitting
+  semantic content;
+- uses the committed conservative Qwen peak-tier price basis with environment
+  overrides disabled; and
+- persists no credential or rejected semantic response.
+
+A parseable model-identity failure may retain only its safe returned model and
+validated usage. A potentially spending call without inspectable accounting
+keeps the whole execution cost `uninspectable`, never zero.
+
+The runner now selects its provider explicitly. Live CLI execution refuses to
+start without `--judge-provider deepseek|qwen`; historical dry-run behavior
+still defaults to DeepSeek. Qwen provider, model, API base, exact request
+endpoint and request schema reach the pre-call manifest, every call journal
+and schema-3 execution artifact. The execution model rejects a schema/provider
+mismatch. `pipeline_worker.py` imports neither provider judge nor this runner.
+
+## Zero-network evidence
+
+The real Qwen dry-run verified:
+
+- 8/8 W development cases;
+- 64/64 candidate identities;
+- 16 bounded prompt identities;
+- every source and provider-specific implementation hash;
+- `real_network_calls_performed=false`; and
+- `real_model_calls_performed=false`.
+
+The adapter and runner subset passed:
+
+```text
+21 passed in 2.08s
+```
+
+The complete zero-network suite passed:
+
+```text
+1782 passed, 657 subtests passed in 32.86s
+```
+
+Latest Ruff and the CI exception-order/unreachable-code Pylint gate also
+passed.
+
+## Defect reinjection
+
+Two seam defects were re-injected independently and then reverted.
+
+Removing top-level `enable_thinking=false` made the raw outbound-body test
+fail with `KeyError: 'enable_thinking'`. This proves the test observes the
+serialized direct-HTTP request rather than an unused configuration field.
+
+Removing the call-journal provider consistency check made the cross-provider
+test fail with `Failed: DID NOT RAISE ValueError`. This proves a DeepSeek
+response cannot be stored under a Qwen request merely because both values were
+individually valid.
+
+Both correct implementations were restored, and the focused tests passed
+again.
+
+## Frozen Qwen implementation identities
+
+| Dependency | SHA-256 |
+|---|---|
+| `qwen_evidence_judge.py` | `6b43ba97049bc51410e9871280b4b67093a09f64290baec360b87abb70a7953e` |
+| `evidence_search.py` | `2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0` |
+| `openalex_evidence_set.py` | `413bf6cea1c555c75bd80aaadae720cbf00886974acfdd443643f6a2f75e992c` |
+| `openalex_scope_link.py` | `abfb9a6b6af1691411f4ad3689b0f5052c42dfeddfdc30cb2e9e21c7d0ff2667` |
+| `openalex_scope_link_unseen.py` | `1e3c0b15c9608cf83b414ee52ac2da7540728149970fa45ab9e6306773ef4749` |
+| `token_usage.py` | `884a314cb6dfa9393afb74e71cdf54e77c22404f647772e88d3845ec89a0acac` |
+
+The runner records its own observed hash in each manifest instead of embedding
+a recursive digest.
+
+## Next gate
+
+No Qwen v5 provider request occurred during this implementation. A later
+W01-W08 development execution requires fresh authorization naming the merged
+revision, exact provider/model, maximum 16 sequential calls and a soft USD
+stop. W01-W08 remain consumed development evidence; even a pass would authorize
+only the separately frozen X01-X08 unseen study.
+
+This work therefore completes the Qwen judge contract, not Tool Calling as a
+production feature. The production workflow remains phase-1 zero-call shadow
+mode until the experimental source-value and unseen gates justify a separately
+reviewed connection.

--- a/openalex_evidence_set_development.py
+++ b/openalex_evidence_set_development.py
@@ -43,9 +43,15 @@ from academic_agent.tools.deepseek_evidence_judge import (
     DeepSeekJudgeRequest,
     DeepSeekJudgeResponse,
     DeepSeekJudgeUsageObservation,
-    prompt_sha256,
 )
 from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+from academic_agent.tools.qwen_evidence_judge import (
+    QwenEvidenceJudgeAdapter,
+    QwenJudgeAdapterError,
+    QwenJudgeRequest,
+    QwenJudgeResponse,
+    QwenJudgeUsageObservation,
+)
 from openalex_scope_link_unseen import (
     DEFAULT_FIXTURE_PATH as DEFAULT_V4_FIXTURE_PATH,
     EXPECTED_FIXTURE_SHA256 as EXPECTED_V4_FIXTURE_SHA256,
@@ -85,10 +91,7 @@ MAXIMUM_SOFT_STOP_USD = 0.20
 _CASE_ORDER = tuple(f"W{index:02d}" for index in range(1, 9))
 _SHA256_PATTERN = r"^[0-9a-f]{64}$"
 _RUNNER_PATH = Path(__file__).resolve()
-_IMPLEMENTATION_PATHS = {
-    "deepseek_evidence_judge.py": (
-        _ROOT / "src/academic_agent/tools/deepseek_evidence_judge.py"
-    ),
+_COMMON_IMPLEMENTATION_PATHS = {
     "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
     "openalex_evidence_set.py": (
         _ROOT / "src/academic_agent/openalex_evidence_set.py"
@@ -98,6 +101,18 @@ _IMPLEMENTATION_PATHS = {
     ),
     "openalex_scope_link_unseen.py": _ROOT / "openalex_scope_link_unseen.py",
     "token_usage.py": _ROOT / "src/academic_agent/token_usage.py",
+}
+_IMPLEMENTATION_PATHS = {
+    "deepseek_evidence_judge.py": (
+        _ROOT / "src/academic_agent/tools/deepseek_evidence_judge.py"
+    ),
+    **_COMMON_IMPLEMENTATION_PATHS,
+}
+_QWEN_IMPLEMENTATION_PATHS = {
+    "qwen_evidence_judge.py": (
+        _ROOT / "src/academic_agent/tools/qwen_evidence_judge.py"
+    ),
+    **_COMMON_IMPLEMENTATION_PATHS,
 }
 # These identities are filled from committed implementation bytes.  The runner
 # itself is recorded as an observed hash because embedding its own expected
@@ -123,6 +138,36 @@ EXPECTED_IMPLEMENTATION_SHA256 = {
         "b2a8cb6df7e6b40efc0b354965c83a205b18297002010299c9aedd0bc56a1e13"
     ),
 }
+
+# Keeping this separate from the DeepSeek lock prevents a new provider from
+# silently rewriting the byte identity of the historical contract.
+EXPECTED_QWEN_IMPLEMENTATION_SHA256 = {
+    "qwen_evidence_judge.py": (
+        "6b43ba97049bc51410e9871280b4b67093a09f64290baec360b87abb70a7953e"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_evidence_set.py": (
+        "413bf6cea1c555c75bd80aaadae720cbf00886974acfdd443643f6a2f75e992c"
+    ),
+    "openalex_scope_link.py": (
+        "abfb9a6b6af1691411f4ad3689b0f5052c42dfeddfdc30cb2e9e21c7d0ff2667"
+    ),
+    "openalex_scope_link_unseen.py": (
+        "1e3c0b15c9608cf83b414ee52ac2da7540728149970fa45ab9e6306773ef4749"
+    ),
+    "token_usage.py": (
+        "884a314cb6dfa9393afb74e71cdf54e77c22404f647772e88d3845ec89a0acac"
+    ),
+}
+
+JudgeProvider = Literal["deepseek", "qwen"]
+JudgeRequest = DeepSeekJudgeRequest | QwenJudgeRequest
+JudgeResponse = DeepSeekJudgeResponse | QwenJudgeResponse
+JudgeUsageObservation = (
+    DeepSeekJudgeUsageObservation | QwenJudgeUsageObservation
+)
 
 _SYSTEM_PROMPT = """You are a bounded academic-evidence classification component.
 You do not decide commercial viability, novelty, or truth. For each supplied
@@ -225,8 +270,8 @@ class PreparedDevelopmentCase:
     candidates: tuple[LockedEvidenceSetCandidate, ...]
     first_input: JudgeBatchInput
     second_input: JudgeBatchInput
-    first_request: DeepSeekJudgeRequest
-    second_request: DeepSeekJudgeRequest
+    first_request: JudgeRequest
+    second_request: JudgeRequest
 
 
 class FrozenDevelopmentCase(BaseModel):
@@ -239,8 +284,8 @@ class FrozenDevelopmentCase(BaseModel):
     query: str = Field(min_length=20, max_length=500)
     profile: EvidenceSetRoleProfile
     profile_sha256: str = Field(pattern=_SHA256_PATTERN)
-    first_request: DeepSeekJudgeRequest
-    second_request: DeepSeekJudgeRequest
+    first_request: JudgeRequest
+    second_request: JudgeRequest
 
 
 class DevelopmentManifest(BaseModel):
@@ -248,7 +293,7 @@ class DevelopmentManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[2] = 2
+    schema_version: Literal[2, 3] = 2
     mode: Literal["openalex_evidence_set_v5_development_manifest"] = (
         "openalex_evidence_set_v5_development_manifest"
     )
@@ -264,15 +309,43 @@ class DevelopmentManifest(BaseModel):
     runner_sha256: str = Field(pattern=_SHA256_PATTERN)
     selection_contract: EvidenceSetSelectionContract
     selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
-    requested_provider: Literal["deepseek"] = "deepseek"
-    requested_model: Literal["deepseek-v4-flash"] = "deepseek-v4-flash"
-    api_base: Literal["https://api.deepseek.com"] = "https://api.deepseek.com"
+    requested_provider: JudgeProvider = "deepseek"
+    requested_model: Literal["deepseek-v4-flash", "qwen3.5-plus"] = (
+        "deepseek-v4-flash"
+    )
+    api_base: Literal[
+        "https://api.deepseek.com",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    ] = "https://api.deepseek.com"
     maximum_model_call_count: Literal[16] = 16
     soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
     cases: tuple[FrozenDevelopmentCase, ...] = Field(min_length=8, max_length=8)
 
     @model_validator(mode="after")
     def _validate_case_contract(self) -> "DevelopmentManifest":
+        expected_contract = {
+            "deepseek": (
+                2,
+                "deepseek-v4-flash",
+                "https://api.deepseek.com",
+                DeepSeekJudgeRequest,
+            ),
+            "qwen": (
+                3,
+                "qwen3.5-plus",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                QwenJudgeRequest,
+            ),
+        }
+        schema, model, api_base, request_type = expected_contract[
+            self.requested_provider
+        ]
+        if (self.schema_version, self.requested_model, self.api_base) != (
+            schema,
+            model,
+            api_base,
+        ):
+            raise ValueError("manifest provider contract fields are inconsistent")
         if tuple(case.case_id for case in self.cases) != _CASE_ORDER:
             raise ValueError("development manifest cases must remain W01-W08")
         for case in self.cases:
@@ -286,6 +359,16 @@ class DevelopmentManifest(BaseModel):
                 f"openalex-v5-{case.case_id.casefold()}-pass-2"
             ):
                 raise ValueError(f"{case.case_id}: second trace identity drifted")
+            if not isinstance(case.first_request, request_type) or not isinstance(
+                case.second_request,
+                request_type,
+            ):
+                raise ValueError(f"{case.case_id}: request provider type drifted")
+            if (
+                case.first_request.requested_model != self.requested_model
+                or case.second_request.requested_model != self.requested_model
+            ):
+                raise ValueError(f"{case.case_id}: request model drifted")
         if self.selection_contract.sha256() != self.selection_contract_sha256:
             raise ValueError("selection contract identity drifted")
         return self
@@ -309,10 +392,10 @@ class JudgeCallJournal(BaseModel):
     case_id: str = Field(pattern=r"^W0[1-8]$")
     pass_number: Literal[1, 2]
     state: CallState
-    request: DeepSeekJudgeRequest
-    response: DeepSeekJudgeResponse | None = None
+    request: JudgeRequest
+    response: JudgeResponse | None = None
     observed_returned_model: str | None = Field(default=None, max_length=200)
-    observed_usage: DeepSeekJudgeUsageObservation | None = None
+    observed_usage: JudgeUsageObservation | None = None
     failure_type: str | None = Field(default=None, max_length=100)
     failure_detail: str | None = Field(default=None, max_length=500)
     failure_retryable: bool | None = None
@@ -346,12 +429,17 @@ class JudgeCallJournal(BaseModel):
             f"openalex-v5-{self.case_id.casefold()}-pass-{self.pass_number}"
         ):
             raise ValueError("journal trace ID drifted from case and pass")
+        if (
+            self.response is not None
+            and self.response.requested_model != self.request.requested_model
+        ):
+            raise ValueError("journal response provider drifted from request")
         return self
 
 
 def _journal_usage(
     call: JudgeCallJournal,
-) -> DeepSeekJudgeUsageObservation | None:
+) -> JudgeUsageObservation | None:
     """Return measured usage regardless of semantic-output admissibility."""
 
     if call.response is not None:
@@ -364,7 +452,7 @@ class DevelopmentExecution(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[2] = 2
+    schema_version: Literal[2, 3] = 2
     mode: Literal["openalex_evidence_set_v5_development_execution"] = (
         "openalex_evidence_set_v5_development_execution"
     )
@@ -403,6 +491,13 @@ class DevelopmentExecution(BaseModel):
     def _validate_complete_execution(self) -> "DevelopmentExecution":
         if self.attempted_model_call_count != len(self.calls):
             raise ValueError("attempted call count drifted from journals")
+        expected_model = (
+            "qwen3.5-plus" if self.schema_version == 3 else "deepseek-v4-flash"
+        )
+        if any(
+            call.request.requested_model != expected_model for call in self.calls
+        ):
+            raise ValueError("execution schema drifted from call providers")
         completed_calls = sum(call.state == "completed" for call in self.calls)
         if self.completed_model_call_count != completed_calls:
             raise ValueError("completed call count drifted from journals")
@@ -479,7 +574,7 @@ class DevelopmentExecution(BaseModel):
 
 
 class JudgeAdapter(Protocol):
-    def __call__(self, request: DeepSeekJudgeRequest) -> DeepSeekJudgeResponse: ...
+    def __call__(self, request: JudgeRequest) -> JudgeResponse: ...
 
 
 AdapterFactory = Callable[[], JudgeAdapter]
@@ -491,6 +586,18 @@ def _sha256_bytes(value: bytes) -> str:
 
 def _file_sha256(path: Path) -> str:
     return _sha256_bytes(path.read_bytes())
+
+
+def _prompt_sha256(system_prompt: str, user_prompt: str) -> str:
+    """Bind both messages without importing either provider implementation."""
+
+    canonical = json.dumps(
+        {"system": system_prompt, "user": user_prompt},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return _sha256_bytes(canonical)
 
 
 def _json_text(value: BaseModel | dict[str, Any] | list[Any]) -> str:
@@ -660,22 +767,30 @@ def _user_prompt(batch: JudgeBatchInput) -> str:
     )
 
 
-def _judge_request(batch: JudgeBatchInput) -> DeepSeekJudgeRequest:
+def _judge_request(
+    batch: JudgeBatchInput,
+    judge_provider: JudgeProvider,
+) -> JudgeRequest:
     user_prompt = _user_prompt(batch)
-    return DeepSeekJudgeRequest(
+    request_type = (
+        QwenJudgeRequest if judge_provider == "qwen" else DeepSeekJudgeRequest
+    )
+    return request_type(
         trace_id=(
             f"openalex-v5-{batch.case_id.casefold()}-pass-{batch.pass_number}"
         ),
         system_prompt=_SYSTEM_PROMPT,
         user_prompt=user_prompt,
         batch_input_sha256=batch.sha256(),
-        prompt_sha256=prompt_sha256(_SYSTEM_PROMPT, user_prompt),
+        prompt_sha256=_prompt_sha256(_SYSTEM_PROMPT, user_prompt),
     )
 
 
 def _prepare_cases(
     packet: DevelopmentPacket,
     v4_cases: tuple[PreparedScopeLinkCase, ...],
+    *,
+    judge_provider: JudgeProvider,
 ) -> tuple[PreparedDevelopmentCase, ...]:
     rows_by_case: defaultdict[str, list[DevelopmentPacketRow]] = defaultdict(list)
     for row in packet.rows:
@@ -710,8 +825,8 @@ def _prepare_cases(
                 candidates=candidates,
                 first_input=first_input,
                 second_input=second_input,
-                first_request=_judge_request(first_input),
-                second_request=_judge_request(second_input),
+                first_request=_judge_request(first_input, judge_provider),
+                second_request=_judge_request(second_input, judge_provider),
             )
         )
     return tuple(prepared)
@@ -719,17 +834,27 @@ def _prepare_cases(
 
 def verify_frozen_implementation(
     expected: Mapping[str, str] | None = None,
+    *,
+    judge_provider: JudgeProvider = "deepseek",
 ) -> dict[str, str]:
     """Reject dependency drift before output reservation or client creation."""
 
-    expected_hashes = dict(expected or EXPECTED_IMPLEMENTATION_SHA256)
-    if set(_IMPLEMENTATION_PATHS) != set(expected_hashes):
+    paths = (
+        _QWEN_IMPLEMENTATION_PATHS
+        if judge_provider == "qwen"
+        else _IMPLEMENTATION_PATHS
+    )
+    frozen_hashes = (
+        EXPECTED_QWEN_IMPLEMENTATION_SHA256
+        if judge_provider == "qwen"
+        else EXPECTED_IMPLEMENTATION_SHA256
+    )
+    expected_hashes = dict(frozen_hashes if expected is None else expected)
+    if set(paths) != set(expected_hashes):
         raise EvidenceSetDevelopmentError(
             "development implementation lock names are inconsistent"
         )
-    observed = {
-        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
-    }
+    observed = {name: _file_sha256(path) for name, path in paths.items()}
     if observed != expected_hashes:
         changed = sorted(
             name
@@ -751,6 +876,7 @@ def _load_prepared_study(
     v4_fixture_path: Path,
     expected_source_sha256: Mapping[str, str],
     expected_v4_fixture_sha256: str,
+    judge_provider: JudgeProvider,
 ) -> tuple[
     dict[str, str],
     str,
@@ -767,7 +893,11 @@ def _load_prepared_study(
         v4_fixture_path,
         expected_fixture_sha256=expected_v4_fixture_sha256,
     )
-    return source_sha256, fixture_sha256, _prepare_cases(packet, v4_cases)
+    return source_sha256, fixture_sha256, _prepare_cases(
+        packet,
+        v4_cases,
+        judge_provider=judge_provider,
+    )
 
 
 def _manifest(
@@ -778,10 +908,24 @@ def _manifest(
     runner_sha256: str,
     cases: tuple[PreparedDevelopmentCase, ...],
     soft_stop_usd: float,
+    judge_provider: JudgeProvider,
 ) -> DevelopmentManifest:
     selection = _selection_contract()
+    provider_contract = {
+        "deepseek": (2, "deepseek-v4-flash", "https://api.deepseek.com"),
+        "qwen": (
+            3,
+            "qwen3.5-plus",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        ),
+    }
+    schema_version, requested_model, api_base = provider_contract[judge_provider]
     return DevelopmentManifest(
         source_sha256=source_sha256,
+        schema_version=schema_version,
+        requested_provider=judge_provider,
+        requested_model=requested_model,
+        api_base=api_base,
         v4_fixture_sha256=v4_fixture_sha256,
         implementation_sha256=implementation_sha256,
         runner_sha256=runner_sha256,
@@ -813,6 +957,7 @@ def protocol_dry_run(
     expected_source_sha256: Mapping[str, str] = EXPECTED_SOURCE_SHA256,
     expected_v4_fixture_sha256: str = EXPECTED_V4_FIXTURE_SHA256,
     expected_implementation_sha256: Mapping[str, str] | None = None,
+    judge_provider: JudgeProvider = "deepseek",
 ) -> dict[str, Any]:
     """Verify all bytes and prompts while constructing no model client."""
 
@@ -824,13 +969,27 @@ def protocol_dry_run(
         v4_fixture_path=v4_fixture_path,
         expected_source_sha256=expected_source_sha256,
         expected_v4_fixture_sha256=expected_v4_fixture_sha256,
+        judge_provider=judge_provider,
     )
     implementation = verify_frozen_implementation(
-        expected_implementation_sha256
+        expected_implementation_sha256,
+        judge_provider=judge_provider,
     )
     return {
         "mode": "openalex_evidence_set_v5_development_dry_run",
         "production_connected": False,
+        "schema_version": 3 if judge_provider == "qwen" else 2,
+        "requested_provider": judge_provider,
+        "requested_model": (
+            "qwen3.5-plus"
+            if judge_provider == "qwen"
+            else "deepseek-v4-flash"
+        ),
+        "api_base": (
+            "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            if judge_provider == "qwen"
+            else "https://api.deepseek.com"
+        ),
         "report_workflow_connected": False,
         "planner_trigger_connected": False,
         "real_network_calls_performed": False,
@@ -861,14 +1020,14 @@ def protocol_dry_run(
 
 def _failed_journal(
     case_id: str,
-    request: DeepSeekJudgeRequest,
+    request: JudgeRequest,
     *,
     failure_type: str,
     failure_detail: str,
     failure_retryable: bool,
     request_may_have_spent: bool,
     observed_returned_model: str | None = None,
-    observed_usage: DeepSeekJudgeUsageObservation | None = None,
+    observed_usage: JudgeUsageObservation | None = None,
 ) -> JudgeCallJournal:
     return JudgeCallJournal(
         case_id=case_id,
@@ -885,8 +1044,8 @@ def _failed_journal(
 
 
 def _validate_response_identity(
-    request: DeepSeekJudgeRequest,
-    response: DeepSeekJudgeResponse,
+    request: JudgeRequest,
+    response: JudgeResponse,
 ) -> str | None:
     expected = {
         "trace_id": request.trace_id,
@@ -939,6 +1098,7 @@ def _evaluate_case(
 def _execution_artifact(
     *,
     manifest_sha256: str,
+    schema_version: Literal[2, 3],
     stop_reason: StopReason,
     calls: list[JudgeCallJournal],
     decisions: list[EvidenceSetCaseAudit],
@@ -974,6 +1134,7 @@ def _execution_artifact(
     candidate_count = sum(len(case.candidate_decisions) for case in decisions)
     all_persisted = complete and candidate_count == 64
     return DevelopmentExecution(
+        schema_version=schema_version,
         manifest_sha256=manifest_sha256,
         overall_state="completed" if complete else "partial",
         stop_reason=stop_reason,
@@ -1046,6 +1207,7 @@ def execute_development_study(
     expected_source_sha256: Mapping[str, str] = EXPECTED_SOURCE_SHA256,
     expected_v4_fixture_sha256: str = EXPECTED_V4_FIXTURE_SHA256,
     expected_implementation_sha256: Mapping[str, str] | None = None,
+    judge_provider: JudgeProvider = "deepseek",
     adapter_factory: AdapterFactory | None = None,
 ) -> DevelopmentExecution:
     """Run at most 16 label-blind calls under a write-once soft stop."""
@@ -1069,9 +1231,11 @@ def execute_development_study(
         v4_fixture_path=v4_fixture_path,
         expected_source_sha256=expected_source_sha256,
         expected_v4_fixture_sha256=expected_v4_fixture_sha256,
+        judge_provider=judge_provider,
     )
     implementation = verify_frozen_implementation(
-        expected_implementation_sha256
+        expected_implementation_sha256,
+        judge_provider=judge_provider,
     )
     runner_sha256 = _file_sha256(_RUNNER_PATH)
     output_dir.mkdir(parents=True, exist_ok=False)
@@ -1082,6 +1246,7 @@ def execute_development_study(
         runner_sha256=runner_sha256,
         cases=cases,
         soft_stop_usd=soft_stop_usd,
+        judge_provider=judge_provider,
     )
     manifest_text = _json_text(manifest)
     _write_new(output_dir / "manifest.json", manifest_text)
@@ -1089,15 +1254,23 @@ def execute_development_study(
     # This must remain after the manifest write.  Constructing the default
     # adapter resolves a real credential; a future refactor may perform other
     # paid-capable setup there.  The durable method boundary comes first.
+    default_adapter_type = (
+        QwenEvidenceJudgeAdapter
+        if judge_provider == "qwen"
+        else DeepSeekEvidenceJudgeAdapter
+    )
     adapter = (
         adapter_factory()
         if adapter_factory is not None
-        else DeepSeekEvidenceJudgeAdapter()
+        else default_adapter_type()
     )
     calls: list[JudgeCallJournal] = []
     decisions: list[EvidenceSetCaseAudit] = []
     known_cost = 0.0
     stop_reason: StopReason = "completed"
+    response_type = (
+        QwenJudgeResponse if judge_provider == "qwen" else DeepSeekJudgeResponse
+    )
 
     for case in cases:
         raw_responses: list[str] = []
@@ -1107,8 +1280,8 @@ def execute_development_study(
                 break
             try:
                 raw_response = adapter(request)
-                response = DeepSeekJudgeResponse.model_validate(raw_response)
-            except DeepSeekJudgeAdapterError as exc:
+                response = response_type.model_validate(raw_response)
+            except (DeepSeekJudgeAdapterError, QwenJudgeAdapterError) as exc:
                 journal = _failed_journal(
                     case.source_case.spec.case_id,
                     request,
@@ -1174,6 +1347,7 @@ def execute_development_study(
 
     execution = _execution_artifact(
         manifest_sha256=_sha256_bytes(manifest_text.encode("utf-8")),
+        schema_version=3 if judge_provider == "qwen" else 2,
         stop_reason=stop_reason,
         calls=calls,
         decisions=decisions,
@@ -1191,6 +1365,11 @@ def _stdout_json(value: object) -> str:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument(
+        "--judge-provider",
+        choices=("deepseek", "qwen"),
+        help="Required for live execution; dry-run defaults to historical DeepSeek.",
+    )
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--soft-stop-usd", type=float)
     parser.add_argument("--acknowledge-model-budget", action="store_true")
@@ -1207,13 +1386,19 @@ def _parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = _parser().parse_args()
+    judge_provider = cast(JudgeProvider, args.judge_provider or "deepseek")
     common = {
         "source_lock_path": args.source_lock,
         "packet_path": args.packet,
         "labels_path": args.labels,
         "declaration_path": args.declaration,
+        "judge_provider": judge_provider,
     }
     if args.execute_live:
+        if args.judge_provider is None:
+            raise SystemExit(
+                "--execute-live requires an explicit --judge-provider"
+            )
         if args.output_dir is None or args.soft_stop_usd is None:
             raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
         result = execute_development_study(

--- a/src/academic_agent/tools/qwen_evidence_judge.py
+++ b/src/academic_agent/tools/qwen_evidence_judge.py
@@ -1,0 +1,476 @@
+"""Strict one-request Qwen adapter for the disconnected v5 study.
+
+The production Qwen path deliberately retries selected transient failures, but
+an evidence-set study cannot hide a second potentially billable request behind
+one adapter invocation.  This adapter therefore owns no retry, repair,
+fallback, streaming, redirect, endpoint override, or model-selection logic.
+Semantic output is admitted only after exact model identity, provider usage,
+and the frozen local price basis are inspectable.
+
+Nothing in the production worker imports this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Literal, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.token_usage import cost_for, price_for
+
+
+QWEN_CHAT_COMPLETIONS_ENDPOINT = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+)
+REQUESTED_MODEL = "qwen3.5-plus"
+_MAX_RESPONSE_BYTES = 1_000_000
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class QwenJudgeAdapterError(RuntimeError):
+    """A credential-safe, classified failure from one Qwen request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_type: str,
+        retryable: bool,
+        request_may_have_spent: bool,
+        observed_returned_model: str | None = None,
+        observed_usage: QwenJudgeUsageObservation | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failure_type = failure_type
+        self.retryable = retryable
+        self.request_may_have_spent = request_may_have_spent
+        # Identity failures may retain non-secret accounting so the aggregate
+        # bill does not become zero.  They deliberately cannot retain semantic
+        # content that could be used to tune a consumed development set.
+        self.observed_returned_model = observed_returned_model
+        self.observed_usage = observed_usage
+
+
+class QwenJudgeRequest(BaseModel):
+    """Credential-free request identity passed across the paid-call seam."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    trace_id: str = Field(pattern=r"^openalex-v5-w0[1-8]-pass-[12]$")
+    requested_provider: Literal["qwen"] = "qwen"
+    requested_model: Literal["qwen3.5-plus"] = "qwen3.5-plus"
+    chat_completions_endpoint: Literal[
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+    ] = QWEN_CHAT_COMPLETIONS_ENDPOINT
+    system_prompt: str = Field(min_length=20, max_length=20_000)
+    user_prompt: str = Field(min_length=20, max_length=250_000)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    temperature: Literal[0.0] = 0.0
+    max_tokens: int = Field(default=8_000, ge=500, le=12_000)
+
+    @model_validator(mode="after")
+    def _validate_prompt_identity(self) -> "QwenJudgeRequest":
+        observed = _sha256_json(
+            {"system": self.system_prompt, "user": self.user_prompt}
+        )
+        if observed != self.prompt_sha256:
+            raise ValueError("prompt SHA-256 does not match the request text")
+        return self
+
+    def body(self) -> bytes:
+        """Return the exact raw-HTTP body, excluding every credential.
+
+        ``extra_body`` is an OpenAI SDK argument, not an HTTP field.  The v5
+        judge sends bytes directly, so Alibaba's extension belongs at the top
+        level.  Keeping that distinction here prevents a configuration object
+        that worked through CrewAI from becoming a silently ignored wire body.
+        """
+
+        return json.dumps(
+            {
+                "enable_thinking": False,
+                "max_tokens": self.max_tokens,
+                "messages": [
+                    {"content": self.system_prompt, "role": "system"},
+                    {"content": self.user_prompt, "role": "user"},
+                ],
+                "model": self.requested_model,
+                "response_format": {"type": "json_object"},
+                "stream": False,
+                "temperature": self.temperature,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+class QwenJudgeUsageObservation(BaseModel):
+    """Safe accounting retained even when semantic output is rejected."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    cached_prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    cost_usd: float | None = Field(default=None, ge=0.0, allow_inf_nan=False)
+    cost_basis: str | None = Field(default=None, min_length=5, max_length=300)
+
+    @model_validator(mode="after")
+    def _validate_token_accounting(self) -> "QwenJudgeUsageObservation":
+        if self.cached_prompt_tokens > self.prompt_tokens:
+            raise ValueError("cached tokens cannot exceed prompt tokens")
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            raise ValueError("total tokens do not match prompt plus completion")
+        if (self.cost_usd is None) != (self.cost_basis is None):
+            raise ValueError("cost and cost basis must be known or unknown together")
+        return self
+
+
+class QwenJudgeUsage(QwenJudgeUsageObservation):
+    """Provider usage with a locally reproducible cost required for success."""
+
+    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+    cost_basis: str = Field(min_length=5, max_length=300)
+
+
+class QwenJudgeResponse(BaseModel):
+    """Complete inspectable result from exactly one Qwen request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    trace_id: str = Field(pattern=r"^openalex-v5-w0[1-8]-pass-[12]$")
+    request_sha256: str = Field(pattern=_SHA256_PATTERN)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    requested_model: Literal["qwen3.5-plus"] = "qwen3.5-plus"
+    returned_model: Literal["qwen3.5-plus"]
+    provider_response_id: str = Field(min_length=3, max_length=300)
+    provider_request_id: str | None = Field(default=None, max_length=300)
+    finish_reason: str = Field(min_length=1, max_length=100)
+    raw_content: str = Field(min_length=1, max_length=200_000)
+    raw_content_sha256: str = Field(pattern=_SHA256_PATTERN)
+    usage: QwenJudgeUsage
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_content_identity(self) -> "QwenJudgeResponse":
+        if _sha256_text(self.raw_content) != self.raw_content_sha256:
+            raise ValueError("raw model content SHA-256 does not match")
+        return self
+
+
+@dataclass(frozen=True)
+class QwenJudgeTransportResponse:
+    """Raw body plus response headers from one transport invocation."""
+
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class QwenOneRequestTransport(Protocol):
+    """Injected seam whose one invocation equals one outbound request."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> QwenJudgeTransportResponse: ...
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects so one adapter call cannot become two requests."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _UrllibOneRequestTransport:
+    """Default transport with no redirect and no retry behavior."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> QwenJudgeTransportResponse:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method="POST",
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            response_headers = {
+                str(key): str(value) for key, value in response.headers.items()
+            }
+            return QwenJudgeTransportResponse(
+                body=response.read(_MAX_RESPONSE_BYTES + 1),
+                headers=response_headers,
+            )
+
+
+class _ProviderMessage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    content: str = Field(min_length=1, max_length=200_000)
+
+
+class _ProviderChoice(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    finish_reason: str = Field(min_length=1, max_length=100)
+    message: _ProviderMessage
+
+
+class _PromptTokenDetails(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    cached_tokens: int = Field(default=0, ge=0)
+
+
+class _ProviderUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    prompt_tokens_details: _PromptTokenDetails | None = None
+
+
+class _ProviderEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str = Field(min_length=3, max_length=300)
+    model: str = Field(min_length=3, max_length=200)
+    choices: tuple[_ProviderChoice, ...] = Field(min_length=1, max_length=1)
+    usage: _ProviderUsage
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return _sha256_text(canonical)
+
+
+def prompt_sha256(system_prompt: str, user_prompt: str) -> str:
+    """Bind both messages without depending on provider wire formatting."""
+
+    return _sha256_json({"system": system_prompt, "user": user_prompt})
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str | None:
+    expected = name.casefold()
+    return next(
+        (value for key, value in headers.items() if key.casefold() == expected),
+        None,
+    )
+
+
+def _safe_validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "provider response schema invalid"
+
+
+def _usage_observation(envelope: _ProviderEnvelope) -> QwenJudgeUsageObservation:
+    """Validate counters before deciding whether semantic output is admissible."""
+
+    details = envelope.usage.prompt_tokens_details
+    cached_tokens = details.cached_tokens if details is not None else 0
+    metrics = SimpleNamespace(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=cached_tokens,
+        cache_creation_tokens=0,
+        completion_tokens=envelope.usage.completion_tokens,
+    )
+    # Operator pricing overrides are useful for normal runs but inadmissible in
+    # a frozen experiment: an uncommitted environment variable must not move a
+    # soft-stop gate.  The dated built-in row and token_usage.py hash are both
+    # persisted by the runner.
+    price = price_for(envelope.model, allow_env_override=False)
+    cost = (
+        cost_for(envelope.model, metrics, allow_env_override=False)
+        if price is not None
+        else None
+    )
+    return QwenJudgeUsageObservation(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=cached_tokens,
+        completion_tokens=envelope.usage.completion_tokens,
+        total_tokens=envelope.usage.total_tokens,
+        cost_usd=cost,
+        cost_basis=price.basis if price is not None else None,
+    )
+
+
+class QwenEvidenceJudgeAdapter:
+    """Perform one fixed-endpoint, fixed-model JSON request with strict usage."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 60.0,
+        transport: QwenOneRequestTransport | None = None,
+        monotonic_clock=None,  # noqa: ANN001
+    ) -> None:
+        resolved_key = (api_key or os.getenv("DASHSCOPE_API_KEY") or "").strip()
+        if not resolved_key:
+            raise ValueError("DASHSCOPE_API_KEY is required for the v5 Qwen judge")
+        if not 0 < timeout <= 120:
+            raise ValueError("timeout must be greater than zero and at most 120 seconds")
+        self._api_key = resolved_key
+        self._timeout = timeout
+        self._transport = transport or _UrllibOneRequestTransport()
+        self._clock = monotonic_clock or time.perf_counter
+
+    def __call__(self, request: QwenJudgeRequest) -> QwenJudgeResponse:
+        """Send one request; every failure is terminal for this study run."""
+
+        body = request.body()
+        request_sha256 = hashlib.sha256(body).hexdigest()
+        started_at = self._clock()
+        try:
+            transport_response = self._transport(
+                endpoint=request.chat_completions_endpoint,
+                body=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "AcademicAgentEvidenceSetV5-Qwen/1.0",
+                    "X-Client-Request-ID": request.trace_id,
+                },
+                timeout=self._timeout,
+            )
+        except HTTPError as exc:
+            is_redirect = 300 <= exc.code < 400
+            raise QwenJudgeAdapterError(
+                f"Qwen HTTP {exc.code}",
+                failure_type=("provider_redirect" if is_redirect else "provider_http"),
+                retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
+                request_may_have_spent=not is_redirect,
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise QwenJudgeAdapterError(
+                f"Qwen transport failed: {type(exc).__name__}",
+                failure_type="provider_transport",
+                retryable=True,
+                request_may_have_spent=True,
+            ) from exc
+        latency_ms = max((self._clock() - started_at) * 1000.0, 0.0)
+
+        if len(transport_response.body) > _MAX_RESPONSE_BYTES:
+            raise QwenJudgeAdapterError(
+                "Qwen response exceeded the byte limit",
+                failure_type="provider_response_too_large",
+                retryable=False,
+                request_may_have_spent=True,
+            )
+        try:
+            decoded = json.loads(transport_response.body.decode("utf-8"))
+            envelope = _ProviderEnvelope.model_validate(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            detail = (
+                _safe_validation_detail(exc)
+                if isinstance(exc, ValidationError)
+                else type(exc).__name__
+            )
+            raise QwenJudgeAdapterError(
+                f"Qwen response failed schema validation: {detail}",
+                failure_type="provider_response_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+            ) from exc
+
+        try:
+            observed_usage = _usage_observation(envelope)
+        except ValidationError as exc:
+            raise QwenJudgeAdapterError(
+                "Qwen usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+            ) from exc
+
+        if envelope.model != request.requested_model:
+            raise QwenJudgeAdapterError(
+                "Qwen returned a model identity inconsistent with the request",
+                failure_type="provider_model_identity_mismatch",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
+            )
+        if observed_usage.cost_usd is None or observed_usage.cost_basis is None:
+            raise QwenJudgeAdapterError(
+                "Qwen token cost is not inspectable for the returned model",
+                failure_type="provider_cost_uninspectable",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
+            )
+        try:
+            usage = QwenJudgeUsage.model_validate(
+                observed_usage.model_dump(mode="python")
+            )
+        except ValidationError as exc:
+            raise QwenJudgeAdapterError(
+                "Qwen usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+            ) from exc
+        choice = envelope.choices[0]
+        return QwenJudgeResponse(
+            trace_id=request.trace_id,
+            request_sha256=request_sha256,
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model=envelope.model,
+            provider_response_id=envelope.id,
+            provider_request_id=(
+                _header_value(transport_response.headers, "x-request-id")
+                or _header_value(
+                    transport_response.headers,
+                    "x-dashscope-request-id",
+                )
+            ),
+            finish_reason=choice.finish_reason,
+            raw_content=choice.message.content,
+            raw_content_sha256=_sha256_text(choice.message.content),
+            usage=usage,
+            latency_ms=latency_ms,
+        )

--- a/tests/test_openalex_evidence_set_development.py
+++ b/tests/test_openalex_evidence_set_development.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -16,6 +17,14 @@ from academic_agent.tools.deepseek_evidence_judge import (
     DeepSeekJudgeResponse,
     DeepSeekJudgeUsage,
     DeepSeekJudgeUsageObservation,
+)
+from academic_agent.tools.qwen_evidence_judge import (
+    QWEN_CHAT_COMPLETIONS_ENDPOINT,
+    QwenJudgeAdapterError,
+    QwenJudgeRequest,
+    QwenJudgeResponse,
+    QwenJudgeUsage,
+    QwenJudgeUsageObservation,
 )
 
 
@@ -123,6 +132,13 @@ def _implementation_hashes() -> dict[str, str]:
     }
 
 
+def _qwen_implementation_hashes() -> dict[str, str]:
+    return {
+        name: development._file_sha256(path)  # noqa: SLF001
+        for name, path in development._QWEN_IMPLEMENTATION_PATHS.items()  # noqa: SLF001
+    }
+
+
 def _common(bundle: SourceBundle) -> dict[str, object]:
     return {
         "source_lock_path": bundle.source_lock,
@@ -136,7 +152,7 @@ def _common(bundle: SourceBundle) -> dict[str, object]:
     }
 
 
-def _abstain_content(request: DeepSeekJudgeRequest) -> str:
+def _abstain_content(request: DeepSeekJudgeRequest | QwenJudgeRequest) -> str:
     batch = json.loads(request.user_prompt.split("\nINPUT:\n", 1)[1])
     order = [item["candidate_sha256"] for item in batch["candidates"]]
     return json.dumps(
@@ -512,3 +528,254 @@ def test_production_worker_remains_disconnected_from_runner_and_adapter():
     assert "openalex_evidence_set_development" not in worker
     assert "deepseek_evidence_judge" not in worker
     assert "DeepSeekEvidenceJudgeAdapter" not in worker
+    assert "qwen_evidence_judge" not in worker
+    assert "QwenEvidenceJudgeAdapter" not in worker
+
+
+def _qwen_response(
+    request: QwenJudgeRequest,
+    *,
+    cost_usd: float = 0.001,
+) -> QwenJudgeResponse:
+    content = _abstain_content(request)
+    return QwenJudgeResponse(
+        trace_id=request.trace_id,
+        request_sha256=hashlib.sha256(request.body()).hexdigest(),
+        batch_input_sha256=request.batch_input_sha256,
+        prompt_sha256=request.prompt_sha256,
+        requested_model="qwen3.5-plus",
+        returned_model="qwen3.5-plus",
+        provider_response_id=f"response-{request.trace_id}",
+        provider_request_id=f"request-{request.trace_id}",
+        finish_reason="stop",
+        raw_content=content,
+        raw_content_sha256=hashlib.sha256(content.encode()).hexdigest(),
+        usage=QwenJudgeUsage(
+            prompt_tokens=10,
+            cached_prompt_tokens=1,
+            completion_tokens=2,
+            total_tokens=12,
+            cost_usd=cost_usd,
+            cost_basis="frozen Qwen test price basis",
+        ),
+        latency_ms=10.0,
+    )
+
+
+class QwenOrderedAdapter:
+    """Assert the same durable ordering at the provider-switched seam."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.requests: list[QwenJudgeRequest] = []
+
+    def __call__(self, request: QwenJudgeRequest) -> QwenJudgeResponse:
+        call_index = len(self.requests)
+        if call_index:
+            previous_case = f"W{((call_index - 1) // 2) + 1:02d}"
+            previous_pass = ((call_index - 1) % 2) + 1
+            assert (
+                self.output_dir
+                / "judge-calls"
+                / f"{previous_case}-pass-{previous_pass}.json"
+            ).is_file()
+        if call_index and call_index % 2 == 0:
+            prior_case = f"W{call_index // 2:02d}"
+            assert (
+                self.output_dir / "case-decisions" / f"{prior_case}.json"
+            ).is_file()
+        self.requests.append(request)
+        return _qwen_response(request)
+
+
+class QwenMeteredFailureAdapter:
+    """Expose safe Qwen usage while withholding rejected semantic content."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        del request
+        self.call_count += 1
+        raise QwenJudgeAdapterError(
+            "provider returned a different canonical model",
+            failure_type="provider_model_identity_mismatch",
+            retryable=False,
+            request_may_have_spent=True,
+            observed_returned_model="qwen3.5-plus-2026-08-01",
+            observed_usage=QwenJudgeUsageObservation(
+                prompt_tokens=100,
+                cached_prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=110,
+                cost_usd=0.002,
+                cost_basis="frozen Qwen test price basis",
+            ),
+        )
+
+
+def test_qwen_failure_reaches_execution_accounting_without_a_retry(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    common = _common(bundle)
+    common["judge_provider"] = "qwen"
+    common["expected_implementation_sha256"] = _qwen_implementation_hashes()
+    output = tmp_path / "qwen-failure"
+    adapter = QwenMeteredFailureAdapter()
+
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **common,
+    )
+
+    assert adapter.call_count == 1
+    assert result.schema_version == 3
+    assert result.stop_reason == "adapter_failed"
+    assert result.completed_model_call_count == 0
+    assert result.total_tokens == 110
+    assert result.cost_state == "known"
+    assert result.cost_usd == pytest.approx(0.002)
+    journal = json.loads(
+        (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
+    )
+    assert journal["request"]["requested_provider"] == "qwen"
+    assert journal["observed_returned_model"] == "qwen3.5-plus-2026-08-01"
+    assert "raw_content" not in journal
+
+
+def test_call_journal_rejects_a_response_from_the_other_provider():
+    system = "Return strict JSON for every supplied evidence candidate."
+    user = (
+        "Keep candidate order and classify every supplied row as JSON.\nINPUT:\n"
+        '{"case_id":"W01","candidates":[]}'
+    )
+    digest = development._prompt_sha256(system, user)  # noqa: SLF001
+    qwen_request = QwenJudgeRequest(
+        trace_id="openalex-v5-w01-pass-1",
+        system_prompt=system,
+        user_prompt=user,
+        batch_input_sha256="a" * 64,
+        prompt_sha256=digest,
+    )
+    deepseek_request = DeepSeekJudgeRequest(
+        trace_id="openalex-v5-w01-pass-1",
+        system_prompt=system,
+        user_prompt=user,
+        batch_input_sha256="a" * 64,
+        prompt_sha256=digest,
+    )
+
+    with pytest.raises(ValueError, match="response provider drifted"):
+        development.JudgeCallJournal(
+            case_id="W01",
+            pass_number=1,
+            state="completed",
+            request=qwen_request,
+            response=_response(deepseek_request),
+            request_may_have_spent=True,
+        )
+
+
+def test_live_cli_requires_an_explicit_judge_provider(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "openalex_evidence_set_development.py",
+            "--execute-live",
+            "--output-dir",
+            str(tmp_path / "unused"),
+            "--soft-stop-usd",
+            "0.05",
+            "--acknowledge-model-budget",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="explicit --judge-provider"):
+        development.main()
+
+
+def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    common = _common(bundle)
+    common["judge_provider"] = "qwen"
+    common["expected_implementation_sha256"] = _qwen_implementation_hashes()
+
+    dry_run = development.protocol_dry_run(**common)
+
+    assert dry_run["schema_version"] == 3
+    assert dry_run["requested_provider"] == "qwen"
+    assert dry_run["requested_model"] == "qwen3.5-plus"
+    assert dry_run["api_base"] == (
+        "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+    assert dry_run["case_count"] == 8
+    assert dry_run["candidate_count"] == 64
+
+    output = tmp_path / "qwen-result"
+    adapter = QwenOrderedAdapter(output)
+    factory = ManifestFirstFactory(output, adapter)
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=factory,
+        **common,
+    )
+
+    assert factory.call_count == 1
+    assert len(adapter.requests) == 16
+    assert result.schema_version == 3
+    assert result.overall_state == "completed"
+    assert result.persisted_candidate_decision_count == 64
+    assert result.cost_usd == pytest.approx(0.016)
+
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 3
+    assert manifest["requested_provider"] == "qwen"
+    assert manifest["requested_model"] == "qwen3.5-plus"
+    assert manifest["api_base"] == (
+        "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+    for case in manifest["cases"]:
+        for request_name in ("first_request", "second_request"):
+            request = case[request_name]
+            assert request["requested_provider"] == "qwen"
+            assert request["requested_model"] == "qwen3.5-plus"
+            assert (
+                request["chat_completions_endpoint"]
+                == QWEN_CHAT_COMPLETIONS_ENDPOINT
+            )
+
+    journal = json.loads(
+        (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
+    )
+    assert journal["request"]["requested_provider"] == "qwen"
+    assert journal["response"]["returned_model"] == "qwen3.5-plus"
+    assert journal["response"]["usage"]["cached_prompt_tokens"] == 1
+    serialized = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert serialized["schema_version"] == 3
+    assert serialized["calls"][0]["request"]["requested_provider"] == "qwen"
+
+
+def test_manifest_rejects_a_provider_identity_mismatch(tmp_path):
+    bundle = _source_bundle(tmp_path)
+    common = _common(bundle)
+    common["judge_provider"] = "qwen"
+    common["expected_implementation_sha256"] = _qwen_implementation_hashes()
+    output = tmp_path / "qwen-result"
+    adapter = QwenOrderedAdapter(output)
+    development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **common,
+    )
+    payload = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    payload["requested_provider"] = "deepseek"
+
+    with pytest.raises(ValueError, match="provider contract fields"):
+        development.DevelopmentManifest.model_validate(payload)

--- a/tests/test_qwen_evidence_judge.py
+++ b/tests/test_qwen_evidence_judge.py
@@ -1,0 +1,203 @@
+"""Zero-network transport and accounting seams for the Qwen v5 judge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from academic_agent.tools.qwen_evidence_judge import (
+    QWEN_CHAT_COMPLETIONS_ENDPOINT,
+    QwenEvidenceJudgeAdapter,
+    QwenJudgeAdapterError,
+    QwenJudgeRequest,
+    QwenJudgeTransportResponse,
+    prompt_sha256,
+)
+
+
+def _request() -> QwenJudgeRequest:
+    system = "Classify supplied evidence and return only strict JSON."
+    user = "Evaluate all candidates and preserve their exact order in JSON."
+    return QwenJudgeRequest(
+        trace_id="openalex-v5-w01-pass-1",
+        system_prompt=system,
+        user_prompt=user,
+        batch_input_sha256="1" * 64,
+        prompt_sha256=prompt_sha256(system, user),
+    )
+
+
+def _provider_body(*, model: str = "qwen3.5-plus") -> bytes:
+    return json.dumps(
+        {
+            "id": "qwen-response-123",
+            "model": model,
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"content": '{"case_id":"W01"}'},
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "prompt_tokens_details": {"cached_tokens": 20},
+                "completion_tokens": 10,
+                "total_tokens": 110,
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class RecordingTransport:
+    def __init__(self, body: bytes | None = None) -> None:
+        self.body = body or _provider_body()
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.calls.append(kwargs)
+        return QwenJudgeTransportResponse(
+            body=self.body,
+            headers={"X-Request-ID": "qwen-request-456"},
+        )
+
+
+def test_adapter_sends_one_raw_http_request_with_top_level_thinking_disabled(
+    monkeypatch,
+):
+    # A deployment override must not move a pre-registered soft-stop boundary.
+    monkeypatch.setenv("LLM_PRICE_PER_MTOK", "99:99:99")
+    transport = RecordingTransport()
+    adapter = QwenEvidenceJudgeAdapter(
+        api_key="secret-qwen-key",
+        transport=transport,
+        monotonic_clock=iter((1.0, 1.25)).__next__,
+    )
+
+    response = adapter(_request())
+
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call["endpoint"] == QWEN_CHAT_COMPLETIONS_ENDPOINT
+    assert call["timeout"] == 60.0
+    assert call["headers"]["Authorization"] == "Bearer secret-qwen-key"
+    assert b"secret-qwen-key" not in call["body"]
+    payload = json.loads(call["body"])
+    assert payload["model"] == "qwen3.5-plus"
+    assert payload["enable_thinking"] is False
+    assert "extra_body" not in payload
+    assert payload["temperature"] == 0.0
+    assert payload["stream"] is False
+    assert payload["response_format"] == {"type": "json_object"}
+    assert response.returned_model == "qwen3.5-plus"
+    assert response.provider_request_id == "qwen-request-456"
+    assert response.latency_ms == pytest.approx(250.0)
+    assert response.usage.cached_prompt_tokens == 20
+    assert response.usage.cost_usd > 0
+    assert "built-in Qwen3.5 Plus peak tier" in response.usage.cost_basis
+    assert "env" not in response.usage.cost_basis
+    assert response.request_sha256 == hashlib.sha256(call["body"]).hexdigest()
+
+
+def test_model_identity_mismatch_is_terminal_and_discards_semantic_content():
+    transport = RecordingTransport(
+        _provider_body(model="qwen3.5-plus-2026-02-15")
+    )
+    adapter = QwenEvidenceJudgeAdapter(
+        api_key="secret",
+        transport=transport,
+    )
+
+    with pytest.raises(
+        QwenJudgeAdapterError,
+        match="model identity inconsistent",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_model_identity_mismatch"
+    assert caught.value.retryable is False
+    assert caught.value.request_may_have_spent is True
+    assert caught.value.observed_returned_model == "qwen3.5-plus-2026-02-15"
+    assert caught.value.observed_usage.prompt_tokens == 100
+    assert caught.value.observed_usage.cost_usd is not None
+    assert not hasattr(caught.value, "raw_content")
+    assert len(transport.calls) == 1
+
+
+class RedirectTransport:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.call_count += 1
+        raise HTTPError(
+            kwargs["endpoint"],
+            302,
+            "redirect",
+            {},
+            None,
+        )
+
+
+def test_redirect_is_one_terminal_attempt_and_never_leaks_the_key():
+    transport = RedirectTransport()
+    adapter = QwenEvidenceJudgeAdapter(
+        api_key="do-not-persist-this-qwen-key",
+        transport=transport,
+    )
+
+    with pytest.raises(QwenJudgeAdapterError) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_redirect"
+    assert caught.value.request_may_have_spent is False
+    assert "do-not-persist-this-qwen-key" not in str(caught.value)
+    assert transport.call_count == 1
+
+
+def test_missing_usage_is_uninspectable_instead_of_zero_cost():
+    payload = json.loads(_provider_body())
+    del payload["usage"]
+    transport = RecordingTransport(json.dumps(payload).encode("utf-8"))
+    adapter = QwenEvidenceJudgeAdapter(api_key="secret", transport=transport)
+
+    with pytest.raises(
+        QwenJudgeAdapterError,
+        match="schema validation",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_response_invalid"
+    assert len(transport.calls) == 1
+
+
+def test_inconsistent_token_totals_are_terminal_and_not_retried():
+    payload = json.loads(_provider_body())
+    payload["usage"]["total_tokens"] = 999
+    transport = RecordingTransport(json.dumps(payload).encode("utf-8"))
+    adapter = QwenEvidenceJudgeAdapter(api_key="secret", transport=transport)
+
+    with pytest.raises(
+        QwenJudgeAdapterError,
+        match="usage accounting",
+    ) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_usage_invalid"
+    assert caught.value.retryable is False
+    assert caught.value.request_may_have_spent is True
+    assert len(transport.calls) == 1
+
+
+def test_request_rejects_a_prompt_hash_that_does_not_bind_both_messages():
+    with pytest.raises(ValueError, match="prompt SHA-256"):
+        QwenJudgeRequest(
+            trace_id="openalex-v5-w01-pass-1",
+            system_prompt="A sufficiently long system classification instruction.",
+            user_prompt="A sufficiently long user evidence classification request.",
+            batch_input_sha256="2" * 64,
+            prompt_sha256="3" * 64,
+        )


### PR DESCRIPTION
Why: the production Qwen adapter includes operational flexibility that is unsuitable for a pre-registered paid experiment where one adapter invocation must equal one inspectable potentially billable request. What: pre-register and implement a separate exact qwen3.5-plus raw-HTTP judge, preserve the historical DeepSeek schema-2 path, add provider-explicit schema-3 manifest/journal/execution identities, and keep every Tool Calling component disconnected from production. Verification: 1,782 tests and 657 subtests pass; latest Ruff and CI-matched narrow Pylint pass; removing top-level non-thinking and cross-provider journal validation each made its seam test fail before restoration. Cost and scope: zero network and zero model calls in this change; no paid run or production connection is authorized.