### PR TITLE
Record the strict Qwen v5 development timeout outcome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,11 +491,21 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   The real zero-network preflight verified 8/8 W cases, 64/64 candidates and
   16 prompt identities with no socket or model call. Removing the thinking
   field and the cross-provider journal check independently made their seam
-  tests fail before restoration. No paid Qwen v5 call is authorized, and this
-  implementation does not complete or connect production Tool Calling. See
+  tests fail before restoration. A separately authorized run on merged
+  revision `d9adfa4` then attempted two sequential Qwen calls. W01 pass 1
+  completed in 41.405 seconds with 4,431 tokens and a locally reconstructed
+  USD 0.006358 cost. Pass 2 exceeded the frozen 60-second timeout and stopped
+  without retry. Because that in-flight request may have spent without
+  returning usage, aggregate cost is `uninspectable`, not USD 0.006358 or zero.
+  The strict result is `partial / not_evaluated`: zero cases and candidate
+  decisions completed, none of the five development gates ran, and all
+  production connections remained false. This does not complete or connect
+  production Tool Calling. See
   `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`
   and
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`.
+  See also
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -785,10 +785,15 @@ and [paid canary record](docs/results-2026-08-30-qwen35-plus-first-paid-canary.m
 
 Separately, the production-disconnected v5 evidence judge now has a strict
 one-request Qwen raw-HTTP profile. Its zero-network preflight verified 8 frozen
-cases, 64 candidates and 16 prompt identities; no paid v5 Qwen call has been
-authorized, and production remains in zero-call shadow mode. See the
-[pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)
-and [implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md).
+cases, 64 candidates and 16 prompt identities. A later authorized execution on
+merged revision `d9adfa4` completed one W01 pass, then stopped without retry
+when the reversed pass exceeded the frozen 60-second timeout. The aggregate
+cost is uninspectable because the timed-out request may have spent without
+returning usage; zero cases and development gates completed. Production remains
+in zero-call shadow mode. See the
+[pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md),
+the [implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md),
+and the [paid timeout result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md).
 Local verification now passes **1,782 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
@@ -1976,9 +1981,13 @@ Token 沿用 DashScope 的 OpenAI 兼容统计格式，成本估算采用已公�
 
 此外，生产隔离的 v5 Evidence Judge 已增加严格的 Qwen 单请求原始 HTTP
 Profile。零网络预检验证了 8 个冻结案例、64 个候选和 16 个 Prompt 身份；
-目前没有授权任何 v5 Qwen 付费调用，生产仍保持零调用 Shadow Mode。详见
+随后在合并版本 `d9adfa4` 上执行了一次获授权的付费开发运行：W01 第一遍完成，
+逆序第二遍超过冻结的 60 秒超时后无重试停止。由于在途请求可能已经产生费用却
+没有返回 usage，聚合成本必须记为不可检查；0 个案例和开发门完成，生产仍保持
+零调用 Shadow Mode。详见
 [预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)
-和[实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md)。
+、[实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md)
+和[付费超时结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md)。
 本地验证现通过 **1,782 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 

--- a/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md
+++ b/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md
@@ -1,0 +1,103 @@
+# Result: Qwen evidence-set v5 development run stopped on transport timeout
+
+Date: 2026-08-31
+
+## Strict outcome
+
+The authorized W01-W08 Qwen development execution is **partial / not_evaluated**.
+It is not a failed relevance result and it is not evidence for or against the
+evidence-set v5 semantic hypothesis. The first W01 pass completed, but the
+second reversed-order pass reached the provider and then exceeded the frozen
+60-second transport timeout. The runner stopped without retry or recovery.
+
+The execution attempted two potentially billable requests, completed one
+request, completed zero cases, persisted zero deterministic candidate
+decisions and evaluated none of the five development gates. It made zero
+OpenAlex requests, did not parse the private human labels, and remained
+disconnected from production, report generation and planner triggering.
+
+## Authorized boundary actually used
+
+- merged revision: `d9adfa4501bb294add25302bee4b59cbd314450b`;
+- frozen public W01-W08 packet containing 64 titles and abstracts;
+- exact provider/model: Qwen / `qwen3.5-plus`;
+- at most 16 sequential calls under a USD 0.20 soft stop;
+- no redirect, retry, repair, fallback, recovery or supplementary retrieval;
+  and
+- production/report/planner connection: false.
+
+Before credentials were read, the real zero-network preflight verified 8/8
+cases, 64/64 candidate identities, 16/16 prompt identities, all source hashes
+and all Qwen implementation hashes. The output directory was
+`outputs/2026-08-31-openalex-evidence-set-v5-qwen-development`. It remains a
+local ignored run artifact rather than a source-controlled fixture.
+
+## What the two calls established
+
+The first W01 pass returned the exact requested model and an inspectable usage
+record after 41.405 seconds:
+
+| Metric | Observed value |
+|---|---:|
+| Prompt tokens | 3,099 |
+| Completion tokens | 1,332 |
+| Total tokens | 4,431 |
+| Cached prompt tokens | 0 |
+| Locally reconstructed cost | USD 0.006358 |
+
+The response passed the provider, request-identity, JSON and usage-accounting
+contracts and was durably committed before the next call. Its individual
+KEEP/ABSTAIN content is not a quality result: the required reversed-order pass
+never completed, so no agreement or deterministic set decision exists.
+
+The second W01 pass failed with `provider_transport / TimeoutError`. It has
+`request_may_have_spent=true`, no response and no usage record. The frozen
+adapter made no retry. The runner then wrote the failed call journal, final
+execution and artifact index and stopped before W02.
+
+## Why aggregate cost is uninspectable
+
+The completed first call has an inspectable local cost estimate, but the second
+request reached the transport boundary and may have been processed or billed
+without returning usage. Therefore the execution correctly reports:
+
+- `cost_state=uninspectable`;
+- `cost_usd=null`; and
+- no claim that total experiment cost was USD 0.006358 or zero.
+
+The known first-call estimate is only an inspectable component, not an upper
+bound or invoice total. A soft stop can prevent a later request only when all
+earlier spending is inspectable; it cannot reconstruct a timed-out in-flight
+request.
+
+## Artifact audit
+
+The artifact index listed five durable files. Their SHA-256 values were
+independently recomputed after the process exited and all five matched:
+
+| Artifact | SHA-256 |
+|---|---|
+| `manifest.json` | `28382e63aa7ec2aade3481a7166b175fca80178586a4f1c8fff753340fe1c09d` |
+| `execution.json` | `4dac0e5f44c63dccc57392885c31f123db355d8baee1cbe45f63b16ba23fcc95` |
+| `candidate-decisions.json` | `37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570` |
+| `judge-calls/W01-pass-1.json` | `12f0376bafe94e738d2f26fc23810a66016a14c5609b75addde197e9735db112` |
+| `judge-calls/W01-pass-2.json` | `7503c451f55adb3aebb677ba19ad4ef2d283c8163cf503e00e3b1d9f74a0b4fa` |
+
+The project models then revalidated the schema-3 manifest, both call journals
+and the final execution. The validated states were `completed, failed`,
+`partial`, `adapter_failed`, `uninspectable` and `not_evaluated`, with zero
+case decisions and every production connection false.
+
+## Disposition and next boundary
+
+The implementation behaved as pre-registered. Raising the timeout, retrying
+the failed pass, replaying W01, or resuming from the successful first pass
+would change the frozen transport method after observing an outcome. None is
+authorized by this run.
+
+If work continues, it needs a separate pre-registered transport-only decision
+that explicitly addresses the consumed first-pass response and the timeout
+boundary. That decision must not relabel this run as complete, reuse X01-X08
+for transport tuning, or authorize production Tool Calling. Until a later
+eligible development execution completes both passes for every case and meets
+all five frozen gates, evidence-set v5 remains not evaluated.


### PR DESCRIPTION
Records the authorized Qwen evidence-set v5 development execution without overstating its result. The first W01 pass completed, the reversed pass exceeded the frozen 60-second timeout, and the runner stopped without retry. The documentation preserves partial/not_evaluated status, uninspectable aggregate cost, verified artifact hashes, and the unchanged production disconnection. Local verification: 1782 tests and 657 subtests, latest Ruff, narrow Pylint, and diff checks all pass.