### PR TITLE
Implement candidate-local role-slot consensus v6 offline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1798 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1820 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -156,6 +156,8 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         role-structured same-segment gate; experimental only
   openalex_evidence_set.py
                         quote-grounded two-pass set selector; experimental only
+  openalex_role_slot.py
+                        candidate-local three-pass role-slot consensus; experimental only
   tools/evidence_search.py
                         one-request read-only adapter response contract
   tools/anonymous_openalex_search.py
@@ -171,7 +173,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  93 test modules plus conftest, organised by subject
+tests/                  102 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -215,6 +217,8 @@ openalex_scope_link_live.py
                         write-once W01-W08 runner; CLI defaults to dry-run
 openalex_scope_link_abstention_review.py
                         post-outcome W01-W08 label-blind diagnostic; zero-network
+openalex_role_slot_unseen.py
+                        frozen Y/Z role-slot identity preflight; zero-network only
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -552,6 +556,28 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   and
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
+  A separately pre-registered candidate-local role-slot consensus v6 now starts
+  from new Y01-Y08 development and Z01-Z08 unseen identities; W stays consumed
+  and X stays unopened. The model no longer owns candidate actions or role IDs.
+  It can only fill fixed positional `SUPPORTED`/`ABSTAIN` role slots with exact
+  title-or-abstract quotes. Malformed candidate rows and slots are contained
+  locally, three deterministic candidate orders require two mechanically
+  verified observations per role, and Python alone derives candidate admission
+  plus a maximum-three-source set cover. The zero-network kernel and preflight
+  pass 22/22 focused tests and expand eight provider request identities plus 24
+  judge-template identities per cohort. Two protocol defects were re-injected:
+  whole-batch invalidation erased a valid neighbour, and dropping computed
+  supporting roles broke the serialized audit boundary; both tests failed
+  before the correct implementations were restored. The full zero-network
+  suite passes 1820 tests plus 657 subtests. This phase has no live runner,
+  provider/model adapter, private-label read, OpenAlex or model request, paid
+  call, or production connection. Y01-Y08 and Z01-Z08 therefore remain unused.
+  Implementing a disconnected runner and exact provider contract is a separate
+  later phase; it must preserve the frozen identities and cannot imply semantic
+  validation. See
+  `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md` and
+  `docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md`.
+
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus
@@ -560,7 +586,7 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   and
   docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md.
   Keep
-  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5
+  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5/v6
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1820 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1821 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -564,12 +564,13 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   locally, three deterministic candidate orders require two mechanically
   verified observations per role, and Python alone derives candidate admission
   plus a maximum-three-source set cover. The zero-network kernel and preflight
-  pass 22/22 focused tests and expand eight provider request identities plus 24
-  judge-template identities per cohort. Two protocol defects were re-injected:
-  whole-batch invalidation erased a valid neighbour, and dropping computed
-  supporting roles broke the serialized audit boundary; both tests failed
-  before the correct implementations were restored. The full zero-network
-  suite passes 1820 tests plus 657 subtests. This phase has no live runner,
+  pass 23/23 focused tests and expand eight provider request identities plus 24
+  judge-template identities per cohort. Three protocol defects were re-injected:
+  whole-batch invalidation erased a valid neighbour, dropping computed supporting
+  roles broke the serialized audit boundary, and the later Sydney calendar date
+  made the same deterministic preflight invalid on the earlier UTC CI date. All
+  three tests failed before the correct implementations were restored. The full
+  zero-network suite passes 1821 tests plus 657 subtests. This phase has no live runner,
   provider/model adapter, private-label read, OpenAlex or model request, paid
   call, or production connection. Y01-Y08 and Z01-Z08 therefore remain unused.
   Implementing a disconnected runner and exact provider contract is a separate

--- a/README.md
+++ b/README.md
@@ -828,7 +828,22 @@ disconnected. See the
 [diagnostic plan](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)
 and [aggregate result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md).
 
-Local verification now passes **1,798 tests plus 657 subtests**, latest Ruff,
+A separately pre-registered **candidate-local role-slot consensus v6** now
+starts from new Y01-Y08 development and Z01-Z08 unseen identities rather than
+replaying W or opening X. The model has no candidate-action field and cannot
+emit role IDs: it may only fill fixed `SUPPORTED`/`ABSTAIN` slots with exact
+title-or-abstract quotes. Three candidate orders require two mechanically
+verified observations per role; malformed candidates and slots are isolated
+locally, while deterministic Python derives admission and a three-source
+maximum set cover. The zero-network kernel and preflight pass 22/22 focused
+tests and expose 8 provider plus 24 judge-template identities per cohort. Two
+re-injected defects proved that a bad row cannot erase a neighbour and a
+computed role cannot disappear at serialization. No runner, provider/model
+adapter, live request, private-label read or production connection is included
+yet. See the [v6 pre-registration](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)
+and [offline implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md).
+
+Local verification now passes **1,820 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2047,7 +2062,19 @@ v5：未执行 repair，X01–X08 保持未打开，生产仍断开。详见
 [诊断计划](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)
 和[聚合结果](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)。
 
-本地验证现通过 **1,798 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+另行预注册的 **candidate-local role-slot consensus v6** 使用全新的 Y01–Y08
+开发集和 Z01–Z08 未见集，不重放 W，也不打开 X。模型不再拥有候选动作字段，
+也不能输出 role ID；它只能为固定位置槽位返回 `SUPPORTED`/`ABSTAIN` 和
+标题或摘要原文引文。三种候选顺序要求每个角色至少获得 2 次机械验证支持；
+错误候选行和槽位只在本地隔离，候选准入与最多三来源的集合覆盖完全由 Python
+确定。零网络内核与预检通过 22/22 个定向测试，每个 cohort 展开 8 个供应商
+请求身份和 24 个 Judge 模板身份；两次缺陷回注分别证明坏行不能拖垮相邻行，
+已计算角色也不能在序列化时丢失。当前尚未实现 runner 与供应商/模型适配层，
+没有真实请求、私有标签读取或生产连接。详见
+[v6 预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)与
+[离线实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md)。
+
+本地验证现通过 **1,820 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/README.md
+++ b/README.md
@@ -835,15 +835,16 @@ emit role IDs: it may only fill fixed `SUPPORTED`/`ABSTAIN` slots with exact
 title-or-abstract quotes. Three candidate orders require two mechanically
 verified observations per role; malformed candidates and slots are isolated
 locally, while deterministic Python derives admission and a three-source
-maximum set cover. The zero-network kernel and preflight pass 22/22 focused
-tests and expose 8 provider plus 24 judge-template identities per cohort. Two
-re-injected defects proved that a bad row cannot erase a neighbour and a
-computed role cannot disappear at serialization. No runner, provider/model
-adapter, live request, private-label read or production connection is included
+maximum set cover. The zero-network kernel and preflight pass 23/23 focused
+tests and expose 8 provider plus 24 judge-template identities per cohort. Three
+re-injected defects proved that a bad row cannot erase a neighbour, a computed
+role cannot disappear at serialization, and a Sydney freeze remains valid on
+the earlier UTC calendar date. No runner, provider/model adapter, live request,
+private-label read or production connection is included
 yet. See the [v6 pre-registration](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)
 and [offline implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md).
 
-Local verification now passes **1,820 tests plus 657 subtests**, latest Ruff,
+Local verification now passes **1,821 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2067,14 +2068,15 @@ v5：未执行 repair，X01–X08 保持未打开，生产仍断开。详见
 也不能输出 role ID；它只能为固定位置槽位返回 `SUPPORTED`/`ABSTAIN` 和
 标题或摘要原文引文。三种候选顺序要求每个角色至少获得 2 次机械验证支持；
 错误候选行和槽位只在本地隔离，候选准入与最多三来源的集合覆盖完全由 Python
-确定。零网络内核与预检通过 22/22 个定向测试，每个 cohort 展开 8 个供应商
-请求身份和 24 个 Judge 模板身份；两次缺陷回注分别证明坏行不能拖垮相邻行，
-已计算角色也不能在序列化时丢失。当前尚未实现 runner 与供应商/模型适配层，
-没有真实请求、私有标签读取或生产连接。详见
+确定。零网络内核与预检通过 23/23 个定向测试，每个 cohort 展开 8 个供应商
+请求身份和 24 个 Judge 模板身份；三次缺陷回注分别证明坏行不能拖垮相邻行、
+已计算角色不能在序列化时丢失，且悉尼冻结日期在前一日 UTC 环境仍然合法。
+当前尚未实现 runner 与供应商/模型适配层，没有真实请求、私有标签读取或
+生产连接。详见
 [v6 预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)与
 [离线实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md)。
 
-本地验证现通过 **1,820 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+本地验证现通过 **1,821 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md
+++ b/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md
@@ -1,0 +1,238 @@
+# Pre-registration: candidate-local role-slot consensus v6
+
+**Frozen:** 2026-09-01, after the completed v5 Qwen failure diagnostic but
+before implementing v6, calculating a v6 decision, opening development or
+unseen labels, or requesting an OpenAlex or model response for Y01-Y08 or
+Z01-Z08.
+
+**Challenge fixture:**
+`tests/fixtures/openalex_role_slot_v6_challenge.json`
+
+**Raw fixture SHA-256:**
+`f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85`
+
+The implementation may read this file only after comparing the raw bytes with
+this value.
+
+**Production connection authorized:** no
+
+**Live provider or model calls authorized:** no. This document authorizes only
+the frozen method, challenge and future zero-network implementation. Any
+OpenAlex or model call requires a separate authorization naming a merged
+revision, provider, model, request limits and soft cost stop.
+
+## Measured reason for a new method
+
+v5 is sealed. Its W01-W08 development run produced zero final `KEEP` sources
+and failed before X01-X08 could be opened. The post-outcome diagnostic joined
+the already committed responses with one eligible human review and assigned
+all 64 rows to a mechanical failure class:
+
+- 37 stable abstentions;
+- 16 rows exposed to one malformed all-row pass;
+- five action disagreements;
+- five role-set disagreements; and
+- one post-consensus source-threshold rejection.
+
+Among the 28 rows labelled directly relevant from the frozen title and
+abstract, 12 were exposed to an invalid all-row pass. The underlying defect
+was local: six candidate rows repeated one or more role IDs, but Pydantic
+correctly rejected the complete batch and v5 therefore discarded 16 rows.
+The remaining 16 relevant rows show that row-local parsing alone is not an
+adequate successor: nine were stable model abstentions, four had role-set
+disagreement, two had action disagreement and one failed a deterministic
+candidate threshold. Qwen proposed `KEEP` for 17 of 56 candidates in the first
+valid provider-order passes but only eight in the corresponding reverse-order
+passes. This is observed order sensitivity, not evidence that either order was
+correct.
+
+These measurements use W01-W08 only as consumed development evidence. They do
+not reopen v5, tune a threshold on W, validate v6, or reveal X01-X08. v6 gets
+new development and unseen challenges.
+
+## Frozen hypothesis
+
+A semantic model can act as a bounded quote extractor more reliably than as a
+source decision maker if the protocol removes free-form role lists and model
+actions:
+
+1. every candidate has one fixed positional slot for every code-owned role;
+2. the model reports only `SUPPORTED` or `ABSTAIN` plus an exact source quote,
+   and never reports `KEEP` or `ABSTAIN` for the candidate as a whole;
+3. each candidate row and each role slot is validated independently, so one
+   malformed row cannot erase unrelated rows;
+4. three deterministic candidate orders are judged, and a role is authorised
+   only when at least two passes independently return mechanically valid source
+   quotes; and
+5. candidate admission and bounded set cover remain deterministic Python
+   decisions.
+
+This is not a parser repair for v5. It changes the model task, pass count,
+consensus rule, failure isolation and challenge identities. v5 artifacts and
+X01-X08 remain historical and untouched.
+
+## Frozen role-slot response contract
+
+Each case receives exactly three batch calls over the same provider candidates:
+
+1. provider result order;
+2. reverse provider result order; and
+3. lexicographic candidate-SHA-256 order.
+
+The role order is identical in all three calls. Each role has a zero-based
+`slot_index`, role kind and code-owned description. For each candidate the
+model must return the candidate SHA-256 and exactly one object for every slot,
+in slot order. A slot contains:
+
+- `slot_index`;
+- `state`, exactly `SUPPORTED` or `ABSTAIN`;
+- `field`, exactly `title`, `abstract`, or `null`; and
+- `quote`, an exact source-text span or `null`.
+
+`SUPPORTED` requires a non-empty field and quote. `ABSTAIN` requires both to be
+null. The model does not output role IDs, candidate actions, relevance,
+novelty, truth, set selection or commercial conclusions. A fixed positional
+slot removes the duplicate-role-ID language-generation failure without
+allowing an unknown role to enter.
+
+The top-level JSON object must identify the case and contain candidate rows.
+JSON syntax failure or a case-identity mismatch invalidates that pass. Once the
+top-level object is readable, rows are isolated:
+
+- a missing, duplicate, unknown or malformed candidate row cannot authorise
+  evidence;
+- the expected candidate receives an explicit row state for every pass;
+- unrelated expected rows continue through validation;
+- an invalid slot is recorded and contributes no support, but cannot erase a
+  different mechanically valid slot in the same row; and
+- unknown rows and extra slots are counted and retained in the audit summary,
+  never silently ignored.
+
+Quote verification may normalise line endings and runs of Unicode whitespace
+only. It may not stem, translate, paraphrase, use provider metadata, use human
+labels or call another model. There is no retry, repair, redirect or fallback.
+
+## Frozen consensus and evidence-set contract
+
+A role becomes a verified candidate contribution only when at least two of the
+three passes return valid `SUPPORTED` slots with quotes present in that
+candidate's title or abstract. The two quotes may be different source spans;
+both must verify. A one-pass assertion is visible as minority support and does
+not authorise the role. A one-pass malformed or missing row can therefore be
+tolerated only when the other two independently support the same role.
+
+The code derives a provisional candidate disposition from each valid pass for
+the order-stability audit. The model never emits that disposition. Final
+candidate admission uses only consensus roles and the fixture's frozen source
+requirements:
+
+1. at least one required role;
+2. at least one scope or supporting role; and
+3. at least one consensus role supported by a title quote in at least two
+   passes.
+
+The deterministic selector considers at most three admitted sources. A set
+must cover every required role, at least one scope role and at least one
+supporting role. It chooses the smallest valid set, then the lowest provider
+index tuple, then candidate SHA-256. No model tie-break, profile relaxation,
+second query or provider-metadata fallback is allowed.
+
+## New Y01-Y08 development qualification
+
+Y01-Y08 are new, byte-frozen development identities. A repository search of
+the parent `main` revision found none of their exact topic strings. They are
+not an unseen validation claim: once any Y request is sent, all Y identities
+are consumed development evidence.
+
+The runner must use one anonymous OpenAlex Works request per attempted case,
+`has_abstract:true`, at most eight provider rows and no redirect, retry,
+supplementary fetch or second query. It may then use at most three
+`qwen3.5-plus` calls per attempted case, with thinking disabled, temperature
+zero and JSON Object mode. The maximum complete development run is eight
+OpenAlex requests and 24 model calls. Every outbound request requires a future
+explicit authorization.
+
+All development gates are conjunctive:
+
+1. all attempted provider and model calls have inspectable request, returned
+   model, token, cost and latency identities;
+2. no top-level model pass is malformed or contract-invalid;
+3. at least 95% of expected candidate-pass rows are locally valid;
+4. at least 80% of candidates have the same code-derived provisional
+   disposition in all three passes; malformed or missing rows count against
+   this denominator;
+5. at least one selected evidence set exists in at least 6/8 cases;
+6. an eligible label-blind human review finds relevant, baseline-novel set
+   evidence in at least 6/8 cases;
+7. human-confirmed role and set coverage passes in at least 6/8 cases;
+8. no more than 5% of selected sources are directly irrelevant;
+9. no more than 5% of consensus role assignments are unsupported; and
+10. every provider candidate, pass, slot, quote check, candidate decision and
+    selected source reaches the audit and review boundaries.
+
+Every provider candidate must be human reviewed even after a mechanical gate
+failure. The review packet remains label-blind and exposes the frozen baseline,
+topic, role descriptions, title and abstract while hiding model slots,
+consensus roles and selected sets until aggregation. The reviewer must attempt
+every source and declare substantive generative-AI use. An incomplete or
+ineligible review is `not_evaluated`, not a pass.
+
+Any failed development gate seals v6. Y may be diagnosed but not tuned and
+rerun into a pass. A successor would require a new method and challenge.
+
+## Unseen Z01-Z08 challenge
+
+Z01-Z08 are byte-frozen but remain unopened until every Y gate passes and a
+separate authorization names the exact merged implementation revision. A
+repository search of the parent `main` revision found none of their exact topic
+strings. Once any Z request is sent, all Z identities are consumed even if the
+run stops later.
+
+The provider, model, request, response, consensus, selection and human-review
+contracts are identical to Y. The unseen gates are the same ten conjunctive
+gates. No Y-derived prompt, threshold, role or parser change may be applied
+after seeing Y outcomes while retaining the v6 identity; such a change starts
+a successor method and requires a fresh unseen challenge.
+
+X01-X08 remain reserved historical v5 identities. v6 does not open, rename or
+reuse them.
+
+## Implementation and falsification requirements
+
+Before any live Y or Z call, the zero-network implementation must:
+
+- verify the exact committed raw-byte SHA-256 above before JSON parsing or case
+  expansion;
+- validate unique method, case, query, role, pass-order and idempotency
+  identities;
+- freeze prompt, parser, quote verifier, consensus, selector, runner and
+  adapter hashes;
+- persist a complete manifest before constructing an OpenAlex or model client;
+- commit each provider response and model-call journal before a later request;
+- preserve each expected candidate and role slot through the serialized audit
+  boundary, including malformed and missing states;
+- prove one malformed candidate row does not erase a valid neighbouring row;
+- prove an invented quote and a one-pass quote cannot authorise a role;
+- prove the model has no candidate-action field and cannot select a source;
+- prove all three candidate orders actually cross the outbound seam;
+- prove deterministic set-cover tie-breaking and the three-source ceiling;
+- assert that production modules do not import v6; and
+- re-inject at least the whole-batch invalidation and computed-but-undelivered
+  defects, confirm their seam tests turn red, then restore the implementation.
+
+The implementation phase must run the complete zero-network suite, latest Ruff
+and narrow Pylint, then record a separate result. Offline success establishes
+only a tested disconnected contract, not semantic quality or Tool Calling
+completion.
+
+## Explicit non-claims
+
+This pre-registration does not authorise model or OpenAlex calls, private-label
+access, production import, report connection or planner trigger. Future Y or Z
+success would still not establish OpenAlex-wide precision or recall,
+literature-wide novelty, source truth beyond the review, inter-rater agreement,
+report improvement, decision correctness, adoption, ROI, latency, an SLO,
+autonomous tool choice or completed production Tool Calling.
+
+`pipeline_worker.py` must remain disconnected from every v6 kernel, fixture,
+adapter, runner, preflight and review module.

