### PR TITLE
Record the failed Qwen v5 schema-four development qualification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,7 +512,8 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   only the default adapter argument to 60 seconds made the client-seam test
   fail with observed `[60.0]`; restoration returned it to green. The focused
   suite passes 26/26 and the full suite passes 1787 tests plus 657 subtests.
-  No later paid request is authorized or has occurred. This still does not
+  At that implementation stage no later paid request had been authorized. The
+  amendment alone did not
   complete or connect production Tool Calling. See
   `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md`,
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-provider-implementation.md`,
@@ -520,6 +521,22 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md`,
   and
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md`.
+
+  A separately authorized run on exact merged revision `7a2d73e` then completed
+  all 16 sequential `qwen3.5-plus` calls and all eight case decisions without
+  retry or recovery. It recorded 74,874 tokens, zero cached tokens, USD
+  0.113971 of known conservative cost, and 25.897-49.900-second observed
+  request latency with a 29.680-second median. All 27 indexed artifact hashes,
+  schema contracts, model identities and key-isolation checks passed; every
+  production/report/planner connection remained false. Transport therefore
+  passed, but the semantic method failed its first frozen gate: reversed-pass
+  disposition agreement was 38/64 (59.375%) against the >=90% requirement,
+  two passes were schema-invalid, the join emitted zero KEEP decisions, and all
+  eight cases abstained. W01-W08 are consumed, X01-X08 must remain unopened,
+  and v5 must not connect to production Tool Calling. Do not tune or replay the
+  consumed set into a pass, lower the threshold, or describe a zero-network
+  diagnostic label join as rescuing the conjunctive protocol. See
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -796,12 +796,25 @@ persisted/actual timeout mismatch before transport, and failed journals retain
 safe monotonic elapsed time. The bound is a pre-existing adapter maximum, not a
 percentile or SLO. Its zero-network preflight verified 8/8 frozen cases, 64/64
 candidates, 16/16 prompt and timeout identities, historical schema-2/3
-compatibility, and zero network/model calls. No later paid call is authorized
-or has occurred; production remains in zero-call shadow mode. See the
+compatibility, and zero network/model calls. At that implementation stage,
+no later paid call had been authorized or had occurred; production remained in
+zero-call shadow mode. See the
 [provider pre-registration](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md),
 [paid timeout result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md),
 [timeout amendment](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md),
 and [schema-4 implementation result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md).
+
+A later authorized run on exact merged revision `7a2d73e` completed all 16
+sequential `qwen3.5-plus` calls and all 8 case decisions without retry or
+recovery. It recorded 74,874 tokens, USD 0.113971 of known conservative cost,
+and observed 25.897-49.900-second request latency (29.680-second median); these
+16 observations are not a percentile or SLO. Artifact hashes, schema
+validation, model identity, key isolation, and production-disconnection checks
+passed. The semantic method did not: order-reversed disposition agreement was
+38/64 (59.375%) against the frozen >=90% gate, two passes were schema-invalid,
+and the join retained 0/64 candidates. W01-W08 are consumed, X01-X08 must
+remain unopened, and v5 remains disconnected from production. See the
+[completed development result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md).
 Local verification now passes **1,787 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
@@ -1996,12 +2009,21 @@ Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 
 身份、manifest、journal 与 execution；持久化值和实际传输值不一致时会在请求
 前拒绝，失败 journal 会保留安全的单调时钟耗时。120 秒只是适配器原有上限，
 不是统计百分位或 SLO。零网络预检验证了 8/8 个冻结案例、64/64 个候选、16/16
-个 Prompt 与超时身份、历史 schema 2/3 兼容性，以及 0 次网络/模型调用。尚未
-授权或执行后续付费运行，生产仍保持零调用 Shadow Mode。详见
+个 Prompt 与超时身份、历史 schema 2/3 兼容性，以及 0 次网络/模型调用。在该实现
+阶段尚未授权或执行后续付费运行，生产仍保持零调用 Shadow Mode。详见
 [Provider 预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-provider-amendment.md)、
 [付费超时结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-development-timeout.md)、
 [超时修正预注册](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment.md)
 和[schema 4 实现结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-timeout-amendment-implementation.md)。
+
+随后在精确合并版本 `7a2d73e` 上获授权的运行无重试、无恢复完成 16/16 次顺序
+`qwen3.5-plus` 调用和 8/8 个案例决策，记录 74,874 Token、已知保守成本
+`$0.113971`；请求耗时观察范围为 25.897–49.900 秒、中位数 29.680 秒，这 16
+个样本不是统计百分位或 SLO。产物哈希、Schema、模型身份、密钥隔离和生产断开
+检查均通过，但语义方法未通过：逆序双遍 disposition 一致性只有 38/64
+（59.375%），低于冻结的 90% 门槛；两遍返回 Schema 无效，确定性合并保留
+0/64 个候选。W01–W08 已被消耗，X01–X08 不得打开，v5 仍不得接入生产。
+详见[完整开发运行结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md)。
 本地验证现通过 **1,787 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 

--- a/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md
+++ b/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md
@@ -1,0 +1,97 @@
+# Qwen schema-4 evidence-set v5 development result
+
+Date: 2026-08-31
+Status: execution completed; frozen mechanical development gate failed
+Production connection: not authorized and not performed
+
+## Question
+
+The earlier schema-3 Qwen run stopped on its second request because the frozen
+60-second transport timeout expired. Schema 4 persisted a 120-second bound at
+every request and artifact seam. This run asked a narrower question: can the
+unchanged quote-grounded, order-reversed two-pass evidence-set v5 method finish
+under that bounded transport contract and satisfy its pre-registered
+development gates?
+
+## Authorization and frozen boundary
+
+The owner authorized one run on exact merged revision
+`7a2d73ea9f5d1b4af47e2c6d93aa86999c4711db` with:
+
+- exact model `qwen3.5-plus`;
+- the consumed W01-W08 development packet, not the unseen X01-X08 challenge;
+- at most 16 sequential calls in a fresh output directory;
+- a USD 0.20 soft stop;
+- no retry, redirect, repair, fallback, recovery, supplemental search, or
+  production connection.
+
+The final zero-network preflight verified the exact revision, schema 4, 8/8
+case identities, 64/64 candidate identities, 16/16 prompt and timeout
+identities, and a 120-second timeout for every request. It made zero network or
+model calls.
+
+## Execution and accounting
+
+| Observation | Result |
+|---|---:|
+| Completed calls | 16/16 |
+| Completed case decisions | 8/8 |
+| Persisted candidate decisions | 64/64 |
+| Returned model identity | 16/16 exactly `qwen3.5-plus` |
+| Total tokens | 74,874 |
+| Cached tokens | 0 |
+| Conservative known cost | USD 0.113971 |
+| Observed request latency | 25.897-49.900 seconds; median 29.680 seconds |
+| Retries / recovery calls | 0 / 0 |
+
+The latency values describe only these 16 requests. They are not a percentile,
+an SLO, or evidence that 120 seconds is generally optimal.
+
+The artifact index contained 27 files. Recomputing every indexed SHA-256 found
+zero mismatches. The schema-4 manifest, all 16 call journals, all eight case
+decisions, and the execution record validated through the committed Pydantic
+contracts. The configured provider key occurred in zero persisted artifacts.
+Planner, report, and production connection flags all remained false.
+
+## Frozen mechanical result
+
+The two order-reversed passes agreed on only 38 of 64 candidate dispositions:
+`59.375%`, below the pre-registered `>= 90%` gate. W01 pass 2 and W07 pass 1
+returned schema-invalid semantic payloads. The per-case agreement counts were:
+
+| Case | Agreement |
+|---|---:|
+| W01 | 0/8 |
+| W02 | 6/8 |
+| W03 | 7/8 |
+| W04 | 8/8 |
+| W05 | 7/8 |
+| W06 | 7/8 |
+| W07 | 0/8 |
+| W08 | 3/8 |
+
+The deterministic join therefore emitted 0 `KEEP` and 64 `ABSTAIN` decisions;
+all eight case-level set selections abstained with `no_valid_candidates`.
+Candidate-level abstentions comprised 37 `judge_abstained`, 16
+`judge_pass_invalid`, five `judge_action_disagreement`, five
+`judge_role_disagreement`, and one `insufficient_context_roles`.
+
+## Decision
+
+The schema-4 transport hypothesis passed: the exact model completed all 16
+bounded calls with inspectable accounting and durable artifacts. The semantic
+method failed its first conjunctive development gate. Label-dependent gates
+cannot make an all-gates protocol pass after this failure, so X01-X08 must not
+be opened and evidence-set v5 must not be connected to production Tool Calling.
+
+W01-W08 are consumed development evidence. They must not be tuned on, replayed
+and described as validation, or rescued by lowering the frozen threshold. A
+future zero-network label join may be useful only as a disclosed failure
+diagnostic; it cannot reverse this protocol decision. No further provider call
+is authorized by this record.
+
+The raw request and response artifacts remain in the ignored local output
+directory
+`outputs/2026-08-31-openalex-evidence-set-v5-qwen-schema4-development-7a2d73e/`.
+They are not committed because they contain provider-generated text rather than
+source-controlled decision evidence.


### PR DESCRIPTION
## Why

The schema-four Qwen run removed transport timeout as the blocking explanation, but the frozen semantic method still failed. Recording the failure prevents a complete 16-call execution from being misreported as successful Tool Calling qualification.

## Result

- 16/16 exact qwen3.5-plus calls completed without retry or recovery
- 74,874 tokens and USD 0.113971 conservative known cost
- 27 indexed artifact hashes and all schema/key-isolation checks passed
- reversed-pass agreement was 38/64, below the frozen 90% gate
- zero candidates survived; X01-X08 remain unopened
- no production, report, or planner connection occurred

## Changes

- add the auditable paid-run result
- update bilingual README and AGENTS decision index
- seal W01-W08 and prohibit threshold relaxation or replay-as-validation
- keep raw provider responses out of source control

## Verification

- 1787 passed, 657 subtests passed
- latest Ruff passed
- narrow CI Pylint gate passed