### PR TITLE
Diagnose the sealed Qwen v5 failure without reopening validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1787 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1798 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -537,6 +537,20 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   consumed set into a pass, lower the threshold, or describe a zero-network
   diagnostic label join as rescuing the conjunctive protocol. See
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md`.
+  A separately frozen post-outcome diagnostic then joined all 64 persisted
+  candidate decisions to the earlier human labels without network, model,
+  retrieval or repair calls. Among 28 human-labelled relevant rows, 12 were
+  exposed to a whole-batch invalid response, nine were stable abstentions,
+  four had role-set instability, two had action instability and one failed a
+  post-consensus rule; zero were stable KEEP. The two invalid batches had full
+  row coverage but duplicate role IDs, while valid calls also proposed 17/56
+  versus 8/56 KEEP rows by order position. This is a disclosed failure
+  diagnostic, not validation or causality: it rejects both a schema-only and
+  an order-only explanation, leaves v5 sealed, and does not open X01-X08 or
+  production. See
+  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md`
+  and
+  `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -815,7 +815,20 @@ passed. The semantic method did not: order-reversed disposition agreement was
 and the join retained 0/64 candidates. W01-W08 are consumed, X01-X08 must
 remain unopened, and v5 remains disconnected from production. See the
 [completed development result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md).
-Local verification now passes **1,787 tests plus 657 subtests**, latest Ruff,
+
+A separately frozen, zero-network post-outcome diagnostic joined all 64
+persisted decisions to the earlier human labels. Among 28 relevant rows, 12
+were exposed to a whole-batch invalid response, nine were stable abstentions,
+four had role-set instability, two had action instability, one failed after
+consensus, and zero were stable KEEP. The invalid batches had full row coverage
+but duplicate role IDs; valid calls also produced 17/56 versus 8/56 KEEP rows
+by order position. This describes multiple failure surfaces rather than
+rescuing v5: no repair ran, X01-X08 stayed unopened, and production remained
+disconnected. See the
+[diagnostic plan](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)
+and [aggregate result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md).
+
+Local verification now passes **1,798 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2024,7 +2037,17 @@ Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 
 （59.375%），低于冻结的 90% 门槛；两遍返回 Schema 无效，确定性合并保留
 0/64 个候选。W01–W08 已被消耗，X01–X08 不得打开，v5 仍不得接入生产。
 详见[完整开发运行结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-schema4-development.md)。
-本地验证现通过 **1,787 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+
+随后另行冻结的零网络事后诊断把 64 条持久化决策与此前人工标签逐行连接。
+28 条人工相关行中，12 条暴露于整批无效响应、9 条稳定弃权、4 条角色集合
+不稳定、2 条动作不稳定、1 条在双遍一致后被确定性规则拒绝，稳定 KEEP 为 0。
+两个无效批次都有完整行覆盖，但候选内部存在重复 role ID；有效调用也显示正序
+位置 17/56 与逆序位置 8/56 的 KEEP 差异。这说明存在多个失败面，而不是挽救
+v5：未执行 repair，X01–X08 保持未打开，生产仍断开。详见
+[诊断计划](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)
+和[聚合结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)。
+
+本地验证现通过 **1,798 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
+++ b/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
@@ -61,8 +61,8 @@ the public repository does not contain or discover them. It must lock:
   `68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616`;
 - completed labels SHA-256:
   `a2a3a16f74d2a7d8790ca90669702c423b0c24a83ccbf779ca5867cbe6338f55`;
-- reviewer declaration SHA-256:
-  `869875cf23004d824395a44d3dc2ea5d6f2866e2108dc24ec2a7862aa91210d5`;
+- normalized reviewer declaration SHA-256:
+  `5c7686d413f4f3050316950899e7f1806ff2a2a0065eacf0bf39e942917d863d`;
 - 64 completed rows with unique `(case_id, candidate_sha256)` identities;
 - `reviewed_all=YES`, `generative_ai_use=NONE`, and
   `external_sources_checked=NONE`; and
@@ -146,3 +146,20 @@ authorize another paid call, or connect Tool Calling to production. Its only
 decision use is choosing whether a separately proposed v6 should investigate
 response-schema robustness, judge abstention, order stability, or whether this
 line of work should stop.
+
+## Input-identity amendment before calculation
+
+The first real invocation validated every mechanical hash and all four private
+hashes, then stopped before label joining or output creation because the raw
+returned declaration encoded `external_sources_checked` as `0`. The existing
+review intake had already preserved that raw file and normalized the owner's
+confirmed meaning to the allowed value `NONE` in
+`reviewer-packet/reviewer_declaration.csv`. This plan initially named the raw
+declaration hash even though the frozen eligibility rule above requires
+`NONE`; those two requirements were inconsistent.
+
+The diagnostic therefore uses the already archived normalized declaration
+whose hash is recorded above. It does not modify the raw return, infer a new
+answer, change any label, or relax declaration eligibility. No diagnostic
+row, aggregate, model call, network request, or output file existed before
+this amendment.

--- a/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
+++ b/docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
@@ -1,0 +1,148 @@
+# Analysis plan: Qwen evidence-set v5 failure diagnostic
+
+**Frozen:** 2026-08-31, after the schema-4 W01-W08 development run failed
+its mechanical agreement gate and after the two schema-invalid raw responses
+had been qualitatively inspected, but before calculating any 64-row join with
+the completed human labels.
+
+**Outcome blindness:** no. This is a disclosed post-outcome diagnostic plan,
+not a validation pre-registration. The aggregate v5 failure, its 38/64
+agreement count, the final candidate reason counts, the earlier human totals
+of 28 directly relevant and five semantic-link rows, and duplicate role IDs in
+the two invalid responses were already known when this plan was written.
+
+**Production connection authorized:** no.
+
+**Network, model, retrieval, repair or recovery calls authorized:** no.
+
+## Question
+
+Which observable boundary most often prevented the frozen Qwen v5 development
+run from retaining human-labelled relevant evidence:
+
+1. a whole-batch invalid pass;
+2. stable model abstention;
+3. action instability between provider order and reversed order;
+4. role-set instability between two KEEP decisions; or
+5. a deterministic post-consensus rule?
+
+The result is descriptive. These classes are observable failure surfaces, not
+causal estimates. In particular, one invalid response makes every candidate
+in that batch unusable even when some raw candidate rows look salvageable.
+
+## Frozen inputs
+
+The public mechanical source is the ignored local directory
+`outputs/2026-08-31-openalex-evidence-set-v5-qwen-schema4-development-7a2d73e/`.
+The diagnostic must verify the complete artifact index before parsing any
+semantic response. At minimum, these externally recorded identities must
+match:
+
+- executed revision: `7a2d73ea9f5d1b4af47e2c6d93aa86999c4711db`;
+- requested and returned model: exactly `qwen3.5-plus` for all 16 calls;
+- manifest SHA-256:
+  `df47b0b53003f8347952d2391a9ab9976ff0bdd2cae637018b8d7f69ee29f7a2`;
+- execution SHA-256:
+  `697472f570f43f9131639244cb19efb79e41fb7941fbf44bc56a79714109d39d`;
+- candidate-decision SHA-256:
+  `5e958cac0e487e740ae1da23611db12c6f04be1f4d323eaead69cae96b8cce26`;
+- 16/16 completed calls, 8/8 completed cases and 64/64 persisted candidate
+  decisions; and
+- zero OpenAlex requests, retries, recoveries, planner, report or production
+  connections.
+
+The private human source is the completed, previously eligible W01-W08
+scope-link v4 abstention diagnostic. The tool receives these paths explicitly;
+the public repository does not contain or discover them. It must lock:
+
+- source-lock SHA-256:
+  `8a9747f4240fc7c529d8d8f2a737fb21b502579ad2f69c19587bf093cabba7af`;
+- packet-manifest SHA-256:
+  `68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616`;
+- completed labels SHA-256:
+  `a2a3a16f74d2a7d8790ca90669702c423b0c24a83ccbf779ca5867cbe6338f55`;
+- reviewer declaration SHA-256:
+  `869875cf23004d824395a44d3dc2ea5d6f2866e2108dc24ec2a7862aa91210d5`;
+- 64 completed rows with unique `(case_id, candidate_sha256)` identities;
+- `reviewed_all=YES`, `generative_ai_use=NONE`, and
+  `external_sources_checked=NONE`; and
+- the already published totals of 28 directly relevant, 36 directly
+  irrelevant and five human-inferred semantic-link rows.
+
+Every label row must match the mechanical packet on case ID, provider index,
+candidate SHA, topic, title and URL. A hash, identity, declaration or context
+drift aborts the diagnostic; it never becomes an empty or partial result.
+
+## Frozen mutually exclusive classification
+
+Every one of the 64 candidates receives exactly one class, in this order:
+
+1. `invalid_pass_exposure`: either persisted pass is not `valid`;
+2. `stable_abstain`: both valid passes return `ABSTAIN`;
+3. `action_instability`: one valid pass returns `KEEP` and the other
+   `ABSTAIN`;
+4. `role_instability`: both valid passes return `KEEP` but the exact role-ID
+   sets differ;
+5. `post_consensus_rejection`: both valid passes return `KEEP` with identical
+   role-ID sets, but deterministic quote/contribution checks return `ABSTAIN`;
+6. `stable_keep`: both valid passes agree and the deterministic candidate
+   action is `KEEP`.
+
+The diagnostic must reject any row that fits none or more than one class. It
+must preserve the final v5 action and abstention reasons rather than inventing
+an alternative decision.
+
+## Invalid-response shape probe
+
+For an invalid persisted pass, raw provider content may be parsed only to
+describe shape. The probe records whether it is JSON, whether case ID,
+candidate order and row coverage match the request, and whether duplicate role
+IDs occur within a candidate. It may not deduplicate roles, repair output,
+re-run the v5 parser, construct a counterfactual KEEP, or alter the candidate
+classification. A shape observation is not evidence that the response would
+otherwise have passed quote or selection checks.
+
+## Frozen outputs
+
+The row-level artifact stays private because it joins human labels to provider
+outputs. The public result may contain aggregate counts only. Both must report:
+
+- counts by failure class overall;
+- counts by failure class among directly relevant and directly irrelevant
+  rows;
+- counts by failure class among the five human semantic-link rows;
+- per-case class counts;
+- pass-one and pass-two KEEP counts only where that pass was valid;
+- invalid-pass shape observations;
+- the number and identities of rows joining successfully; and
+- `production_connected=false`, `report_workflow_connected=false`,
+  `planner_trigger_connected=false`, and `x_challenge_opened=false`.
+
+The largest class among the 28 directly relevant rows is labelled the
+`dominant_observed_failure_surface`; a tie is `mixed`. This label is descriptive
+and does not authorize a v6 design.
+
+## Falsification and seam tests
+
+The implementation must prove that:
+
+- changing any indexed mechanical artifact is rejected before label parsing;
+- changing label context while retaining candidate IDs is rejected;
+- a missing or duplicated candidate cannot change a denominator;
+- an ineligible reviewer declaration cannot produce metrics;
+- every computed class reaches both the row artifact and aggregate boundary;
+- invalid-pass rows cannot be silently reclassified from raw content; and
+- production modules do not import the diagnostic.
+
+After implementation, one boundary defect must be re-injected so a new test
+turns red before the correct code is restored. The complete zero-network suite,
+latest Ruff and narrow Pylint must pass.
+
+## Non-claims and stopping rule
+
+This diagnostic cannot rescue v5, reopen W01-W08, open X01-X08, lower the 90%
+gate, estimate source truth, establish causality, validate a repaired parser,
+authorize another paid call, or connect Tool Calling to production. Its only
+decision use is choosing whether a separately proposed v6 should investigate
+response-schema robustness, judge abstention, order stability, or whether this
+line of work should stop.

--- a/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
+++ b/docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md
@@ -1,0 +1,138 @@
+# Qwen evidence-set v5 post-outcome failure diagnostic
+
+- Date: 2026-08-31
+- Status: complete diagnostic; original v5 failure unchanged
+- Network, model and retrieval calls: 0
+- Production connection: not authorized and not performed
+
+## Question and boundary
+
+The schema-4 W01-W08 development run completed all 16 bounded Qwen calls but
+failed its frozen disposition-agreement gate at 38/64. This separately frozen
+post-outcome diagnostic asks which observable boundary prevented the 28
+human-labelled relevant rows from surviving.
+
+This is not a blind validation. Before the analysis plan was committed, the
+aggregate v5 result, the earlier human totals and the two schema-invalid raw
+responses were already known. The diagnostic cannot rescue v5, lower its gate,
+reopen W01-W08, open X01-X08, or authorize production Tool Calling.
+
+## Provenance and execution
+
+The zero-network utility validated the complete 27-file Qwen artifact index,
+then parsed the schema-4 manifest, execution, 16 call journals, eight case
+decisions and 64-candidate aggregate through the committed Pydantic contracts.
+Repeated call and decision files had to equal the copies already embedded in
+the execution artifact.
+
+The private side was independently locked before label parsing:
+
+- the original v4 diagnostic source lock;
+- the exact 64-row packet manifest;
+- the completed human labels; and
+- the already archived normalized reviewer declaration.
+
+The first invocation correctly stopped before label joining because the raw
+returned declaration used `0` for `external_sources_checked`, outside the
+allowed vocabulary. The earlier review intake had preserved that raw file and
+normalized the owner's confirmed meaning to `NONE`. An explicit analysis-plan
+amendment changed only the declaration input identity to that existing
+normalized artifact. No output had been written before the amendment.
+
+All 64 label rows then had to match the mechanical packet on case, provider
+index, candidate SHA, topic, title and URL. The eligible declaration states
+that one reviewer read all rows, used no substantive generative AI and opened
+no external sources. The labels therefore describe only the frozen titles and
+abstracts; they are not source-truth or inter-rater evidence.
+
+## Mutually exclusive failure partition
+
+Every candidate was classified once, using persisted v5 state rather than a
+counterfactual repair:
+
+| Observable failure surface | All 64 | Human relevant (28) | Human irrelevant (36) |
+|---|---:|---:|---:|
+| Whole-batch invalid-pass exposure | 16 | 12 | 4 |
+| Stable abstention in both valid passes | 37 | 9 | 28 |
+| KEEP/ABSTAIN action instability | 5 | 2 | 3 |
+| KEEP role-set instability | 5 | 4 | 1 |
+| Deterministic post-consensus rejection | 1 | 1 | 0 |
+| Stable retained candidate | 0 | 0 | 0 |
+
+The largest single class among the 28 relevant rows was
+`invalid_pass_exposure` at 12. This is an observable system boundary, not a
+causal claim that every exposed candidate would have survived a different
+schema.
+
+For the five human-inferred semantic-link rows, two were exposed to an invalid
+pass, two had role-set instability, and one was stably abstained. No one failure
+class explains all five.
+
+## What the two invalid responses show
+
+W01 pass 2 and W07 pass 1 were valid JSON objects with the correct case ID,
+candidate order, all eight decision rows and recognized actions. They failed
+the strict response schema because role IDs were duplicated within individual
+candidate decisions:
+
+| Invalid pass | Candidates with duplicate role IDs | Extra duplicate role quotes |
+|---|---:|---:|
+| W01 pass 2 | 4 | 7 |
+| W07 pass 1 | 2 | 2 |
+
+The shape probe did not deduplicate those rows or run a repaired parser. Under
+the frozen contract, one malformed batch still exposes all eight candidates to
+`invalid_pass_exposure`. These observations establish schema fragility in two
+calls, not the quality of any hypothetical repaired output.
+
+## Order sensitivity
+
+Among the seven valid calls in each pass position, pass one proposed 17 KEEP
+rows out of 56 candidates while the reversed second pass proposed 8/56. Five
+candidates changed action and five retained KEEP but changed exact role sets.
+
+This directional 17-versus-8 observation is consistent with order sensitivity,
+but one frozen run cannot separate ordering from ordinary model variability.
+It does explain why simply accepting syntactically valid batches would not be
+sufficient: the valid-valid cases still contained ten action or role-set
+disagreements.
+
+## Decision
+
+Evidence-set v5 remains sealed and failed. The diagnostic does not justify:
+
+- relaxing the 90% agreement gate;
+- silently deduplicating duplicate roles;
+- replaying W01-W08 until they pass;
+- opening X01-X08;
+- another paid v5 run; or
+- production or report integration.
+
+If this research line continues, a v6 proposal would need a new hypothesis and
+new frozen challenge. Its design must address both response-schema robustness
+and order stability before spending money. A schema-only patch is not enough,
+because 16 of the 28 relevant rows failed elsewhere; an order-only patch is
+also not enough, because two whole batches were lost before comparison.
+
+The more conservative alternative is to stop this Tool Calling admission
+candidate here. The existing deterministic evidence pipeline remains the
+production path, while v5 serves as evidence that bounded tools and detailed
+audits do not automatically produce a reliable semantic admission rule.
+
+## Verification
+
+The public aggregate seam was defect-reinjected by temporarily dropping the
+computed `metrics` object. The boundary test failed with `KeyError: 'metrics'`;
+restoring the implementation returned the focused diagnostic suite to 11/11.
+The complete zero-network suite then passed 1,798 tests plus 657 subtests.
+Latest Ruff and the CI-equivalent narrow Pylint gate also passed.
+
+## Artifacts
+
+- Analysis plan:
+  `docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md`
+- Zero-network utility: `openalex_evidence_set_failure_diagnostic.py`
+- Regression seams:
+  `tests/test_openalex_evidence_set_failure_diagnostic.py`
+- Private row-level result: retained only in the separate private notes
+  repository.

--- a/openalex_evidence_set_failure_diagnostic.py
+++ b/openalex_evidence_set_failure_diagnostic.py
@@ -1,0 +1,817 @@
+"""Explain the sealed Qwen evidence-set v5 failure without rerunning it.
+
+The schema-4 W01-W08 development run completed, persisted every bounded model
+call, and failed its frozen agreement gate.  This utility joins that immutable
+mechanical trace to the already completed human labels only after validating
+both sources byte-for-byte.  It classifies observable failure surfaces; it
+does not repair model output, recalculate v5, open X01-X08, or connect anything
+to the production workflow.
+
+The row-level join is private.  A separate projection deliberately contains
+only aggregates so a public result can describe the failure without publishing
+the reviewer packet or provider-generated candidate-level judgments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import TypeAdapter
+
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetCandidateAudit,
+    EvidenceSetCaseAudit,
+    JudgePassAudit,
+)
+from evidence_gap_phase4_review import (
+    DECLARATION_FIELDS,
+    _file_sha256,
+    _read_csv,
+    _validated_declaration,
+    _write_text_new,
+)
+from openalex_evidence_set_development import (
+    DevelopmentExecution,
+    DevelopmentManifest,
+    DevelopmentPacket,
+    DevelopmentPacketRow,
+    JudgeCallJournal,
+)
+from openalex_scope_link_abstention_review import (
+    CONTEXT_FIELDS,
+    LABEL_FIELDS,
+    LABEL_VALUE_FIELDS,
+    VALID_LABEL_COMBINATIONS,
+)
+
+
+CASE_IDS = tuple(f"W{index:02d}" for index in range(1, 9))
+EXPECTED_EXECUTED_REVISION = "7a2d73ea9f5d1b4af47e2c6d93aa86999c4711db"
+EXPECTED_MECHANICAL_KEY_SHA256 = {
+    "manifest.json": (
+        "df47b0b53003f8347952d2391a9ab9976ff0bdd2cae637018b8d7f69ee29f7a2"
+    ),
+    "execution.json": (
+        "697472f570f43f9131639244cb19efb79e41fb7941fbf44bc56a79714109d39d"
+    ),
+    "candidate-decisions.json": (
+        "5e958cac0e487e740ae1da23611db12c6f04be1f4d323eaead69cae96b8cce26"
+    ),
+}
+EXPECTED_PRIVATE_SHA256 = {
+    "source-lock.json": (
+        "8a9747f4240fc7c529d8d8f2a737fb21b502579ad2f69c19587bf093cabba7af"
+    ),
+    "packet_manifest.json": (
+        "68e15abdca46f4a65d33a75aedaa9a0eac2112a90a8b1e6eb1d00e71e59b8616"
+    ),
+    "labels.csv": (
+        "a2a3a16f74d2a7d8790ca90669702c423b0c24a83ccbf779ca5867cbe6338f55"
+    ),
+    "reviewer_declaration.csv": (
+        "5c7686d413f4f3050316950899e7f1806ff2a2a0065eacf0bf39e942917d863d"
+    ),
+}
+
+FailureClass = Literal[
+    "invalid_pass_exposure",
+    "stable_abstain",
+    "action_instability",
+    "role_instability",
+    "post_consensus_rejection",
+    "stable_keep",
+]
+FAILURE_CLASSES: tuple[FailureClass, ...] = (
+    "invalid_pass_exposure",
+    "stable_abstain",
+    "action_instability",
+    "role_instability",
+    "post_consensus_rejection",
+    "stable_keep",
+)
+MEASUREMENT_LIMIT = (
+    "This disclosed post-outcome diagnostic associates one eligible reviewer's "
+    "frozen title/abstract labels with the sealed Qwen v5 trace. It cannot rescue "
+    "v5, establish causality or source truth, open X01-X08, authorize another "
+    "provider call, or connect Tool Calling to production."
+)
+
+
+class EvidenceSetFailureDiagnosticError(ValueError):
+    """Raised when frozen provenance or a diagnostic invariant does not hold."""
+
+
+@dataclass(frozen=True)
+class MechanicalSnapshot:
+    """Strictly validated projection of the immutable Qwen execution."""
+
+    source_sha256: Mapping[str, str]
+    manifest: DevelopmentManifest
+    execution: DevelopmentExecution
+    cases: tuple[EvidenceSetCaseAudit, ...]
+    calls: Mapping[tuple[str, int], JudgeCallJournal]
+
+
+@dataclass(frozen=True)
+class HumanLabel:
+    """One eligible label with context already matched to the public packet."""
+
+    case_id: str
+    provider_result_index: int
+    candidate_sha256: str
+    direct_relevance: str
+    semantic_scope_link: str
+    baseline_novelty: str
+    abstract_sufficient: str
+
+
+@dataclass(frozen=True)
+class HumanSnapshot:
+    """Validated private labels; free text is intentionally not retained."""
+
+    source_sha256: Mapping[str, str]
+    declaration: Mapping[str, Any]
+    packet_rows: tuple[DevelopmentPacketRow, ...]
+    labels: Mapping[tuple[str, str], HumanLabel]
+
+
+def _json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceSetFailureDiagnosticError(
+            f"cannot read JSON object {path}: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise EvidenceSetFailureDiagnosticError(f"{path} must contain one JSON object")
+    return value
+
+
+def _expected_mechanical_files() -> set[str]:
+    return {
+        "manifest.json",
+        "execution.json",
+        "candidate-decisions.json",
+        *(f"case-decisions/{case_id}.json" for case_id in CASE_IDS),
+        *(
+            f"judge-calls/{case_id}-pass-{pass_number}.json"
+            for case_id in CASE_IDS
+            for pass_number in (1, 2)
+        ),
+    }
+
+
+def _validate_indexed_files(
+    source_dir: Path,
+    expected_key_sha256: Mapping[str, str],
+) -> dict[str, str]:
+    """Hash every indexed byte before any semantic response is parsed."""
+
+    index = _json_object(source_dir / "artifact-index.json")
+    if index.get("mode") != "openalex_evidence_set_v5_development_artifact_index":
+        raise EvidenceSetFailureDiagnosticError("mechanical artifact-index mode drifted")
+    file_hashes = index.get("files")
+    if not isinstance(file_hashes, dict) or set(file_hashes) != _expected_mechanical_files():
+        raise EvidenceSetFailureDiagnosticError(
+            "mechanical artifact-index file coverage drifted"
+        )
+    if any(
+        not isinstance(path, str)
+        or not isinstance(digest, str)
+        or len(digest) != 64
+        for path, digest in file_hashes.items()
+    ):
+        raise EvidenceSetFailureDiagnosticError(
+            "mechanical artifact-index contains an invalid SHA-256 entry"
+        )
+
+    observed: dict[str, str] = {}
+    for relative_path in sorted(file_hashes):
+        path = source_dir / relative_path
+        if not path.is_file():
+            raise EvidenceSetFailureDiagnosticError(
+                f"mechanical artifact is missing: {relative_path}"
+            )
+        observed[relative_path] = _file_sha256(path)
+    if observed != dict(sorted(file_hashes.items())):
+        raise EvidenceSetFailureDiagnosticError(
+            "mechanical artifact bytes drifted from artifact-index"
+        )
+    for relative_path, expected in expected_key_sha256.items():
+        if observed.get(relative_path) != expected:
+            raise EvidenceSetFailureDiagnosticError(
+                f"frozen mechanical identity drifted: {relative_path}"
+            )
+    return observed
+
+
+def load_mechanical_snapshot(
+    source_dir: Path,
+    *,
+    expected_key_sha256: Mapping[str, str] = EXPECTED_MECHANICAL_KEY_SHA256,
+) -> MechanicalSnapshot:
+    """Validate the complete public trace and its repeated serialization seams."""
+
+    if not source_dir.is_dir():
+        raise EvidenceSetFailureDiagnosticError(
+            f"mechanical source directory does not exist: {source_dir}"
+        )
+    observed = _validate_indexed_files(source_dir, expected_key_sha256)
+    manifest = DevelopmentManifest.model_validate_json(
+        (source_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+    execution = DevelopmentExecution.model_validate_json(
+        (source_dir / "execution.json").read_text(encoding="utf-8")
+    )
+    if (
+        manifest.schema_version != 4
+        or manifest.requested_provider != "qwen"
+        or manifest.requested_model != "qwen3.5-plus"
+        or manifest.maximum_model_call_count != 16
+    ):
+        raise EvidenceSetFailureDiagnosticError(
+            "mechanical manifest is not the frozen Qwen schema-4 contract"
+        )
+    if execution.manifest_sha256 != observed["manifest.json"]:
+        raise EvidenceSetFailureDiagnosticError(
+            "execution does not bind the frozen manifest bytes"
+        )
+    if (
+        execution.overall_state != "completed"
+        or execution.completed_model_call_count != 16
+        or execution.completed_case_count != 8
+        or execution.persisted_candidate_decision_count != 64
+        or execution.disposition_agreement_numerator != 38
+        or execution.disposition_agreement_denominator != 64
+        or execution.mechanical_agreement_gate_passed is not False
+        or execution.openalex_request_count != 0
+        or execution.production_connected
+        or execution.report_workflow_connected
+        or execution.planner_trigger_connected
+    ):
+        raise EvidenceSetFailureDiagnosticError(
+            "execution summary drifted from the sealed failed development result"
+        )
+    if any(
+        call.state != "completed"
+        or call.request.requested_model != "qwen3.5-plus"
+        or call.response is None
+        or call.response.returned_model != "qwen3.5-plus"
+        for call in execution.calls
+    ):
+        raise EvidenceSetFailureDiagnosticError(
+            "one or more model-call identities drifted from the frozen run"
+        )
+
+    case_adapter = TypeAdapter(tuple[EvidenceSetCaseAudit, ...])
+    cases = case_adapter.validate_json(
+        (source_dir / "candidate-decisions.json").read_text(encoding="utf-8")
+    )
+    if cases != execution.case_decisions:
+        raise EvidenceSetFailureDiagnosticError(
+            "candidate decisions were computed but changed at the aggregate seam"
+        )
+    if tuple(case.case_id for case in cases) != CASE_IDS:
+        raise EvidenceSetFailureDiagnosticError("mechanical case order drifted")
+
+    calls = {(call.case_id, call.pass_number): call for call in execution.calls}
+    if len(calls) != 16:
+        raise EvidenceSetFailureDiagnosticError("model-call identities are not unique")
+    for key, call in calls.items():
+        relative_path = f"judge-calls/{key[0]}-pass-{key[1]}.json"
+        serialized = JudgeCallJournal.model_validate_json(
+            (source_dir / relative_path).read_text(encoding="utf-8")
+        )
+        if serialized != call:
+            raise EvidenceSetFailureDiagnosticError(
+                f"model call changed at its file boundary: {relative_path}"
+            )
+    for case in cases:
+        relative_path = f"case-decisions/{case.case_id}.json"
+        serialized = EvidenceSetCaseAudit.model_validate_json(
+            (source_dir / relative_path).read_text(encoding="utf-8")
+        )
+        if serialized != case:
+            raise EvidenceSetFailureDiagnosticError(
+                f"case decision changed at its file boundary: {relative_path}"
+            )
+    return MechanicalSnapshot(observed, manifest, execution, cases, calls)
+
+
+def _expected_context(row: DevelopmentPacketRow) -> dict[str, str]:
+    values = row.model_dump(mode="python")
+    return {
+        field: "" if values[field] is None else str(values[field])
+        for field in CONTEXT_FIELDS
+    }
+
+
+def _validated_human_label(
+    row: Mapping[str, str],
+    expected: DevelopmentPacketRow,
+) -> HumanLabel:
+    observed_context = {field: row[field] for field in CONTEXT_FIELDS}
+    if observed_context != _expected_context(expected):
+        raise EvidenceSetFailureDiagnosticError(
+            f"human label context drifted for {expected.case_id}/"
+            f"{expected.candidate_sha256}"
+        )
+    values = tuple(row[field].strip() for field in LABEL_VALUE_FIELDS)
+    if not all(values):
+        raise EvidenceSetFailureDiagnosticError(
+            f"human label is incomplete for {expected.case_id}/"
+            f"{expected.candidate_sha256}"
+        )
+    direct, semantic, novelty, sufficient, note = values
+    normalized = (
+        direct.upper(),
+        semantic.upper(),
+        novelty.upper(),
+        sufficient.upper(),
+    )
+    if normalized not in VALID_LABEL_COMBINATIONS:
+        raise EvidenceSetFailureDiagnosticError(
+            f"human label values are invalid for {expected.case_id}/"
+            f"{expected.candidate_sha256}"
+        )
+    if len("".join(note.split())) < 12:
+        raise EvidenceSetFailureDiagnosticError(
+            f"human label note is not grounded for {expected.case_id}/"
+            f"{expected.candidate_sha256}"
+        )
+    return HumanLabel(
+        case_id=expected.case_id,
+        provider_result_index=expected.provider_result_index,
+        candidate_sha256=expected.candidate_sha256,
+        direct_relevance=normalized[0],
+        semantic_scope_link=normalized[1],
+        baseline_novelty=normalized[2],
+        abstract_sufficient=normalized[3],
+    )
+
+
+def load_human_snapshot(
+    *,
+    source_lock_path: Path,
+    packet_manifest_path: Path,
+    labels_path: Path,
+    declaration_path: Path,
+    expected_sha256: Mapping[str, str] = EXPECTED_PRIVATE_SHA256,
+) -> HumanSnapshot:
+    """Hash all private inputs before parsing any human judgment."""
+
+    paths = {
+        "source-lock.json": source_lock_path,
+        "packet_manifest.json": packet_manifest_path,
+        "labels.csv": labels_path,
+        "reviewer_declaration.csv": declaration_path,
+    }
+    if set(paths) != set(expected_sha256):
+        raise EvidenceSetFailureDiagnosticError("private source identity is incomplete")
+    observed: dict[str, str] = {}
+    for name, path in paths.items():
+        if not path.is_file():
+            raise EvidenceSetFailureDiagnosticError(f"private source is missing: {name}")
+        observed[name] = _file_sha256(path)
+    if observed != dict(expected_sha256):
+        drifted = sorted(
+            name for name in observed if observed[name] != expected_sha256[name]
+        )
+        raise EvidenceSetFailureDiagnosticError(
+            f"private source bytes drifted: {drifted}"
+        )
+
+    # Parsing begins only after all four private byte identities are known.
+    packet = DevelopmentPacket.model_validate_json(
+        packet_manifest_path.read_text(encoding="utf-8")
+    )
+    if packet.source_lock_sha256 != observed["source-lock.json"]:
+        raise EvidenceSetFailureDiagnosticError(
+            "packet manifest does not bind the frozen source lock"
+        )
+    label_rows = _read_csv(labels_path, LABEL_FIELDS)
+    if len(label_rows) != 64:
+        raise EvidenceSetFailureDiagnosticError("human label denominator must be 64")
+    expected_by_key = {
+        (row.case_id, row.candidate_sha256): row for row in packet.rows
+    }
+    if len(expected_by_key) != 64:
+        raise EvidenceSetFailureDiagnosticError(
+            "packet candidate identities are not unique"
+        )
+    observed_keys = [
+        (row["case_id"], row["candidate_sha256"]) for row in label_rows
+    ]
+    if len(observed_keys) != len(set(observed_keys)):
+        raise EvidenceSetFailureDiagnosticError(
+            "human labels contain duplicate candidate identities"
+        )
+    if set(observed_keys) != set(expected_by_key):
+        raise EvidenceSetFailureDiagnosticError(
+            "human-label identities drifted from the frozen packet"
+        )
+    labels = {
+        key: _validated_human_label(row, expected_by_key[key])
+        for key, row in zip(observed_keys, label_rows, strict=True)
+    }
+
+    declarations = _read_csv(declaration_path, DECLARATION_FIELDS)
+    if len(declarations) != 1:
+        raise EvidenceSetFailureDiagnosticError(
+            "reviewer declaration must contain exactly one row"
+        )
+    declaration = _validated_declaration(declarations[0])
+    if declaration is None:
+        raise EvidenceSetFailureDiagnosticError("reviewer declaration is incomplete")
+    if (
+        declaration["reviewed_all"] != "YES"
+        or declaration["generative_ai_use"] != "NONE"
+        or declaration["external_sources_checked"] != "NONE"
+    ):
+        raise EvidenceSetFailureDiagnosticError(
+            "reviewer declaration is not eligible for this frozen diagnostic"
+        )
+    direct_counts = Counter(label.direct_relevance for label in labels.values())
+    semantic_count = sum(
+        label.semantic_scope_link == "YES" for label in labels.values()
+    )
+    if direct_counts != Counter({"YES": 28, "NO": 36}) or semantic_count != 5:
+        raise EvidenceSetFailureDiagnosticError(
+            "human aggregate drifted from the published eligible review"
+        )
+    return HumanSnapshot(observed, declaration, packet.rows, labels)
+
+
+def _pass_decision(
+    judge_pass: JudgePassAudit,
+    candidate_sha256: str,
+) -> tuple[str, tuple[str, ...]]:
+    if judge_pass.state != "valid" or judge_pass.response is None:
+        raise EvidenceSetFailureDiagnosticError(
+            "invalid pass cannot be interpreted as a candidate decision"
+        )
+    by_id = {
+        decision.candidate_sha256: decision
+        for decision in judge_pass.response.decisions
+    }
+    try:
+        decision = by_id[candidate_sha256]
+    except KeyError as exc:
+        raise EvidenceSetFailureDiagnosticError(
+            "valid pass omitted a frozen candidate identity"
+        ) from exc
+    return decision.action, tuple(sorted(item.role_id for item in decision.role_quotes))
+
+
+def classify_candidate(
+    case: EvidenceSetCaseAudit,
+    candidate: EvidenceSetCandidateAudit,
+) -> tuple[FailureClass, str | None, str | None]:
+    """Apply the frozen precedence without consulting raw invalid content."""
+
+    if case.first_pass.state != "valid" or case.second_pass.state != "valid":
+        return "invalid_pass_exposure", None, None
+    first_action, first_roles = _pass_decision(
+        case.first_pass, candidate.candidate_sha256
+    )
+    second_action, second_roles = _pass_decision(
+        case.second_pass, candidate.candidate_sha256
+    )
+    if first_action == second_action == "ABSTAIN":
+        failure_class: FailureClass = "stable_abstain"
+    elif first_action != second_action:
+        failure_class = "action_instability"
+    elif first_roles != second_roles:
+        failure_class = "role_instability"
+    elif candidate.action == "ABSTAIN":
+        failure_class = "post_consensus_rejection"
+    else:
+        failure_class = "stable_keep"
+    return failure_class, first_action, second_action
+
+
+def _shape_probe(
+    call: JudgeCallJournal,
+    expected_order: Sequence[str],
+) -> dict[str, Any]:
+    """Describe invalid raw shape without producing a repaired v5 response."""
+
+    if call.response is None:
+        raise EvidenceSetFailureDiagnosticError(
+            "completed invalid-pass call has no persisted provider response"
+        )
+    raw_content = call.response.raw_content
+    try:
+        payload = json.loads(raw_content)
+    except json.JSONDecodeError:
+        return {
+            "case_id": call.case_id,
+            "pass_number": call.pass_number,
+            "persisted_error_code": "schema_invalid",
+            "json_object": False,
+            "case_id_matches": False,
+            "candidate_order_matches": False,
+            "decision_row_coverage_matches": False,
+            "recognized_actions_only": False,
+            "duplicate_role_id_candidate_count": 0,
+            "duplicate_role_quote_count": 0,
+        }
+    if not isinstance(payload, dict):
+        payload = {}
+    decisions = payload.get("decisions")
+    decision_rows = decisions if isinstance(decisions, list) else []
+    duplicate_candidates = 0
+    duplicate_quotes = 0
+    recognized_actions_only = bool(decision_rows)
+    decision_ids: list[object] = []
+    for row in decision_rows:
+        if not isinstance(row, dict):
+            recognized_actions_only = False
+            continue
+        decision_ids.append(row.get("candidate_sha256"))
+        if row.get("action") not in {"KEEP", "ABSTAIN"}:
+            recognized_actions_only = False
+        quotes = row.get("role_quotes")
+        if not isinstance(quotes, list):
+            recognized_actions_only = False
+            continue
+        role_ids = [
+            quote.get("role_id")
+            for quote in quotes
+            if isinstance(quote, dict) and isinstance(quote.get("role_id"), str)
+        ]
+        duplicates = len(role_ids) - len(set(role_ids))
+        if duplicates:
+            duplicate_candidates += 1
+            duplicate_quotes += duplicates
+    return {
+        "case_id": call.case_id,
+        "pass_number": call.pass_number,
+        "persisted_error_code": "schema_invalid",
+        "json_object": bool(payload),
+        "case_id_matches": payload.get("case_id") == call.case_id,
+        "candidate_order_matches": payload.get("candidate_order")
+        == list(expected_order),
+        "decision_row_coverage_matches": decision_ids == list(expected_order),
+        "recognized_actions_only": recognized_actions_only,
+        "duplicate_role_id_candidate_count": duplicate_candidates,
+        "duplicate_role_quote_count": duplicate_quotes,
+    }
+
+
+def _dominant_failure_surface(rows: Sequence[Mapping[str, Any]]) -> str:
+    counts = Counter(
+        row["failure_class"]
+        for row in rows
+        if row["direct_relevance"] == "YES"
+    )
+    if not counts:
+        return "not_evaluated"
+    maximum = max(counts.values())
+    winners = sorted(name for name, count in counts.items() if count == maximum)
+    return winners[0] if len(winners) == 1 else "mixed"
+
+
+def _aggregate_metrics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    class_counts = Counter(row["failure_class"] for row in rows)
+    if sum(class_counts.values()) != 64 or set(class_counts) - set(FAILURE_CLASSES):
+        raise EvidenceSetFailureDiagnosticError(
+            "failure classes do not form one complete 64-row partition"
+        )
+    by_relevance = {
+        relevance: dict(
+            sorted(
+                Counter(
+                    row["failure_class"]
+                    for row in rows
+                    if row["direct_relevance"] == relevance
+                ).items()
+            )
+        )
+        for relevance in ("YES", "NO")
+    }
+    semantic_rows = [row for row in rows if row["semantic_scope_link"] == "YES"]
+    by_case = {
+        case_id: dict(
+            sorted(
+                Counter(
+                    row["failure_class"]
+                    for row in rows
+                    if row["case_id"] == case_id
+                ).items()
+            )
+        )
+        for case_id in CASE_IDS
+    }
+    return {
+        "candidate_count": 64,
+        "joined_candidate_count": len(rows),
+        "direct_relevant_count": sum(
+            row["direct_relevance"] == "YES" for row in rows
+        ),
+        "direct_irrelevant_count": sum(
+            row["direct_relevance"] == "NO" for row in rows
+        ),
+        "human_semantic_link_count": len(semantic_rows),
+        "failure_class_counts": dict(sorted(class_counts.items())),
+        "failure_class_counts_by_direct_relevance": by_relevance,
+        "failure_class_counts_among_human_semantic_links": dict(
+            sorted(Counter(row["failure_class"] for row in semantic_rows).items())
+        ),
+        "failure_class_counts_by_case": by_case,
+        "dominant_observed_failure_surface": _dominant_failure_surface(rows),
+    }
+
+
+def build_failure_diagnostic(
+    mechanical: MechanicalSnapshot,
+    human: HumanSnapshot,
+) -> dict[str, Any]:
+    """Join labels only after both snapshots have independently passed."""
+
+    mechanical_ids = {
+        (case.case_id, candidate.candidate_sha256)
+        for case in mechanical.cases
+        for candidate in case.candidate_decisions
+    }
+    if mechanical_ids != set(human.labels):
+        raise EvidenceSetFailureDiagnosticError(
+            "mechanical and human candidate identities do not form an exact join"
+        )
+    rows: list[dict[str, Any]] = []
+    pass_actions = {
+        "pass_1": Counter(valid_candidate_count=0, keep_count=0),
+        "pass_2": Counter(valid_candidate_count=0, keep_count=0),
+    }
+    invalid_shapes: list[dict[str, Any]] = []
+    for case in mechanical.cases:
+        provider_order = tuple(
+            candidate.candidate_sha256
+            for candidate in sorted(
+                case.candidate_decisions,
+                key=lambda item: item.provider_result_index,
+            )
+        )
+        for pass_number, judge_pass in (
+            (1, case.first_pass),
+            (2, case.second_pass),
+        ):
+            if judge_pass.state == "valid" and judge_pass.response is not None:
+                counter = pass_actions[f"pass_{pass_number}"]
+                counter["valid_candidate_count"] += len(judge_pass.response.decisions)
+                counter["keep_count"] += sum(
+                    decision.action == "KEEP"
+                    for decision in judge_pass.response.decisions
+                )
+            else:
+                expected_order = (
+                    provider_order if pass_number == 1 else tuple(reversed(provider_order))
+                )
+                invalid_shapes.append(
+                    _shape_probe(
+                        mechanical.calls[(case.case_id, pass_number)],
+                        expected_order,
+                    )
+                )
+        for candidate in case.candidate_decisions:
+            label = human.labels[(case.case_id, candidate.candidate_sha256)]
+            failure_class, first_action, second_action = classify_candidate(
+                case, candidate
+            )
+            rows.append(
+                {
+                    "case_id": case.case_id,
+                    "provider_result_index": candidate.provider_result_index,
+                    "candidate_sha256": candidate.candidate_sha256,
+                    "direct_relevance": label.direct_relevance,
+                    "semantic_scope_link": label.semantic_scope_link,
+                    "baseline_novelty": label.baseline_novelty,
+                    "abstract_sufficient": label.abstract_sufficient,
+                    "failure_class": failure_class,
+                    "first_pass_state": case.first_pass.state,
+                    "second_pass_state": case.second_pass.state,
+                    "first_action": first_action,
+                    "second_action": second_action,
+                    "final_action": candidate.action,
+                    "final_abstention_reasons": list(candidate.abstention_reasons),
+                }
+            )
+    rows.sort(key=lambda row: (row["case_id"], row["provider_result_index"]))
+    if len(rows) != 64 or len({row["candidate_sha256"] for row in rows}) != 64:
+        raise EvidenceSetFailureDiagnosticError(
+            "joined row boundary lost or duplicated a candidate"
+        )
+    metrics = _aggregate_metrics(rows)
+    metrics["valid_pass_action_counts"] = {
+        name: dict(counter) for name, counter in pass_actions.items()
+    }
+    return {
+        "schema_version": 1,
+        "mode": "openalex_evidence_set_v5_qwen_failure_diagnostic",
+        "diagnostic_only": True,
+        "protocol_status": "complete",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "x_challenge_opened": False,
+        "v5_result_changed": False,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "mechanical_source_sha256": dict(mechanical.source_sha256),
+        "private_source_sha256": dict(human.source_sha256),
+        "review_method": {
+            "reviewed_all": human.declaration["reviewed_all"],
+            "generative_ai_use": human.declaration["generative_ai_use"],
+            "external_sources_checked": human.declaration[
+                "external_sources_checked"
+            ],
+            "reviewer_count": 1,
+        },
+        "metrics": metrics,
+        "invalid_pass_shape_observations": invalid_shapes,
+        "rows": rows,
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def public_projection(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop candidate identities and the private row-level label join."""
+
+    if result.get("protocol_status") != "complete" or len(result.get("rows", ())) != 64:
+        raise EvidenceSetFailureDiagnosticError(
+            "only a complete 64-row diagnostic can be projected publicly"
+        )
+    return {
+        key: value
+        for key, value in result.items()
+        if key
+        not in {
+            "rows",
+            "private_source_sha256",
+            "review_method",
+        }
+    }
+
+
+def _json_text(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _stdout_json(value: object) -> None:
+    text = _json_text(value)
+    stream = getattr(sys.stdout, "buffer", None)
+    if stream is None:
+        sys.stdout.write(text)
+        return
+    stream.write(text.encode("utf-8"))
+    stream.flush()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mechanical-dir", type=Path, required=True)
+    parser.add_argument("--source-lock", type=Path, required=True)
+    parser.add_argument("--packet-manifest", type=Path, required=True)
+    parser.add_argument("--labels", type=Path, required=True)
+    parser.add_argument("--reviewer-declaration", type=Path, required=True)
+    parser.add_argument("--private-output", type=Path, required=True)
+    parser.add_argument("--public-output", type=Path, required=True)
+    parser.add_argument(
+        "--acknowledge-post-outcome-diagnostic",
+        action="store_true",
+        help="Confirm that this cannot rescue v5 or authorize X01-X08.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.acknowledge_post_outcome_diagnostic:
+        raise EvidenceSetFailureDiagnosticError(
+            "post-outcome diagnostic acknowledgement is required"
+        )
+    mechanical = load_mechanical_snapshot(args.mechanical_dir)
+    human = load_human_snapshot(
+        source_lock_path=args.source_lock,
+        packet_manifest_path=args.packet_manifest,
+        labels_path=args.labels,
+        declaration_path=args.reviewer_declaration,
+    )
+    result = build_failure_diagnostic(mechanical, human)
+    # The private artifact commits first. A crash before the public projection
+    # cannot leave a reassuring aggregate without the underlying joined rows.
+    _write_text_new(args.private_output, _json_text(result))
+    projection = public_projection(result)
+    _write_text_new(args.public_output, _json_text(projection))
+    _stdout_json(projection)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_evidence_set_failure_diagnostic.py
+++ b/tests/test_openalex_evidence_set_failure_diagnostic.py
@@ -1,0 +1,332 @@
+"""Regression seams for the sealed v5 post-outcome failure diagnostic."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import openalex_evidence_set_failure_diagnostic as diagnostic
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetCaseAudit,
+)
+from openalex_evidence_set_development import (
+    DevelopmentExecution,
+    DevelopmentManifest,
+    DevelopmentPacketRow,
+)
+
+
+def _sha(value: int) -> str:
+    return f"{value:064x}"
+
+
+def _valid_pass(
+    case_id: str,
+    pass_number: int,
+    candidate_ids: tuple[str, ...],
+) -> dict[str, object]:
+    ordered = candidate_ids if pass_number == 1 else tuple(reversed(candidate_ids))
+    return {
+        "pass_number": pass_number,
+        "state": "valid",
+        "raw_response_sha256": _sha(800 + pass_number),
+        "input_sha256": _sha(900 + pass_number),
+        "error_code": None,
+        "response": {
+            "case_id": case_id,
+            "candidate_order": ordered,
+            "decisions": [
+                {
+                    "candidate_sha256": candidate_id,
+                    "action": "ABSTAIN",
+                    "role_quotes": [],
+                }
+                for candidate_id in ordered
+            ],
+        },
+    }
+
+
+def _stable_abstain_case(case_number: int) -> EvidenceSetCaseAudit:
+    case_id = f"W{case_number:02d}"
+    candidate_ids = tuple(_sha(case_number * 100 + index) for index in range(8))
+    return EvidenceSetCaseAudit.model_validate(
+        {
+            "case_id": case_id,
+            "topic": f"Synthetic diagnostic topic for frozen case number {case_number}",
+            "action": "ABSTAIN",
+            "profile_sha256": _sha(1),
+            "selection_contract_sha256": _sha(2),
+            "production_connected": False,
+            "report_workflow_connected": False,
+            "planner_trigger_connected": False,
+            "provider_candidate_count": 8,
+            "first_pass": _valid_pass(case_id, 1, candidate_ids),
+            "second_pass": _valid_pass(case_id, 2, candidate_ids),
+            "candidate_decisions": [
+                {
+                    "candidate_sha256": candidate_id,
+                    "provider_result_index": index,
+                    "action": "ABSTAIN",
+                    "first_action": "ABSTAIN",
+                    "second_action": "ABSTAIN",
+                    "judge_agreement": True,
+                    "required_role_ids": [],
+                    "scope_role_ids": [],
+                    "supporting_role_ids": [],
+                    "title_anchor_role_ids": [],
+                    "verified_role_quotes": [],
+                    "abstention_reasons": ["judge_abstained"],
+                }
+                for index, candidate_id in enumerate(candidate_ids)
+            ],
+            "selected_sources": [],
+            "covered_required_role_ids": [],
+            "covered_scope_role_ids": [],
+            "covered_supporting_role_ids": [],
+            "judge_agreement_numerator": 8,
+            "judge_agreement_denominator": 8,
+            "judge_disposition_agreement": 1.0,
+            "abstention_reasons": ["no_valid_candidates"],
+        }
+    )
+
+
+def _snapshots() -> tuple[diagnostic.MechanicalSnapshot, diagnostic.HumanSnapshot]:
+    cases = tuple(_stable_abstain_case(index) for index in range(1, 9))
+    labels: dict[tuple[str, str], diagnostic.HumanLabel] = {}
+    row_number = 0
+    for case in cases:
+        for candidate in case.candidate_decisions:
+            row_number += 1
+            relevant = row_number <= 28
+            labels[(case.case_id, candidate.candidate_sha256)] = diagnostic.HumanLabel(
+                case_id=case.case_id,
+                provider_result_index=candidate.provider_result_index,
+                candidate_sha256=candidate.candidate_sha256,
+                direct_relevance="YES" if relevant else "NO",
+                semantic_scope_link="YES" if row_number <= 5 else (
+                    "NO" if relevant else "N/A"
+                ),
+                baseline_novelty="YES" if relevant else "N/A",
+                abstract_sufficient="YES",
+            )
+    mechanical = diagnostic.MechanicalSnapshot(
+        source_sha256={"execution.json": _sha(10)},
+        manifest=cast(DevelopmentManifest, None),
+        execution=cast(DevelopmentExecution, None),
+        cases=cases,
+        calls={},
+    )
+    human = diagnostic.HumanSnapshot(
+        source_sha256={"labels.csv": _sha(11)},
+        declaration={
+            "reviewed_all": "YES",
+            "generative_ai_use": "NONE",
+            "external_sources_checked": "NONE",
+        },
+        packet_rows=(),
+        labels=labels,
+    )
+    return mechanical, human
+
+
+def _pass(action: str, candidate_id: str, roles: tuple[str, ...] = ()):
+    return SimpleNamespace(
+        state="valid",
+        response=SimpleNamespace(
+            decisions=(
+                SimpleNamespace(
+                    candidate_sha256=candidate_id,
+                    action=action,
+                    role_quotes=tuple(
+                        SimpleNamespace(role_id=role_id) for role_id in roles
+                    ),
+                ),
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "first_roles", "second_roles", "final", "expected"),
+    [
+        ("ABSTAIN", "ABSTAIN", (), (), "ABSTAIN", "stable_abstain"),
+        ("KEEP", "ABSTAIN", ("role_a",), (), "ABSTAIN", "action_instability"),
+        ("KEEP", "KEEP", ("role_a",), ("role_b",), "ABSTAIN", "role_instability"),
+        (
+            "KEEP",
+            "KEEP",
+            ("role_a",),
+            ("role_a",),
+            "ABSTAIN",
+            "post_consensus_rejection",
+        ),
+        ("KEEP", "KEEP", ("role_a",), ("role_a",), "KEEP", "stable_keep"),
+    ],
+)
+def test_classification_is_mutually_exclusive_at_the_candidate_seam(
+    first,
+    second,
+    first_roles,
+    second_roles,
+    final,
+    expected,
+):
+    candidate_id = _sha(99)
+    case = SimpleNamespace(
+        first_pass=_pass(first, candidate_id, first_roles),
+        second_pass=_pass(second, candidate_id, second_roles),
+    )
+    candidate = SimpleNamespace(candidate_sha256=candidate_id, action=final)
+
+    observed, _, _ = diagnostic.classify_candidate(case, candidate)
+
+    assert observed == expected
+
+
+def test_invalid_pass_shape_cannot_reclassify_the_persisted_candidate():
+    candidate_id = _sha(100)
+    invalid = SimpleNamespace(state="malformed", response=None)
+    case = SimpleNamespace(
+        first_pass=invalid,
+        second_pass=_pass("KEEP", candidate_id, ("role_a",)),
+    )
+    candidate = SimpleNamespace(candidate_sha256=candidate_id, action="ABSTAIN")
+    raw = {
+        "case_id": "W01",
+        "candidate_order": [candidate_id],
+        "decisions": [
+            {
+                "candidate_sha256": candidate_id,
+                "action": "KEEP",
+                "role_quotes": [
+                    {"field": "title", "quote": "one", "role_id": "role_a"},
+                    {"field": "abstract", "quote": "two", "role_id": "role_a"},
+                ],
+            }
+        ],
+    }
+    call = SimpleNamespace(
+        case_id="W01",
+        pass_number=1,
+        response=SimpleNamespace(raw_content=json.dumps(raw)),
+    )
+
+    failure_class, first_action, _ = diagnostic.classify_candidate(case, candidate)
+    shape = diagnostic._shape_probe(call, (candidate_id,))
+
+    assert failure_class == "invalid_pass_exposure"
+    assert first_action is None
+    assert shape["duplicate_role_id_candidate_count"] == 1
+    assert shape["duplicate_role_quote_count"] == 1
+
+
+def test_indexed_byte_drift_fails_before_semantic_parsing(tmp_path):
+    file_hashes: dict[str, str] = {}
+    for relative_path in diagnostic._expected_mechanical_files():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"frozen:{relative_path}\n", encoding="utf-8")
+        file_hashes[relative_path] = hashlib.sha256(path.read_bytes()).hexdigest()
+    (tmp_path / "artifact-index.json").write_text(
+        json.dumps(
+            {
+                "mode": "openalex_evidence_set_v5_development_artifact_index",
+                "files": file_hashes,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "judge-calls" / "W01-pass-1.json").write_text(
+        "changed after indexing\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        diagnostic.EvidenceSetFailureDiagnosticError,
+        match="bytes drifted",
+    ):
+        diagnostic._validate_indexed_files(
+            tmp_path,
+            {
+                name: file_hashes[name]
+                for name in diagnostic.EXPECTED_MECHANICAL_KEY_SHA256
+            },
+        )
+
+
+def test_label_context_drift_is_rejected_even_when_identity_matches():
+    packet_row = DevelopmentPacketRow(
+        baseline_sources_json="[]",
+        candidate_sha256=_sha(200),
+        case_id="W01",
+        declared_gap="Frozen synthetic academic evidence gap",
+        doi=None,
+        evidence_summary="A complete synthetic abstract for the diagnostic seam.",
+        identity_sha256=_sha(201),
+        provider="openalex",
+        provider_result_index=0,
+        published_date="2026-01-01",
+        publisher="Synthetic Publisher",
+        query="synthetic frozen query for diagnostic source",
+        summary_source="abstract",
+        title="Synthetic frozen candidate title",
+        topic="Synthetic frozen commercialization topic",
+        url="https://openalex.org/W1",
+    )
+    row = {
+        **diagnostic._expected_context(packet_row),
+        "direct_relevance": "YES",
+        "semantic_scope_link": "YES",
+        "baseline_novelty": "YES",
+        "abstract_sufficient": "YES",
+        "review_note": "This note grounds the complete synthetic judgment.",
+    }
+    row["title"] = "A different title with the same candidate identity"
+
+    with pytest.raises(
+        diagnostic.EvidenceSetFailureDiagnosticError,
+        match="context drifted",
+    ):
+        diagnostic._validated_human_label(row, packet_row)
+
+
+def test_every_computed_class_reaches_private_and_public_aggregate_boundaries():
+    mechanical, human = _snapshots()
+
+    result = diagnostic.build_failure_diagnostic(mechanical, human)
+    public = diagnostic.public_projection(result)
+
+    assert len(result["rows"]) == 64
+    assert {row["failure_class"] for row in result["rows"]} == {
+        "stable_abstain"
+    }
+    assert result["metrics"]["failure_class_counts"] == {"stable_abstain": 64}
+    assert public["metrics"]["failure_class_counts"] == {"stable_abstain": 64}
+    assert "rows" not in public
+    assert "private_source_sha256" not in public
+    assert "review_method" not in public
+
+
+def test_public_projection_refuses_a_silent_zero_denominator():
+    with pytest.raises(
+        diagnostic.EvidenceSetFailureDiagnosticError,
+        match="complete 64-row",
+    ):
+        diagnostic.public_projection(
+            {"protocol_status": "complete", "rows": [], "metrics": {}}
+        )
+
+
+def test_production_worker_cannot_import_the_failure_diagnostic():
+    worker = (
+        diagnostic.Path("src/academic_agent/pipeline_worker.py")
+        .read_text(encoding="utf-8")
+        .casefold()
+    )
+    assert "openalex_evidence_set_failure_diagnostic" not in worker


### PR DESCRIPTION
## Why
The frozen Qwen schema-4 development run failed its agreement gate, but aggregate counts did not show where human-relevant evidence was lost. Replaying or tuning the consumed W01-W08 set would invalidate the experiment.

## What
- adds a zero-network, provenance-locked 64-row failure diagnostic
- verifies all indexed mechanical artifacts and explicit private-input hashes before label parsing
- partitions candidates into mutually exclusive observable failure surfaces
- publishes aggregate results only and keeps row-level joins private
- documents that v5 remains sealed, X01-X08 remain unopened, and production remains disconnected

## Verification
- defect reinjection: dropping public metrics makes the boundary test fail
- focused diagnostic suite: 11 passed
- full zero-network suite: 1,798 tests and 657 subtests passed
- latest Ruff passed
- CI-equivalent narrow Pylint passed