--- a/docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md
+++ b/docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md
@@ -62,10 +62,10 @@ Current file identities are:
 | File | SHA-256 |
 |---|---|
 | `src/academic_agent/openalex_role_slot.py` | `166eb6d6568a7a187e2f6654c27d3db938a79553c0205501d9328b38437ed8d4` |
-| `openalex_role_slot_unseen.py` | `283ff436b8e4a5383a9f35710f0eb8273da4514aac58c3ebe1ddd47e4707cbe8` |
+| `openalex_role_slot_unseen.py` | `3bd69fa0a6703c1b928c905fbde1ce5639aaa3559c2a54f3356cbdb914800a75` |
 | `tests/fixtures/openalex_role_slot_v6_challenge.json` | `f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85` |
 | `tests/test_openalex_role_slot.py` | `dded711c853e0f6c8ba64112ff29af8079a6027e0ea937018d0739489c459149` |
-| `tests/test_openalex_role_slot_unseen.py` | `c5a25172f2c6f8e30be49cdc6ba1443acaf4ff119ef81efe8581c2a9e9c09c7e` |
+| `tests/test_openalex_role_slot_unseen.py` | `ba793a810529dc3596b162aebd32ab8649cf19ae6a0454d5cf3337113e98fea2` |
 
 These hashes describe this offline implementation record. A future runner and
 adapter must freeze their own committed dependency set before any live call;
@@ -76,30 +76,34 @@ this result does not pre-authorise those missing components.
 The focused v6 suite passed:
 
 ```text
-22 passed in 1.58s
+23 passed in 2.03s
 ```
 
 The complete zero-network suite passed:
 
 ```text
-1820 passed, 657 subtests passed in 27.73s
+1821 passed, 657 subtests passed in 35.38s
 ```
 
 Latest Ruff passed the kernel, preflight and both test modules. The CI-matched
 narrow Pylint gate passed the two implementation modules with no output.
 
