### PR TITLE
Add a durable Qwen v5 schema-four timeout contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1782 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1787 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -482,30 +482,44 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   correct implementation was restored. No later paid request is authorized or
   has occurred. W01-W08 remain consumed development evidence, and this
   transport amendment does not reopen their semantic method or gates.
-  A separately pre-registered Qwen profile is now implemented without editing
-  that historical DeepSeek contract. Its raw one-request adapter fixes exact
+  A separately pre-registered Qwen profile is implemented without editing that
+  historical DeepSeek contract. Its raw one-request adapter fixes exact
   `qwen3.5-plus`, top-level `enable_thinking=false`, JSON Object mode, nested
-  cached-token accounting and the committed conservative price basis. Qwen
-  uses manifest/execution schema 3, requires an explicit provider for live
-  CLI execution, and reaches every manifest, journal and execution boundary.
-  The real zero-network preflight verified 8/8 W cases, 64/64 candidates and
-  16 prompt identities with no socket or model call. Removing the thinking
-  field and the cross-provider journal check independently made their seam
-  tests fail before restoration. A separately authorized run on merged
-  revision `d9adfa4` then attempted two sequential Qwen calls. W01 pass 1
-  completed in 41.405 seconds with 4,431 tokens and a locally reconstructed
-  USD 0.006358 cost. Pass 2 exceeded the frozen 60-second timeout and stopped
-  without retry. Because that in-flight request may have spent without
-  returning usage, aggregate cost is `uninspectable`, not USD 0.006358 or zero.
-  The strict result is `partial / not_evaluated`: zero cases and candidate
-  decisions completed, none of the five development gates ran, and all
-  production connections remained false. This does not complete or connect
-  production Tool Calling. See
-  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`
+  cached-token accounting and the committed conservative price basis. The
+  historical Qwen contract uses manifest/execution schema 3 and a 60-second
+  timeout. Its real zero-network preflight verified 8/8 W cases, 64/64
+  candidates and 16 prompt identities with no socket or model call. Removing
+  the thinking field and the cross-provider journal check independently made
+  their seam tests fail before restoration. A separately authorized run on
+  merged revision `d9adfa4` then attempted two sequential Qwen calls. W01 pass
+  1 completed in 41.405 seconds with 4,431 tokens and a locally reconstructed
+  USD 0.006358 cost. Pass 2 exceeded 60 seconds and stopped without retry.
+  Because that in-flight request may have spent without returning usage,
+  aggregate cost is `uninspectable`, not USD 0.006358 or zero. The strict
+  result remains `partial / not_evaluated`: zero cases and candidate decisions
+  completed, none of the five development gates ran, and every production
+  connection remained false.
+
+  A later transport-only amendment is now implemented for fresh Qwen
+  development runs. Schema 4 persists a bounded 120-second timeout in all 16
+  request identities, the manifest, each journal and the execution. The
+  adapter rejects persisted/actual timeout drift before transport and records
+  safe monotonic elapsed time on failures. Historical schemas 2 and 3 remain
+  readable with their original behavior. The bound is the adapter's
+  pre-existing maximum, not a measured percentile or SLO. The real zero-network
+  preflight again verified 8/8 cases, 64/64 candidates, 16/16 prompt/timeout
+  identities and all dependency hashes with no socket or model call. Restoring
+  only the default adapter argument to 60 seconds made the client-seam test
+  fail with observed `[60.0]`; restoration returned it to green. The focused
+  suite passes 26/26 and the full suite passes 1787 tests plus 657 subtests.
+  No later paid request is authorized or has occurred. This still does not
+  complete or connect production Tool Calling. See
+  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`,
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`,
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md`,
+  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md`,
   and
-  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`.
-  See also
-  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md`.
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -783,18 +783,26 @@ A separate invented-threshold/citation-entailment finding remains open. See
 the [implementation record](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
 and [paid canary record](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md).
 
-Separately, the production-disconnected v5 evidence judge now has a strict
-one-request Qwen raw-HTTP profile. Its zero-network preflight verified 8 frozen
-cases, 64 candidates and 16 prompt identities. A later authorized execution on
+Separately, the production-disconnected v5 evidence judge has a strict
+one-request Qwen raw-HTTP profile. Its first authorized schema-3 execution on
 merged revision `d9adfa4` completed one W01 pass, then stopped without retry
-when the reversed pass exceeded the frozen 60-second timeout. The aggregate
-cost is uninspectable because the timed-out request may have spent without
-returning usage; zero cases and development gates completed. Production remains
-in zero-call shadow mode. See the
-[pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md),
-the [implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md),
-and the [paid timeout result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md).
-Local verification now passes **1,782 tests plus 657 subtests**, latest Ruff,
+when the reversed pass exceeded the frozen 60-second timeout. Aggregate cost
+remains uninspectable, zero cases and development gates completed, and that
+historical result remains `partial / not_evaluated`.
+
+A separately pre-registered transport-only amendment now creates schema-4 Qwen
+artifacts with a persisted 120-second request timeout. The adapter rejects a
+persisted/actual timeout mismatch before transport, and failed journals retain
+safe monotonic elapsed time. The bound is a pre-existing adapter maximum, not a
+percentile or SLO. Its zero-network preflight verified 8/8 frozen cases, 64/64
+candidates, 16/16 prompt and timeout identities, historical schema-2/3
+compatibility, and zero network/model calls. No later paid call is authorized
+or has occurred; production remains in zero-call shadow mode. See the
+[provider pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md),
+[paid timeout result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md),
+[timeout amendment](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md),
+and [schema-4 implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md).
+Local verification now passes **1,787 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -1979,16 +1987,22 @@ Token 沿用 DashScope 的 OpenAI 兼容统计格式，成本估算采用已公�
 [实现记录](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
 和[付费 canary 记录](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md)。
 
-此外，生产隔离的 v5 Evidence Judge 已增加严格的 Qwen 单请求原始 HTTP
-Profile。零网络预检验证了 8 个冻结案例、64 个候选和 16 个 Prompt 身份；
-随后在合并版本 `d9adfa4` 上执行了一次获授权的付费开发运行：W01 第一遍完成，
-逆序第二遍超过冻结的 60 秒超时后无重试停止。由于在途请求可能已经产生费用却
-没有返回 usage，聚合成本必须记为不可检查；0 个案例和开发门完成，生产仍保持
-零调用 Shadow Mode。详见
-[预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)
-、[实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md)
-和[付费超时结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md)。
-本地验证现通过 **1,782 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+此外，生产隔离的 v5 Evidence Judge 已实现严格的 Qwen 单请求原始 HTTP
+Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 W01 第一遍，
+逆序第二遍超过冻结的 60 秒超时后无重试停止。聚合成本仍不可检查，0 个案例和
+开发门完成；该历史结果保持为 `partial / not_evaluated`。
+
+另行预注册的纯传输修正现为新 Qwen 运行生成 schema 4：120 秒超时同时写入请求
+身份、manifest、journal 与 execution；持久化值和实际传输值不一致时会在请求
+前拒绝，失败 journal 会保留安全的单调时钟耗时。120 秒只是适配器原有上限，
+不是统计百分位或 SLO。零网络预检验证了 8/8 个冻结案例、64/64 个候选、16/16
+个 Prompt 与超时身份、历史 schema 2/3 兼容性，以及 0 次网络/模型调用。尚未
+授权或执行后续付费运行，生产仍保持零调用 Shadow Mode。详见
+[Provider 预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)、
+[付费超时结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md)、
+[超时修正预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md)
+和[schema 4 实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md)。
+本地验证现通过 **1,787 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md
+++ b/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md
@@ -1,0 +1,115 @@
+# Pre-registration amendment: evidence-set v5 Qwen transport timeout
+
+Date: 2026-08-31
+
+Status: frozen after the first Qwen development timeout and before any later
+provider request. This amendment authorizes no paid call, does not relabel the
+earlier partial execution, and does not change the evidence-set v5 semantic
+method.
+
+## Why another amendment is necessary
+
+The first authorized Qwen development execution completed W01 pass 1 in
+41.404828 seconds. The reversed pass then reached the transport boundary and
+exceeded the frozen 60-second timeout. The runner stopped without retry, as
+required, and the strict result remains `partial / not_evaluated`.
+
+Only one completed per-request latency and one 60-second right-censored
+observation exist on disk. The earlier production canary records 306 seconds
+for an entire seven-request workflow, but that total includes retrieval,
+orchestration, validation and persistence and cannot be divided into seven
+provider latencies. These observations are insufficient for a percentile,
+tail-latency distribution or SLO claim.
+
+The next timeout is therefore not described as statistically calibrated. It
+is a bounded development choice: 120 seconds, which was already the committed
+Qwen adapter's hard maximum before this outcome. The purpose is to test whether
+the exact frozen prompts can finish within that pre-existing bound, not to
+claim that 120 seconds is optimal or production-ready.
+
+## Frozen transport-only change
+
+For a later Qwen development execution only:
+
+1. each request has a 120-second client timeout;
+2. one judge invocation still makes exactly one potentially billable HTTP
+   request, with no redirect, retry, repair, fallback or recovery;
+3. the exact endpoint, model, non-thinking JSON body, output-token limit,
+   prompts, candidate order and semantic decision rules remain unchanged;
+4. the timeout value must be part of the persisted request identity and reach
+   the pre-call manifest, every call journal and the final execution artifact;
+5. the adapter must reject a mismatch between the persisted timeout and the
+   timeout actually supplied to the HTTP transport before making a request;
+6. a failed call should retain a safe monotonic elapsed-time observation when
+   available, without retaining semantic content or credentials; and
+7. any potentially spending failure with missing usage keeps aggregate cost
+   `uninspectable` and stops the run immediately.
+
+Qwen uses manifest/execution schema version 4 for this amendment. Historical
+DeepSeek schema 2 and Qwen schema 3 artifacts must remain valid and keep their
+original 60-second behavior. The normal six-stage Qwen provider and its retry
+policy are outside this experiment and are not changed.
+
+## Treatment of the consumed W01 response
+
+The successful W01 pass-1 response from the partial run remains an immutable
+historical artifact but is excluded from every future gate calculation. A
+later amended execution must use a fresh output directory and make both W01
+passes under the same schema-4 transport contract. Resuming only pass 2 would
+mix two post-outcome transport methods inside one agreement pair.
+
+W01-W08 are already disclosed development evidence. Repeating them after this
+transport-only amendment can at most evaluate development qualification; it
+cannot convert them into unseen validation. X01-X08 remain untouched and may
+be opened only if the complete amended development execution passes every
+previously frozen gate.
+
+## Frozen interpretation and stop rules
+
+- A timeout, redirect, identity drift, malformed response, uninspectable
+  spending event or other adapter failure stops the amended execution without
+  retry and leaves it `partial / not_evaluated`.
+- Completing fewer than 16 calls or fewer than eight two-pass cases is not a
+  transport pass and does not run the five development gates.
+- Completing all calls only establishes bounded transport compatibility. The
+  unchanged quote, agreement, set-cover and human-label gates still decide the
+  semantic development result.
+- Failure of any semantic gate seals v5 on W01-W08. The timeout amendment may
+  not be used to tune prompts, roles, selectors or thresholds.
+- Neither transport success nor a development pass authorizes planner
+  triggering, report insertion or production Tool Calling.
+
+## Required zero-network evidence before authorization
+
+1. schema-4 dry-run exposes 120 seconds at the top level and inside all 16
+   persisted request identities;
+2. the default live Qwen factory uses the same 120-second value at the actual
+   HTTP transport seam;
+3. a request/adapter timeout mismatch fails before the fake transport records
+   a call;
+4. a simulated timeout persists elapsed time, one failed journal,
+   `request_may_have_spent=true`, uninspectable aggregate cost and no retry;
+5. historical schema-2 and schema-3 artifacts still validate without a
+   backfilled schema-4 claim;
+6. the timeout passed to the fake transport is temporarily restored to 60
+   while the request remains 120 and the seam test fails before restoration;
+7. the complete W01-W08 dry-run verifies eight cases, 64 candidates, 16 prompt
+   identities, source hashes and provider implementation hashes with zero
+   sockets and zero model calls; and
+8. the full zero-network suite, latest Ruff and narrow Pylint pass.
+
+## Later paid boundary
+
+This document and its implementation authorize zero provider requests. Any
+later execution requires fresh user authorization naming the merged revision,
+exact `qwen3.5-plus` model, maximum 16 sequential calls, soft USD stop, fresh
+output directory and the prohibitions on retry, recovery and production
+connection. A timed-out in-flight request may still cause a small soft-stop
+overrun and must remain visibly uninspectable when usage is absent.
+
+Related records:
+
+- `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`;
+- `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`;
+  and
+- `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md`.

--- a/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md
+++ b/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md
@@ -1,0 +1,110 @@
+# Result: Qwen evidence-set v5 bounded timeout amendment implementation
+
+Date: 2026-08-31
+
+## Outcome
+
+The transport-only amendment is implemented and verified with zero provider
+requests. New Qwen development artifacts use manifest/execution schema 4 and
+persist a 120-second timeout in every request identity, the manifest and the
+final execution. The default Qwen judge adapter receives the same value at the
+actual transport seam.
+
+This implementation does not authorize or execute another W01-W08 paid run. It
+does not relabel the earlier schema-3 execution, which remains
+`partial / not_evaluated`, and it does not connect the evidence-gap planner,
+supplementary retrieval or report generation.
+
+## Evidence used for the bound
+
+Only one exact completed Qwen v5 request latency is available on disk:
+41.404828 seconds for W01 pass 1. W01 pass 2 is right-censored by the historical
+60-second timeout. A separate 306-second production workflow contains seven
+provider calls plus retrieval, orchestration, validation and persistence, so it
+cannot be converted into seven request latencies.
+
+The 120-second value is therefore not a percentile, p95 or SLO. It is the
+adapter's pre-existing hard maximum, frozen as a bounded development choice
+before any later provider request.
+
+## Implemented contract
+
+- `QwenJudgeRequest.transport_timeout_seconds` is a durable, credential-free
+  request field; it is deliberately excluded from the provider JSON body.
+- Historical schema-3 Qwen requests continue to default to 60 seconds.
+- New runner-created Qwen requests explicitly use 120 seconds and schema 4.
+- The adapter rejects request/transport timeout drift before body construction
+  or transport invocation.
+- HTTP and transport failures retain safe monotonic elapsed time when available.
+- Failed-call journals persist that elapsed time without semantic content or
+  credentials.
+- A potentially spending timeout without usage still makes aggregate cost
+  `uninspectable` and stops the run without retry.
+- DeepSeek schema 2 and historical Qwen schema 3 remain readable.
+- No CLI timeout option was added; an operator cannot silently mutate the
+  frozen experiment contract.
+
+The Qwen behavior dependency is frozen at SHA-256
+`1a4d20a0cfb2f39ffdb4ae4c878929b187f34e77e057ae98d4082fb6d64e67c0`.
+
+## Seam verification
+
+The focused adapter and runner suite passes 26/26 tests. It verifies:
+
+1. historical 60 seconds still reaches the raw transport for schema 3;
+2. amended 120 seconds reaches the raw transport for schema 4;
+3. a 120-second request paired with a 60-second adapter is rejected with zero
+   transport calls;
+4. a simulated timeout makes one call, records 120,250 ms, performs no retry
+   and leaves cost uninspectable;
+5. manifest construction happens before the default paid-capable adapter;
+6. all 16 manifest requests, call journals and the execution expose 120 seconds;
+   and
+7. historical schema-3 manifest and execution payloads validate without
+   backfilling a schema-4 claim.
+
+The required defect was re-injected by temporarily restoring the default live
+adapter argument to 60 seconds while requests remained at 120. The client-seam
+test failed with observed `[60.0]` versus expected `[120.0]`; after restoring
+the implementation, the identical test passed.
+
+## Zero-network protocol verification
+
+The real W01-W08 dry-run completed with:
+
+| Check | Result |
+|---|---:|
+| Frozen cases | 8/8 |
+| Candidate identities | 64/64 |
+| Prompt identities | 16/16 |
+| Request timeout identities | 16/16 at 120 seconds |
+| Schema | 4 |
+| Network calls | 0 |
+| Model calls | 0 |
+
+The complete project verification then passed:
+
+- `1787 passed, 657 subtests passed`;
+- latest Ruff, all files; and
+- narrow Pylint for exception ordering, unreachable code, use-before-assignment
+  and undefined variables.
+
+## Remaining boundary
+
+A later paid execution still requires separate user authorization naming the
+merged revision, exact `qwen3.5-plus` model, at most 16 sequential calls, a
+soft USD stop, a fresh output directory and the prohibitions on retry, repair,
+fallback, recovery and production connection. Both W01 passes must be fresh;
+the earlier successful schema-3 pass is immutable history and cannot be reused.
+
+Even a complete schema-4 run would establish only bounded transport
+compatibility. The unchanged quote, two-pass agreement, set-cover and human
+label gates must still pass before X01-X08 may be opened. Production Tool
+Calling remains disabled.
+
+Related records:
+
+- `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md`;
+- `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md`;
+  and
+- `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`.

--- a/openalex_evidence_set_development.py
+++ b/openalex_evidence_set_development.py
@@ -46,6 +46,8 @@ from academic_agent.tools.deepseek_evidence_judge import (
 )
 from academic_agent.tools.evidence_search import ToolEvidenceCandidate
 from academic_agent.tools.qwen_evidence_judge import (
+    QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    QWEN_V5_INITIAL_TIMEOUT_SECONDS,
     QwenEvidenceJudgeAdapter,
     QwenJudgeAdapterError,
     QwenJudgeRequest,
@@ -143,7 +145,7 @@ EXPECTED_IMPLEMENTATION_SHA256 = {
 # silently rewriting the byte identity of the historical contract.
 EXPECTED_QWEN_IMPLEMENTATION_SHA256 = {
     "qwen_evidence_judge.py": (
-        "6b43ba97049bc51410e9871280b4b67093a09f64290baec360b87abb70a7953e"
+        "1a4d20a0cfb2f39ffdb4ae4c878929b187f34e77e057ae98d4082fb6d64e67c0"
     ),
     "evidence_search.py": (
         "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
@@ -293,7 +295,7 @@ class DevelopmentManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[2, 3] = 2
+    schema_version: Literal[2, 3, 4] = 2
     mode: Literal["openalex_evidence_set_v5_development_manifest"] = (
         "openalex_evidence_set_v5_development_manifest"
     )
@@ -317,34 +319,49 @@ class DevelopmentManifest(BaseModel):
         "https://api.deepseek.com",
         "https://dashscope.aliyuncs.com/compatible-mode/v1",
     ] = "https://api.deepseek.com"
+    transport_timeout_seconds: float | None = Field(
+        default=None,
+        gt=0.0,
+        le=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    )
     maximum_model_call_count: Literal[16] = 16
     soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
     cases: tuple[FrozenDevelopmentCase, ...] = Field(min_length=8, max_length=8)
 
     @model_validator(mode="after")
     def _validate_case_contract(self) -> "DevelopmentManifest":
-        expected_contract = {
-            "deepseek": (
-                2,
-                "deepseek-v4-flash",
-                "https://api.deepseek.com",
-                DeepSeekJudgeRequest,
-            ),
-            "qwen": (
-                3,
-                "qwen3.5-plus",
-                "https://dashscope.aliyuncs.com/compatible-mode/v1",
-                QwenJudgeRequest,
-            ),
-        }
-        schema, model, api_base, request_type = expected_contract[
-            self.requested_provider
-        ]
-        if (self.schema_version, self.requested_model, self.api_base) != (
-            schema,
-            model,
-            api_base,
-        ):
+        if self.requested_provider == "deepseek":
+            schema = 2
+            model = "deepseek-v4-flash"
+            api_base = "https://api.deepseek.com"
+            request_type = DeepSeekJudgeRequest
+            manifest_timeout = None
+            request_timeout = None
+        elif self.schema_version == 3:
+            # Schema 3 remains readable as the historical 60-second Qwen
+            # contract.  It intentionally has no top-level timeout because that
+            # field did not exist when the artifact was written.
+            schema = 3
+            model = "qwen3.5-plus"
+            api_base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            request_type = QwenJudgeRequest
+            manifest_timeout = None
+            request_timeout = QWEN_V5_INITIAL_TIMEOUT_SECONDS
+        elif self.schema_version == 4:
+            schema = 4
+            model = "qwen3.5-plus"
+            api_base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            request_type = QwenJudgeRequest
+            manifest_timeout = QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            request_timeout = QWEN_V5_AMENDED_TIMEOUT_SECONDS
+        else:
+            raise ValueError("Qwen manifests require schema version 3 or 4")
+        if (
+            self.schema_version,
+            self.requested_model,
+            self.api_base,
+            self.transport_timeout_seconds,
+        ) != (schema, model, api_base, manifest_timeout):
             raise ValueError("manifest provider contract fields are inconsistent")
         if tuple(case.case_id for case in self.cases) != _CASE_ORDER:
             raise ValueError("development manifest cases must remain W01-W08")
@@ -369,6 +386,16 @@ class DevelopmentManifest(BaseModel):
                 or case.second_request.requested_model != self.requested_model
             ):
                 raise ValueError(f"{case.case_id}: request model drifted")
+            if request_timeout is not None:
+                requests = (case.first_request, case.second_request)
+                if any(
+                    not isinstance(request, QwenJudgeRequest)
+                    or request.transport_timeout_seconds != request_timeout
+                    for request in requests
+                ):
+                    raise ValueError(
+                        f"{case.case_id}: request timeout identity drifted"
+                    )
         if self.selection_contract.sha256() != self.selection_contract_sha256:
             raise ValueError("selection contract identity drifted")
         return self
@@ -396,6 +423,9 @@ class JudgeCallJournal(BaseModel):
     response: JudgeResponse | None = None
     observed_returned_model: str | None = Field(default=None, max_length=200)
     observed_usage: JudgeUsageObservation | None = None
+    observed_latency_ms: float | None = Field(
+        default=None, ge=0.0, allow_inf_nan=False
+    )
     failure_type: str | None = Field(default=None, max_length=100)
     failure_detail: str | None = Field(default=None, max_length=500)
     failure_retryable: bool | None = None
@@ -414,6 +444,7 @@ class JudgeCallJournal(BaseModel):
                 self.response is None
                 or any(value is not None for value in failures)
                 or any(value is not None for value in observations)
+                or self.observed_latency_ms is not None
                 or not self.request_may_have_spent
             ):
                 raise ValueError("completed call requires only a response")
@@ -452,7 +483,7 @@ class DevelopmentExecution(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal[2, 3] = 2
+    schema_version: Literal[2, 3, 4] = 2
     mode: Literal["openalex_evidence_set_v5_development_execution"] = (
         "openalex_evidence_set_v5_development_execution"
     )
@@ -462,6 +493,11 @@ class DevelopmentExecution(BaseModel):
     openalex_request_count: Literal[0] = 0
     private_label_content_parsed: Literal[False] = False
     manifest_sha256: str = Field(pattern=_SHA256_PATTERN)
+    transport_timeout_seconds: float | None = Field(
+        default=None,
+        gt=0.0,
+        le=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    )
     overall_state: Literal["completed", "partial"]
     stop_reason: StopReason
     attempted_model_call_count: int = Field(ge=0, le=16)
@@ -491,13 +527,30 @@ class DevelopmentExecution(BaseModel):
     def _validate_complete_execution(self) -> "DevelopmentExecution":
         if self.attempted_model_call_count != len(self.calls):
             raise ValueError("attempted call count drifted from journals")
-        expected_model = (
-            "qwen3.5-plus" if self.schema_version == 3 else "deepseek-v4-flash"
-        )
+        if self.schema_version == 2:
+            expected_model = "deepseek-v4-flash"
+            execution_timeout = None
+            request_timeout = None
+        elif self.schema_version == 3:
+            expected_model = "qwen3.5-plus"
+            execution_timeout = None
+            request_timeout = QWEN_V5_INITIAL_TIMEOUT_SECONDS
+        else:
+            expected_model = "qwen3.5-plus"
+            execution_timeout = QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            request_timeout = QWEN_V5_AMENDED_TIMEOUT_SECONDS
+        if self.transport_timeout_seconds != execution_timeout:
+            raise ValueError("execution timeout drifted from schema contract")
         if any(
             call.request.requested_model != expected_model for call in self.calls
         ):
             raise ValueError("execution schema drifted from call providers")
+        if request_timeout is not None and any(
+            not isinstance(call.request, QwenJudgeRequest)
+            or call.request.transport_timeout_seconds != request_timeout
+            for call in self.calls
+        ):
+            raise ValueError("execution request timeout drifted from schema contract")
         completed_calls = sum(call.state == "completed" for call in self.calls)
         if self.completed_model_call_count != completed_calls:
             raise ValueError("completed call count drifted from journals")
@@ -771,18 +824,27 @@ def _judge_request(
     batch: JudgeBatchInput,
     judge_provider: JudgeProvider,
 ) -> JudgeRequest:
+    trace_id = f"openalex-v5-{batch.case_id.casefold()}-pass-{batch.pass_number}"
     user_prompt = _user_prompt(batch)
-    request_type = (
-        QwenJudgeRequest if judge_provider == "qwen" else DeepSeekJudgeRequest
-    )
-    return request_type(
-        trace_id=(
-            f"openalex-v5-{batch.case_id.casefold()}-pass-{batch.pass_number}"
-        ),
+    prompt_identity = _prompt_sha256(_SYSTEM_PROMPT, user_prompt)
+    if judge_provider == "qwen":
+        # This explicit field creates schema 4 request identities.  Leaving it
+        # at the model default would make a new run indistinguishable from the
+        # historical schema 3 contract that timed out at 60 seconds.
+        return QwenJudgeRequest(
+            trace_id=trace_id,
+            system_prompt=_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+            batch_input_sha256=batch.sha256(),
+            prompt_sha256=prompt_identity,
+            transport_timeout_seconds=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+        )
+    return DeepSeekJudgeRequest(
+        trace_id=trace_id,
         system_prompt=_SYSTEM_PROMPT,
         user_prompt=user_prompt,
         batch_input_sha256=batch.sha256(),
-        prompt_sha256=_prompt_sha256(_SYSTEM_PROMPT, user_prompt),
+        prompt_sha256=prompt_identity,
     )
 
 
@@ -914,7 +976,7 @@ def _manifest(
     provider_contract = {
         "deepseek": (2, "deepseek-v4-flash", "https://api.deepseek.com"),
         "qwen": (
-            3,
+            4,
             "qwen3.5-plus",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
         ),
@@ -925,6 +987,11 @@ def _manifest(
         schema_version=schema_version,
         requested_provider=judge_provider,
         requested_model=requested_model,
+        transport_timeout_seconds=(
+            QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            if judge_provider == "qwen"
+            else None
+        ),
         api_base=api_base,
         v4_fixture_sha256=v4_fixture_sha256,
         implementation_sha256=implementation_sha256,
@@ -978,7 +1045,7 @@ def protocol_dry_run(
     return {
         "mode": "openalex_evidence_set_v5_development_dry_run",
         "production_connected": False,
-        "schema_version": 3 if judge_provider == "qwen" else 2,
+        "schema_version": 4 if judge_provider == "qwen" else 2,
         "requested_provider": judge_provider,
         "requested_model": (
             "qwen3.5-plus"
@@ -989,6 +1056,11 @@ def protocol_dry_run(
             "https://dashscope.aliyuncs.com/compatible-mode/v1"
             if judge_provider == "qwen"
             else "https://api.deepseek.com"
+        ),
+        "transport_timeout_seconds": (
+            QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            if judge_provider == "qwen"
+            else None
         ),
         "report_workflow_connected": False,
         "planner_trigger_connected": False,
@@ -1012,6 +1084,16 @@ def protocol_dry_run(
                 "second_input_sha256": case.second_input.sha256(),
                 "first_prompt_sha256": case.first_request.prompt_sha256,
                 "second_prompt_sha256": case.second_request.prompt_sha256,
+                "first_transport_timeout_seconds": (
+                    case.first_request.transport_timeout_seconds
+                    if isinstance(case.first_request, QwenJudgeRequest)
+                    else None
+                ),
+                "second_transport_timeout_seconds": (
+                    case.second_request.transport_timeout_seconds
+                    if isinstance(case.second_request, QwenJudgeRequest)
+                    else None
+                ),
             }
             for case in cases
         ],
@@ -1028,6 +1110,7 @@ def _failed_journal(
     request_may_have_spent: bool,
     observed_returned_model: str | None = None,
     observed_usage: JudgeUsageObservation | None = None,
+    observed_latency_ms: float | None = None,
 ) -> JudgeCallJournal:
     return JudgeCallJournal(
         case_id=case_id,
@@ -1036,6 +1119,7 @@ def _failed_journal(
         request=request,
         observed_returned_model=observed_returned_model,
         observed_usage=observed_usage,
+        observed_latency_ms=observed_latency_ms,
         failure_type=failure_type,
         failure_detail=failure_detail[:500],
         failure_retryable=failure_retryable,
@@ -1098,7 +1182,7 @@ def _evaluate_case(
 def _execution_artifact(
     *,
     manifest_sha256: str,
-    schema_version: Literal[2, 3],
+    schema_version: Literal[2, 3, 4],
     stop_reason: StopReason,
     calls: list[JudgeCallJournal],
     decisions: list[EvidenceSetCaseAudit],
@@ -1136,6 +1220,11 @@ def _execution_artifact(
     return DevelopmentExecution(
         schema_version=schema_version,
         manifest_sha256=manifest_sha256,
+        transport_timeout_seconds=(
+            QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            if schema_version == 4
+            else None
+        ),
         overall_state="completed" if complete else "partial",
         stop_reason=stop_reason,
         attempted_model_call_count=len(calls),
@@ -1254,16 +1343,14 @@ def execute_development_study(
     # This must remain after the manifest write.  Constructing the default
     # adapter resolves a real credential; a future refactor may perform other
     # paid-capable setup there.  The durable method boundary comes first.
-    default_adapter_type = (
-        QwenEvidenceJudgeAdapter
-        if judge_provider == "qwen"
-        else DeepSeekEvidenceJudgeAdapter
-    )
-    adapter = (
-        adapter_factory()
-        if adapter_factory is not None
-        else default_adapter_type()
-    )
+    if adapter_factory is not None:
+        adapter = adapter_factory()
+    elif judge_provider == "qwen":
+        adapter = QwenEvidenceJudgeAdapter(
+            timeout=QWEN_V5_AMENDED_TIMEOUT_SECONDS
+        )
+    else:
+        adapter = DeepSeekEvidenceJudgeAdapter()
     calls: list[JudgeCallJournal] = []
     decisions: list[EvidenceSetCaseAudit] = []
     known_cost = 0.0
@@ -1291,6 +1378,7 @@ def execute_development_study(
                     request_may_have_spent=exc.request_may_have_spent,
                     observed_returned_model=exc.observed_returned_model,
                     observed_usage=exc.observed_usage,
+                    observed_latency_ms=getattr(exc, "observed_latency_ms", None),
                 )
                 stop_reason = "adapter_failed"
             except ValidationError as exc:
@@ -1317,6 +1405,7 @@ def execute_development_study(
                         request_may_have_spent=True,
                         observed_returned_model=response.returned_model,
                         observed_usage=response.usage,
+                        observed_latency_ms=response.latency_ms,
                     )
                     stop_reason = "response_identity_mismatch"
                 else:
@@ -1347,7 +1436,7 @@ def execute_development_study(
 
     execution = _execution_artifact(
         manifest_sha256=_sha256_bytes(manifest_text.encode("utf-8")),
-        schema_version=3 if judge_provider == "qwen" else 2,
+        schema_version=4 if judge_provider == "qwen" else 2,
         stop_reason=stop_reason,
         calls=calls,
         decisions=decisions,

--- a/src/academic_agent/tools/qwen_evidence_judge.py
+++ b/src/academic_agent/tools/qwen_evidence_judge.py
@@ -32,6 +32,8 @@ QWEN_CHAT_COMPLETIONS_ENDPOINT = (
     "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
 )
 REQUESTED_MODEL = "qwen3.5-plus"
+QWEN_V5_INITIAL_TIMEOUT_SECONDS = 60.0
+QWEN_V5_AMENDED_TIMEOUT_SECONDS = 120.0
 _MAX_RESPONSE_BYTES = 1_000_000
 _SHA256_PATTERN = r"^[0-9a-f]{64}$"
 
@@ -48,6 +50,7 @@ class QwenJudgeAdapterError(RuntimeError):
         request_may_have_spent: bool,
         observed_returned_model: str | None = None,
         observed_usage: QwenJudgeUsageObservation | None = None,
+        observed_latency_ms: float | None = None,
     ) -> None:
         super().__init__(message)
         self.failure_type = failure_type
@@ -58,6 +61,7 @@ class QwenJudgeAdapterError(RuntimeError):
         # content that could be used to tune a consumed development set.
         self.observed_returned_model = observed_returned_model
         self.observed_usage = observed_usage
+        self.observed_latency_ms = observed_latency_ms
 
 
 class QwenJudgeRequest(BaseModel):
@@ -77,6 +81,14 @@ class QwenJudgeRequest(BaseModel):
     prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
     temperature: Literal[0.0] = 0.0
     max_tokens: int = Field(default=8_000, ge=500, le=12_000)
+    # The timeout is part of the durable request identity even though it is not
+    # a provider-body field.  Otherwise an artifact could claim the amended
+    # contract while the transport silently kept the historical 60-second cap.
+    transport_timeout_seconds: float = Field(
+        default=QWEN_V5_INITIAL_TIMEOUT_SECONDS,
+        gt=0.0,
+        le=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    )
 
     @model_validator(mode="after")
     def _validate_prompt_identity(self) -> "QwenJudgeRequest":
@@ -339,14 +351,14 @@ class QwenEvidenceJudgeAdapter:
         self,
         *,
         api_key: str | None = None,
-        timeout: float = 60.0,
+        timeout: float = QWEN_V5_INITIAL_TIMEOUT_SECONDS,
         transport: QwenOneRequestTransport | None = None,
         monotonic_clock=None,  # noqa: ANN001
     ) -> None:
         resolved_key = (api_key or os.getenv("DASHSCOPE_API_KEY") or "").strip()
         if not resolved_key:
             raise ValueError("DASHSCOPE_API_KEY is required for the v5 Qwen judge")
-        if not 0 < timeout <= 120:
+        if not 0 < timeout <= QWEN_V5_AMENDED_TIMEOUT_SECONDS:
             raise ValueError("timeout must be greater than zero and at most 120 seconds")
         self._api_key = resolved_key
         self._timeout = timeout
@@ -356,6 +368,16 @@ class QwenEvidenceJudgeAdapter:
     def __call__(self, request: QwenJudgeRequest) -> QwenJudgeResponse:
         """Send one request; every failure is terminal for this study run."""
 
+        if request.transport_timeout_seconds != self._timeout:
+            # Refuse before body construction or transport invocation.  The
+            # runner and adapter are independent seams, so equality here is
+            # what makes the persisted timeout an executed timeout.
+            raise QwenJudgeAdapterError(
+                "Qwen request timeout identity does not match the adapter",
+                failure_type="request_timeout_identity_mismatch",
+                retryable=False,
+                request_may_have_spent=False,
+            )
         body = request.body()
         request_sha256 = hashlib.sha256(body).hexdigest()
         started_at = self._clock()
@@ -378,6 +400,10 @@ class QwenEvidenceJudgeAdapter:
                 failure_type=("provider_redirect" if is_redirect else "provider_http"),
                 retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
                 request_may_have_spent=not is_redirect,
+                observed_latency_ms=max(
+                    (self._clock() - started_at) * 1000.0,
+                    0.0,
+                ),
             ) from exc
         except (URLError, TimeoutError, OSError) as exc:
             raise QwenJudgeAdapterError(
@@ -385,6 +411,10 @@ class QwenEvidenceJudgeAdapter:
                 failure_type="provider_transport",
                 retryable=True,
                 request_may_have_spent=True,
+                observed_latency_ms=max(
+                    (self._clock() - started_at) * 1000.0,
+                    0.0,
+                ),
             ) from exc
         latency_ms = max((self._clock() - started_at) * 1000.0, 0.0)
 
@@ -394,6 +424,7 @@ class QwenEvidenceJudgeAdapter:
                 failure_type="provider_response_too_large",
                 retryable=False,
                 request_may_have_spent=True,
+                observed_latency_ms=latency_ms,
             )
         try:
             decoded = json.loads(transport_response.body.decode("utf-8"))
@@ -409,6 +440,7 @@ class QwenEvidenceJudgeAdapter:
                 failure_type="provider_response_invalid",
                 retryable=False,
                 request_may_have_spent=True,
+                observed_latency_ms=latency_ms,
             ) from exc
 
         try:
@@ -420,6 +452,7 @@ class QwenEvidenceJudgeAdapter:
                 retryable=False,
                 request_may_have_spent=True,
                 observed_returned_model=envelope.model,
+                observed_latency_ms=latency_ms,
             ) from exc
 
         if envelope.model != request.requested_model:
@@ -430,6 +463,7 @@ class QwenEvidenceJudgeAdapter:
                 request_may_have_spent=True,
                 observed_returned_model=envelope.model,
                 observed_usage=observed_usage,
+                observed_latency_ms=latency_ms,
             )
         if observed_usage.cost_usd is None or observed_usage.cost_basis is None:
             raise QwenJudgeAdapterError(
@@ -439,6 +473,7 @@ class QwenEvidenceJudgeAdapter:
                 request_may_have_spent=True,
                 observed_returned_model=envelope.model,
                 observed_usage=observed_usage,
+                observed_latency_ms=latency_ms,
             )
         try:
             usage = QwenJudgeUsage.model_validate(
@@ -451,6 +486,7 @@ class QwenEvidenceJudgeAdapter:
                 retryable=False,
                 request_may_have_spent=True,
                 observed_returned_model=envelope.model,
+                observed_latency_ms=latency_ms,
             ) from exc
         choice = envelope.choices[0]
         return QwenJudgeResponse(

--- a/tests/test_openalex_evidence_set_development.py
+++ b/tests/test_openalex_evidence_set_development.py
@@ -20,6 +20,8 @@ from academic_agent.tools.deepseek_evidence_judge import (
 )
 from academic_agent.tools.qwen_evidence_judge import (
     QWEN_CHAT_COMPLETIONS_ENDPOINT,
+    QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    QWEN_V5_INITIAL_TIMEOUT_SECONDS,
     QwenJudgeAdapterError,
     QwenJudgeRequest,
     QwenJudgeResponse,
@@ -611,6 +613,7 @@ class QwenMeteredFailureAdapter:
                 cost_usd=0.002,
                 cost_basis="frozen Qwen test price basis",
             ),
+            observed_latency_ms=65_000.0,
         )
 
 
@@ -631,7 +634,8 @@ def test_qwen_failure_reaches_execution_accounting_without_a_retry(tmp_path):
     )
 
     assert adapter.call_count == 1
-    assert result.schema_version == 3
+    assert result.schema_version == 4
+    assert result.transport_timeout_seconds == QWEN_V5_AMENDED_TIMEOUT_SECONDS
     assert result.stop_reason == "adapter_failed"
     assert result.completed_model_call_count == 0
     assert result.total_tokens == 110
@@ -641,7 +645,9 @@ def test_qwen_failure_reaches_execution_accounting_without_a_retry(tmp_path):
         (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
     )
     assert journal["request"]["requested_provider"] == "qwen"
+    assert journal["request"]["transport_timeout_seconds"] == 120.0
     assert journal["observed_returned_model"] == "qwen3.5-plus-2026-08-01"
+    assert journal["observed_latency_ms"] == 65_000.0
     assert "raw_content" not in journal
 
 
@@ -705,7 +711,8 @@ def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
 
     dry_run = development.protocol_dry_run(**common)
 
-    assert dry_run["schema_version"] == 3
+    assert dry_run["schema_version"] == 4
+    assert dry_run["transport_timeout_seconds"] == QWEN_V5_AMENDED_TIMEOUT_SECONDS
     assert dry_run["requested_provider"] == "qwen"
     assert dry_run["requested_model"] == "qwen3.5-plus"
     assert dry_run["api_base"] == (
@@ -713,6 +720,9 @@ def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
     )
     assert dry_run["case_count"] == 8
     assert dry_run["candidate_count"] == 64
+    for case in dry_run["cases"]:
+        assert case["first_transport_timeout_seconds"] == 120.0
+        assert case["second_transport_timeout_seconds"] == 120.0
 
     output = tmp_path / "qwen-result"
     adapter = QwenOrderedAdapter(output)
@@ -727,13 +737,15 @@ def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
 
     assert factory.call_count == 1
     assert len(adapter.requests) == 16
-    assert result.schema_version == 3
+    assert result.schema_version == 4
+    assert result.transport_timeout_seconds == QWEN_V5_AMENDED_TIMEOUT_SECONDS
     assert result.overall_state == "completed"
     assert result.persisted_candidate_decision_count == 64
     assert result.cost_usd == pytest.approx(0.016)
 
     manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["schema_version"] == 3
+    assert manifest["schema_version"] == 4
+    assert manifest["transport_timeout_seconds"] == 120.0
     assert manifest["requested_provider"] == "qwen"
     assert manifest["requested_model"] == "qwen3.5-plus"
     assert manifest["api_base"] == (
@@ -744,6 +756,7 @@ def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
             request = case[request_name]
             assert request["requested_provider"] == "qwen"
             assert request["requested_model"] == "qwen3.5-plus"
+            assert request["transport_timeout_seconds"] == 120.0
             assert (
                 request["chat_completions_endpoint"]
                 == QWEN_CHAT_COMPLETIONS_ENDPOINT
@@ -753,11 +766,119 @@ def test_qwen_dry_run_and_execution_reach_every_persisted_boundary(tmp_path):
         (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
     )
     assert journal["request"]["requested_provider"] == "qwen"
+    assert journal["request"]["transport_timeout_seconds"] == 120.0
     assert journal["response"]["returned_model"] == "qwen3.5-plus"
     assert journal["response"]["usage"]["cached_prompt_tokens"] == 1
     serialized = json.loads((output / "execution.json").read_text(encoding="utf-8"))
-    assert serialized["schema_version"] == 3
+    assert serialized["schema_version"] == 4
+    assert serialized["transport_timeout_seconds"] == 120.0
     assert serialized["calls"][0]["request"]["requested_provider"] == "qwen"
+
+
+class QwenTimeoutFailureAdapter:
+    """Simulate one potentially billed timeout without exposing semantics."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        assert request.transport_timeout_seconds == QWEN_V5_AMENDED_TIMEOUT_SECONDS
+        self.call_count += 1
+        raise QwenJudgeAdapterError(
+            "simulated Qwen timeout",
+            failure_type="provider_transport",
+            retryable=True,
+            request_may_have_spent=True,
+            observed_latency_ms=120_250.0,
+        )
+
+
+def test_default_qwen_factory_executes_120_seconds_after_manifest_and_persists_timeout(
+    monkeypatch,
+    tmp_path,
+):
+    bundle = _source_bundle(tmp_path)
+    common = _common(bundle)
+    common["judge_provider"] = "qwen"
+    common["expected_implementation_sha256"] = _qwen_implementation_hashes()
+    output = tmp_path / "qwen-default-timeout"
+    adapter = QwenTimeoutFailureAdapter()
+    constructed_timeouts: list[float] = []
+
+    def construct_adapter(*, timeout):  # noqa: ANN001, ANN202
+        assert (output / "manifest.json").is_file()
+        constructed_timeouts.append(timeout)
+        return adapter
+
+    monkeypatch.setattr(development, "QwenEvidenceJudgeAdapter", construct_adapter)
+
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        **common,
+    )
+
+    assert constructed_timeouts == [QWEN_V5_AMENDED_TIMEOUT_SECONDS]
+    assert adapter.call_count == 1
+    assert result.schema_version == 4
+    assert result.cost_state == "uninspectable"
+    journal = json.loads(
+        (output / "judge-calls/W01-pass-1.json").read_text(encoding="utf-8")
+    )
+    assert journal["failure_type"] == "provider_transport"
+    assert journal["observed_latency_ms"] == pytest.approx(120_250.0)
+    assert journal["request"]["transport_timeout_seconds"] == 120.0
+
+
+def test_historical_qwen_schema_3_remains_readable_with_implicit_60_seconds(
+    tmp_path,
+):
+    bundle = _source_bundle(tmp_path)
+    common = _common(bundle)
+    common["judge_provider"] = "qwen"
+    common["expected_implementation_sha256"] = _qwen_implementation_hashes()
+    output = tmp_path / "qwen-schema-3-compatibility"
+    adapter = QwenOrderedAdapter(output)
+    result = development.execute_development_study(
+        output_dir=output,
+        soft_stop_usd=0.05,
+        acknowledge_model_budget=True,
+        adapter_factory=lambda: adapter,
+        **common,
+    )
+
+    manifest_payload = json.loads(
+        (output / "manifest.json").read_text(encoding="utf-8")
+    )
+    manifest_payload["schema_version"] = 3
+    manifest_payload.pop("transport_timeout_seconds")
+    for case in manifest_payload["cases"]:
+        case["first_request"].pop("transport_timeout_seconds")
+        case["second_request"].pop("transport_timeout_seconds")
+    historical_manifest = development.DevelopmentManifest.model_validate(
+        manifest_payload
+    )
+
+    execution_payload = result.model_dump(mode="json")
+    execution_payload["schema_version"] = 3
+    execution_payload.pop("transport_timeout_seconds")
+    for call in execution_payload["calls"]:
+        call["request"].pop("transport_timeout_seconds")
+    historical_execution = development.DevelopmentExecution.model_validate(
+        execution_payload
+    )
+
+    assert historical_manifest.transport_timeout_seconds is None
+    assert (
+        historical_manifest.cases[0].first_request.transport_timeout_seconds
+        == QWEN_V5_INITIAL_TIMEOUT_SECONDS
+    )
+    assert historical_execution.transport_timeout_seconds is None
+    assert (
+        historical_execution.calls[0].request.transport_timeout_seconds
+        == QWEN_V5_INITIAL_TIMEOUT_SECONDS
+    )
 
 
 def test_manifest_rejects_a_provider_identity_mismatch(tmp_path):

--- a/tests/test_qwen_evidence_judge.py
+++ b/tests/test_qwen_evidence_judge.py
@@ -10,6 +10,8 @@ import pytest
 
 from academic_agent.tools.qwen_evidence_judge import (
     QWEN_CHAT_COMPLETIONS_ENDPOINT,
+    QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+    QWEN_V5_INITIAL_TIMEOUT_SECONDS,
     QwenEvidenceJudgeAdapter,
     QwenJudgeAdapterError,
     QwenJudgeRequest,
@@ -18,7 +20,9 @@ from academic_agent.tools.qwen_evidence_judge import (
 )
 
 
-def _request() -> QwenJudgeRequest:
+def _request(
+    *, transport_timeout_seconds: float = QWEN_V5_INITIAL_TIMEOUT_SECONDS
+) -> QwenJudgeRequest:
     system = "Classify supplied evidence and return only strict JSON."
     user = "Evaluate all candidates and preserve their exact order in JSON."
     return QwenJudgeRequest(
@@ -27,6 +31,7 @@ def _request() -> QwenJudgeRequest:
         user_prompt=user,
         batch_input_sha256="1" * 64,
         prompt_sha256=prompt_sha256(system, user),
+        transport_timeout_seconds=transport_timeout_seconds,
     )
 
 
@@ -100,6 +105,75 @@ def test_adapter_sends_one_raw_http_request_with_top_level_thinking_disabled(
     assert "built-in Qwen3.5 Plus peak tier" in response.usage.cost_basis
     assert "env" not in response.usage.cost_basis
     assert response.request_sha256 == hashlib.sha256(call["body"]).hexdigest()
+
+
+def test_amended_timeout_reaches_the_actual_transport_seam():
+    transport = RecordingTransport()
+    adapter = QwenEvidenceJudgeAdapter(
+        api_key="secret",
+        timeout=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+        transport=transport,
+        monotonic_clock=iter((1.0, 1.01)).__next__,
+    )
+    request = _request(
+        transport_timeout_seconds=QWEN_V5_AMENDED_TIMEOUT_SECONDS
+    )
+
+    adapter(request)
+
+    assert len(transport.calls) == 1
+    assert transport.calls[0]["timeout"] == QWEN_V5_AMENDED_TIMEOUT_SECONDS
+    assert request.transport_timeout_seconds == QWEN_V5_AMENDED_TIMEOUT_SECONDS
+    assert "transport_timeout_seconds" not in json.loads(transport.calls[0]["body"])
+
+
+def test_timeout_identity_mismatch_stops_before_transport_invocation():
+    transport = RecordingTransport()
+    adapter = QwenEvidenceJudgeAdapter(api_key="secret", transport=transport)
+
+    with pytest.raises(QwenJudgeAdapterError) as caught:
+        adapter(
+            _request(
+                transport_timeout_seconds=QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            )
+        )
+
+    assert caught.value.failure_type == "request_timeout_identity_mismatch"
+    assert caught.value.request_may_have_spent is False
+    assert caught.value.observed_latency_ms is None
+    assert transport.calls == []
+
+
+class TimeoutTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.calls.append(kwargs)
+        raise TimeoutError("simulated bounded timeout")
+
+
+def test_timeout_failure_retains_monotonic_latency_without_retry():
+    transport = TimeoutTransport()
+    adapter = QwenEvidenceJudgeAdapter(
+        api_key="secret",
+        timeout=QWEN_V5_AMENDED_TIMEOUT_SECONDS,
+        transport=transport,
+        monotonic_clock=iter((1.0, 121.25)).__next__,
+    )
+
+    with pytest.raises(QwenJudgeAdapterError) as caught:
+        adapter(
+            _request(
+                transport_timeout_seconds=QWEN_V5_AMENDED_TIMEOUT_SECONDS
+            )
+        )
+
+    assert caught.value.failure_type == "provider_transport"
+    assert caught.value.request_may_have_spent is True
+    assert caught.value.observed_latency_ms == pytest.approx(120_250.0)
+    assert len(transport.calls) == 1
+    assert transport.calls[0]["timeout"] == QWEN_V5_AMENDED_TIMEOUT_SECONDS
 
 
 def test_model_identity_mismatch_is_terminal_and_discards_semantic_content():


### PR DESCRIPTION
## Why

The first paid Qwen v5 development attempt completed one call in 41.405 seconds and right-censored the next at the historical 60-second timeout. That is not enough evidence for p95, an SLO, or an optimal timeout, but it exposed a durable-contract gap: the persisted request did not prove which timeout the transport actually executed.

## What changed

- pre-registers a transport-only amendment without changing prompts, semantic gates, call caps, or production wiring
- introduces Qwen schema 4 with a bounded 120-second timeout persisted through the manifest, all 16 request identities, journals, and execution
- rejects persisted-versus-actual timeout drift before any request
- records safe monotonic latency on terminal failures while preserving unknown-cost semantics
- keeps historical DeepSeek schema 2 and Qwen schema 3 artifacts readable
- updates README, AGENTS.md, and the implementation result without claiming a paid quality result

## Validation

- 26/26 focused tests
- defect reinjection: restoring the live adapter to 60 seconds made the client seam fail with observed `[60.0]`
- 1787 tests + 657 subtests passed, zero network
- latest Ruff and narrow Pylint passed
- real dry run verified 8 cases, 64 candidates, and 16 prompt/timeout identities with zero network/model calls

## Boundaries

No paid request was made. W01-W08 remain consumed development evidence, the completed historical pass is not reused, and Tool Calling remains disconnected from the production report path. A future paid run requires separate authorization on a merged revision.