-Two protocol-mandated defects were re-injected and then reverted:
+Three protocol-mandated defects were re-injected and then reverted:
 
 1. restoring whole-batch invalidation for one malformed candidate changed the
    valid neighbouring row to `pass_unavailable`; the candidate-isolation seam
    failed as required;
 2. serializing only required roles after computing required, scope and
    supporting roles triggered `selected source must deliver every deterministic
-   KEEP role` at the case boundary.
+   KEEP role` at the case boundary; and
+3. restoring the later Sydney `2026-09-01` access date while the validator clock
+   was frozen to UTC `2026-08-31` reproduced the cross-platform CI failure before
+   the globally elapsed UTC date was restored.
 
-After restoration, all 22 focused tests passed again. These checks cover the
-two historical high-risk seams: unrelated values being discarded together,
-and correct internal values never reaching the audit consumer.
+After restoration, all 23 focused tests passed again. These checks cover three
+high-risk seams: unrelated values being discarded together, correct internal
+values never reaching the audit consumer, and deterministic artifact metadata
+changing validity across local and CI calendar zones.
 
 ## What is still missing
 

--- a/docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md
+++ b/docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md
@@ -1,0 +1,118 @@
+# Result: role-slot consensus v6 zero-network implementation
+
+**Date:** 2026-09-01
+
+**Pre-registration commit:** `e93d792`
+
+**Production connection:** false
+
+**OpenAlex requests:** 0
+
+**Model calls:** 0
+
+**Private labels opened:** no
+
+## Outcome
+
+The candidate-local role-slot v6 decision kernel and frozen Y/Z preflight are
+implemented and remain production-disconnected. This establishes only that the
+new contract is mechanically testable without network or paid-provider access.
+It does not establish that Qwen will follow the contract, that OpenAlex will
+return useful candidates, that the method passes its human-value gates, or that
+Tool Calling is ready for production.
+
+The pre-registration was committed before implementation. The frozen fixture
+contains eight new development cases, Y01-Y08, and eight new unseen cases,
+Z01-Z08. Its raw bytes remain:
+
+`f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85`
+
+W01-W08 and X01-X08 were not reused. No historical v5 source, response, label
+or decision enters the v6 preflight.
+
+## Implemented boundary
+
+`src/academic_agent/openalex_role_slot.py` implements:
+
+- provider, reverse-provider and candidate-SHA order inputs;
+- a prompt that exposes title, abstract, candidate identity, role kind,
+  description and positional slot, but no provider metadata, human labels,
+  role IDs or candidate-action field;
+- strict `SUPPORTED`/`ABSTAIN` role-slot proposals;
+- top-level failure states distinct from candidate-row and role-slot failures;
+- candidate-local handling of missing, duplicate, unknown or malformed rows;
+- slot-local handling of missing, duplicate, reordered, malformed or
+  unverifiable slots;
+- exact title/abstract quote verification with layout-only normalization;
+- deterministic two-of-three role consensus;
+- code-derived provisional and final candidate dispositions;
+- deterministic set cover of at most three sources; and
+- one serialized audit containing all three passes, every expected candidate,
+  every role slot, local-valid-row and order-unanimity metrics, all consensus
+  roles and all selected-source roles.
+
+`openalex_role_slot_unseen.py` verifies the raw fixture hash before JSON
+parsing, validates all 16 case/query/profile identities, and expands separate
+development and unseen Evidence-gap plans. Each cohort exposes eight distinct
+provider idempotency keys and 24 distinct judge-request-template identities.
+The module imports no provider adapter, model adapter or execution client.
+
+Current file identities are:
+
+| File | SHA-256 |
+|---|---|
+| `src/academic_agent/openalex_role_slot.py` | `166eb6d6568a7a187e2f6654c27d3db938a79553c0205501d9328b38437ed8d4` |
+| `openalex_role_slot_unseen.py` | `283ff436b8e4a5383a9f35710f0eb8273da4514aac58c3ebe1ddd47e4707cbe8` |
+| `tests/fixtures/openalex_role_slot_v6_challenge.json` | `f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85` |
+| `tests/test_openalex_role_slot.py` | `dded711c853e0f6c8ba64112ff29af8079a6027e0ea937018d0739489c459149` |
+| `tests/test_openalex_role_slot_unseen.py` | `c5a25172f2c6f8e30be49cdc6ba1443acaf4ff119ef81efe8581c2a9e9c09c7e` |
+
+These hashes describe this offline implementation record. A future runner and
+adapter must freeze their own committed dependency set before any live call;
+this result does not pre-authorise those missing components.
+
+## Verification
+
+The focused v6 suite passed:
+
+```text
+22 passed in 1.58s
+```
+
+The complete zero-network suite passed:
+
+```text
+1820 passed, 657 subtests passed in 27.73s
+```
+
+Latest Ruff passed the kernel, preflight and both test modules. The CI-matched
+narrow Pylint gate passed the two implementation modules with no output.
+
+Two protocol-mandated defects were re-injected and then reverted:
+
+1. restoring whole-batch invalidation for one malformed candidate changed the
+   valid neighbouring row to `pass_unavailable`; the candidate-isolation seam
+   failed as required;
+2. serializing only required roles after computing required, scope and
+   supporting roles triggered `selected source must deliver every deterministic
+   KEEP role` at the case boundary.
+
+After restoration, all 22 focused tests passed again. These checks cover the
+two historical high-risk seams: unrelated values being discarded together,
+and correct internal values never reaching the audit consumer.
+
+## What is still missing
+
+v6 is not ready for a paid run or production connection. The next separately
+reviewed implementation phase must add a write-once development runner and a
+strict one-request Qwen adapter profile while reusing the existing anonymous
+OpenAlex response contract. Before client construction it must freeze the
+prompt, parser, quote verifier, consensus, selector, runner, adapter and every
+transitive decision dependency. It must persist the complete manifest before
+any request and each provider/model journal before a later request.
+
+Only after that runner passes its own zero-network seams may the owner
+separately authorise Y01-Y08. A complete Y run would permit at most eight
+anonymous OpenAlex requests and 24 sequential `qwen3.5-plus` calls. Z01-Z08
+remain unavailable until every frozen Y gate passes. No live request is
+authorised by this result.

--- a/openalex_role_slot_unseen.py
+++ b/openalex_role_slot_unseen.py
@@ -1,0 +1,491 @@
+"""Zero-network preflight for the frozen role-slot consensus v6 challenge.
+
+Y01-Y08 and Z01-Z08 were frozen before this implementation existed.  This
+module verifies the raw fixture bytes before JSON parsing, expands deterministic
+evidence-gap and judge-template identities, and exposes the exact contracts a
+future separately authorised runner would need.  It imports no provider or
+model adapter, so even the CLI cannot spend either budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetRoleProfile,
+    EvidenceSetRoleSpec,
+    EvidenceSetSelectionContract,
+)
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = _ROOT / "tests/fixtures/openalex_role_slot_v6_challenge.json"
+EXPECTED_FIXTURE_SHA256 = (
+    "f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85"
+)
+_DEVELOPMENT_ORDER = tuple(f"Y{index:02d}" for index in range(1, 9))
+_UNSEEN_ORDER = tuple(f"Z{index:02d}" for index in range(1, 9))
+_COLLECTED_AT = datetime(2026, 9, 1, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 9, 1)
+
+
+class OpenAlexRoleSlotPreflightError(ValueError):
+    """Raised before case expansion when the frozen v6 contract drifts."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+class RoleSlotProviderContract(BaseModel):
+    """Anonymous one-request OpenAlex contract without a transport import."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["anonymous_openalex"] = "anonymous_openalex"
+    requests_per_case: Literal[1] = 1
+    result_limit: Literal[8] = 8
+    require_abstract: Literal[True] = True
+    allow_redirects: Literal[False] = False
+    allow_retries: Literal[False] = False
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleSlotJudgeContract(BaseModel):
+    """Exact future quote-extraction boundary without a model client."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["qwen"] = "qwen"
+    model: Literal["qwen3.5-plus"] = "qwen3.5-plus"
+    passes_per_case: Literal[3] = 3
+    candidate_orders: tuple[str, ...]
+    temperature: Literal[0.0] = 0.0
+    allow_retries: Literal[False] = False
+    allow_repair: Literal[False] = False
+    allow_fallback: Literal[False] = False
+    minimum_verified_passes_per_role: Literal[2] = 2
+
+    @model_validator(mode="after")
+    def _validate_exact_pass_orders(self) -> "RoleSlotJudgeContract":
+        if self.candidate_orders != (
+            "provider_order",
+            "reverse_provider_order",
+            "candidate_sha256_order",
+        ):
+            raise ValueError("judge pass orders drifted from the frozen protocol")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class FrozenRoleGroups(BaseModel):
+    """Fixture-friendly role groups converted to the shared immutable profile."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required: tuple[EvidenceSetRoleSpec, ...] = Field(min_length=2, max_length=4)
+    scope: tuple[EvidenceSetRoleSpec, ...] = Field(min_length=1, max_length=4)
+    supporting: tuple[EvidenceSetRoleSpec, ...] = Field(
+        min_length=2,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_unique_role_ids(self) -> "FrozenRoleGroups":
+        role_ids = tuple(
+            role.role_id
+            for roles in (self.required, self.scope, self.supporting)
+            for role in roles
+        )
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("case role IDs must be unique")
+        return self
+
+    def profile(self) -> EvidenceSetRoleProfile:
+        return EvidenceSetRoleProfile(
+            required_roles=self.required,
+            scope_roles=self.scope,
+            supporting_roles=self.supporting,
+        )
+
+
+class RoleSlotCaseSpec(BaseModel):
+    """One exact query and natural-language role profile."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^[YZ]0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    query: str = Field(min_length=20, max_length=500)
+    roles: FrozenRoleGroups
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleSlotChallengeManifest(BaseModel):
+    """Complete raw-byte-frozen v6 development and unseen input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    method_id: Literal["openalex-candidate-local-role-slot-consensus-v6"]
+    provider_contract: RoleSlotProviderContract
+    judge_contract: RoleSlotJudgeContract
+    selection_contract: EvidenceSetSelectionContract
+    development_cases: tuple[RoleSlotCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+    unseen_cases: tuple[RoleSlotCaseSpec, ...] = Field(min_length=8, max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_cross_contracts(self) -> "RoleSlotChallengeManifest":
+        if tuple(item.case_id for item in self.development_cases) != (
+            _DEVELOPMENT_ORDER
+        ):
+            raise ValueError("development cases must remain Y01 through Y08")
+        if tuple(item.case_id for item in self.unseen_cases) != _UNSEEN_ORDER:
+            raise ValueError("unseen cases must remain Z01 through Z08")
+        all_cases = (*self.development_cases, *self.unseen_cases)
+        if len({item.topic for item in all_cases}) != len(all_cases):
+            raise ValueError("topic strings must be unique across both cohorts")
+        if len({item.query for item in all_cases}) != len(all_cases):
+            raise ValueError("queries must be unique across both cohorts")
+        if self.selection_contract.maximum_selected_sources_per_case != 3:
+            raise ValueError("v6 selected-source ceiling must remain three")
+        for case in all_cases:
+            profile = case.roles.profile()
+            if self.selection_contract.minimum_scope_roles > len(
+                profile.scope_roles
+            ):
+                raise ValueError(f"{case.case_id}: impossible scope threshold")
+            if self.selection_contract.minimum_supporting_roles > len(
+                profile.supporting_roles
+            ):
+                raise ValueError(f"{case.case_id}: impossible supporting threshold")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedRoleSlotCase:
+    """Deterministic identities for a future separately locked runner."""
+
+    spec: RoleSlotCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+    profile_sha256: str
+    case_contract_sha256: str
+    judge_request_template_sha256s: tuple[str, str, str]
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _case_contract_sha256(
+    spec: RoleSlotCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    judge_contract_sha256: str,
+    selection_contract_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "method_id": method_id,
+            "spec": spec.model_dump(mode="json"),
+            "provider_contract_sha256": provider_contract_sha256,
+            "judge_contract_sha256": judge_contract_sha256,
+            "selection_contract_sha256": selection_contract_sha256,
+        }
+    )
+
+
+def _judge_request_template_sha256s(
+    spec: RoleSlotCaseSpec,
+    *,
+    method_id: str,
+    judge_contract: RoleSlotJudgeContract,
+) -> tuple[str, str, str]:
+    profile_sha256 = spec.roles.profile().sha256()
+    return tuple(
+        _sha256_json(
+            {
+                "method_id": method_id,
+                "case_id": spec.case_id,
+                "topic": spec.topic,
+                "query": spec.query,
+                "profile_sha256": profile_sha256,
+                "pass_number": pass_number,
+                "candidate_order": candidate_order,
+                "judge_contract_sha256": judge_contract.sha256(),
+            }
+        )
+        for pass_number, candidate_order in enumerate(
+            judge_contract.candidate_orders,
+            start=1,
+        )
+    )
+
+
+def _seed_source(spec: RoleSlotCaseSpec) -> EvidenceSource:
+    """Create a valid gap context without pretending retrieval already ran."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen role-slot baseline context",
+        url=f"https://doi.org/10.5555/openalex-role-slot-v6.{spec.case_id.casefold()}",
+        publisher="Frozen Role-slot v6 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider candidate and does not satisfy the explicit "
+            "academic retrieval gap used by this disconnected study."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(
+    spec: RoleSlotCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    judge_contract: RoleSlotJudgeContract,
+    selection_contract_sha256: str,
+) -> PreparedRoleSlotCase:
+    """Expand one case without network, clocks, randomness, or model calls."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen role-slot v6 retrieval challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexRoleSlotPreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen role-slot case authorizes one read-only academic "
+                "request for its explicit evidence gap."
+            ),
+            calls=(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=spec.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=8,
+                ),
+            ),
+        ),
+    )
+    return PreparedRoleSlotCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+        profile_sha256=spec.roles.profile().sha256(),
+        case_contract_sha256=_case_contract_sha256(
+            spec,
+            method_id=method_id,
+            provider_contract_sha256=provider_contract_sha256,
+            judge_contract_sha256=judge_contract.sha256(),
+            selection_contract_sha256=selection_contract_sha256,
+        ),
+        judge_request_template_sha256s=_judge_request_template_sha256s(
+            spec,
+            method_id=method_id,
+            judge_contract=judge_contract,
+        ),
+    )
+
+
+def load_frozen_cases(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    RoleSlotChallengeManifest,
+    tuple[PreparedRoleSlotCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding either cohort."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexRoleSlotPreflightError(
+            "role-slot v6 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = RoleSlotChallengeManifest.model_validate_json(raw)
+    specs = (
+        manifest.development_cases
+        if cohort == "development"
+        else manifest.unseen_cases
+    )
+    provider_sha256 = manifest.provider_contract.sha256()
+    selection_sha256 = manifest.selection_contract.sha256()
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(
+            build_case(
+                spec,
+                method_id=manifest.method_id,
+                provider_contract_sha256=provider_sha256,
+                judge_contract=manifest.judge_contract,
+                selection_contract_sha256=selection_sha256,
+            )
+            for spec in specs
+        ),
+    )
+
+
+def dry_run(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose frozen identities while constructing no provider or model client."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        cohort,
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    return {
+        "mode": "openalex_role_slot_v6_dry_run",
+        "cohort": cohort,
+        "method_id": manifest.method_id,
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "private_labels_opened": False,
+        "live_provider_requests_authorized": False,
+        "live_model_calls_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_search_request_count": len(cases),
+        "maximum_judge_call_count": (
+            len(cases) * manifest.judge_contract.passes_per_case
+        ),
+        "provider_contract": manifest.provider_contract.model_dump(mode="json"),
+        "judge_contract": manifest.judge_contract.model_dump(mode="json"),
+        "selection_contract": manifest.selection_contract.model_dump(mode="json"),
+        "provider_contract_sha256": manifest.provider_contract.sha256(),
+        "judge_contract_sha256": manifest.judge_contract.sha256(),
+        "selection_contract_sha256": manifest.selection_contract.sha256(),
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "case_spec_sha256": case.spec.sha256(),
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+                "profile_sha256": case.profile_sha256,
+                "case_contract_sha256": case.case_contract_sha256,
+                "provider_idempotency_key": case.plan.calls[0].idempotency_key,
+                "judge_request_template_sha256s": (
+                    case.judge_request_template_sha256s
+                ),
+                "result_limit": case.plan.calls[0].result_limit,
+            }
+            for case in cases
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cohort",
+        choices=("development", "unseen"),
+        default="development",
+    )
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE_PATH)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(
+        json.dumps(
+            dry_run(args.cohort, args.fixture),
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openalex_role_slot_unseen.py
+++ b/openalex_role_slot_unseen.py
@@ -45,7 +45,11 @@ EXPECTED_FIXTURE_SHA256 = (
 _DEVELOPMENT_ORDER = tuple(f"Y{index:02d}" for index in range(1, 9))
 _UNSEEN_ORDER = tuple(f"Z{index:02d}" for index in range(1, 9))
 _COLLECTED_AT = datetime(2026, 9, 1, tzinfo=UTC)
-_ACCESSED_DATE = date(2026, 9, 1)
+# The Sydney pre-registration happened while UTC was still 2026-08-31.  The
+# EvidenceSource validator intentionally compares against the process-local
+# calendar date, so freezing the later Sydney date makes the same bytes invalid
+# on CI.  Keep the latest date that had elapsed in both environments instead.
+_ACCESSED_DATE = date(2026, 8, 31)
 
 
 class OpenAlexRoleSlotPreflightError(ValueError):

--- a/src/academic_agent/openalex_role_slot.py
+++ b/src/academic_agent/openalex_role_slot.py
@@ -1,0 +1,1260 @@
+"""Candidate-local role-slot consensus kernel for disconnected v6 studies.
+
+The v5 development result showed that a semantically useful candidate could be
+lost for three unrelated reasons: a neighbouring row invalidated the complete
+batch, the model changed its candidate action with input order, or two valid
+passes proposed slightly different role sets.  This successor removes those
+three language-generation decisions from the trust boundary.  The model may
+only propose fixed positional quote slots; deterministic code isolates each
+row and slot, verifies source text, derives candidate admission, and selects a
+bounded evidence set.
+
+This module deliberately contains no HTTP client, model client, retry, repair,
+label access, planner trigger, or production import.  It is a zero-network
+decision kernel whose output remains disconnected from reports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from itertools import combinations
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.openalex_evidence_set import (
+    EvidenceRoleKind,
+    EvidenceSetRoleProfile,
+    EvidenceSetSelectionContract,
+    JudgeQuoteField,
+    SelectedEvidenceSource,
+)
+
+
+RoleSlotProposalState = Literal["SUPPORTED", "ABSTAIN"]
+ProvisionalCandidateAction = Literal["KEEP", "ABSTAIN"]
+EvidenceSetAction = Literal["SELECT", "ABSTAIN"]
+RoleSlotPassState = Literal["valid", "malformed", "contract_invalid"]
+RoleSlotPassError = Literal[
+    "response_too_large",
+    "json_invalid",
+    "envelope_invalid",
+    "case_id_mismatch",
+]
+CandidateRowState = Literal[
+    "valid",
+    "partial",
+    "missing",
+    "duplicate",
+    "malformed",
+    "pass_unavailable",
+]
+RoleSlotAuditState = Literal[
+    "supported",
+    "abstained",
+    "invalid_quote",
+    "malformed",
+    "missing",
+    "duplicate",
+    "order_mismatch",
+    "row_unavailable",
+]
+CandidateAbstentionReason = Literal[
+    "insufficient_required_roles",
+    "insufficient_context_roles",
+    "missing_title_anchor",
+]
+CaseAbstentionReason = Literal["no_valid_candidates", "no_covering_set"]
+
+_CASE_ID_PATTERN = r"^[A-Z][0-9]{2}$"
+_ROLE_ID_PATTERN = r"^[a-z][a-z0-9_]{2,63}$"
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+_WHITESPACE = re.compile(r"\s+")
+_MAX_RAW_RESPONSE_CHARACTERS = 200_000
+_EXPECTED_ENVELOPE_KEYS = {"case_id", "candidates"}
+_EXPECTED_CANDIDATE_KEYS = {"candidate_sha256", "slots"}
+
+_SYSTEM_PROMPT = """You are a bounded academic quote-extraction component.
+For every supplied candidate and every numbered role slot, report SUPPORTED
+only when an exact quote from that candidate's title or abstract directly
+supports the role description. Otherwise report ABSTAIN. Do not decide source
+admission, relevance, novelty, truth, set selection, or commercial value. Do
+not use outside knowledge, paraphrase quotes, omit slots, add slots, change
+slot order, omit candidates, or return prose outside one JSON object."""
+
+
+class RoleSlotContractError(ValueError):
+    """Raised when code-owned inputs cannot satisfy the frozen v6 contract."""
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_text(value.model_dump_json(exclude_none=False))
+
+
+def _normalized_quote_text(value: str) -> str:
+    """Normalize layout only; lexical changes are not quote verification."""
+
+    # This intentionally mirrors the historical evidence-set boundary without
+    # importing its private helper.  Case folding, Unicode normalization,
+    # stemming, and translation would turn paraphrases into apparent quotes.
+    return _WHITESPACE.sub(
+        " ",
+        value.replace("\r\n", "\n").replace("\r", "\n"),
+    ).strip()
+
+
+class RoleSlotInput(BaseModel):
+    """One internal role identity and its fixed outbound slot."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    slot_index: int = Field(ge=0, le=15)
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    role_kind: EvidenceRoleKind
+    description: str = Field(min_length=10, max_length=600)
+
+
+class RoleSlotCandidateInput(BaseModel):
+    """The only candidate fields permitted to cross the model boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    title: str = Field(min_length=5, max_length=600)
+    abstract: str = Field(min_length=1, max_length=8000)
+
+
+class RoleSlotBatchInput(BaseModel):
+    """One immutable pass over a code-owned candidate and role order."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=_CASE_ID_PATTERN)
+    topic: str = Field(min_length=20, max_length=300)
+    pass_number: Literal[1, 2, 3]
+    roles: tuple[RoleSlotInput, ...] = Field(min_length=5, max_length=16)
+    candidates: tuple[RoleSlotCandidateInput, ...] = Field(
+        min_length=1,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_fixed_slots_and_candidates(self) -> "RoleSlotBatchInput":
+        slot_indices = tuple(role.slot_index for role in self.roles)
+        if slot_indices != tuple(range(len(self.roles))):
+            raise ValueError("role slots must be zero-based and contiguous")
+        role_ids = tuple(role.role_id for role in self.roles)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("role slot IDs must be unique")
+        candidate_ids = tuple(item.candidate_sha256 for item in self.candidates)
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("candidate identities must be unique within a pass")
+        return self
+
+    def sha256(self) -> str:
+        """Bind internal role IDs as well as every outbound field and order."""
+
+        return _model_sha256(self)
+
+
+class RoleSlotProposal(BaseModel):
+    """One strict model proposal before source-text verification."""
+
+    # Strict primitives prevent JSON booleans from becoming integer slot 0/1.
+    # Only this provider-facing object needs strict coercion; audit models are
+    # constructed by code from already typed values.
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    slot_index: int = Field(ge=0, le=15)
+    state: RoleSlotProposalState
+    field: JudgeQuoteField | None = None
+    quote: str | None = Field(default=None, max_length=8000)
+
+    @model_validator(mode="after")
+    def _validate_state_shape(self) -> "RoleSlotProposal":
+        if self.state == "SUPPORTED":
+            if self.field is None or self.quote is None or not self.quote.strip():
+                raise ValueError("SUPPORTED requires a non-empty field and quote")
+        elif self.field is not None or self.quote is not None:
+            raise ValueError("ABSTAIN requires null field and quote")
+        return self
+
+
+class RoleSlotAudit(BaseModel):
+    """One slot after local schema and exact-quote checks."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    slot_index: int = Field(ge=0, le=15)
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    role_kind: EvidenceRoleKind
+    state: RoleSlotAuditState
+    proposal_state: RoleSlotProposalState | None = None
+    field: JudgeQuoteField | None = None
+    quote: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_audit_shape(self) -> "RoleSlotAudit":
+        if self.state == "supported":
+            if (
+                self.proposal_state != "SUPPORTED"
+                or self.field is None
+                or self.quote is None
+            ):
+                raise ValueError("supported slot requires its verified proposal")
+        elif self.state == "abstained":
+            if (
+                self.proposal_state != "ABSTAIN"
+                or self.field is not None
+                or self.quote is not None
+            ):
+                raise ValueError("abstained slot requires only an ABSTAIN proposal")
+        elif self.state == "invalid_quote":
+            if (
+                self.proposal_state != "SUPPORTED"
+                or self.field is None
+                or self.quote is None
+            ):
+                raise ValueError("invalid quote must retain the rejected proposal")
+        return self
+
+
+class CandidatePassAudit(BaseModel):
+    """Every expected role slot for one candidate in one pass."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    row_state: CandidateRowState
+    slots: tuple[RoleSlotAudit, ...] = Field(min_length=5, max_length=16)
+    provisional_action: ProvisionalCandidateAction | None
+    invalid_slot_count: int = Field(ge=0, le=32)
+    unknown_slot_count: int = Field(ge=0, le=32)
+
+    @model_validator(mode="after")
+    def _validate_complete_slot_boundary(self) -> "CandidatePassAudit":
+        indices = tuple(item.slot_index for item in self.slots)
+        if indices != tuple(range(len(self.slots))):
+            raise ValueError("every expected slot must reach the candidate audit")
+        role_ids = tuple(item.role_id for item in self.slots)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("candidate audit role IDs must be unique")
+        clean_states = {"supported", "abstained"}
+        if self.row_state == "valid":
+            if any(item.state not in clean_states for item in self.slots):
+                raise ValueError("valid row cannot contain an invalid slot")
+            if self.invalid_slot_count or self.unknown_slot_count:
+                raise ValueError("valid row cannot report slot errors")
+            if self.provisional_action is None:
+                raise ValueError("valid row requires a code-derived disposition")
+        elif self.row_state == "partial":
+            if (
+                all(item.state in clean_states for item in self.slots)
+                and self.unknown_slot_count == 0
+            ):
+                raise ValueError("partial row requires at least one invalid slot")
+            if self.provisional_action is not None:
+                raise ValueError("partial row cannot enter the stability metric")
+        else:
+            if any(item.state != "row_unavailable" for item in self.slots):
+                raise ValueError("unavailable row must expose unavailable slots")
+            if self.provisional_action is not None:
+                raise ValueError("unavailable row cannot have a disposition")
+        return self
+
+
+class RoleSlotPassAudit(BaseModel):
+    """Top-level parse state plus every expected candidate row."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pass_number: Literal[1, 2, 3]
+    state: RoleSlotPassState
+    raw_response_sha256: str = Field(pattern=_SHA256_PATTERN)
+    input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    error_code: RoleSlotPassError | None = None
+    expected_candidate_order: tuple[str, ...] = Field(min_length=1, max_length=8)
+    candidate_rows: tuple[CandidatePassAudit, ...] = Field(
+        min_length=1,
+        max_length=8,
+    )
+    unknown_candidate_sha256s: tuple[str, ...] = Field(max_length=32)
+    malformed_unidentified_row_count: int = Field(ge=0, le=32)
+    local_valid_row_count: int = Field(ge=0, le=8)
+
+    @model_validator(mode="after")
+    def _validate_complete_candidate_boundary(self) -> "RoleSlotPassAudit":
+        if any(
+            re.fullmatch(_SHA256_PATTERN, value) is None
+            for value in self.expected_candidate_order
+        ):
+            raise ValueError("expected candidate order contains an invalid identity")
+        observed = tuple(item.candidate_sha256 for item in self.candidate_rows)
+        if observed != self.expected_candidate_order:
+            raise ValueError("every expected candidate must reach the pass boundary")
+        valid_count = sum(
+            item.row_state == "valid" for item in self.candidate_rows
+        )
+        if valid_count != self.local_valid_row_count:
+            raise ValueError("local valid-row count does not match candidate rows")
+        if self.state == "valid":
+            if self.error_code is not None:
+                raise ValueError("valid pass cannot carry a top-level error")
+        else:
+            if self.error_code is None:
+                raise ValueError("invalid pass requires an explicit error code")
+            if any(
+                item.row_state != "pass_unavailable"
+                for item in self.candidate_rows
+            ):
+                raise ValueError("invalid pass must expose unavailable rows")
+        return self
+
+
+class RolePassObservation(BaseModel):
+    """One pass contribution retained inside the final role decision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pass_number: Literal[1, 2, 3]
+    state: RoleSlotAuditState
+    field: JudgeQuoteField | None
+    quote: str | None
+
+
+class RoleConsensusAudit(BaseModel):
+    """Three pass observations and the deterministic two-of-three outcome."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    slot_index: int = Field(ge=0, le=15)
+    role_id: str = Field(pattern=_ROLE_ID_PATTERN)
+    role_kind: EvidenceRoleKind
+    observations: tuple[RolePassObservation, ...] = Field(
+        min_length=3,
+        max_length=3,
+    )
+    support_count: int = Field(ge=0, le=3)
+    title_support_count: int = Field(ge=0, le=3)
+    consensus_supported: bool
+
+    @model_validator(mode="after")
+    def _validate_consensus_math(self) -> "RoleConsensusAudit":
+        if tuple(item.pass_number for item in self.observations) != (1, 2, 3):
+            raise ValueError("role observations must cover passes one through three")
+        support_count = sum(
+            item.state == "supported" for item in self.observations
+        )
+        title_count = sum(
+            item.state == "supported" and item.field == "title"
+            for item in self.observations
+        )
+        if (support_count, title_count) != (
+            self.support_count,
+            self.title_support_count,
+        ):
+            raise ValueError("role consensus counts do not match observations")
+        if self.consensus_supported != (self.support_count >= 2):
+            raise ValueError("role consensus must use the frozen two-of-three rule")
+        return self
+
+
+class CandidateRoleSlotAudit(BaseModel):
+    """Final candidate decision derived entirely from verified role slots."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate_sha256: str = Field(pattern=_SHA256_PATTERN)
+    provider_result_index: int = Field(ge=0)
+    action: ProvisionalCandidateAction
+    pass_row_states: tuple[CandidateRowState, ...] = Field(
+        min_length=3,
+        max_length=3,
+    )
+    provisional_actions: tuple[ProvisionalCandidateAction | None, ...] = Field(
+        min_length=3,
+        max_length=3,
+    )
+    provisional_disposition_unanimous: bool
+    role_consensus: tuple[RoleConsensusAudit, ...] = Field(
+        min_length=5,
+        max_length=16,
+    )
+    required_role_ids: tuple[str, ...]
+    scope_role_ids: tuple[str, ...]
+    supporting_role_ids: tuple[str, ...]
+    title_anchor_role_ids: tuple[str, ...]
+    abstention_reasons: tuple[CandidateAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_candidate_derivation(self) -> "CandidateRoleSlotAudit":
+        role_ids = tuple(item.role_id for item in self.role_consensus)
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("candidate role consensus identities must be unique")
+        supported = {
+            item.role_id for item in self.role_consensus if item.consensus_supported
+        }
+        assigned = {
+            *self.required_role_ids,
+            *self.scope_role_ids,
+            *self.supporting_role_ids,
+        }
+        if assigned != supported:
+            raise ValueError("every consensus role must reach candidate assignments")
+        if not set(self.title_anchor_role_ids).issubset(supported):
+            raise ValueError("title anchors must be consensus-supported roles")
+        expected_unanimous = (
+            None not in self.provisional_actions
+            and len(set(self.provisional_actions)) == 1
+        )
+        if self.provisional_disposition_unanimous != expected_unanimous:
+            raise ValueError("provisional unanimity does not match pass actions")
+        if self.action == "KEEP" and self.abstention_reasons:
+            raise ValueError("KEEP candidate cannot carry abstention reasons")
+        if self.action == "ABSTAIN" and not self.abstention_reasons:
+            raise ValueError("ABSTAIN candidate requires explicit threshold reasons")
+        return self
+
+
+class RoleSlotCaseAudit(BaseModel):
+    """Complete v6 decision at the future runner and review seam."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=_CASE_ID_PATTERN)
+    topic: str = Field(min_length=20, max_length=300)
+    action: EvidenceSetAction
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    provider_candidate_count: int = Field(ge=1, le=8)
+    passes: tuple[RoleSlotPassAudit, ...] = Field(min_length=3, max_length=3)
+    candidate_decisions: tuple[CandidateRoleSlotAudit, ...] = Field(
+        min_length=1,
+        max_length=8,
+    )
+    selected_sources: tuple[SelectedEvidenceSource, ...] = Field(max_length=3)
+    covered_required_role_ids: tuple[str, ...]
+    covered_scope_role_ids: tuple[str, ...]
+    covered_supporting_role_ids: tuple[str, ...]
+    local_valid_row_numerator: int = Field(ge=0, le=24)
+    local_valid_row_denominator: int = Field(ge=3, le=24)
+    local_valid_row_rate: float = Field(ge=0.0, le=1.0)
+    provisional_unanimity_numerator: int = Field(ge=0, le=8)
+    provisional_unanimity_denominator: int = Field(ge=1, le=8)
+    provisional_disposition_unanimity: float = Field(ge=0.0, le=1.0)
+    abstention_reasons: tuple[CaseAbstentionReason, ...]
+
+    @model_validator(mode="after")
+    def _validate_complete_case_boundary(self) -> "RoleSlotCaseAudit":
+        if tuple(item.pass_number for item in self.passes) != (1, 2, 3):
+            raise ValueError("case audit must retain all three passes")
+        if len(self.candidate_decisions) != self.provider_candidate_count:
+            raise ValueError("every provider candidate must reach the case boundary")
+        candidate_ids = tuple(
+            item.candidate_sha256 for item in self.candidate_decisions
+        )
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("candidate decision identities must be unique")
+        for pass_audit in self.passes:
+            if set(pass_audit.expected_candidate_order) != set(candidate_ids):
+                raise ValueError("each pass must cover the same candidate identities")
+        decisions_by_id = {
+            item.candidate_sha256: item for item in self.candidate_decisions
+        }
+        selected_ids = tuple(item.candidate_sha256 for item in self.selected_sources)
+        if len(selected_ids) != len(set(selected_ids)):
+            raise ValueError("selected source identities must be unique")
+        if not set(selected_ids).issubset(decisions_by_id):
+            raise ValueError("selected source is missing from candidate decisions")
+        for selected in self.selected_sources:
+            decision = decisions_by_id[selected.candidate_sha256]
+            expected_roles = (
+                *decision.required_role_ids,
+                *decision.scope_role_ids,
+                *decision.supporting_role_ids,
+            )
+            if decision.action != "KEEP" or selected.role_ids != expected_roles:
+                raise ValueError(
+                    "selected source must deliver every deterministic KEEP role"
+                )
+        expected_row_denominator = self.provider_candidate_count * 3
+        expected_valid_rows = sum(
+            item.local_valid_row_count for item in self.passes
+        )
+        if (
+            self.local_valid_row_denominator != expected_row_denominator
+            or self.local_valid_row_numerator != expected_valid_rows
+            or self.local_valid_row_rate
+            != expected_valid_rows / expected_row_denominator
+        ):
+            raise ValueError("local valid-row metric does not match pass audits")
+        expected_unanimous = sum(
+            item.provisional_disposition_unanimous
+            for item in self.candidate_decisions
+        )
+        if (
+            self.provisional_unanimity_denominator != self.provider_candidate_count
+            or self.provisional_unanimity_numerator != expected_unanimous
+            or self.provisional_disposition_unanimity
+            != expected_unanimous / self.provider_candidate_count
+        ):
+            raise ValueError("provisional unanimity metric does not match candidates")
+        if self.action == "SELECT":
+            if not self.selected_sources or self.abstention_reasons:
+                raise ValueError("SELECT requires sources and no abstention reason")
+        elif self.selected_sources or not self.abstention_reasons:
+            raise ValueError("ABSTAIN requires no sources and an explicit reason")
+        return self
+
+
+def _ordered_roles(profile: EvidenceSetRoleProfile) -> tuple[RoleSlotInput, ...]:
+    return tuple(
+        RoleSlotInput(
+            slot_index=index,
+            role_id=role.role_id,
+            role_kind=kind,
+            description=role.description,
+        )
+        for index, (kind, role) in enumerate(
+            (kind, role)
+            for kind, roles in (
+                ("required", profile.required_roles),
+                ("scope", profile.scope_roles),
+                ("supporting", profile.supporting_roles),
+            )
+            for role in roles
+        )
+    )
+
+
+def _provider_ordered_candidates(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+) -> tuple[OpenAlexClaimScopeCandidate, ...]:
+    if not candidates:
+        raise RoleSlotContractError("at least one candidate is required")
+    if len(candidates) > 8:
+        raise RoleSlotContractError("at most eight provider candidates are allowed")
+    indices = tuple(item.evidence.provider_result_index for item in candidates)
+    if any(index is None for index in indices):
+        raise RoleSlotContractError("every candidate requires a provider result index")
+    if len(indices) != len(set(indices)):
+        raise RoleSlotContractError("provider result indices must be unique")
+    identities = tuple(item.sha256() for item in candidates)
+    if len(identities) != len(set(identities)):
+        raise RoleSlotContractError("candidate identities must be unique")
+    return tuple(
+        sorted(
+            candidates,
+            key=lambda item: (
+                item.evidence.provider_result_index,
+                item.sha256(),
+            ),
+        )
+    )
+
+
+def build_role_slot_inputs(
+    *,
+    case_id: str,
+    topic: str,
+    profile: EvidenceSetRoleProfile,
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+) -> tuple[RoleSlotBatchInput, RoleSlotBatchInput, RoleSlotBatchInput]:
+    """Build provider, reverse, and candidate-identity pass orders."""
+
+    ordered = _provider_ordered_candidates(candidates)
+    roles = _ordered_roles(profile)
+
+    def candidate_input(
+        candidate: OpenAlexClaimScopeCandidate,
+    ) -> RoleSlotCandidateInput:
+        return RoleSlotCandidateInput(
+            candidate_sha256=candidate.sha256(),
+            title=candidate.evidence.title,
+            abstract=candidate.evidence.evidence_summary,
+        )
+
+    provider_order = tuple(candidate_input(item) for item in ordered)
+    identity_order = tuple(
+        sorted(provider_order, key=lambda item: item.candidate_sha256)
+    )
+    return (
+        RoleSlotBatchInput(
+            case_id=case_id,
+            topic=topic,
+            pass_number=1,
+            roles=roles,
+            candidates=provider_order,
+        ),
+        RoleSlotBatchInput(
+            case_id=case_id,
+            topic=topic,
+            pass_number=2,
+            roles=roles,
+            candidates=tuple(reversed(provider_order)),
+        ),
+        RoleSlotBatchInput(
+            case_id=case_id,
+            topic=topic,
+            pass_number=3,
+            roles=roles,
+            candidates=identity_order,
+        ),
+    )
+
+
+def build_role_slot_prompts(batch: RoleSlotBatchInput) -> tuple[str, str]:
+    """Serialize the exact action-free provider prompt for one v6 pass."""
+
+    # Internal role IDs are deliberately absent.  The slot index is sufficient
+    # to map a returned quote to the immutable profile, and removing the ID
+    # prevents the model from duplicating or inventing role identifiers.
+    outbound = {
+        "case_id": batch.case_id,
+        "topic": batch.topic,
+        "pass_number": batch.pass_number,
+        "roles": [
+            {
+                "slot_index": role.slot_index,
+                "role_kind": role.role_kind,
+                "description": role.description,
+            }
+            for role in batch.roles
+        ],
+        "candidates": [
+            candidate.model_dump(mode="json") for candidate in batch.candidates
+        ],
+    }
+    response_shape = {
+        "case_id": batch.case_id,
+        "candidates": [
+            {
+                "candidate_sha256": "candidate identity",
+                "slots": [
+                    {
+                        "slot_index": 0,
+                        "state": "SUPPORTED or ABSTAIN",
+                        "field": "title, abstract, or null",
+                        "quote": "exact source span or null",
+                    }
+                ],
+            }
+        ],
+    }
+    user_prompt = (
+        "Extract every numbered role slot for every candidate. SUPPORTED requires "
+        "one exact title-or-abstract quote; ABSTAIN requires null field and quote. "
+        "Return candidates and slots in the supplied order. Return only strict "
+        "JSON with this shape:\n"
+        f"{json.dumps(response_shape, ensure_ascii=True, sort_keys=True)}\n"
+        "INPUT:\n"
+        f"{json.dumps(outbound, ensure_ascii=True, separators=(',', ':'))}"
+    )
+    return _SYSTEM_PROMPT, user_prompt
+
+
+def _quote_is_valid(
+    proposal: RoleSlotProposal,
+    candidate: RoleSlotCandidateInput,
+) -> bool:
+    if proposal.field is None or proposal.quote is None:
+        return False
+    source = candidate.title if proposal.field == "title" else candidate.abstract
+    normalized_quote = _normalized_quote_text(proposal.quote)
+    return bool(
+        normalized_quote and normalized_quote in _normalized_quote_text(source)
+    )
+
+
+def _unavailable_slots(
+    roles: tuple[RoleSlotInput, ...],
+) -> tuple[RoleSlotAudit, ...]:
+    return tuple(
+        RoleSlotAudit(
+            slot_index=role.slot_index,
+            role_id=role.role_id,
+            role_kind=role.role_kind,
+            state="row_unavailable",
+        )
+        for role in roles
+    )
+
+
+def _unavailable_candidate_row(
+    *,
+    candidate_sha256: str,
+    roles: tuple[RoleSlotInput, ...],
+    row_state: Literal["missing", "duplicate", "malformed", "pass_unavailable"],
+) -> CandidatePassAudit:
+    return CandidatePassAudit(
+        candidate_sha256=candidate_sha256,
+        row_state=row_state,
+        slots=_unavailable_slots(roles),
+        provisional_action=None,
+        invalid_slot_count=len(roles),
+        unknown_slot_count=0,
+    )
+
+
+def _slot_audit(
+    *,
+    raw_slot: object,
+    raw_position: int,
+    role: RoleSlotInput,
+    candidate: RoleSlotCandidateInput,
+) -> RoleSlotAudit:
+    try:
+        proposal = RoleSlotProposal.model_validate(raw_slot)
+    except ValidationError:
+        return RoleSlotAudit(
+            slot_index=role.slot_index,
+            role_id=role.role_id,
+            role_kind=role.role_kind,
+            state="malformed",
+        )
+    if raw_position != role.slot_index:
+        return RoleSlotAudit(
+            slot_index=role.slot_index,
+            role_id=role.role_id,
+            role_kind=role.role_kind,
+            state="order_mismatch",
+            proposal_state=proposal.state,
+            field=proposal.field,
+            quote=proposal.quote,
+        )
+    if proposal.state == "ABSTAIN":
+        return RoleSlotAudit(
+            slot_index=role.slot_index,
+            role_id=role.role_id,
+            role_kind=role.role_kind,
+            state="abstained",
+            proposal_state=proposal.state,
+        )
+    if not _quote_is_valid(proposal, candidate):
+        return RoleSlotAudit(
+            slot_index=role.slot_index,
+            role_id=role.role_id,
+            role_kind=role.role_kind,
+            state="invalid_quote",
+            proposal_state=proposal.state,
+            field=proposal.field,
+            quote=proposal.quote,
+        )
+    return RoleSlotAudit(
+        slot_index=role.slot_index,
+        role_id=role.role_id,
+        role_kind=role.role_kind,
+        state="supported",
+        proposal_state=proposal.state,
+        field=proposal.field,
+        quote=proposal.quote,
+    )
+
+
+def _provisional_action(
+    slots: tuple[RoleSlotAudit, ...],
+    contract: EvidenceSetSelectionContract,
+) -> ProvisionalCandidateAction:
+    supported = tuple(item for item in slots if item.state == "supported")
+    required_count = sum(item.role_kind == "required" for item in supported)
+    context_count = sum(
+        item.role_kind in {"scope", "supporting"} for item in supported
+    )
+    title_count = sum(item.field == "title" for item in supported)
+    return (
+        "KEEP"
+        if required_count >= contract.minimum_candidate_required_roles
+        and context_count >= contract.minimum_candidate_context_roles
+        and title_count >= contract.minimum_candidate_title_anchor_roles
+        else "ABSTAIN"
+    )
+
+
+def _candidate_row_from_raw(
+    *,
+    raw_row: object,
+    candidate: RoleSlotCandidateInput,
+    roles: tuple[RoleSlotInput, ...],
+    contract: EvidenceSetSelectionContract,
+) -> CandidatePassAudit:
+    if (
+        not isinstance(raw_row, dict)
+        or set(raw_row) != _EXPECTED_CANDIDATE_KEYS
+        or raw_row.get("candidate_sha256") != candidate.candidate_sha256
+        or not isinstance(raw_row.get("slots"), list)
+    ):
+        return _unavailable_candidate_row(
+            candidate_sha256=candidate.candidate_sha256,
+            roles=roles,
+            row_state="malformed",
+        )
+
+    raw_slots = raw_row["slots"]
+    by_index: dict[int, list[tuple[int, object]]] = {}
+    unknown_slot_count = 0
+    for position, raw_slot in enumerate(raw_slots):
+        if not isinstance(raw_slot, dict):
+            unknown_slot_count += 1
+            continue
+        slot_index = raw_slot.get("slot_index")
+        # bool is an int subclass, but it is never a valid JSON slot identity.
+        if (
+            isinstance(slot_index, bool)
+            or not isinstance(slot_index, int)
+            or not 0 <= slot_index < len(roles)
+        ):
+            unknown_slot_count += 1
+            continue
+        by_index.setdefault(slot_index, []).append((position, raw_slot))
+
+    audits: list[RoleSlotAudit] = []
+    for role in roles:
+        matches = by_index.get(role.slot_index, [])
+        if not matches:
+            audits.append(
+                RoleSlotAudit(
+                    slot_index=role.slot_index,
+                    role_id=role.role_id,
+                    role_kind=role.role_kind,
+                    state="missing",
+                )
+            )
+        elif len(matches) > 1:
+            audits.append(
+                RoleSlotAudit(
+                    slot_index=role.slot_index,
+                    role_id=role.role_id,
+                    role_kind=role.role_kind,
+                    state="duplicate",
+                )
+            )
+        else:
+            position, raw_slot = matches[0]
+            audits.append(
+                _slot_audit(
+                    raw_slot=raw_slot,
+                    raw_position=position,
+                    role=role,
+                    candidate=candidate,
+                )
+            )
+
+    slots = tuple(audits)
+    clean_states = {"supported", "abstained"}
+    invalid_slot_count = sum(item.state not in clean_states for item in slots)
+    row_is_valid = (
+        len(raw_slots) == len(roles)
+        and unknown_slot_count == 0
+        and invalid_slot_count == 0
+    )
+    return CandidatePassAudit(
+        candidate_sha256=candidate.candidate_sha256,
+        row_state="valid" if row_is_valid else "partial",
+        slots=slots,
+        provisional_action=(
+            _provisional_action(slots, contract) if row_is_valid else None
+        ),
+        invalid_slot_count=invalid_slot_count,
+        unknown_slot_count=unknown_slot_count,
+    )
+
+
+def _invalid_pass_audit(
+    *,
+    raw_response_sha256: str,
+    expected_input: RoleSlotBatchInput,
+    error_code: RoleSlotPassError,
+    state: Literal["malformed", "contract_invalid"],
+) -> RoleSlotPassAudit:
+    return RoleSlotPassAudit(
+        pass_number=expected_input.pass_number,
+        state=state,
+        raw_response_sha256=raw_response_sha256,
+        input_sha256=expected_input.sha256(),
+        error_code=error_code,
+        expected_candidate_order=tuple(
+            item.candidate_sha256 for item in expected_input.candidates
+        ),
+        candidate_rows=tuple(
+            _unavailable_candidate_row(
+                candidate_sha256=item.candidate_sha256,
+                roles=expected_input.roles,
+                row_state="pass_unavailable",
+            )
+            for item in expected_input.candidates
+        ),
+        unknown_candidate_sha256s=(),
+        malformed_unidentified_row_count=0,
+        local_valid_row_count=0,
+    )
+
+
+def parse_role_slot_pass(
+    raw_response: str,
+    expected_input: RoleSlotBatchInput,
+    selection_contract: EvidenceSetSelectionContract,
+) -> RoleSlotPassAudit:
+    """Parse one response while containing schema failures to their row."""
+
+    response_sha256 = _sha256_text(raw_response)
+    if len(raw_response) > _MAX_RAW_RESPONSE_CHARACTERS:
+        return _invalid_pass_audit(
+            raw_response_sha256=response_sha256,
+            expected_input=expected_input,
+            error_code="response_too_large",
+            state="malformed",
+        )
+    try:
+        payload = json.loads(raw_response)
+    except json.JSONDecodeError:
+        return _invalid_pass_audit(
+            raw_response_sha256=response_sha256,
+            expected_input=expected_input,
+            error_code="json_invalid",
+            state="malformed",
+        )
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != _EXPECTED_ENVELOPE_KEYS
+        or not isinstance(payload.get("case_id"), str)
+        or not isinstance(payload.get("candidates"), list)
+        or len(payload["candidates"]) > 32
+    ):
+        return _invalid_pass_audit(
+            raw_response_sha256=response_sha256,
+            expected_input=expected_input,
+            error_code="envelope_invalid",
+            state="malformed",
+        )
+    if payload["case_id"] != expected_input.case_id:
+        return _invalid_pass_audit(
+            raw_response_sha256=response_sha256,
+            expected_input=expected_input,
+            error_code="case_id_mismatch",
+            state="contract_invalid",
+        )
+
+    expected_by_id = {
+        item.candidate_sha256: item for item in expected_input.candidates
+    }
+    grouped: dict[str, list[object]] = {
+        candidate_sha256: [] for candidate_sha256 in expected_by_id
+    }
+    unknown_candidate_sha256s: list[str] = []
+    malformed_unidentified_rows = 0
+    for raw_row in payload["candidates"]:
+        candidate_sha256 = (
+            raw_row.get("candidate_sha256")
+            if isinstance(raw_row, dict)
+            else None
+        )
+        if (
+            not isinstance(candidate_sha256, str)
+            or re.fullmatch(_SHA256_PATTERN, candidate_sha256) is None
+        ):
+            malformed_unidentified_rows += 1
+        elif candidate_sha256 not in grouped:
+            unknown_candidate_sha256s.append(candidate_sha256)
+        else:
+            grouped[candidate_sha256].append(raw_row)
+
+    candidate_rows: list[CandidatePassAudit] = []
+    for candidate in expected_input.candidates:
+        rows = grouped[candidate.candidate_sha256]
+        if not rows:
+            candidate_rows.append(
+                _unavailable_candidate_row(
+                    candidate_sha256=candidate.candidate_sha256,
+                    roles=expected_input.roles,
+                    row_state="missing",
+                )
+            )
+        elif len(rows) > 1:
+            candidate_rows.append(
+                _unavailable_candidate_row(
+                    candidate_sha256=candidate.candidate_sha256,
+                    roles=expected_input.roles,
+                    row_state="duplicate",
+                )
+            )
+        else:
+            candidate_rows.append(
+                _candidate_row_from_raw(
+                    raw_row=rows[0],
+                    candidate=candidate,
+                    roles=expected_input.roles,
+                    contract=selection_contract,
+                )
+            )
+
+    candidate_rows_tuple = tuple(candidate_rows)
+    return RoleSlotPassAudit(
+        pass_number=expected_input.pass_number,
+        state="valid",
+        raw_response_sha256=response_sha256,
+        input_sha256=expected_input.sha256(),
+        error_code=None,
+        expected_candidate_order=tuple(expected_by_id),
+        candidate_rows=candidate_rows_tuple,
+        unknown_candidate_sha256s=tuple(unknown_candidate_sha256s),
+        malformed_unidentified_row_count=malformed_unidentified_rows,
+        local_valid_row_count=sum(
+            item.row_state == "valid" for item in candidate_rows_tuple
+        ),
+    )
+
+
+def _selection_contract_is_possible(
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> None:
+    if contract.minimum_scope_roles > len(profile.scope_roles):
+        raise RoleSlotContractError(
+            "minimum_scope_roles exceeds the profile scope-role count"
+        )
+    if contract.minimum_supporting_roles > len(profile.supporting_roles):
+        raise RoleSlotContractError(
+            "minimum_supporting_roles exceeds the supporting-role count"
+        )
+
+
+def _candidate_decision(
+    *,
+    candidate: OpenAlexClaimScopeCandidate,
+    pass_rows: tuple[CandidatePassAudit, CandidatePassAudit, CandidatePassAudit],
+    roles: tuple[RoleSlotInput, ...],
+    contract: EvidenceSetSelectionContract,
+) -> CandidateRoleSlotAudit:
+    role_consensus: list[RoleConsensusAudit] = []
+    for role in roles:
+        slot_observations = tuple(
+            row.slots[role.slot_index] for row in pass_rows
+        )
+        observations = tuple(
+            RolePassObservation(
+                pass_number=pass_number,
+                state=slot.state,
+                field=slot.field,
+                quote=slot.quote,
+            )
+            for pass_number, slot in enumerate(slot_observations, start=1)
+        )
+        support_count = sum(item.state == "supported" for item in observations)
+        title_support_count = sum(
+            item.state == "supported" and item.field == "title"
+            for item in observations
+        )
+        role_consensus.append(
+            RoleConsensusAudit(
+                slot_index=role.slot_index,
+                role_id=role.role_id,
+                role_kind=role.role_kind,
+                observations=observations,
+                support_count=support_count,
+                title_support_count=title_support_count,
+                consensus_supported=support_count >= 2,
+            )
+        )
+
+    consensus = tuple(role_consensus)
+    required = tuple(
+        item.role_id
+        for item in consensus
+        if item.consensus_supported and item.role_kind == "required"
+    )
+    scope = tuple(
+        item.role_id
+        for item in consensus
+        if item.consensus_supported and item.role_kind == "scope"
+    )
+    supporting = tuple(
+        item.role_id
+        for item in consensus
+        if item.consensus_supported and item.role_kind == "supporting"
+    )
+    title_anchors = tuple(
+        item.role_id
+        for item in consensus
+        if item.consensus_supported and item.title_support_count >= 2
+    )
+    reasons: list[CandidateAbstentionReason] = []
+    if len(required) < contract.minimum_candidate_required_roles:
+        reasons.append("insufficient_required_roles")
+    if len(scope) + len(supporting) < contract.minimum_candidate_context_roles:
+        reasons.append("insufficient_context_roles")
+    if len(title_anchors) < contract.minimum_candidate_title_anchor_roles:
+        reasons.append("missing_title_anchor")
+    provisional_actions = tuple(row.provisional_action for row in pass_rows)
+    unanimous = (
+        None not in provisional_actions and len(set(provisional_actions)) == 1
+    )
+    return CandidateRoleSlotAudit(
+        candidate_sha256=candidate.sha256(),
+        provider_result_index=candidate.evidence.provider_result_index,
+        action="ABSTAIN" if reasons else "KEEP",
+        pass_row_states=tuple(row.row_state for row in pass_rows),
+        provisional_actions=provisional_actions,
+        provisional_disposition_unanimous=unanimous,
+        role_consensus=consensus,
+        required_role_ids=required,
+        scope_role_ids=scope,
+        supporting_role_ids=supporting,
+        title_anchor_role_ids=title_anchors,
+        abstention_reasons=tuple(reasons),
+    )
+
+
+def _covers_profile(
+    decisions: tuple[CandidateRoleSlotAudit, ...],
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> bool:
+    required = {role_id for item in decisions for role_id in item.required_role_ids}
+    scope = {role_id for item in decisions for role_id in item.scope_role_ids}
+    supporting = {
+        role_id for item in decisions for role_id in item.supporting_role_ids
+    }
+    return (
+        required == {role.role_id for role in profile.required_roles}
+        and len(scope) >= contract.minimum_scope_roles
+        and len(supporting) >= contract.minimum_supporting_roles
+    )
+
+
+def _select_sources(
+    decisions: tuple[CandidateRoleSlotAudit, ...],
+    profile: EvidenceSetRoleProfile,
+    contract: EvidenceSetSelectionContract,
+) -> tuple[CandidateRoleSlotAudit, ...]:
+    eligible = tuple(
+        sorted(
+            (item for item in decisions if item.action == "KEEP"),
+            key=lambda item: (item.provider_result_index, item.candidate_sha256),
+        )
+    )
+    for size in range(1, contract.maximum_selected_sources_per_case + 1):
+        valid = tuple(
+            group
+            for group in combinations(eligible, size)
+            if _covers_profile(group, profile, contract)
+        )
+        if valid:
+            return min(
+                valid,
+                key=lambda group: (
+                    tuple(item.provider_result_index for item in group),
+                    tuple(item.candidate_sha256 for item in group),
+                ),
+            )
+    return ()
+
+
+def evaluate_role_slot_case(
+    *,
+    case_id: str,
+    topic: str,
+    profile: EvidenceSetRoleProfile,
+    selection_contract: EvidenceSetSelectionContract,
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+    raw_responses: tuple[str, str, str],
+) -> RoleSlotCaseAudit:
+    """Evaluate three responses and preserve every local outcome at one seam."""
+
+    _selection_contract_is_possible(profile, selection_contract)
+    ordered_candidates = _provider_ordered_candidates(candidates)
+    inputs = build_role_slot_inputs(
+        case_id=case_id,
+        topic=topic,
+        profile=profile,
+        candidates=ordered_candidates,
+    )
+    passes = tuple(
+        parse_role_slot_pass(raw_response, expected_input, selection_contract)
+        for raw_response, expected_input in zip(raw_responses, inputs, strict=True)
+    )
+    rows_by_pass = tuple(
+        {row.candidate_sha256: row for row in pass_audit.candidate_rows}
+        for pass_audit in passes
+    )
+    roles = inputs[0].roles
+    candidate_decisions = tuple(
+        _candidate_decision(
+            candidate=candidate,
+            pass_rows=tuple(
+                rows[candidate.sha256()] for rows in rows_by_pass
+            ),
+            roles=roles,
+            contract=selection_contract,
+        )
+        for candidate in ordered_candidates
+    )
+    selected = _select_sources(candidate_decisions, profile, selection_contract)
+    selected_sources = tuple(
+        SelectedEvidenceSource(
+            candidate_sha256=item.candidate_sha256,
+            provider_result_index=item.provider_result_index,
+            role_ids=(
+                *item.required_role_ids,
+                *item.scope_role_ids,
+                *item.supporting_role_ids,
+            ),
+        )
+        for item in selected
+    )
+    covered_required = tuple(
+        role.role_id
+        for role in profile.required_roles
+        if any(role.role_id in item.required_role_ids for item in selected)
+    )
+    covered_scope = tuple(
+        role.role_id
+        for role in profile.scope_roles
+        if any(role.role_id in item.scope_role_ids for item in selected)
+    )
+    covered_supporting = tuple(
+        role.role_id
+        for role in profile.supporting_roles
+        if any(role.role_id in item.supporting_role_ids for item in selected)
+    )
+    eligible_count = sum(item.action == "KEEP" for item in candidate_decisions)
+    abstention_reasons: tuple[CaseAbstentionReason, ...] = ()
+    if not selected:
+        abstention_reasons = (
+            "no_valid_candidates" if eligible_count == 0 else "no_covering_set",
+        )
+    valid_rows = sum(item.local_valid_row_count for item in passes)
+    row_denominator = len(ordered_candidates) * 3
+    unanimous = sum(
+        item.provisional_disposition_unanimous for item in candidate_decisions
+    )
+    return RoleSlotCaseAudit(
+        case_id=case_id,
+        topic=topic,
+        action="SELECT" if selected else "ABSTAIN",
+        profile_sha256=profile.sha256(),
+        selection_contract_sha256=selection_contract.sha256(),
+        provider_candidate_count=len(ordered_candidates),
+        passes=passes,
+        candidate_decisions=candidate_decisions,
+        selected_sources=selected_sources,
+        covered_required_role_ids=covered_required,
+        covered_scope_role_ids=covered_scope,
+        covered_supporting_role_ids=covered_supporting,
+        local_valid_row_numerator=valid_rows,
+        local_valid_row_denominator=row_denominator,
+        local_valid_row_rate=valid_rows / row_denominator,
+        provisional_unanimity_numerator=unanimous,
+        provisional_unanimity_denominator=len(ordered_candidates),
+        provisional_disposition_unanimity=unanimous / len(ordered_candidates),
+        abstention_reasons=abstention_reasons,
+    )

--- a/tests/fixtures/openalex_role_slot_v6_challenge.json
+++ b/tests/fixtures/openalex_role_slot_v6_challenge.json
@@ -1,0 +1,568 @@
+{
+  "schema_version": 1,
+  "method_id": "openalex-candidate-local-role-slot-consensus-v6",
+  "provider_contract": {
+    "provider": "anonymous_openalex",
+    "requests_per_case": 1,
+    "result_limit": 8,
+    "require_abstract": true,
+    "allow_redirects": false,
+    "allow_retries": false
+  },
+  "judge_contract": {
+    "provider": "qwen",
+    "model": "qwen3.5-plus",
+    "passes_per_case": 3,
+    "candidate_orders": [
+      "provider_order",
+      "reverse_provider_order",
+      "candidate_sha256_order"
+    ],
+    "temperature": 0.0,
+    "allow_retries": false,
+    "allow_repair": false,
+    "allow_fallback": false,
+    "minimum_verified_passes_per_role": 2
+  },
+  "selection_contract": {
+    "required_roles_covered": "all",
+    "minimum_scope_roles": 1,
+    "minimum_supporting_roles": 1,
+    "maximum_selected_sources_per_case": 3,
+    "minimum_candidate_required_roles": 1,
+    "minimum_candidate_context_roles": 1,
+    "minimum_candidate_title_anchor_roles": 1
+  },
+  "development_cases": [
+    {
+      "case_id": "Y01",
+      "topic": "Lignin-derived carbon fibres for recyclable automotive structural composites",
+      "query": "lignin carbon fiber automotive composite recycling",
+      "roles": {
+        "required": [
+          {
+            "role_id": "lignin_precursor",
+            "description": "Evidence that lignin is used as the material precursor or feedstock."
+          },
+          {
+            "role_id": "carbon_fibre",
+            "description": "Evidence that the work produces or evaluates carbon fibre materials."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "automotive_composite",
+            "description": "Evidence of an automotive or structural composite application context."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "mechanical_performance",
+            "description": "Evidence reporting strength, modulus, toughness, or related mechanical performance."
+          },
+          {
+            "role_id": "recyclable_composite",
+            "description": "Evidence addressing recycling, reuse, or circularity of the resulting composite."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y02",
+      "topic": "Enzymatic depolymerisation of blended polyester textile waste for closed-loop recycling",
+      "query": "enzymatic polyester textile waste depolymerization recycling",
+      "roles": {
+        "required": [
+          {
+            "role_id": "enzymatic_depolymerisation",
+            "description": "Evidence that enzymes catalyse polymer depolymerisation or hydrolysis."
+          },
+          {
+            "role_id": "polyester_material",
+            "description": "Evidence that polyester or PET is the target polymer material."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "blended_textile_waste",
+            "description": "Evidence that blended fabrics or post-consumer textile waste are treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "monomer_recovery",
+            "description": "Evidence of recovered monomers, oligomers, or purified depolymerisation products."
+          },
+          {
+            "role_id": "closed_loop_recycling",
+            "description": "Evidence that recovered material is reused to make polymer or textile products."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y03",
+      "topic": "Solid-state sodium-sulfur batteries for grid-scale energy storage",
+      "query": "solid state sodium sulfur battery grid energy storage",
+      "roles": {
+        "required": [
+          {
+            "role_id": "sodium_sulfur_battery",
+            "description": "Evidence that the electrochemical system is a sodium-sulfur battery."
+          },
+          {
+            "role_id": "solid_state_electrolyte",
+            "description": "Evidence that a solid electrolyte or all-solid-state architecture is used."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "grid_scale_storage",
+            "description": "Evidence of stationary, grid-scale, or long-duration energy-storage use."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "cycling_performance",
+            "description": "Evidence reporting capacity retention, cycle life, or reversible cycling."
+          },
+          {
+            "role_id": "safety_or_temperature",
+            "description": "Evidence addressing safety or reduced operating-temperature requirements."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y04",
+      "topic": "Injectable self-healing hydrogels for chronic diabetic wound treatment",
+      "query": "injectable self healing hydrogel diabetic wound treatment",
+      "roles": {
+        "required": [
+          {
+            "role_id": "injectable_hydrogel",
+            "description": "Evidence that the material is an injectable hydrogel."
+          },
+          {
+            "role_id": "self_healing",
+            "description": "Evidence of autonomous self-healing or reversible network recovery."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "diabetic_wound",
+            "description": "Evidence that diabetic or chronic wound treatment is the target context."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "antimicrobial_activity",
+            "description": "Evidence of antibacterial, antimicrobial, or infection-control activity."
+          },
+          {
+            "role_id": "tissue_regeneration",
+            "description": "Evidence of wound closure, angiogenesis, or tissue regeneration outcomes."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y05",
+      "topic": "Metal-organic framework membranes for low-concentration carbon dioxide capture",
+      "query": "metal organic framework membrane low concentration carbon dioxide capture",
+      "roles": {
+        "required": [
+          {
+            "role_id": "metal_organic_framework",
+            "description": "Evidence that a metal-organic framework is an active separation material."
+          },
+          {
+            "role_id": "membrane_separation",
+            "description": "Evidence that gas separation is performed with a membrane architecture."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "low_concentration_co2",
+            "description": "Evidence involving dilute or low-partial-pressure carbon dioxide streams."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "selectivity_permeability",
+            "description": "Evidence reporting carbon-dioxide selectivity, permeability, or permeance."
+          },
+          {
+            "role_id": "operational_stability",
+            "description": "Evidence addressing humidity, contaminants, aging, or membrane stability."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y06",
+      "topic": "Indoor perovskite photovoltaics for battery-free wireless sensor networks",
+      "query": "indoor perovskite photovoltaic wireless sensor power",
+      "roles": {
+        "required": [
+          {
+            "role_id": "perovskite_photovoltaic",
+            "description": "Evidence that the energy harvester is a perovskite photovoltaic device."
+          },
+          {
+            "role_id": "indoor_light",
+            "description": "Evidence that device operation or testing uses indoor or low-intensity light."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "wireless_sensor",
+            "description": "Evidence of powering a wireless sensor, Internet-of-Things node, or similar device."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "conversion_efficiency",
+            "description": "Evidence reporting photovoltaic power-conversion efficiency or delivered power."
+          },
+          {
+            "role_id": "device_stability",
+            "description": "Evidence addressing operational lifetime, encapsulation, or device stability."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y07",
+      "topic": "Cell-free biosynthesis of rare sugars from agricultural residues",
+      "query": "cell free biosynthesis rare sugar agricultural waste",
+      "roles": {
+        "required": [
+          {
+            "role_id": "cell_free_biosynthesis",
+            "description": "Evidence that synthesis uses a cell-free enzyme or lysate system."
+          },
+          {
+            "role_id": "rare_sugar",
+            "description": "Evidence that a rare, uncommon, or specialty sugar is produced."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "agricultural_residue",
+            "description": "Evidence that an agricultural residue or biomass-derived feedstock is used."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "enzyme_cascade",
+            "description": "Evidence of a multi-enzyme cascade or coupled biocatalytic pathway."
+          },
+          {
+            "role_id": "conversion_yield",
+            "description": "Evidence reporting product yield, titre, productivity, or conversion efficiency."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Y08",
+      "topic": "Integrated photonic biosensors for rapid bloodstream infection diagnosis",
+      "query": "integrated photonic biosensor bloodstream infection diagnosis",
+      "roles": {
+        "required": [
+          {
+            "role_id": "integrated_photonics",
+            "description": "Evidence that sensing uses an integrated photonic or on-chip optical platform."
+          },
+          {
+            "role_id": "biosensing",
+            "description": "Evidence of biological detection or biomolecular sensing."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "bloodstream_infection",
+            "description": "Evidence that bloodstream infection, sepsis, or blood-borne pathogens are targeted."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "rapid_detection",
+            "description": "Evidence reporting rapid, real-time, or short-turnaround detection."
+          },
+          {
+            "role_id": "pathogen_identification",
+            "description": "Evidence of identifying, discriminating, or quantifying infectious organisms."
+          }
+        ]
+      }
+    }
+  ],
+  "unseen_cases": [
+    {
+      "case_id": "Z01",
+      "topic": "Electrochemical lithium extraction from geothermal brines using ion-selective electrodes",
+      "query": "electrochemical lithium extraction geothermal brine selective electrode",
+      "roles": {
+        "required": [
+          {
+            "role_id": "electrochemical_lithium_extraction",
+            "description": "Evidence that lithium is recovered through an electrochemical process."
+          },
+          {
+            "role_id": "ion_selective_electrode",
+            "description": "Evidence that an ion-selective electrode or intercalation material provides selectivity."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "geothermal_brine",
+            "description": "Evidence that geothermal brine or a comparable high-salinity brine is treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "lithium_selectivity",
+            "description": "Evidence reporting selectivity against sodium, magnesium, calcium, or competing ions."
+          },
+          {
+            "role_id": "regeneration_or_cycles",
+            "description": "Evidence of electrode regeneration, repeated extraction, or cycle stability."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z02",
+      "topic": "Mycelium-based acoustic insulation panels from agricultural by-products",
+      "query": "mycelium acoustic insulation agricultural waste panel",
+      "roles": {
+        "required": [
+          {
+            "role_id": "mycelium_composite",
+            "description": "Evidence that fungal mycelium forms or binds the composite material."
+          },
+          {
+            "role_id": "acoustic_insulation",
+            "description": "Evidence that sound absorption or acoustic insulation is evaluated."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "agricultural_byproduct",
+            "description": "Evidence that crop residue or another agricultural by-product is the substrate."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "sound_absorption",
+            "description": "Evidence reporting an absorption coefficient or related acoustic performance."
+          },
+          {
+            "role_id": "building_panel",
+            "description": "Evidence of a board, panel, or building-material form factor."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z03",
+      "topic": "Microfluidic organ-on-chip platforms for personalised chemotherapy selection",
+      "query": "microfluidic organ on chip personalized chemotherapy selection",
+      "roles": {
+        "required": [
+          {
+            "role_id": "organ_on_chip",
+            "description": "Evidence that a microphysiological organ-on-chip model is used."
+          },
+          {
+            "role_id": "microfluidic_platform",
+            "description": "Evidence that the model operates in a microfluidic device."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "personalised_chemotherapy",
+            "description": "Evidence that patient-specific chemotherapy response or treatment selection is targeted."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "patient_derived_cells",
+            "description": "Evidence that patient-derived tumour cells, organoids, or biopsies are used."
+          },
+          {
+            "role_id": "drug_response_prediction",
+            "description": "Evidence that the platform measures or predicts response to anticancer drugs."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z04",
+      "topic": "Thermochemical heat storage using salt hydrates for industrial waste-heat recovery",
+      "query": "salt hydrate thermochemical heat storage industrial waste heat",
+      "roles": {
+        "required": [
+          {
+            "role_id": "salt_hydrate",
+            "description": "Evidence that a salt hydrate is the thermochemical storage medium."
+          },
+          {
+            "role_id": "thermochemical_storage",
+            "description": "Evidence of reversible chemical heat storage rather than sensible heat alone."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "industrial_waste_heat",
+            "description": "Evidence that industrial waste heat or process-heat recovery is the application."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "energy_density",
+            "description": "Evidence reporting gravimetric or volumetric storage density."
+          },
+          {
+            "role_id": "cycling_stability",
+            "description": "Evidence of hydration-dehydration cycling, reversibility, or material stability."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z05",
+      "topic": "Bacteriophage-based crop protection against bacterial plant diseases",
+      "query": "bacteriophage crop protection bacterial plant disease",
+      "roles": {
+        "required": [
+          {
+            "role_id": "bacteriophage_therapy",
+            "description": "Evidence that bacteriophages are used to control bacterial infection."
+          },
+          {
+            "role_id": "plant_pathogen",
+            "description": "Evidence that the target is a bacterial pathogen of plants."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "crop_protection",
+            "description": "Evidence of disease management in crops, plants, or agricultural production."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "disease_suppression",
+            "description": "Evidence reporting reduced disease severity, pathogen load, or crop loss."
+          },
+          {
+            "role_id": "field_or_greenhouse",
+            "description": "Evidence from greenhouse, field, or whole-plant testing."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z06",
+      "topic": "Quantum-dot short-wave infrared image sensors for machine vision",
+      "query": "quantum dot short wave infrared image sensor machine vision",
+      "roles": {
+        "required": [
+          {
+            "role_id": "quantum_dot_detector",
+            "description": "Evidence that quantum dots form the active photodetector material."
+          },
+          {
+            "role_id": "short_wave_infrared",
+            "description": "Evidence of detection or imaging in the short-wave infrared spectral range."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "machine_vision",
+            "description": "Evidence of industrial inspection, robotics, autonomous sensing, or machine vision."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "imaging_array",
+            "description": "Evidence of a pixel array, focal-plane array, or imaging demonstration."
+          },
+          {
+            "role_id": "detector_performance",
+            "description": "Evidence reporting detectivity, responsivity, noise, speed, or spectral response."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z07",
+      "topic": "Electrospun nanofibre membranes for lithium-ion battery separator safety",
+      "query": "electrospun nanofiber membrane lithium ion battery separator safety",
+      "roles": {
+        "required": [
+          {
+            "role_id": "electrospun_nanofibre",
+            "description": "Evidence that the membrane is fabricated using electrospun nanofibres."
+          },
+          {
+            "role_id": "battery_separator",
+            "description": "Evidence that the membrane functions as a lithium-ion battery separator."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "battery_safety",
+            "description": "Evidence addressing thermal, mechanical, shutdown, or fire safety."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "thermal_stability",
+            "description": "Evidence reporting heat resistance, shrinkage, or dimensional stability."
+          },
+          {
+            "role_id": "electrochemical_performance",
+            "description": "Evidence reporting ionic conductivity, cycling, rate capability, or cell performance."
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "Z08",
+      "topic": "Methane-oxidising biocatalysts for greenhouse-gas-to-protein conversion",
+      "query": "methane oxidizing biocatalyst methane to protein conversion",
+      "roles": {
+        "required": [
+          {
+            "role_id": "methane_oxidation",
+            "description": "Evidence that methane is biologically oxidised or assimilated."
+          },
+          {
+            "role_id": "protein_product",
+            "description": "Evidence that microbial protein, single-cell protein, or protein-rich biomass is produced."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "greenhouse_gas_feedstock",
+            "description": "Evidence that methane is treated as a greenhouse-gas or waste-gas feedstock."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "methanotroph",
+            "description": "Evidence involving methane-oxidising microorganisms or methanotrophs."
+          },
+          {
+            "role_id": "protein_yield_or_quality",
+            "description": "Evidence reporting biomass yield, productivity, amino-acid profile, or nutritional quality."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_openalex_role_slot.py
+++ b/tests/test_openalex_role_slot.py
@@ -1,0 +1,535 @@
+"""Zero-network seams for candidate-local role-slot consensus v6."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from academic_agent.openalex_claim_scope import (
+    OpenAlexAboutnessSignal,
+    OpenAlexClaimScopeCandidate,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetRoleProfile,
+    EvidenceSetSelectionContract,
+)
+from academic_agent.openalex_role_slot import (
+    RoleSlotCaseAudit,
+    build_role_slot_inputs,
+    build_role_slot_prompts,
+    evaluate_role_slot_case,
+    parse_role_slot_pass,
+)
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_TOPIC = (
+    "Lignin-derived carbon fibres for recyclable automotive structural "
+    "composites"
+)
+
+
+def _profile() -> EvidenceSetRoleProfile:
+    return EvidenceSetRoleProfile.model_validate(
+        {
+            "required_roles": [
+                {
+                    "role_id": "lignin_precursor",
+                    "description": "lignin used as the material precursor or feedstock",
+                },
+                {
+                    "role_id": "carbon_fibre",
+                    "description": "production or evaluation of carbon fibre materials",
+                },
+            ],
+            "scope_roles": [
+                {
+                    "role_id": "automotive_composite",
+                    "description": "an automotive or structural composite application",
+                }
+            ],
+            "supporting_roles": [
+                {
+                    "role_id": "mechanical_performance",
+                    "description": "strength, modulus, toughness, or mechanical performance",
+                },
+                {
+                    "role_id": "recyclable_composite",
+                    "description": "recycling, reuse, or circularity of the composite",
+                },
+            ],
+        }
+    )
+
+
+def _contract(**overrides: object) -> EvidenceSetSelectionContract:
+    payload = {
+        "required_roles_covered": "all",
+        "minimum_scope_roles": 1,
+        "minimum_supporting_roles": 1,
+        "maximum_selected_sources_per_case": 3,
+        "minimum_candidate_required_roles": 1,
+        "minimum_candidate_context_roles": 1,
+        "minimum_candidate_title_anchor_roles": 1,
+    }
+    payload.update(overrides)
+    return EvidenceSetSelectionContract.model_validate(payload)
+
+
+def _candidate(index: int, *, title: str, abstract: str) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=title,
+            url=f"https://openalex.org/W46000000{index}",
+            publisher="Frozen Test Journal",
+            evidence_summary=abstract,
+            summary_source="abstract",
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+def _lignin_candidate(index: int = 0) -> OpenAlexClaimScopeCandidate:
+    return _candidate(
+        index,
+        title="Lignin-derived precursor for automotive composites",
+        abstract=(
+            "The lignin feedstock formed a structural automotive composite "
+            "with high tensile strength."
+        ),
+    )
+
+
+def _fibre_candidate(index: int = 1) -> OpenAlexClaimScopeCandidate:
+    return _candidate(
+        index,
+        title="Carbon fibre with recyclable composite performance",
+        abstract=(
+            "The carbon fibre retained modulus after composite recycling and "
+            "reuse."
+        ),
+    )
+
+
+def _assignments() -> dict[str, dict[str, tuple[str, str]]]:
+    lignin = _lignin_candidate()
+    fibre = _fibre_candidate()
+    return {
+        lignin.sha256(): {
+            "lignin_precursor": ("title", "Lignin-derived precursor"),
+            "automotive_composite": ("title", "automotive composites"),
+            "mechanical_performance": ("abstract", "high tensile strength"),
+        },
+        fibre.sha256(): {
+            "carbon_fibre": ("title", "Carbon fibre"),
+            "recyclable_composite": (
+                "title",
+                "recyclable composite performance",
+            ),
+        },
+    }
+
+
+def _raw_response(
+    batch,
+    assignments: dict[str, dict[str, tuple[str, str]]],
+) -> str:
+    rows = []
+    for candidate in batch.candidates:
+        candidate_assignments = assignments.get(candidate.candidate_sha256, {})
+        slots = []
+        for role in batch.roles:
+            evidence = candidate_assignments.get(role.role_id)
+            slots.append(
+                {
+                    "slot_index": role.slot_index,
+                    "state": "ABSTAIN" if evidence is None else "SUPPORTED",
+                    "field": None if evidence is None else evidence[0],
+                    "quote": None if evidence is None else evidence[1],
+                }
+            )
+        rows.append(
+            {
+                "candidate_sha256": candidate.candidate_sha256,
+                "slots": slots,
+            }
+        )
+    return json.dumps(
+        {"case_id": batch.case_id, "candidates": rows},
+        ensure_ascii=True,
+    )
+
+
+def _responses(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+    assignments_by_pass: tuple[
+        dict[str, dict[str, tuple[str, str]]],
+        dict[str, dict[str, tuple[str, str]]],
+        dict[str, dict[str, tuple[str, str]]],
+    ]
+    | None = None,
+) -> tuple[str, str, str]:
+    inputs = build_role_slot_inputs(
+        case_id="Y01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=candidates,
+    )
+    chosen = assignments_by_pass or (
+        _assignments(),
+        _assignments(),
+        _assignments(),
+    )
+    return tuple(
+        _raw_response(batch, assignments)
+        for batch, assignments in zip(inputs, chosen, strict=True)
+    )
+
+
+def _evaluate(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+    raw_responses: tuple[str, str, str] | None = None,
+    *,
+    contract: EvidenceSetSelectionContract | None = None,
+) -> RoleSlotCaseAudit:
+    return evaluate_role_slot_case(
+        case_id="Y01",
+        topic=_TOPIC,
+        profile=_profile(),
+        selection_contract=contract or _contract(),
+        candidates=candidates,
+        raw_responses=raw_responses or _responses(candidates),
+    )
+
+
+def _payloads(
+    candidates: tuple[OpenAlexClaimScopeCandidate, ...],
+) -> tuple[dict, dict, dict]:
+    return tuple(json.loads(item) for item in _responses(candidates))
+
+
+def _row(payload: dict, candidate_sha256: str) -> dict:
+    return next(
+        item
+        for item in payload["candidates"]
+        if item["candidate_sha256"] == candidate_sha256
+    )
+
+
+def test_inputs_send_three_orders_and_hide_provider_metadata_and_role_ids():
+    signal = OpenAlexAboutnessSignal(
+        kind="topic",
+        provider_id="https://openalex.org/T999",
+        display_name="Secret provider topic",
+        score=0.99,
+    )
+    first_candidate = _lignin_candidate()
+    second_candidate = _fibre_candidate()
+    second_candidate = second_candidate.model_copy(update={"aboutness": (signal,)})
+
+    inputs = build_role_slot_inputs(
+        case_id="Y01",
+        topic=_TOPIC,
+        profile=_profile(),
+        candidates=(second_candidate, first_candidate),
+    )
+
+    provider_order = tuple(item.candidate_sha256 for item in inputs[0].candidates)
+    assert tuple(item.pass_number for item in inputs) == (1, 2, 3)
+    assert tuple(item.candidate_sha256 for item in inputs[1].candidates) == tuple(
+        reversed(provider_order)
+    )
+    assert tuple(item.candidate_sha256 for item in inputs[2].candidates) == tuple(
+        sorted(provider_order)
+    )
+    system_prompt, user_prompt = build_role_slot_prompts(inputs[0])
+    assert "Secret provider topic" not in user_prompt
+    assert "https://openalex.org" not in user_prompt
+    assert "lignin_precursor" not in user_prompt
+    assert '"action"' not in user_prompt
+    assert "Do not decide source" in system_prompt
+    assert "admission" in system_prompt
+
+
+def test_three_valid_passes_select_a_complementary_evidence_set():
+    result = _evaluate((_fibre_candidate(), _lignin_candidate()))
+
+    assert result.action == "SELECT"
+    assert [item.provider_result_index for item in result.selected_sources] == [0, 1]
+    assert result.local_valid_row_rate == 1.0
+    assert result.provisional_disposition_unanimity == 1.0
+    assert all(len(item.role_consensus) == 5 for item in result.candidate_decisions)
+    assert result.production_connected is False
+    assert result.report_workflow_connected is False
+    assert result.planner_trigger_connected is False
+
+
+def test_one_malformed_candidate_row_does_not_erase_a_valid_neighbour():
+    candidates = (_lignin_candidate(), _fibre_candidate())
+    payloads = _payloads(candidates)
+    broken = _row(payloads[0], _fibre_candidate().sha256())
+    # v5 failed the complete pass for this class of local schema error.  v6
+    # rejects the row because the model has no authority to emit an action,
+    # while preserving the neighbouring candidate and the later two passes.
+    broken["action"] = "KEEP"
+    raw = tuple(json.dumps(item) for item in payloads)
+
+    result = _evaluate(candidates, raw)
+
+    first_by_id = {
+        item.candidate_sha256: item for item in result.passes[0].candidate_rows
+    }
+    assert first_by_id[_lignin_candidate().sha256()].row_state == "valid"
+    assert first_by_id[_fibre_candidate().sha256()].row_state == "malformed"
+    assert result.local_valid_row_numerator == 5
+    assert result.action == "SELECT"
+    assert len(result.selected_sources) == 2
+
+
+def test_one_malformed_slot_preserves_other_slots_in_the_same_row():
+    candidates = (_lignin_candidate(), _fibre_candidate())
+    payloads = _payloads(candidates)
+    lignin_row = _row(payloads[0], _lignin_candidate().sha256())
+    lignin_row["slots"][3]["unexpected"] = "not allowed"
+    raw = tuple(json.dumps(item) for item in payloads)
+
+    result = _evaluate(candidates, raw)
+
+    first_lignin = next(
+        item
+        for item in result.passes[0].candidate_rows
+        if item.candidate_sha256 == _lignin_candidate().sha256()
+    )
+    assert first_lignin.row_state == "partial"
+    assert first_lignin.slots[0].state == "supported"
+    assert first_lignin.slots[3].state == "malformed"
+    assert result.action == "SELECT"
+
+
+def test_invented_quotes_never_authorize_a_role():
+    candidate = _lignin_candidate()
+    payloads = _payloads((candidate,))
+    for payload in payloads:
+        row = _row(payload, candidate.sha256())
+        row["slots"][0]["quote"] = "invented lignin pilot result"
+    raw = tuple(json.dumps(item) for item in payloads)
+
+    result = _evaluate((candidate,), raw)
+
+    role = result.candidate_decisions[0].role_consensus[0]
+    assert role.support_count == 0
+    assert role.consensus_supported is False
+    assert all(item.state == "invalid_quote" for item in role.observations)
+    assert result.action == "ABSTAIN"
+
+
+def test_one_pass_support_is_visible_but_cannot_authorize_a_role():
+    candidate = _lignin_candidate()
+    supported = _assignments()
+    empty = {candidate.sha256(): {}}
+    raw = _responses((candidate,), (supported, empty, empty))
+
+    result = _evaluate((candidate,), raw)
+
+    role = result.candidate_decisions[0].role_consensus[0]
+    assert role.support_count == 1
+    assert role.consensus_supported is False
+    assert result.action == "ABSTAIN"
+
+
+def test_two_different_exact_quotes_can_form_role_consensus():
+    candidate = _lignin_candidate()
+    first = {
+        candidate.sha256(): {
+            "lignin_precursor": ("title", "Lignin-derived precursor"),
+            "automotive_composite": ("title", "automotive composites"),
+        }
+    }
+    second = {
+        candidate.sha256(): {
+            "lignin_precursor": ("abstract", "lignin feedstock"),
+            "automotive_composite": ("title", "automotive composites"),
+        }
+    }
+    third = {candidate.sha256(): {}}
+
+    result = _evaluate((candidate,), _responses((candidate,), (first, second, third)))
+
+    lignin = result.candidate_decisions[0].role_consensus[0]
+    assert lignin.support_count == 2
+    assert lignin.consensus_supported is True
+    assert {item.quote for item in lignin.observations if item.quote} == {
+        "Lignin-derived precursor",
+        "lignin feedstock",
+    }
+
+
+def test_one_top_level_failure_can_be_audited_without_hiding_two_valid_passes():
+    candidates = (_lignin_candidate(), _fibre_candidate())
+    raw = _responses(candidates)
+    raw = ("not-json", raw[1], raw[2])
+
+    result = _evaluate(candidates, raw)
+
+    assert result.passes[0].state == "malformed"
+    assert result.passes[0].error_code == "json_invalid"
+    assert all(
+        item.row_state == "pass_unavailable"
+        for item in result.passes[0].candidate_rows
+    )
+    assert result.action == "SELECT"
+    assert result.local_valid_row_numerator == 4
+
+
+def test_unknown_and_duplicate_candidate_rows_are_explicit_and_local():
+    candidates = (_lignin_candidate(), _fibre_candidate())
+    payloads = _payloads(candidates)
+    duplicate = deepcopy(_row(payloads[0], _lignin_candidate().sha256()))
+    unknown = deepcopy(_row(payloads[0], _fibre_candidate().sha256()))
+    unknown["candidate_sha256"] = "f" * 64
+    payloads[0]["candidates"].extend([duplicate, unknown, {"bad": "row"}])
+
+    audit = parse_role_slot_pass(
+        json.dumps(payloads[0]),
+        build_role_slot_inputs(
+            case_id="Y01",
+            topic=_TOPIC,
+            profile=_profile(),
+            candidates=candidates,
+        )[0],
+        _contract(),
+    )
+
+    rows = {item.candidate_sha256: item for item in audit.candidate_rows}
+    assert rows[_lignin_candidate().sha256()].row_state == "duplicate"
+    assert rows[_fibre_candidate().sha256()].row_state == "valid"
+    assert audit.unknown_candidate_sha256s == ("f" * 64,)
+    assert audit.malformed_unidentified_row_count == 1
+
+
+def test_duplicate_and_out_of_order_slots_cannot_authorize_the_affected_roles():
+    candidate = _lignin_candidate()
+    payloads = _payloads((candidate,))
+    row = _row(payloads[0], candidate.sha256())
+    row["slots"].append(deepcopy(row["slots"][0]))
+    row["slots"][1], row["slots"][2] = row["slots"][2], row["slots"][1]
+
+    audit = parse_role_slot_pass(
+        json.dumps(payloads[0]),
+        build_role_slot_inputs(
+            case_id="Y01",
+            topic=_TOPIC,
+            profile=_profile(),
+            candidates=(candidate,),
+        )[0],
+        _contract(),
+    )
+
+    candidate_row = audit.candidate_rows[0]
+    assert candidate_row.row_state == "partial"
+    assert candidate_row.slots[0].state == "duplicate"
+    assert candidate_row.slots[1].state == "order_mismatch"
+    assert candidate_row.slots[2].state == "order_mismatch"
+
+
+def test_unknown_extra_slot_is_counted_without_erasing_expected_slots():
+    candidate = _lignin_candidate()
+    payloads = _payloads((candidate,))
+    row = _row(payloads[0], candidate.sha256())
+    row["slots"].append(
+        {
+            "slot_index": 99,
+            "state": "ABSTAIN",
+            "field": None,
+            "quote": None,
+        }
+    )
+
+    audit = parse_role_slot_pass(
+        json.dumps(payloads[0]),
+        build_role_slot_inputs(
+            case_id="Y01",
+            topic=_TOPIC,
+            profile=_profile(),
+            candidates=(candidate,),
+        )[0],
+        _contract(),
+    )
+
+    candidate_row = audit.candidate_rows[0]
+    assert candidate_row.row_state == "partial"
+    assert candidate_row.unknown_slot_count == 1
+    assert candidate_row.slots[0].state == "supported"
+
+
+def test_serialization_cannot_drop_a_computed_selected_role():
+    result = _evaluate((_lignin_candidate(), _fibre_candidate()))
+    payload = result.model_dump(mode="json")
+    payload["selected_sources"][0]["role_ids"].pop()
+
+    with pytest.raises(
+        ValidationError,
+        match="deliver every deterministic KEEP role",
+    ):
+        RoleSlotCaseAudit.model_validate(payload)
+
+
+def test_three_source_ceiling_abstains_when_four_sources_are_required():
+    profile_payload = _profile().model_dump(mode="json")
+    profile_payload["required_roles"].extend(
+        [
+            {"role_id": "required_three", "description": "third required role"},
+            {"role_id": "required_four", "description": "fourth required role"},
+        ]
+    )
+    profile = EvidenceSetRoleProfile.model_validate(profile_payload)
+    candidates = tuple(
+        _candidate(
+            index,
+            title=f"Role source {index} with title evidence",
+            abstract="A distinct context measurement supports this source.",
+        )
+        for index in range(4)
+    )
+    required_ids = tuple(role.role_id for role in profile.required_roles)
+    assignments = {
+        candidate.sha256(): {
+            required_ids[index]: ("title", f"Role source {index}"),
+            "mechanical_performance": ("abstract", "context measurement"),
+        }
+        for index, candidate in enumerate(candidates)
+    }
+    inputs = build_role_slot_inputs(
+        case_id="Y01",
+        topic=_TOPIC,
+        profile=profile,
+        candidates=candidates,
+    )
+    raw = tuple(_raw_response(item, assignments) for item in inputs)
+
+    result = evaluate_role_slot_case(
+        case_id="Y01",
+        topic=_TOPIC,
+        profile=profile,
+        selection_contract=_contract(),
+        candidates=candidates,
+        raw_responses=raw,
+    )
+
+    assert all(item.action == "KEEP" for item in result.candidate_decisions)
+    assert result.action == "ABSTAIN"
+    assert result.abstention_reasons == ("no_covering_set",)
+
+
+def test_production_entrypoints_do_not_import_v6():
+    for path in (
+        _ROOT / "src" / "academic_agent" / "pipeline_worker.py",
+        _ROOT / "api" / "main.py",
+    ):
+        assert "openalex_role_slot" not in path.read_text(encoding="utf-8")

--- a/tests/test_openalex_role_slot_unseen.py
+++ b/tests/test_openalex_role_slot_unseen.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import date
 import json
 import socket
 from pathlib import Path
 
 import pytest
 
+import academic_agent.evidence as evidence_module
 import openalex_role_slot_unseen as unseen
 
 
@@ -69,6 +71,23 @@ def test_development_dry_run_expands_all_identities_without_live_authority():
     assert result["production_connected"] is False
     assert result["report_workflow_connected"] is False
     assert result["planner_trigger_connected"] is False
+
+
+def test_frozen_preflight_is_valid_on_the_earlier_utc_calendar_date(monkeypatch):
+    """A Sydney freeze must not become future-dated on the UTC CI runner."""
+
+    class FrozenUtcDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 8, 31)
+
+    # Patch the validator clock, not the preflight constant.  This recreates
+    # the client boundary that failed after local Sydney tests had passed.
+    monkeypatch.setattr(evidence_module, "date", FrozenUtcDate)
+
+    result = unseen.dry_run("development")
+
+    assert result["case_count"] == 8
 
 
 def test_unseen_cohort_has_distinct_frozen_identities_but_no_live_authority():

--- a/tests/test_openalex_role_slot_unseen.py
+++ b/tests/test_openalex_role_slot_unseen.py
@@ -1,0 +1,199 @@
+"""Zero-network seams for the frozen role-slot consensus v6 preflight."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+import openalex_role_slot_unseen as unseen
+
+
+def test_development_dry_run_expands_all_identities_without_live_authority():
+    result = unseen.dry_run("development")
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [item["case_id"] for item in result["cases"]] == [
+        f"Y{index:02d}" for index in range(1, 9)
+    ]
+    for key in (
+        "case_spec_sha256",
+        "collection_sha256",
+        "plan_sha256",
+        "profile_sha256",
+        "case_contract_sha256",
+        "provider_idempotency_key",
+    ):
+        assert len({item[key] for item in result["cases"]}) == 8
+    template_ids = [
+        identity
+        for item in result["cases"]
+        for identity in item["judge_request_template_sha256s"]
+    ]
+    assert len(template_ids) == 24
+    assert len(set(template_ids)) == 24
+    assert {item["result_limit"] for item in result["cases"]} == {8}
+    assert result["maximum_search_request_count"] == 8
+    assert result["maximum_judge_call_count"] == 24
+    assert result["provider_contract"] == {
+        "provider": "anonymous_openalex",
+        "requests_per_case": 1,
+        "result_limit": 8,
+        "require_abstract": True,
+        "allow_redirects": False,
+        "allow_retries": False,
+    }
+    assert result["judge_contract"] == {
+        "provider": "qwen",
+        "model": "qwen3.5-plus",
+        "passes_per_case": 3,
+        "candidate_orders": [
+            "provider_order",
+            "reverse_provider_order",
+            "candidate_sha256_order",
+        ],
+        "temperature": 0.0,
+        "allow_retries": False,
+        "allow_repair": False,
+        "allow_fallback": False,
+        "minimum_verified_passes_per_role": 2,
+    }
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["private_labels_opened"] is False
+    assert result["live_provider_requests_authorized"] is False
+    assert result["live_model_calls_authorized"] is False
+    assert result["production_connected"] is False
+    assert result["report_workflow_connected"] is False
+    assert result["planner_trigger_connected"] is False
+
+
+def test_unseen_cohort_has_distinct_frozen_identities_but_no_live_authority():
+    development = unseen.dry_run("development")
+    challenge = unseen.dry_run("unseen")
+
+    assert [item["case_id"] for item in challenge["cases"]] == [
+        f"Z{index:02d}" for index in range(1, 9)
+    ]
+    assert {
+        item["case_contract_sha256"] for item in development["cases"]
+    }.isdisjoint(
+        item["case_contract_sha256"] for item in challenge["cases"]
+    )
+    assert challenge["real_network_calls_performed"] is False
+    assert challenge["real_model_calls_performed"] is False
+    assert challenge["live_provider_requests_authorized"] is False
+    assert challenge["live_model_calls_authorized"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path, monkeypatch):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    def must_not_expand(*args, **kwargs):
+        raise AssertionError("case expansion ran before the raw hash check")
+
+    monkeypatch.setattr(unseen, "build_case", must_not_expand)
+    with pytest.raises(
+        unseen.OpenAlexRoleSlotPreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases("development", fixture)
+
+
+def test_case_order_drift_is_rejected_with_a_matching_test_hash(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0], payload["development_cases"][1] = (
+        payload["development_cases"][1],
+        payload["development_cases"][0],
+    )
+    fixture = tmp_path / "reordered.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="Y01 through Y08"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_judge_order_or_call_count_drift_fails_closed(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["judge_contract"]["candidate_orders"][2] = "provider_order"
+    fixture = tmp_path / "judge-drift.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="judge pass orders drifted"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_role_drift_changes_role_bound_identities_but_not_provider_plan(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["roles"]["scope"][0][
+        "description"
+    ] += " under documented end-of-life conditions"
+    fixture = tmp_path / "role-drift.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    fixture_hash = unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+    original = unseen.dry_run("development")
+    drifted = unseen.dry_run(
+        "development",
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+
+    assert drifted["cases"][0]["profile_sha256"] != (
+        original["cases"][0]["profile_sha256"]
+    )
+    assert drifted["cases"][0]["case_contract_sha256"] != (
+        original["cases"][0]["case_contract_sha256"]
+    )
+    assert drifted["cases"][0]["judge_request_template_sha256s"] != (
+        original["cases"][0]["judge_request_template_sha256s"]
+    )
+    assert drifted["cases"][0]["plan_sha256"] == (
+        original["cases"][0]["plan_sha256"]
+    )
+
+
+def test_dry_run_opens_no_socket_even_when_socket_creation_is_blocked(monkeypatch):
+    def block_socket(*args, **kwargs):
+        raise AssertionError("preflight attempted to create a socket")
+
+    monkeypatch.setattr(socket, "socket", block_socket)
+
+    result = unseen.dry_run("development")
+
+    assert result["case_count"] == 8
+    assert result["real_network_calls_performed"] is False
+
+
+def test_preflight_imports_no_provider_model_or_execution_client():
+    source = Path("openalex_role_slot_unseen.py").read_text(encoding="utf-8")
+
+    assert "anonymous_openalex_search" not in source
+    assert "qwen_evidence_judge" not in source
+    assert "execute_gap_plan" not in source
+    assert "litellm" not in source
+    assert "crewai" not in source
+    assert "urllib" not in source


### PR DESCRIPTION
## Summary

- pre-register fresh Y01-Y08 development and Z01-Z08 unseen identities without reopening W or X
- replace model-owned actions and role identifiers with candidate-local fixed role slots and exact source quotes
- derive two-of-three consensus, candidate admission, and a maximum-three-source set cover deterministically in Python
- add a zero-network identity preflight, 23 focused tests, three defect re-injections, and synchronized public documentation

## Verification

- full zero-network suite -> 1,821 passed + 657 subtests
- focused v6 suite -> 23 passed
- CI-matched local coverage -> 87.83%, above the 85% floor
- latest Ruff and the narrow CI Pylint gate -> passed
- development and unseen dry runs each expose 8 provider and 24 judge-template identities with network/model/labels/production all false
- GitHub Actions on `10351fe` -> Linux/Windows Python matrix, coverage, lint, Chromium smoke, and Docker all passed

## Cross-zone regression

The first CI run correctly rejected a Sydney `2026-09-01` synthetic access date while runners were still on UTC `2026-08-31`. The production future-date validator remains strict; the deterministic seed now uses the latest date elapsed in both environments. Re-injecting the later date makes the new clock-boundary test fail with the original Pydantic error.

## Boundaries

This PR adds no live runner, provider/model adapter, paid request, private-label read, report connection, planner trigger, or production Tool Calling authorization. Y and Z remain unused.