### PR TITLE
Implement the disconnected role-slot v6 development runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1821 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1837 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -158,6 +158,8 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
                         quote-grounded two-pass set selector; experimental only
   openalex_role_slot.py
                         candidate-local three-pass role-slot consensus; experimental only
+  tools/qwen_role_slot_judge.py
+                        strict one-request Qwen v6 judge; never production imported
   tools/evidence_search.py
                         one-request read-only adapter response contract
   tools/anonymous_openalex_search.py
@@ -173,7 +175,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  102 test modules plus conftest, organised by subject
+tests/                  105 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -219,6 +221,8 @@ openalex_scope_link_abstention_review.py
                         post-outcome W01-W08 label-blind diagnostic; zero-network
 openalex_role_slot_unseen.py
                         frozen Y/Z role-slot identity preflight; zero-network only
+openalex_role_slot_development.py
+                        write-once Y runner; CLI defaults to zero-network dry-run
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -556,28 +560,45 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   and
   `docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md`.
   See docs/prereg-2026-08-29-openalex-evidence-set-v5.md,
-  A separately pre-registered candidate-local role-slot consensus v6 now starts
-  from new Y01-Y08 development and Z01-Z08 unseen identities; W stays consumed
-  and X stays unopened. The model no longer owns candidate actions or role IDs.
-  It can only fill fixed positional `SUPPORTED`/`ABSTAIN` role slots with exact
-  title-or-abstract quotes. Malformed candidate rows and slots are contained
-  locally, three deterministic candidate orders require two mechanically
-  verified observations per role, and Python alone derives candidate admission
-  plus a maximum-three-source set cover. The zero-network kernel and preflight
-  pass 23/23 focused tests and expand eight provider request identities plus 24
-  judge-template identities per cohort. Three protocol defects were re-injected:
-  whole-batch invalidation erased a valid neighbour, dropping computed supporting
-  roles broke the serialized audit boundary, and the later Sydney calendar date
-  made the same deterministic preflight invalid on the earlier UTC CI date. All
-  three tests failed before the correct implementations were restored. The full
-  zero-network suite passes 1821 tests plus 657 subtests. This phase has no live runner,
-  provider/model adapter, private-label read, OpenAlex or model request, paid
-  call, or production connection. Y01-Y08 and Z01-Z08 therefore remain unused.
-  Implementing a disconnected runner and exact provider contract is a separate
-  later phase; it must preserve the frozen identities and cannot imply semantic
-  validation. See
-  `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md` and
-  `docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md`.
+  A separately pre-registered candidate-local role-slot consensus v6 starts from
+  new Y01-Y08 development and Z01-Z08 unseen identities; W stays consumed and X
+  stays unopened. The model no longer owns candidate actions or role IDs. It can
+  only fill fixed positional `SUPPORTED`/`ABSTAIN` role slots with exact title-
+  or-abstract quotes. Malformed candidate rows and slots are contained locally,
+  three deterministic candidate orders require two mechanically verified
+  observations per role, and Python alone derives candidate admission plus a
+  maximum-three-source set cover.
+
+  The production-disconnected Y development runner and exact
+  `qwen3.5-plus` one-request adapter are now implemented. A global manifest
+  freezes eight OpenAlex request identities, 24 judge-template identities and
+  12 transitive implementation hashes before client construction. Because exact
+  prompts depend on provider-returned source text, each provider journal and its
+  derived three-request model plan are durable before Qwen construction or a
+  model call. OpenAlex and Qwen have separate request ceilings, soft stops, cost
+  states and write-once journals. No candidate means no model client; a paid
+  malformed semantic object becomes an explicit unavailable pass without repair;
+  any uninspectable potentially spending call cannot become zero cost. Every
+  provider row, model request, candidate row and fixed role slot reaches the final
+  serialized boundary.
+
+  The combined v6 kernel/preflight/adapter/runner subset passes 39/39 tests; the
+  new runner/adapter subset passes 16/16, and the full zero-network suite passes
+  1837 tests plus 657 subtests. Moving manifest persistence after adapter
+  construction and dropping Y08 only from the final aggregate were each
+  re-injected and made their exact seam tests fail before restoration. The
+  default CLI remains zero-network dry-run, `pipeline_worker.py` imports none of
+  v6, and this phase made no OpenAlex or Qwen request, paid call, label read or
+  production connection. Y01-Y08 and Z01-Y08 therefore remain unused. A live Y
+  attempt requires a separate authorization naming an exact merged revision,
+  request ceilings and provider-specific cost stops; Z remains unavailable until
+  every frozen Y gate passes. See
+  `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md`,
+  `docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md`,
+  `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md`,
+  `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-runner-identity-clarification.md`
+  and
+  `docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -828,23 +828,38 @@ disconnected. See the
 [diagnostic plan](docs/prereg-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md)
 and [aggregate result](docs/results-2026-08-31-openalex-evidence-set-v5-qwen-failure-diagnostic.md).
 
-A separately pre-registered **candidate-local role-slot consensus v6** now
-starts from new Y01-Y08 development and Z01-Z08 unseen identities rather than
+A separately pre-registered **candidate-local role-slot consensus v6** starts
+from new Y01-Y08 development and Z01-Z08 unseen identities rather than
 replaying W or opening X. The model has no candidate-action field and cannot
 emit role IDs: it may only fill fixed `SUPPORTED`/`ABSTAIN` slots with exact
 title-or-abstract quotes. Three candidate orders require two mechanically
 verified observations per role; malformed candidates and slots are isolated
 locally, while deterministic Python derives admission and a three-source
-maximum set cover. The zero-network kernel and preflight pass 23/23 focused
-tests and expose 8 provider plus 24 judge-template identities per cohort. Three
-re-injected defects proved that a bad row cannot erase a neighbour, a computed
-role cannot disappear at serialization, and a Sydney freeze remains valid on
-the earlier UTC calendar date. No runner, provider/model adapter, live request,
-private-label read or production connection is included
-yet. See the [v6 pre-registration](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)
-and [offline implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md).
+maximum set cover.
 
-Local verification now passes **1,821 tests plus 657 subtests**, latest Ruff,
+The production-disconnected Y runner and exact `qwen3.5-plus` one-request
+adapter are now implemented. A global write-once manifest freezes 8 OpenAlex
+request identities, 24 judge-template identities and 12 transitive code hashes
+before client construction. Each provider journal and its three exact derived
+model requests are durable before Qwen construction or a model call. Separate
+OpenAlex/Qwen request ceilings, cost states and journals prevent a potentially
+spending uninspectable request from becoming zero cost. Empty provider results
+make no model call, and a paid malformed semantic response becomes an explicit
+unavailable pass without repair. Every provider row, model request, candidate
+row and fixed role slot reaches the final artifact boundary.
+
+The combined v6 subset passes 39/39 focused tests and the new runner/adapter
+subset passes 16/16. Two additional re-injections proved that the manifest must
+precede client construction and that a correctly computed Y08 audit cannot be
+dropped only at the aggregate client artifact. The default CLI remains a
+zero-network dry-run; no live request, private-label read, paid call or
+production connection occurred, so Y01-Y08 and Z01-Z08 remain unused. See the
+[v6 pre-registration](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md),
+[offline implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md),
+[runner amendment](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md)
+and [runner implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md).
+
+Local verification now passes **1,837 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2068,15 +2083,28 @@ v5：未执行 repair，X01–X08 保持未打开，生产仍断开。详见
 也不能输出 role ID；它只能为固定位置槽位返回 `SUPPORTED`/`ABSTAIN` 和
 标题或摘要原文引文。三种候选顺序要求每个角色至少获得 2 次机械验证支持；
 错误候选行和槽位只在本地隔离，候选准入与最多三来源的集合覆盖完全由 Python
-确定。零网络内核与预检通过 23/23 个定向测试，每个 cohort 展开 8 个供应商
-请求身份和 24 个 Judge 模板身份；三次缺陷回注分别证明坏行不能拖垮相邻行、
-已计算角色不能在序列化时丢失，且悉尼冻结日期在前一日 UTC 环境仍然合法。
-当前尚未实现 runner 与供应商/模型适配层，没有真实请求、私有标签读取或
-生产连接。详见
-[v6 预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)与
-[离线实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md)。
+确定。
 
-本地验证现通过 **1,821 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+生产隔离的 Y 开发运行器与精确 `qwen3.5-plus` 单请求适配器现已实现。全局
+write-once manifest 会在客户端构造前冻结 8 个 OpenAlex 请求身份、24 个 Judge
+模板身份和 12 个传递依赖代码哈希；每个供应商日志与该案例派生出的 3 个精确
+模型请求也会在 Qwen 客户端构造或调用前落盘。OpenAlex 与 Qwen 分别维护请求
+上限、成本状态和日志，任何可能产生费用但不可审计的请求都不能被显示为零成本。
+空检索结果不会构造模型客户端；已付费但语义 JSON 损坏的响应会成为明确的
+不可用 pass，不做 repair。所有供应商行、模型请求、候选行和固定角色槽位均会
+到达最终客户端工件。
+
+v6 内核、预检、适配器与运行器合计通过 39/39 个定向测试，其中新增运行器与
+适配器为 16/16。两次新增缺陷回注证明 manifest 必须先于客户端构造，且内部
+正确计算并写入单案文件的 Y08 不能只在最终聚合中消失。默认 CLI 仍为零网络
+dry-run；本阶段没有真实请求、私有标签读取、付费调用或生产连接，因此
+Y01–Y08 与 Z01–Z08 仍未使用。详见
+[v6 预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)、
+[离线实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md)、
+[运行器补充预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md)
+与[运行器实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md)。
+
+本地验证现通过 **1,837 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md
+++ b/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md
@@ -1,0 +1,245 @@
+# Pre-registration amendment: role-slot consensus v6 development runner
+
+**Frozen:** 2026-09-01, on top of phase-one revision
+`10351fef80090e9a8bf8ed88ee8240698f9939d2`, before implementing the runner
+or its model adapter, constructing a provider client, opening a private label,
+or sending any Y01-Y08 or Z01-Z08 request.
+
+**Parent method:**
+[`prereg-2026-09-01-openalex-role-slot-consensus-v6.md`](prereg-2026-09-01-openalex-role-slot-consensus-v6.md)
+
+**Challenge fixture:**
+`tests/fixtures/openalex_role_slot_v6_challenge.json`
+
+**Raw fixture SHA-256:**
+`f07c457f81fc5b198cb180874895410a4502b9fe3558c9e21c8b42a1f8240c85`
+
+**Production connection authorized:** no
+
+**Live provider or model calls authorized:** no. This amendment authorizes
+only a zero-network runner, adapter and artifact implementation. A later paid
+Y01-Y08 run requires a separate user authorization naming the exact merged
+revision, provider, model, request ceilings and cost stops. Z01-Z08 remain
+unavailable until every frozen Y gate passes.
+
+## Why this phase is separate
+
+The phase-one implementation proved that a malformed candidate row can be
+contained locally, exact quotes can be checked mechanically, three pass orders
+can be joined deterministically, and every computed role can reach one case
+audit. It deliberately imported no provider or model adapter. That result
+therefore did not prove the more dangerous paid-call boundaries:
+
+- the frozen method is durable before a credential or network client exists;
+- one adapter invocation equals one potentially billable request;
+- every spent request and its accounting are durable before a later request;
+- every OpenAlex row, model pass, candidate row and role slot reaches a final
+  artifact even when a neighbouring value is malformed; and
+- an interrupted or uninspectable call cannot be reported as free or passed.
+
+The historical v5 runner already establishes useful transport patterns, but
+its two all-candidate response models are part of the failure that v6 replaces.
+This phase may reuse strict one-request and write-once mechanics. It may not
+reuse v5's batch parser, model-owned candidate actions, two-pass consensus,
+consumed W01-W08 inputs, reserved X01-X08 inputs, or post-outcome labels.
+
+## Frozen development scope
+
+Only Y01-Y08 may enter the development runner. Z01-Z08 may be byte-checked and
+expanded by the existing zero-network preflight, but a live runner must reject
+the unseen cohort before adapter construction. W01-W08 and X01-X08 remain
+historical and cannot enter the v6 artifacts.
+
+A complete development attempt may perform at most:
+
+- eight anonymous OpenAlex Works requests, one for each Y case; and
+- 24 sequential `qwen3.5-plus` requests, the three frozen candidate orders for
+  each case that retained at least one valid provider candidate.
+
+The ceilings are upper bounds, not a requirement to spend. A case with no
+valid provider candidate records that state and makes no model call. No retry,
+redirect, second query, result-page fetch, semantic repair, fallback, recovery,
+parallel call, model substitution or supplementary search is permitted.
+
+## Frozen anonymous OpenAlex contract
+
+The runner must reuse the existing abstract-bearing anonymous OpenAlex Works
+response contract rather than introducing a new parser. Each case request:
+
+1. uses the frozen query and Evidence-gap plan identity from phase one;
+2. requests `has_abstract:true`, at most eight rows and only the committed
+   Works fields;
+3. sends no API key and refuses to start when `OPENALEX_API_KEY` is configured;
+4. invokes an injected no-redirect, no-retry transport exactly once;
+5. requires provider-reported USD accounting and a complete provider-row index;
+6. retains candidates and provider rejections separately; and
+7. writes the complete provider journal before the first model call for that
+   case or any later OpenAlex request.
+
+OpenAlex topics and keywords may remain in the provider response because the
+reused parser accounts for them, but they cannot enter a v6 model prompt,
+quote check, role consensus, admission decision or set-cover decision. Only
+the title, reconstructed abstract, provider index and candidate identity enter
+the semantic method.
+
+## Frozen Qwen one-request contract
+
+The v6 adapter is a new historical profile rather than an edit to the sealed
+v5 adapter. Every model request must:
+
+1. use `POST https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`;
+2. authenticate only with `DASHSCOPE_API_KEY` in the outbound bearer header;
+3. request and accept exactly `qwen3.5-plus`;
+4. put `enable_thinking=false` at the top level of the raw JSON body;
+5. use JSON Object mode, temperature `0`, non-streaming output and
+   `max_tokens=8000`;
+6. use a 120-second transport timeout persisted in the request identity;
+7. contain the exact phase-one system and user prompt for one of the three
+   frozen candidate orders; and
+8. invoke its transport once with no redirect, retry, repair, fallback,
+   endpoint override, model switch or hidden formatting call.
+
+The response is usable only after validating one non-empty choice, exact
+returned-model identity, finish reason, prompt/completion/total token
+arithmetic, nested cached tokens, locally reproducible conservative cost,
+latency, response identity and raw-content hash. Environment price overrides
+must remain disabled for this experiment.
+
+A parseable identity failure may retain only safe returned-model, usage and
+latency observations. It may not persist rejected semantic content. Any
+potentially spending request without inspectable usage and cost makes model
+cost `uninspectable` and stops the run. A syntactically or contract-invalid
+semantic JSON object after a transport-successful response remains a completed,
+accounted call: it is persisted and converted by the phase-one kernel into an
+explicit unavailable pass without repair.
+
+## Frozen request identities and ordering
+
+The manifest must commit all eight OpenAlex calls and all 24 possible model
+requests before either adapter is constructed. For each Y case, model calls
+remain sequential in this order:
+
+1. `provider_order`;
+2. `reverse_provider_order`; and
+3. `candidate_sha256_order`.
+
+Each request identity binds the method, case, order, input SHA-256, prompt
+SHA-256, exact model, endpoint, timeout, maximum output tokens and production-
+disconnection flags. The actual serialized outbound candidate order must be
+checked against the persisted input immediately before transport. An internal
+list with the correct order is not evidence if the request body carries a
+different order.
+
+## Write-once crash and accounting boundary
+
+The implementation must reject an existing output directory. For a new path,
+the required sequence is:
+
+1. verify raw fixture and every transitive implementation hash before output
+   reservation;
+2. create the output directory and write a complete manifest;
+3. only then construct the OpenAlex and Qwen adapters or resolve credentials;
+4. write each OpenAlex request/response/failure journal before a model call or
+   later provider request;
+5. write each model request/response/failure journal before another model
+   request;
+6. after all available passes for a case, write the complete deterministic
+   case audit before the next case; and
+7. write execution, provider-row, candidate/slot and artifact-index outputs.
+
+The runner records its observed self-hash because embedding its own expected
+hash would be recursive. The merged revision named by a future authorization
+binds that observed runner. Every other behavior-bearing dependency must have
+an expected committed SHA-256 checked before output reservation.
+
+The execution keeps OpenAlex and Qwen accounting separate. Each provider has
+`not_observed`, `known` and `uninspectable` states where applicable. A numeric
+total is forbidden when any potentially spending request in that provider is
+uninspectable. The runner checks a provider-specific soft stop before a later
+request, while acknowledging that one in-flight request may exceed it.
+
+The implementation accepts at most USD 0.01 as the anonymous OpenAlex soft
+stop and at most USD 0.25 as the Qwen soft stop. The Qwen ceiling is a bounded
+engineering limit, not a prediction: the consumed v5 run observed USD
+0.113971 for 16 different calls, and v6 permits 24 calls with a different
+response shape. A later authorization may choose lower stops.
+
+## Final artifacts and states
+
+Every output model uses `extra="forbid"` and validates totals against its child
+journals. The final boundary must retain:
+
+- all provider candidates and provider rejections in exact provider-index
+  order;
+- every attempted model request and safe response/accounting state;
+- all three expected pass identities, including unavailable passes;
+- every expected candidate row and fixed role slot for each available pass;
+- every quote-verification result, local failure reason, provisional action,
+  role consensus, final candidate action and selected source; and
+- separate provider, model, mechanical-gate, human-review and production-
+  connection states.
+
+`completed` means all eight provider cases reached a durable terminal journal
+and every model call made possible by those provider candidates reached a
+durable terminal journal. It does not mean a mechanical or human gate passed.
+Transport or accounting failure is `partial`. A complete execution calculates
+the frozen non-human gates without opening private labels:
+
+- top-level pass contract validity;
+- candidate-pass local-valid-row rate;
+- code-derived provisional-disposition unanimity;
+- selected-set case coverage; and
+- serialized boundary completeness.
+
+Human relevance, novelty, role support and wrong-source gates remain
+`not_evaluated`. A later label-blind review packet must include every provider
+candidate even if the mechanical gates fail. This phase may expose a source-
+lock-ready state but cannot open labels or announce a source-value result.
+
+## Required zero-network evidence
+
+Before any paid Y authorization, tests must prove:
+
+1. the real dry-run verifies Y01-Y08, all request identities and all dependency
+   hashes while constructing no adapter and opening no socket;
+2. the manifest exists before either injected adapter factory runs;
+3. a provider journal exists before the first model call for that case;
+4. each model journal exists before the next model call and each case audit
+   exists before the next provider call;
+5. the three actual outbound request bodies carry the three frozen candidate
+   orders;
+6. top-level, candidate-row and role-slot malformed states remain distinct and
+   one bad row or slot cannot erase a valid neighbour;
+7. every provider candidate and rejection reaches the aggregate boundary;
+8. every computed candidate and role-slot value reaches the final serialized
+   boundary rather than stopping in memory;
+9. provider or model identity, accounting, timeout and cost failures make no
+   retry and cannot produce a false pass or false zero cost;
+10. configured OpenAlex credentials, existing output paths and unseen-cohort
+    execution fail before adapter construction;
+11. the raw Qwen body contains top-level `enable_thinking=false`, exact model,
+    JSON Object mode, temperature zero, 8000 output tokens and the frozen
+    timeout identity;
+12. `pipeline_worker.py` and every production entry point import no v6 kernel,
+    runner or experimental adapter; and
+13. the complete zero-network suite, latest Ruff and narrow Pylint pass.
+
+At least two paid-boundary defects must be re-injected and observed red before
+restoration: moving manifest persistence after adapter construction, and
+dropped or reordered candidate/slot data at the final client artifact. The
+phase-one whole-batch, quote and set-cover tests remain required and cannot be
+weakened or skipped.
+
+## Explicit non-claims
+
+This amendment does not authorize or perform a provider request, model call,
+private-label read, review aggregation, report insertion, planner trigger or
+production import. Passing the runner tests would establish only a durable,
+bounded and inspectable disconnected execution contract. It would not
+establish model compliance, semantic accuracy, source truth, OpenAlex precision
+or recall, Tool Calling value, report improvement, user utility, cost or
+latency stability, an SLO, autonomous tool choice, or completed production Tool
+Calling.
+
+`pipeline_worker.py` must remain disconnected from the v6 kernel, fixture,
+preflight, runner, adapters, outputs and any later review module.

--- a/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-runner-identity-clarification.md
+++ b/docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-runner-identity-clarification.md
@@ -1,0 +1,40 @@
+# Pre-registration clarification: v6 derived request identities
+
+**Frozen:** 2026-09-01, after commit `488276f` and before implementing a v6
+runner or model adapter, constructing a provider client, or sending any Y or Z
+request.
+
+The development-runner pre-registration used the phrase "all 24 possible model
+requests" when describing the pre-provider manifest. Exact Qwen prompts contain
+OpenAlex titles and abstracts that do not exist locally until the corresponding
+provider response arrives. Claiming those complete prompt hashes before
+retrieval would therefore be an impossible and false durability boundary.
+
+The executable interpretation is narrower and stronger at the real seam:
+
+1. the global manifest commits all eight OpenAlex requests and all 24
+   code-owned model request **templates** before constructing the OpenAlex
+   adapter;
+2. each complete OpenAlex response or failure journal is durable before a
+   model call or later provider request;
+3. after a successful provider response, the runner derives and writes that
+   case's complete three-request model plan, including actual input and prompt
+   hashes;
+4. only after that plan is durable may the runner construct the Qwen adapter,
+   if no earlier case required one, or send the first Qwen request; and
+5. each Qwen journal is durable before another Qwen request, and the case audit
+   is durable before the next OpenAlex request.
+
+The pre-provider template identity binds method, case, pass order, profile and
+fixed judge contract without pretending to know future candidate bytes. Each
+derived request identity additionally binds candidate order, complete input,
+complete prompt, exact model, endpoint, timeout and output-token ceiling. Tests
+must observe both boundaries: the manifest before the OpenAlex adapter factory,
+and the provider journal plus three-request case plan before the Qwen adapter
+factory or outbound model call.
+
+This clarification changes no method, query, role, prompt, threshold, request
+ceiling, cost ceiling or cohort. It authorizes no network, model, label or
+production access. It exists solely to prevent an implementation from either
+claiming unknowable pre-retrieval prompt hashes or weakening the real
+post-retrieval, pre-model write-once boundary.

--- a/docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md
+++ b/docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md
@@ -1,0 +1,108 @@
+# Result: role-slot consensus v6 disconnected development runner
+
+**Implemented:** 2026-09-01, on top of pre-registration commits `488276f`
+and `4f3e5fb`.
+
+**Production connection authorized:** no
+
+**Live provider or model calls performed:** none
+
+**Private labels opened:** none
+
+## Outcome
+
+The Y01-Y08 development runner and its exact `qwen3.5-plus` one-request
+adapter are implemented, but remain disconnected from the production worker,
+report workflow and planner trigger.  The default command is a zero-network
+dry-run.  Live mode is limited to the development cohort and still requires a
+separate user authorization naming a merged revision, provider, request
+ceilings and cost stops.  Z01-Z08 remain unopened.
+
+This phase establishes an inspectable execution contract only.  It does not
+establish model compliance, semantic quality, source truth, provider
+precision, report improvement, cost stability or completed Tool Calling.
+
+## Implemented boundaries
+
+- The global manifest freezes the raw challenge bytes, eight OpenAlex request
+  identities, 24 code-owned judge-template identities and 12 transitive
+  implementation hashes before an adapter or credential-capable client is
+  constructed.
+- Because exact prompts depend on provider-returned source text, every case
+  writes its complete provider journal and then its three derived request
+  identities before Qwen construction or the first model call.
+- OpenAlex and Qwen each use a one-request, no-redirect, no-retry transport.
+  A provider or model failure stops the study rather than repairing, retrying,
+  switching models or issuing a supplementary search.
+- The Qwen wire contract fixes exact `qwen3.5-plus`, top-level
+  `enable_thinking=false`, JSON Object mode, temperature zero, 8,000 output
+  tokens and a 120-second timeout.  Environment price overrides are disabled.
+- Every provider candidate and rejection, every attempted model request and
+  safe accounting observation, all expected pass identities, every candidate
+  row and every fixed role slot reaches write-once artifacts.
+- Empty provider results are represented as checked-but-empty cases and never
+  construct the model adapter.  A transport-successful but malformed semantic
+  response remains a paid, completed call and becomes an explicit unavailable
+  pass without repair.
+- OpenAlex and Qwen costs remain separate.  A potentially spending call with
+  missing usage makes that provider's total `uninspectable`; it can never be
+  serialized as zero.
+
+## Findings caught during implementation
+
+The first focused run found two implementation defects without changing a
+test expectation:
+
+1. a provider failure before model planning omitted the explicit empty
+   `model_calls` tuple from its durable case state; and
+2. fixture-byte drift escaped as the phase-one preflight exception instead of
+   the development runner's public error type.
+
+Both were fixed at the failure boundary.  The first failure now serializes a
+complete provider-failed case without implying model work, and the second is
+wrapped without losing its original cause.
+
+## Defect re-injection
+
+The two pre-registered paid-boundary defects were deliberately restored one at
+a time after the implementation passed:
+
+1. Moving `manifest.json` persistence after provider-adapter construction made
+   `test_complete_execution_persists_every_seam_and_actual_candidate_order`
+   fail at the factory boundary because the manifest was absent.
+2. Dropping Y08 only from the final `case-audits.json` aggregate made
+   `test_malformed_semantic_json_is_accounted_unavailable_and_reaches_clients`
+   fail even though the execution object and per-case audit still contained
+   the correct value.
+
+Each defect was reverted immediately, and both exact tests passed again.  This
+demonstrates that the tests cover capability ordering and the final client
+artifact, not merely internal fields.
+
+## Verification
+
+- Default zero-network dry-run: 8/8 Y cases, 8 provider identities, 24 distinct
+  judge-template identities and 12/12 implementation hashes verified; no
+  adapter, socket or model call constructed.
+- Combined v6 kernel, preflight, adapter and runner subset: 39/39 tests passed.
+- New runner/adapter subset: 16/16 tests passed.
+- Full zero-network suite: 1,837 tests and 657 subtests passed.
+- Latest Ruff: passed for the new implementation and tests.
+- CI-equivalent narrow Pylint: passed.
+
+No paid or anonymous OpenAlex request, Qwen request, private-label read,
+review aggregation, production import or planner-trigger study occurred in
+this phase.
+
+## Next authorized step
+
+After this implementation is reviewed, merged and deployed, a separate
+authorization may permit one bounded Y01-Y08 development run.  That
+authorization must name the exact merged revision, anonymous OpenAlex and
+exact `qwen3.5-plus`, at most eight OpenAlex requests and 24 sequential model
+requests, provider-specific soft stops, and the prohibition on retry, repair,
+fallback, recovery, supplementary search and production connection.
+
+The returned development artifacts must then be mechanically checked before a
+label-blind source-review packet is prepared.  Z01-Z08 cannot be opened unless
+all pre-registered Y gates, including eligible human review, pass.

--- a/openalex_role_slot_development.py
+++ b/openalex_role_slot_development.py
@@ -1,0 +1,1800 @@
+"""Write-once Y01-Y08 runner for role-slot consensus v6.
+
+The default CLI path is a zero-network preflight.  A live development attempt
+requires two explicit budget acknowledgements and two bounded soft stops.  The
+global method manifest is durable before constructing an OpenAlex adapter; for
+each successful provider response, the exact three-request model plan is
+durable before constructing or invoking the Qwen adapter.  Every request
+journal is written before another request may begin.
+
+This runner is deliberately disconnected from the production worker, report
+workflow, planner trigger, private labels, and the frozen Z01-Z08 unseen cohort.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence_gap import (
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    source_collection_sha256,
+)
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.openalex_role_slot import (
+    RoleSlotBatchInput,
+    RoleSlotCaseAudit,
+    build_role_slot_inputs,
+    build_role_slot_prompts,
+    evaluate_role_slot_case,
+)
+from academic_agent.source_pipeline import SourceCollection
+from academic_agent.tools.evidence_search import ToolAdapterFailure
+from academic_agent.tools.openalex_claim_scope_search import (
+    AnonymousOpenAlexClaimScopeAdapter,
+    OpenAlexClaimScopeAdapterResponse,
+)
+from academic_agent.tools.qwen_role_slot_judge import (
+    QWEN_ROLE_SLOT_MAX_TOKENS,
+    QWEN_ROLE_SLOT_MODEL,
+    QWEN_ROLE_SLOT_TIMEOUT_SECONDS,
+    QwenRoleSlotJudgeAdapter,
+    QwenRoleSlotJudgeError,
+    QwenRoleSlotRequest,
+    QwenRoleSlotResponse,
+    QwenRoleSlotUsageObservation,
+    RoleSlotCandidateOrder,
+    prompt_sha256,
+)
+from openalex_role_slot_unseen import (
+    DEFAULT_FIXTURE_PATH,
+    EXPECTED_FIXTURE_SHA256,
+    OpenAlexRoleSlotPreflightError,
+    PreparedRoleSlotCase,
+    RoleSlotCaseSpec,
+    RoleSlotChallengeManifest,
+    dry_run as phase_one_dry_run,
+    load_frozen_cases,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_RUNNER_PATH = Path(__file__).resolve()
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+_CASE_ORDER = tuple(f"Y{index:02d}" for index in range(1, 9))
+_CANDIDATE_ORDERS: tuple[RoleSlotCandidateOrder, ...] = (
+    "provider_order",
+    "reverse_provider_order",
+    "candidate_sha256_order",
+)
+MAXIMUM_OPENALEX_REQUEST_COUNT = 8
+MAXIMUM_MODEL_CALL_COUNT = 24
+MAXIMUM_OPENALEX_SOFT_STOP_USD = 0.01
+MAXIMUM_MODEL_SOFT_STOP_USD = 0.25
+ANONYMOUS_OPENALEX_DAILY_BUDGET_USD = 0.10
+_MAX_PROVIDER_RESPONSE_BYTES = 1_000_000
+_PROVIDER_ROW_COLUMNS = (
+    "case_id",
+    "provider_result_index",
+    "adapter_disposition",
+    "candidate_sha256",
+    "title",
+    "url",
+    "doi",
+    "publisher",
+    "published_date",
+    "abstract",
+    "provider_rejection_code",
+    "rejection_detail",
+    "provider_request_id",
+    "provider_cost_basis",
+    "trace_id",
+)
+
+_IMPLEMENTATION_PATHS = {
+    "domain_evidence_search.py": (
+        _ROOT / "src/academic_agent/tools/domain_evidence_search.py"
+    ),
+    "evidence.py": _ROOT / "src/academic_agent/evidence.py",
+    "evidence_gap.py": _ROOT / "src/academic_agent/evidence_gap.py",
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_claim_scope.py": _ROOT / "src/academic_agent/openalex_claim_scope.py",
+    "openalex_claim_scope_search.py": (
+        _ROOT / "src/academic_agent/tools/openalex_claim_scope_search.py"
+    ),
+    "openalex_evidence_set.py": (
+        _ROOT / "src/academic_agent/openalex_evidence_set.py"
+    ),
+    "openalex_role_slot.py": _ROOT / "src/academic_agent/openalex_role_slot.py",
+    "openalex_role_slot_unseen.py": _ROOT / "openalex_role_slot_unseen.py",
+    "qwen_role_slot_judge.py": (
+        _ROOT / "src/academic_agent/tools/qwen_role_slot_judge.py"
+    ),
+    "source_pipeline.py": _ROOT / "src/academic_agent/source_pipeline.py",
+    "token_usage.py": _ROOT / "src/academic_agent/token_usage.py",
+}
+
+# Populated from committed implementation bytes before any provider call.  The
+# runner itself remains an observed hash because embedding its expected digest
+# in itself would create a recursive identity.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "domain_evidence_search.py": (
+        "ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab"
+    ),
+    "evidence.py": "8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5",
+    "evidence_gap.py": (
+        "f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_claim_scope.py": (
+        "739e165838ff5042ec863c3c510311e737216e8d90804c8d3da5095acce22f16"
+    ),
+    "openalex_claim_scope_search.py": (
+        "070d07ac8c4bcaa32bfbc563513b4034162b012aea1f47ce3208ed06cb085642"
+    ),
+    "openalex_evidence_set.py": (
+        "413bf6cea1c555c75bd80aaadae720cbf00886974acfdd443643f6a2f75e992c"
+    ),
+    "openalex_role_slot.py": (
+        "166eb6d6568a7a187e2f6654c27d3db938a79553c0205501d9328b38437ed8d4"
+    ),
+    "openalex_role_slot_unseen.py": (
+        "3bd69fa0a6703c1b928c905fbde1ce5639aaa3559c2a54f3356cbdb914800a75"
+    ),
+    "qwen_role_slot_judge.py": (
+        "e0bb13862169de8dfd1efbffbcddaf6a88582690865160953a4de49b668a5f84"
+    ),
+    "source_pipeline.py": (
+        "056a545325bc231b1501bbf53cc993faaba55adb0e9c222db6c0b45b90628286"
+    ),
+    "token_usage.py": (
+        "884a314cb6dfa9393afb74e71cdf54e77c22404f647772e88d3845ec89a0acac"
+    ),
+}
+
+
+class OpenAlexRoleSlotDevelopmentError(ValueError):
+    """Raised before or at one explicit experimental boundary."""
+
+
+class FrozenRoleSlotCaseArtifact(BaseModel):
+    """All code-owned identities committed before provider construction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: RoleSlotCaseSpec
+    collection_sha256: str = Field(pattern=_SHA256_PATTERN)
+    plan_sha256: str = Field(pattern=_SHA256_PATTERN)
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    case_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    judge_request_template_sha256s: tuple[str, str, str]
+    source_collection: SourceCollection
+    validated_plan: ValidatedGapPlan
+
+    @model_validator(mode="after")
+    def _validate_expansion(self) -> "FrozenRoleSlotCaseArtifact":
+        if source_collection_sha256(self.source_collection) != self.collection_sha256:
+            raise ValueError("expanded source collection identity drifted")
+        observed_plan = _sha256_bytes(
+            self.validated_plan.model_dump_json(exclude_none=False).encode("utf-8")
+        )
+        if observed_plan != self.plan_sha256:
+            raise ValueError("expanded validated plan identity drifted")
+        if self.spec.roles.profile().sha256() != self.profile_sha256:
+            raise ValueError("expanded role profile identity drifted")
+        if len(set(self.judge_request_template_sha256s)) != 3:
+            raise ValueError("judge request template identities must be distinct")
+        if len(self.validated_plan.calls) != 1:
+            raise ValueError("each frozen case must retain exactly one provider call")
+        return self
+
+
+class RoleSlotDevelopmentManifest(BaseModel):
+    """Durable global method boundary written before any client exists."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_role_slot_v6_development_manifest"] = (
+        "openalex_role_slot_v6_development_manifest"
+    )
+    cohort: Literal["development"] = "development"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    private_labels_opened: Literal[False] = False
+    unseen_cohort_opened: Literal[False] = False
+    openalex_access_mode: Literal["anonymous_no_key"] = "anonymous_no_key"
+    requested_model: Literal["qwen3.5-plus"] = QWEN_ROLE_SLOT_MODEL
+    fixture_sha256: str = Field(pattern=_SHA256_PATTERN)
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=_SHA256_PATTERN)
+    method_id: str = Field(min_length=20, max_length=200)
+    provider_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    judge_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    selection_contract_sha256: str = Field(pattern=_SHA256_PATTERN)
+    maximum_openalex_request_count: Literal[8] = MAXIMUM_OPENALEX_REQUEST_COUNT
+    maximum_model_call_count: Literal[24] = MAXIMUM_MODEL_CALL_COUNT
+    openalex_soft_stop_usd: float = Field(
+        gt=0.0,
+        le=MAXIMUM_OPENALEX_SOFT_STOP_USD,
+    )
+    model_soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_MODEL_SOFT_STOP_USD)
+    model_transport_timeout_seconds: Literal[120.0] = (
+        QWEN_ROLE_SLOT_TIMEOUT_SECONDS
+    )
+    model_max_tokens: Literal[8000] = QWEN_ROLE_SLOT_MAX_TOKENS
+    cases: tuple[FrozenRoleSlotCaseArtifact, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> "RoleSlotDevelopmentManifest":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("manifest fixture identity drifted")
+        if tuple(case.spec.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("manifest cases must remain Y01 through Y08")
+        if set(self.implementation_sha256) != set(_IMPLEMENTATION_PATHS):
+            raise ValueError("manifest implementation lock names drifted")
+        if any(
+            len(value) != 64
+            or any(character not in "0123456789abcdef" for character in value)
+            for value in self.implementation_sha256.values()
+        ):
+            raise ValueError("manifest implementation hashes are invalid")
+        return self
+
+
+class RoleSlotModelPlan(BaseModel):
+    """Three exact requests persisted after retrieval and before Qwen."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    provider_response_sha256: str = Field(pattern=_SHA256_PATTERN)
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    inputs: tuple[RoleSlotBatchInput, RoleSlotBatchInput, RoleSlotBatchInput]
+    requests: tuple[
+        QwenRoleSlotRequest,
+        QwenRoleSlotRequest,
+        QwenRoleSlotRequest,
+    ]
+
+    @model_validator(mode="after")
+    def _validate_plan(self) -> "RoleSlotModelPlan":
+        candidate_sets: list[set[str]] = []
+        for pass_number, (candidate_order, batch, request) in enumerate(
+            zip(_CANDIDATE_ORDERS, self.inputs, self.requests, strict=True),
+            start=1,
+        ):
+            if (
+                batch.case_id != self.case_id
+                or request.case_id != self.case_id
+                or batch.pass_number != pass_number
+                or request.pass_number != pass_number
+                or request.candidate_order != candidate_order
+                or request.batch_input_sha256 != batch.sha256()
+            ):
+                raise ValueError("model plan request identity drifted")
+            candidate_sets.append(
+                {candidate.candidate_sha256 for candidate in batch.candidates}
+            )
+        if any(value != candidate_sets[0] for value in candidate_sets[1:]):
+            raise ValueError("all model passes must contain the same candidates")
+        provider_order = tuple(
+            item.candidate_sha256 for item in self.inputs[0].candidates
+        )
+        if tuple(
+            item.candidate_sha256 for item in self.inputs[1].candidates
+        ) != tuple(reversed(provider_order)):
+            raise ValueError("reverse-provider model order drifted")
+        if tuple(
+            item.candidate_sha256 for item in self.inputs[2].candidates
+        ) != tuple(sorted(provider_order)):
+            raise ValueError("candidate-SHA model order drifted")
+        return self
+
+
+ProviderJournalState = Literal["completed", "failed"]
+ModelJournalState = Literal["completed", "failed"]
+
+
+class RoleSlotProviderJournal(BaseModel):
+    """One anonymous OpenAlex request and complete returned-row accounting."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    collection_sha256: str = Field(pattern=_SHA256_PATTERN)
+    plan_sha256: str = Field(pattern=_SHA256_PATTERN)
+    profile_sha256: str = Field(pattern=_SHA256_PATTERN)
+    idempotency_key: str = Field(pattern=_SHA256_PATTERN)
+    trace_id: str = Field(pattern=r"^openalex-role-slot-v6-y0[1-8]$")
+    state: ProviderJournalState
+    outbound_attempt_count: Literal[1] = 1
+    response: OpenAlexClaimScopeAdapterResponse | None = None
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    request_may_have_spent: Literal[True] = True
+    search_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_journal(self) -> "RoleSlotProviderJournal":
+        expected_trace = f"openalex-role-slot-v6-{self.case_id.casefold()}"
+        if self.trace_id != expected_trace:
+            raise ValueError("provider trace identity drifted")
+        failures = (
+            self.failure_type,
+            self.failure_detail,
+            self.failure_retryable,
+        )
+        if self.state == "completed":
+            if self.response is None or any(value is not None for value in failures):
+                raise ValueError("completed provider journal requires only a response")
+            if self.response.idempotency_key != self.idempotency_key:
+                raise ValueError("provider response idempotency identity drifted")
+            if self.response.search_cost_usd != self.search_cost_usd:
+                raise ValueError("provider cost drifted from response")
+            if self.response.provider_usage.result_count > 8:
+                raise ValueError("provider returned more than eight rows")
+        elif self.failure_type is None or self.failure_detail is None:
+            raise ValueError("failed provider journal requires failure metadata")
+        elif self.response is not None and (
+            self.response.search_cost_usd != self.search_cost_usd
+        ):
+            raise ValueError("failed provider cost drifted from retained response")
+        return self
+
+
+class RoleSlotModelJournal(BaseModel):
+    """One potentially billed Qwen call written before a later call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    pass_number: Literal[1, 2, 3]
+    candidate_order: RoleSlotCandidateOrder
+    state: ModelJournalState
+    request: QwenRoleSlotRequest
+    response: QwenRoleSlotResponse | None = None
+    observed_returned_model: str | None = Field(default=None, max_length=200)
+    observed_usage: QwenRoleSlotUsageObservation | None = None
+    observed_latency_ms: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    request_may_have_spent: bool
+
+    @model_validator(mode="after")
+    def _validate_journal(self) -> "RoleSlotModelJournal":
+        if (
+            self.request.case_id != self.case_id
+            or self.request.pass_number != self.pass_number
+            or self.request.candidate_order != self.candidate_order
+        ):
+            raise ValueError("model journal request identity drifted")
+        failures = (
+            self.failure_type,
+            self.failure_detail,
+            self.failure_retryable,
+        )
+        observations = (self.observed_returned_model, self.observed_usage)
+        if self.state == "completed":
+            if (
+                self.response is None
+                or any(value is not None for value in failures)
+                or any(value is not None for value in observations)
+                or self.observed_latency_ms is not None
+                or not self.request_may_have_spent
+            ):
+                raise ValueError("completed model journal requires only a response")
+            if _response_identity_drift(self.request, self.response):
+                raise ValueError("completed response identity drifted from request")
+        elif self.response is not None or any(value is None for value in failures):
+            raise ValueError("failed model journal requires only failure metadata")
+        if self.observed_usage is not None and self.observed_returned_model is None:
+            raise ValueError("observed usage requires a returned model")
+        if not self.request_may_have_spent and any(
+            value is not None for value in observations
+        ):
+            raise ValueError("non-spending failure cannot carry provider usage")
+        return self
+
+
+CaseExecutionState = Literal[
+    "completed",
+    "no_candidates",
+    "provider_failed",
+    "model_incomplete",
+]
+
+
+class RoleSlotCaseExecution(BaseModel):
+    """One provider journal, optional model plan, calls and deterministic audit."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    state: CaseExecutionState
+    provider_journal: RoleSlotProviderJournal
+    model_plan: RoleSlotModelPlan | None = None
+    model_calls: tuple[RoleSlotModelJournal, ...] = Field(max_length=3)
+    case_audit: RoleSlotCaseAudit | None = None
+
+    @model_validator(mode="after")
+    def _validate_case(self) -> "RoleSlotCaseExecution":
+        if self.provider_journal.case_id != self.case_id:
+            raise ValueError("case provider journal identity drifted")
+        response = self.provider_journal.response
+        candidate_count = len(response.candidates) if response is not None else 0
+        if self.state == "provider_failed":
+            if (
+                self.provider_journal.state != "failed"
+                or self.model_plan is not None
+                or self.model_calls
+                or self.case_audit is not None
+            ):
+                raise ValueError("provider-failed case cannot imply model work")
+            return self
+        if self.provider_journal.state != "completed" or response is None:
+            raise ValueError("non-provider-failed case requires a completed provider")
+        if self.state == "no_candidates":
+            if (
+                candidate_count
+                or self.model_plan is not None
+                or self.model_calls
+                or self.case_audit is not None
+            ):
+                raise ValueError("no-candidate case cannot imply model work")
+            return self
+        if candidate_count == 0 or self.model_plan is None:
+            raise ValueError("model case requires candidates and a persisted plan")
+        if self.model_plan.case_id != self.case_id:
+            raise ValueError("case model plan identity drifted")
+        planned_ids = {
+            item.candidate_sha256 for item in self.model_plan.inputs[0].candidates
+        }
+        response_ids = {item.sha256() for item in response.candidates}
+        if planned_ids != response_ids:
+            raise ValueError("model plan candidates drifted from provider response")
+        expected_calls = self.model_plan.requests[: len(self.model_calls)]
+        if tuple(item.request for item in self.model_calls) != expected_calls:
+            raise ValueError("model calls must preserve the planned request prefix")
+        if self.state == "completed":
+            if (
+                len(self.model_calls) != 3
+                or any(call.state != "completed" for call in self.model_calls)
+                or self.case_audit is None
+            ):
+                raise ValueError("completed case requires three calls and one audit")
+            if self.case_audit.case_id != self.case_id:
+                raise ValueError("case audit identity drifted")
+            if self.case_audit.provider_candidate_count != candidate_count:
+                raise ValueError("every provider candidate must reach the case audit")
+        elif self.case_audit is not None:
+            raise ValueError("incomplete model case cannot carry a final audit")
+        return self
+
+
+StopReason = Literal[
+    "completed",
+    "openalex_soft_stop",
+    "model_soft_stop",
+    "provider_failed",
+    "model_failed",
+    "accounting_invalid",
+]
+CostState = Literal["known", "uninspectable", "not_observed"]
+MechanicalGateState = Literal["pass", "fail", "not_evaluated"]
+
+
+class RoleSlotDevelopmentExecution(BaseModel):
+    """Final mechanical state; human-value gates remain unopened."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_role_slot_v6_development_execution"] = (
+        "openalex_role_slot_v6_development_execution"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    private_labels_opened: Literal[False] = False
+    unseen_cohort_opened: Literal[False] = False
+    manifest_sha256: str = Field(pattern=_SHA256_PATTERN)
+    overall_state: Literal["completed", "partial"]
+    stop_reason: StopReason
+    openalex_request_count: int = Field(ge=0, le=8)
+    openalex_successful_case_count: int = Field(ge=0, le=8)
+    openalex_cost_state: CostState
+    openalex_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    model_call_count: int = Field(ge=0, le=24)
+    model_completed_call_count: int = Field(ge=0, le=24)
+    model_cost_state: CostState
+    model_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    prompt_tokens: int = Field(ge=0)
+    cached_prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    provider_row_count: int = Field(ge=0, le=64)
+    provider_candidate_count: int = Field(ge=0, le=64)
+    provider_rejection_count: int = Field(ge=0, le=64)
+    completed_case_audit_count: int = Field(ge=0, le=8)
+    selected_case_count: int = Field(ge=0, le=8)
+    top_level_valid_pass_numerator: int = Field(ge=0, le=24)
+    top_level_valid_pass_denominator: int = Field(ge=0, le=24)
+    top_level_valid_pass_rate: float | None = Field(default=None, ge=0.0, le=1.0)
+    top_level_contract_gate_passed: bool | None
+    local_valid_row_numerator: int = Field(ge=0, le=192)
+    local_valid_row_denominator: int = Field(ge=0, le=192)
+    local_valid_row_rate: float | None = Field(default=None, ge=0.0, le=1.0)
+    local_valid_row_gate_passed: bool | None
+    provisional_unanimity_numerator: int = Field(ge=0, le=64)
+    provisional_unanimity_denominator: int = Field(ge=0, le=64)
+    provisional_unanimity_rate: float | None = Field(default=None, ge=0.0, le=1.0)
+    provisional_unanimity_gate_passed: bool | None
+    selected_case_coverage_gate_passed: bool | None
+    audit_boundary_complete: bool
+    mechanical_gate_state: MechanicalGateState
+    source_lock_readiness: Literal["ready", "not_ready"]
+    human_review_state: Literal["not_prepared"] = "not_prepared"
+    source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    cases: tuple[RoleSlotCaseExecution, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_execution(self) -> "RoleSlotDevelopmentExecution":
+        case_ids = tuple(case.case_id for case in self.cases)
+        if case_ids != _CASE_ORDER[: len(case_ids)]:
+            raise ValueError("execution cases must preserve the frozen prefix")
+        provider_journals = tuple(case.provider_journal for case in self.cases)
+        if self.openalex_request_count != len(provider_journals):
+            raise ValueError("provider request total drifted from journals")
+        provider_successes = sum(
+            journal.state == "completed" for journal in provider_journals
+        )
+        if self.openalex_successful_case_count != provider_successes:
+            raise ValueError("provider success total drifted")
+        provider_responses = tuple(
+            journal.response
+            for journal in provider_journals
+            if journal.response is not None
+        )
+        candidate_count = sum(len(response.candidates) for response in provider_responses)
+        rejection_count = sum(
+            len(response.provider_rejections) for response in provider_responses
+        )
+        if (
+            self.provider_candidate_count,
+            self.provider_rejection_count,
+            self.provider_row_count,
+        ) != (
+            candidate_count,
+            rejection_count,
+            candidate_count + rejection_count,
+        ):
+            raise ValueError("provider row totals drifted from journals")
+        calls = tuple(call for case in self.cases for call in case.model_calls)
+        if self.model_call_count != len(calls):
+            raise ValueError("model call total drifted from journals")
+        completed_calls = sum(call.state == "completed" for call in calls)
+        if self.model_completed_call_count != completed_calls:
+            raise ValueError("completed model call total drifted")
+        usages = tuple(
+            usage for call in calls if (usage := _model_journal_usage(call)) is not None
+        )
+        if (
+            self.prompt_tokens,
+            self.cached_prompt_tokens,
+            self.completion_tokens,
+            self.total_tokens,
+        ) != (
+            sum(item.prompt_tokens for item in usages),
+            sum(item.cached_prompt_tokens for item in usages),
+            sum(item.completion_tokens for item in usages),
+            sum(item.total_tokens for item in usages),
+        ):
+            raise ValueError("aggregate model tokens drifted from journals")
+        expected_provider_state, expected_provider_cost = _provider_cost(provider_journals)
+        if (self.openalex_cost_state, self.openalex_cost_usd) != (
+            expected_provider_state,
+            expected_provider_cost,
+        ):
+            raise ValueError("aggregate OpenAlex cost drifted from journals")
+        expected_model_state, expected_model_cost = _model_cost(calls)
+        if self.model_cost_state != expected_model_state:
+            raise ValueError("aggregate model cost state drifted from journals")
+        if expected_model_cost is None:
+            if self.model_cost_usd is not None:
+                raise ValueError("unknown model cost cannot carry a numeric total")
+        elif self.model_cost_usd is None or not math.isclose(
+            self.model_cost_usd,
+            expected_model_cost,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("aggregate model cost drifted from journals")
+        audits = tuple(
+            case.case_audit for case in self.cases if case.case_audit is not None
+        )
+        if self.completed_case_audit_count != len(audits):
+            raise ValueError("completed case-audit total drifted")
+        if self.selected_case_count != sum(audit.action == "SELECT" for audit in audits):
+            raise ValueError("selected-case total drifted")
+        valid_passes = sum(
+            pass_audit.state == "valid" for audit in audits for pass_audit in audit.passes
+        )
+        pass_denominator = sum(len(audit.passes) for audit in audits)
+        local_numerator = sum(audit.local_valid_row_numerator for audit in audits)
+        local_denominator = sum(audit.local_valid_row_denominator for audit in audits)
+        unanimity_numerator = sum(
+            audit.provisional_unanimity_numerator for audit in audits
+        )
+        unanimity_denominator = sum(
+            audit.provisional_unanimity_denominator for audit in audits
+        )
+        _validate_rate(
+            self.top_level_valid_pass_numerator,
+            self.top_level_valid_pass_denominator,
+            self.top_level_valid_pass_rate,
+            valid_passes,
+            pass_denominator,
+            "top-level pass",
+        )
+        _validate_rate(
+            self.local_valid_row_numerator,
+            self.local_valid_row_denominator,
+            self.local_valid_row_rate,
+            local_numerator,
+            local_denominator,
+            "local row",
+        )
+        _validate_rate(
+            self.provisional_unanimity_numerator,
+            self.provisional_unanimity_denominator,
+            self.provisional_unanimity_rate,
+            unanimity_numerator,
+            unanimity_denominator,
+            "provisional unanimity",
+        )
+        complete = (
+            len(self.cases) == 8
+            and all(
+                case.state in {"completed", "no_candidates"} for case in self.cases
+            )
+            and self.stop_reason == "completed"
+        )
+        if (self.overall_state == "completed") != complete:
+            raise ValueError("overall completion drifted from case journals")
+        expected_top = valid_passes == pass_denominator if pass_denominator else None
+        expected_local = (
+            local_numerator / local_denominator >= 0.95
+            if local_denominator
+            else None
+        )
+        expected_unanimity = (
+            unanimity_numerator / unanimity_denominator >= 0.8
+            if unanimity_denominator
+            else None
+        )
+        expected_selected = self.selected_case_count >= 6 if complete else None
+        if (
+            self.top_level_contract_gate_passed,
+            self.local_valid_row_gate_passed,
+            self.provisional_unanimity_gate_passed,
+            self.selected_case_coverage_gate_passed,
+        ) != (expected_top, expected_local, expected_unanimity, expected_selected):
+            raise ValueError("mechanical gate values drifted from audit metrics")
+        expected_boundary = _audit_boundary_complete(self.cases)
+        if self.audit_boundary_complete != expected_boundary:
+            raise ValueError("audit-boundary state drifted from child artifacts")
+        all_gates = (
+            expected_top,
+            expected_local,
+            expected_unanimity,
+            expected_selected,
+            expected_boundary if complete else None,
+        )
+        expected_gate_state: MechanicalGateState
+        if not complete:
+            expected_gate_state = "not_evaluated"
+        elif all(value is True for value in all_gates):
+            expected_gate_state = "pass"
+        else:
+            expected_gate_state = "fail"
+        if self.mechanical_gate_state != expected_gate_state:
+            raise ValueError("mechanical gate state drifted")
+        expected_readiness = "ready" if complete and expected_boundary else "not_ready"
+        if self.source_lock_readiness != expected_readiness:
+            raise ValueError("source-lock readiness drifted")
+        return self
+
+
+ProviderAdapter = Callable[
+    [ValidatedGapCall],
+    OpenAlexClaimScopeAdapterResponse | dict[str, Any],
+]
+ProviderAdapterFactory = Callable[[], ProviderAdapter]
+
+
+class ModelAdapter(Protocol):
+    def __call__(
+        self,
+        request: QwenRoleSlotRequest,
+    ) -> QwenRoleSlotResponse | dict[str, Any]: ...
+
+
+ModelAdapterFactory = Callable[[], ModelAdapter]
+Clock = Callable[[], float]
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects because one case authorizes one OpenAlex request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _OneRequestTransport:
+    """Concrete OpenAlex transport with no redirect or retry behavior."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(endpoint, data=body, headers=dict(headers), method=method)
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read(_MAX_PROVIDER_RESPONSE_BYTES + 1)
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _json_text(value: BaseModel | dict[str, Any] | list[Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise OpenAlexRoleSlotDevelopmentError(
+            f"could not create write-once artifact {path}: {exc}"
+        ) from exc
+
+
+def _safe_validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "response validation failed"
+
+
+def _elapsed_ms(clock: Clock, started_at: float) -> float:
+    elapsed = (clock() - started_at) * 1000.0
+    if not math.isfinite(elapsed):
+        raise OpenAlexRoleSlotDevelopmentError("request clock became non-finite")
+    return max(0.0, elapsed)
+
+
+def _validate_rate(
+    numerator: int,
+    denominator: int,
+    rate: float | None,
+    expected_numerator: int,
+    expected_denominator: int,
+    label: str,
+) -> None:
+    if (numerator, denominator) != (expected_numerator, expected_denominator):
+        raise ValueError(f"{label} counts drifted")
+    expected_rate = numerator / denominator if denominator else None
+    if expected_rate is None:
+        if rate is not None:
+            raise ValueError(f"zero {label} denominator cannot report a rate")
+    elif rate is None or not math.isclose(rate, expected_rate, abs_tol=1e-12):
+        raise ValueError(f"{label} rate drifted")
+
+
+def verify_frozen_implementation(
+    expected: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Reject dependency drift before output reservation or client creation."""
+
+    expected_hashes = dict(
+        EXPECTED_IMPLEMENTATION_SHA256 if expected is None else expected
+    )
+    if set(expected_hashes) != set(_IMPLEMENTATION_PATHS):
+        raise OpenAlexRoleSlotDevelopmentError(
+            "v6 implementation lock names are inconsistent"
+        )
+    observed = {
+        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+    if observed != expected_hashes:
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if expected_hashes.get(name) != digest
+        )
+        raise OpenAlexRoleSlotDevelopmentError(
+            "v6 implementation identity drifted: " + ", ".join(changed)
+        )
+    return observed
+
+
+def _frozen_case(case: PreparedRoleSlotCase) -> FrozenRoleSlotCaseArtifact:
+    return FrozenRoleSlotCaseArtifact(
+        spec=case.spec,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        judge_request_template_sha256s=case.judge_request_template_sha256s,
+        source_collection=case.collection,
+        validated_plan=case.plan,
+    )
+
+
+def _manifest(
+    fixture_sha256: str,
+    challenge: RoleSlotChallengeManifest,
+    cases: tuple[PreparedRoleSlotCase, ...],
+    implementation_sha256: dict[str, str],
+    *,
+    openalex_soft_stop_usd: float,
+    model_soft_stop_usd: float,
+) -> RoleSlotDevelopmentManifest:
+    return RoleSlotDevelopmentManifest(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=_file_sha256(_RUNNER_PATH),
+        method_id=challenge.method_id,
+        provider_contract_sha256=challenge.provider_contract.sha256(),
+        judge_contract_sha256=challenge.judge_contract.sha256(),
+        selection_contract_sha256=challenge.selection_contract.sha256(),
+        openalex_soft_stop_usd=openalex_soft_stop_usd,
+        model_soft_stop_usd=model_soft_stop_usd,
+        cases=tuple(_frozen_case(case) for case in cases),
+    )
+
+
+def protocol_dry_run(
+    *,
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+    expected_implementation_sha256: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Verify every frozen byte and template while constructing no adapter."""
+
+    phase_one = phase_one_dry_run(
+        "development",
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    implementation = verify_frozen_implementation(expected_implementation_sha256)
+    return {
+        "mode": "openalex_role_slot_v6_development_dry_run",
+        "cohort": "development",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "private_labels_opened": False,
+        "unseen_cohort_opened": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "fixture_sha256": phase_one["fixture_sha256"],
+        "implementation_sha256": implementation,
+        "runner_sha256": _file_sha256(_RUNNER_PATH),
+        "case_count": phase_one["case_count"],
+        "maximum_openalex_request_count": MAXIMUM_OPENALEX_REQUEST_COUNT,
+        "maximum_model_call_count": MAXIMUM_MODEL_CALL_COUNT,
+        "requested_model": QWEN_ROLE_SLOT_MODEL,
+        "model_transport_timeout_seconds": QWEN_ROLE_SLOT_TIMEOUT_SECONDS,
+        "model_max_tokens": QWEN_ROLE_SLOT_MAX_TOKENS,
+        "cases": phase_one["cases"],
+    }
+
+
+def _judge_request(
+    batch: RoleSlotBatchInput,
+    candidate_order: RoleSlotCandidateOrder,
+) -> QwenRoleSlotRequest:
+    system_prompt, user_prompt = build_role_slot_prompts(batch)
+    return QwenRoleSlotRequest(
+        case_id=batch.case_id,
+        pass_number=batch.pass_number,
+        candidate_order=candidate_order,
+        trace_id=(
+            f"openalex-v6-{batch.case_id.casefold()}-pass-{batch.pass_number}"
+        ),
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        batch_input_sha256=batch.sha256(),
+        prompt_sha256=prompt_sha256(system_prompt, user_prompt),
+    )
+
+
+def _model_plan(
+    case: PreparedRoleSlotCase,
+    response: OpenAlexClaimScopeAdapterResponse,
+) -> RoleSlotModelPlan:
+    candidates = cast(
+        tuple[OpenAlexClaimScopeCandidate, ...],
+        response.candidates,
+    )
+    inputs = build_role_slot_inputs(
+        case_id=case.spec.case_id,
+        topic=case.spec.topic,
+        profile=case.spec.roles.profile(),
+        candidates=candidates,
+    )
+    requests = tuple(
+        _judge_request(batch, candidate_order)
+        for batch, candidate_order in zip(inputs, _CANDIDATE_ORDERS, strict=True)
+    )
+    return RoleSlotModelPlan(
+        case_id=case.spec.case_id,
+        provider_response_sha256=_model_sha256(response),
+        profile_sha256=case.profile_sha256,
+        inputs=inputs,
+        requests=cast(
+            tuple[QwenRoleSlotRequest, QwenRoleSlotRequest, QwenRoleSlotRequest],
+            requests,
+        ),
+    )
+
+
+def _response_identity_drift(
+    request: QwenRoleSlotRequest,
+    response: QwenRoleSlotResponse,
+) -> tuple[str, ...]:
+    expected = {
+        "case_id": request.case_id,
+        "pass_number": request.pass_number,
+        "candidate_order": request.candidate_order,
+        "trace_id": request.trace_id,
+        "batch_input_sha256": request.batch_input_sha256,
+        "prompt_sha256": request.prompt_sha256,
+        "requested_model": request.requested_model,
+    }
+    observed = {
+        "case_id": response.case_id,
+        "pass_number": response.pass_number,
+        "candidate_order": response.candidate_order,
+        "trace_id": response.trace_id,
+        "batch_input_sha256": response.batch_input_sha256,
+        "prompt_sha256": response.prompt_sha256,
+        "requested_model": response.requested_model,
+    }
+    return tuple(key for key in expected if expected[key] != observed[key])
+
+
+def _model_journal_usage(
+    journal: RoleSlotModelJournal,
+) -> QwenRoleSlotUsageObservation | None:
+    if journal.response is not None:
+        return journal.response.usage
+    return journal.observed_usage
+
+
+def _provider_cost(
+    journals: tuple[RoleSlotProviderJournal, ...],
+) -> tuple[CostState, float | None]:
+    if not journals:
+        return "not_observed", None
+    values = tuple(journal.search_cost_usd for journal in journals)
+    if any(value is None for value in values):
+        return "uninspectable", None
+    return "known", sum(value for value in values if value is not None)
+
+
+def _model_cost(
+    journals: tuple[RoleSlotModelJournal, ...],
+) -> tuple[CostState, float | None]:
+    if not journals:
+        return "not_observed", None
+    usages = tuple(_model_journal_usage(journal) for journal in journals)
+    known = all(
+        not journal.request_may_have_spent
+        or (usage is not None and usage.cost_usd is not None)
+        for journal, usage in zip(journals, usages, strict=True)
+    )
+    if not known:
+        return "uninspectable", None
+    return (
+        "known",
+        sum(
+            usage.cost_usd
+            for usage in usages
+            if usage is not None and usage.cost_usd is not None
+        ),
+    )
+
+
+def _audit_boundary_complete(
+    cases: tuple[RoleSlotCaseExecution, ...],
+) -> bool:
+    if len(cases) != 8:
+        return False
+    for case in cases:
+        response = case.provider_journal.response
+        if response is None:
+            return False
+        if case.state == "no_candidates":
+            if response.candidates:
+                return False
+            continue
+        if case.state != "completed" or case.case_audit is None:
+            return False
+        candidate_ids = {candidate.sha256() for candidate in response.candidates}
+        audit_ids = {
+            candidate.candidate_sha256
+            for candidate in case.case_audit.candidate_decisions
+        }
+        if candidate_ids != audit_ids:
+            return False
+        for pass_audit in case.case_audit.passes:
+            if {row.candidate_sha256 for row in pass_audit.candidate_rows} != candidate_ids:
+                return False
+            expected_slot_count = len(case.model_plan.inputs[0].roles)
+            if any(len(row.slots) != expected_slot_count for row in pass_audit.candidate_rows):
+                return False
+    return True
+
+
+def _write_provider_journal(
+    output_dir: Path,
+    journal: RoleSlotProviderJournal,
+) -> None:
+    directory = output_dir / "provider-journals"
+    directory.mkdir(exist_ok=True)
+    _write_new(directory / f"{journal.case_id}.json", _json_text(journal))
+
+
+def _write_model_plan(output_dir: Path, plan: RoleSlotModelPlan) -> None:
+    directory = output_dir / "model-plans"
+    directory.mkdir(exist_ok=True)
+    _write_new(directory / f"{plan.case_id}.json", _json_text(plan))
+
+
+def _write_model_journal(
+    output_dir: Path,
+    journal: RoleSlotModelJournal,
+) -> None:
+    directory = output_dir / "model-journals"
+    directory.mkdir(exist_ok=True)
+    _write_new(
+        directory / f"{journal.case_id}-pass-{journal.pass_number}.json",
+        _json_text(journal),
+    )
+
+
+def _write_case_audit(output_dir: Path, audit: RoleSlotCaseAudit) -> None:
+    directory = output_dir / "case-audits"
+    directory.mkdir(exist_ok=True)
+    _write_new(directory / f"{audit.case_id}.json", _json_text(audit))
+
+
+def _write_case_execution(
+    output_dir: Path,
+    execution: RoleSlotCaseExecution,
+) -> None:
+    directory = output_dir / "case-executions"
+    directory.mkdir(exist_ok=True)
+    _write_new(directory / f"{execution.case_id}.json", _json_text(execution))
+
+
+def _provider_rows(
+    cases: tuple[RoleSlotCaseExecution, ...],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for case in cases:
+        journal = case.provider_journal
+        response = journal.response
+        if response is None:
+            continue
+        usage = response.provider_usage
+        for candidate in response.candidates:
+            evidence = candidate.evidence
+            index = evidence.provider_result_index
+            if index is None:
+                raise OpenAlexRoleSlotDevelopmentError(
+                    "provider candidate lost its result index"
+                )
+            rows.append(
+                {
+                    "case_id": case.case_id,
+                    "provider_result_index": str(index),
+                    "adapter_disposition": "candidate",
+                    "candidate_sha256": candidate.sha256(),
+                    "title": evidence.title,
+                    "url": evidence.url,
+                    "doi": evidence.doi or "",
+                    "publisher": evidence.publisher,
+                    "published_date": (
+                        evidence.published_date.isoformat()
+                        if evidence.published_date is not None
+                        else ""
+                    ),
+                    "abstract": evidence.evidence_summary,
+                    "provider_rejection_code": "",
+                    "rejection_detail": "",
+                    "provider_request_id": response.provider_request_id,
+                    "provider_cost_basis": usage.cost_basis,
+                    "trace_id": journal.trace_id,
+                }
+            )
+        for rejection in response.provider_rejections:
+            rows.append(
+                {
+                    "case_id": case.case_id,
+                    "provider_result_index": str(rejection.provider_result_index),
+                    "adapter_disposition": "provider_rejected",
+                    "candidate_sha256": "",
+                    "title": rejection.title or "",
+                    "url": rejection.url or "",
+                    "doi": "",
+                    "publisher": "",
+                    "published_date": "",
+                    "abstract": "",
+                    "provider_rejection_code": rejection.code,
+                    "rejection_detail": rejection.detail,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_cost_basis": usage.cost_basis,
+                    "trace_id": journal.trace_id,
+                }
+            )
+    rows.sort(key=lambda row: (row["case_id"], int(row["provider_result_index"])))
+    return rows
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _execution_artifact(
+    *,
+    manifest_sha256: str,
+    stop_reason: StopReason,
+    cases: list[RoleSlotCaseExecution],
+) -> RoleSlotDevelopmentExecution:
+    frozen_cases = tuple(cases)
+    provider_journals = tuple(case.provider_journal for case in frozen_cases)
+    model_journals = tuple(
+        call for case in frozen_cases for call in case.model_calls
+    )
+    provider_state, provider_cost = _provider_cost(provider_journals)
+    model_state, model_cost = _model_cost(model_journals)
+    usages = tuple(
+        usage
+        for journal in model_journals
+        if (usage := _model_journal_usage(journal)) is not None
+    )
+    responses = tuple(
+        journal.response
+        for journal in provider_journals
+        if journal.response is not None
+    )
+    audits = tuple(
+        case.case_audit for case in frozen_cases if case.case_audit is not None
+    )
+    complete = (
+        stop_reason == "completed"
+        and len(frozen_cases) == 8
+        and all(
+            case.state in {"completed", "no_candidates"} for case in frozen_cases
+        )
+    )
+    valid_passes = sum(
+        pass_audit.state == "valid" for audit in audits for pass_audit in audit.passes
+    )
+    pass_denominator = sum(len(audit.passes) for audit in audits)
+    local_numerator = sum(audit.local_valid_row_numerator for audit in audits)
+    local_denominator = sum(audit.local_valid_row_denominator for audit in audits)
+    unanimity_numerator = sum(
+        audit.provisional_unanimity_numerator for audit in audits
+    )
+    unanimity_denominator = sum(
+        audit.provisional_unanimity_denominator for audit in audits
+    )
+    selected_case_count = sum(audit.action == "SELECT" for audit in audits)
+    top_gate = valid_passes == pass_denominator if pass_denominator else None
+    local_gate = (
+        local_numerator / local_denominator >= 0.95 if local_denominator else None
+    )
+    unanimity_gate = (
+        unanimity_numerator / unanimity_denominator >= 0.8
+        if unanimity_denominator
+        else None
+    )
+    selected_gate = selected_case_count >= 6 if complete else None
+    boundary = _audit_boundary_complete(frozen_cases)
+    if not complete:
+        gate_state: MechanicalGateState = "not_evaluated"
+    elif all(
+        value is True
+        for value in (top_gate, local_gate, unanimity_gate, selected_gate, boundary)
+    ):
+        gate_state = "pass"
+    else:
+        gate_state = "fail"
+    return RoleSlotDevelopmentExecution(
+        manifest_sha256=manifest_sha256,
+        overall_state="completed" if complete else "partial",
+        stop_reason=stop_reason,
+        openalex_request_count=len(provider_journals),
+        openalex_successful_case_count=sum(
+            journal.state == "completed" for journal in provider_journals
+        ),
+        openalex_cost_state=provider_state,
+        openalex_cost_usd=provider_cost,
+        model_call_count=len(model_journals),
+        model_completed_call_count=sum(
+            journal.state == "completed" for journal in model_journals
+        ),
+        model_cost_state=model_state,
+        model_cost_usd=model_cost,
+        prompt_tokens=sum(usage.prompt_tokens for usage in usages),
+        cached_prompt_tokens=sum(usage.cached_prompt_tokens for usage in usages),
+        completion_tokens=sum(usage.completion_tokens for usage in usages),
+        total_tokens=sum(usage.total_tokens for usage in usages),
+        provider_row_count=sum(
+            len(response.candidates) + len(response.provider_rejections)
+            for response in responses
+        ),
+        provider_candidate_count=sum(len(response.candidates) for response in responses),
+        provider_rejection_count=sum(
+            len(response.provider_rejections) for response in responses
+        ),
+        completed_case_audit_count=len(audits),
+        selected_case_count=selected_case_count,
+        top_level_valid_pass_numerator=valid_passes,
+        top_level_valid_pass_denominator=pass_denominator,
+        top_level_valid_pass_rate=(
+            valid_passes / pass_denominator if pass_denominator else None
+        ),
+        top_level_contract_gate_passed=top_gate,
+        local_valid_row_numerator=local_numerator,
+        local_valid_row_denominator=local_denominator,
+        local_valid_row_rate=(
+            local_numerator / local_denominator if local_denominator else None
+        ),
+        local_valid_row_gate_passed=local_gate,
+        provisional_unanimity_numerator=unanimity_numerator,
+        provisional_unanimity_denominator=unanimity_denominator,
+        provisional_unanimity_rate=(
+            unanimity_numerator / unanimity_denominator
+            if unanimity_denominator
+            else None
+        ),
+        provisional_unanimity_gate_passed=unanimity_gate,
+        selected_case_coverage_gate_passed=selected_gate,
+        audit_boundary_complete=boundary,
+        mechanical_gate_state=gate_state,
+        source_lock_readiness="ready" if complete and boundary else "not_ready",
+        cases=frozen_cases,
+    )
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    execution: RoleSlotDevelopmentExecution,
+) -> None:
+    _write_new(output_dir / "execution.json", _json_text(execution))
+    _write_new(
+        output_dir / "provider-rows.csv",
+        _csv_text(_PROVIDER_ROW_COLUMNS, _provider_rows(execution.cases)),
+    )
+    _write_new(
+        output_dir / "case-audits.json",
+        _json_text(
+            [
+                case.case_audit.model_dump(mode="json")
+                for case in execution.cases
+                if case.case_audit is not None
+            ]
+        ),
+    )
+    indexed = [
+        "manifest.json",
+        "execution.json",
+        "provider-rows.csv",
+        "case-audits.json",
+    ]
+    for case in execution.cases:
+        indexed.append(f"provider-journals/{case.case_id}.json")
+        indexed.append(f"case-executions/{case.case_id}.json")
+        if case.model_plan is not None:
+            indexed.append(f"model-plans/{case.case_id}.json")
+        indexed.extend(
+            f"model-journals/{call.case_id}-pass-{call.pass_number}.json"
+            for call in case.model_calls
+        )
+        if case.case_audit is not None:
+            indexed.append(f"case-audits/{case.case_id}.json")
+    index = {
+        "schema_version": 1,
+        "mode": "openalex_role_slot_v6_development_artifact_index",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "files": {name: _file_sha256(output_dir / name) for name in indexed},
+    }
+    _write_new(output_dir / "artifact-index.json", _json_text(index))
+
+
+def _failed_provider_journal(
+    case: PreparedRoleSlotCase,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool | None,
+    latency_ms: float,
+    search_cost_usd: float | None,
+    response: OpenAlexClaimScopeAdapterResponse | None = None,
+) -> RoleSlotProviderJournal:
+    return RoleSlotProviderJournal(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-role-slot-v6-{case.spec.case_id.casefold()}",
+        state="failed",
+        response=response,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        search_cost_usd=search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _completed_provider_journal(
+    case: PreparedRoleSlotCase,
+    response: OpenAlexClaimScopeAdapterResponse,
+    latency_ms: float,
+) -> RoleSlotProviderJournal:
+    return RoleSlotProviderJournal(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        idempotency_key=case.plan.calls[0].idempotency_key,
+        trace_id=f"openalex-role-slot-v6-{case.spec.case_id.casefold()}",
+        state="completed",
+        response=response,
+        search_cost_usd=response.search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _failed_model_journal(
+    request: QwenRoleSlotRequest,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool,
+    request_may_have_spent: bool,
+    observed_returned_model: str | None = None,
+    observed_usage: QwenRoleSlotUsageObservation | None = None,
+    observed_latency_ms: float | None = None,
+) -> RoleSlotModelJournal:
+    return RoleSlotModelJournal(
+        case_id=request.case_id,
+        pass_number=request.pass_number,
+        candidate_order=request.candidate_order,
+        state="failed",
+        request=request,
+        observed_returned_model=observed_returned_model,
+        observed_usage=observed_usage,
+        observed_latency_ms=observed_latency_ms,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        request_may_have_spent=request_may_have_spent,
+    )
+
+
+def execute_development_study(
+    *,
+    output_dir: Path,
+    openalex_soft_stop_usd: float,
+    model_soft_stop_usd: float,
+    acknowledge_anonymous_daily_budget: bool,
+    acknowledge_model_budget: bool,
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+    expected_implementation_sha256: Mapping[str, str] | None = None,
+    provider_adapter_factory: ProviderAdapterFactory | None = None,
+    model_adapter_factory: ModelAdapterFactory | None = None,
+    monotonic_clock: Clock | None = None,
+) -> RoleSlotDevelopmentExecution:
+    """Run a bounded Y development attempt with no retry or recovery."""
+
+    if not 0.0 < openalex_soft_stop_usd <= MAXIMUM_OPENALEX_SOFT_STOP_USD:
+        raise OpenAlexRoleSlotDevelopmentError(
+            "OpenAlex soft stop must be greater than zero and at most USD 0.01"
+        )
+    if not 0.0 < model_soft_stop_usd <= MAXIMUM_MODEL_SOFT_STOP_USD:
+        raise OpenAlexRoleSlotDevelopmentError(
+            "Qwen soft stop must be greater than zero and at most USD 0.25"
+        )
+    if not acknowledge_anonymous_daily_budget:
+        raise OpenAlexRoleSlotDevelopmentError(
+            "v6 execution requires anonymous OpenAlex budget acknowledgement"
+        )
+    if not acknowledge_model_budget:
+        raise OpenAlexRoleSlotDevelopmentError(
+            "v6 execution requires Qwen model-budget acknowledgement"
+        )
+    if (os.getenv("OPENALEX_API_KEY") or "").strip():
+        raise OpenAlexRoleSlotDevelopmentError(
+            "anonymous v6 study refuses a configured OPENALEX_API_KEY"
+        )
+    if output_dir.exists():
+        raise FileExistsError(f"v6 development output already exists: {output_dir}")
+
+    try:
+        fixture_sha256, challenge, cases = load_frozen_cases(
+            "development",
+            fixture_path,
+            expected_fixture_sha256=expected_fixture_sha256,
+        )
+    except OpenAlexRoleSlotPreflightError as exc:
+        # The live runner owns its public failure contract.  Preserving the
+        # phase-one exception here would force callers to know which earlier
+        # preflight helper happened to reject a frozen identity.
+        raise OpenAlexRoleSlotDevelopmentError(str(exc)) from exc
+    implementation = verify_frozen_implementation(
+        expected_implementation_sha256
+    )
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest(
+        fixture_sha256,
+        challenge,
+        cases,
+        implementation,
+        openalex_soft_stop_usd=openalex_soft_stop_usd,
+        model_soft_stop_usd=model_soft_stop_usd,
+    )
+    manifest_text = _json_text(manifest)
+    _write_new(output_dir / "manifest.json", manifest_text)
+
+    # Client construction is a capability boundary because default factories
+    # resolve credentials and own socket-capable transports.  The global
+    # manifest must already be durable when either custom or default provider
+    # construction begins.
+    provider_adapter = (
+        provider_adapter_factory()
+        if provider_adapter_factory is not None
+        else AnonymousOpenAlexClaimScopeAdapter(transport=_OneRequestTransport())
+    )
+    model_adapter: ModelAdapter | None = None
+    clock = monotonic_clock or time.perf_counter
+    case_executions: list[RoleSlotCaseExecution] = []
+    known_openalex_cost = 0.0
+    known_model_cost = 0.0
+    stop_reason: StopReason = "completed"
+
+    for case in cases:
+        if known_openalex_cost + 1e-12 >= openalex_soft_stop_usd:
+            stop_reason = "openalex_soft_stop"
+            break
+        call = case.plan.calls[0]
+        started_at = clock()
+        provider_stop: StopReason | None = None
+        try:
+            raw_provider_response = provider_adapter(call)
+        except ToolAdapterFailure as exc:
+            provider_journal = _failed_provider_journal(
+                case,
+                failure_type=exc.failure_type,
+                failure_detail=str(exc),
+                failure_retryable=exc.retryable,
+                latency_ms=_elapsed_ms(clock, started_at),
+                search_cost_usd=exc.search_cost_usd,
+            )
+            provider_stop = "provider_failed"
+        else:
+            latency_ms = _elapsed_ms(clock, started_at)
+            try:
+                provider_response = OpenAlexClaimScopeAdapterResponse.model_validate(
+                    raw_provider_response
+                )
+            except ValidationError as exc:
+                provider_journal = _failed_provider_journal(
+                    case,
+                    failure_type="adapter_response_invalid",
+                    failure_detail=_safe_validation_detail(exc),
+                    failure_retryable=False,
+                    latency_ms=latency_ms,
+                    search_cost_usd=None,
+                )
+                provider_stop = "accounting_invalid"
+            else:
+                if provider_response.idempotency_key != call.idempotency_key:
+                    provider_journal = _failed_provider_journal(
+                        case,
+                        failure_type="adapter_identity_mismatch",
+                        failure_detail=(
+                            "provider response idempotency key does not match the "
+                            "authorized call"
+                        ),
+                        failure_retryable=False,
+                        latency_ms=latency_ms,
+                        search_cost_usd=provider_response.search_cost_usd,
+                        response=provider_response,
+                    )
+                    provider_stop = "accounting_invalid"
+                else:
+                    provider_journal = _completed_provider_journal(
+                        case,
+                        provider_response,
+                        latency_ms,
+                    )
+
+        # A spent provider request and every returned row are durable before
+        # model planning, Qwen construction, or the next OpenAlex request.
+        _write_provider_journal(output_dir, provider_journal)
+        if provider_journal.search_cost_usd is None:
+            provider_stop = provider_stop or "accounting_invalid"
+        else:
+            known_openalex_cost += provider_journal.search_cost_usd
+        if provider_stop is not None:
+            case_execution = RoleSlotCaseExecution(
+                case_id=case.spec.case_id,
+                state="provider_failed",
+                provider_journal=provider_journal,
+                model_calls=(),
+            )
+            _write_case_execution(output_dir, case_execution)
+            case_executions.append(case_execution)
+            stop_reason = provider_stop
+            break
+
+        provider_response = cast(
+            OpenAlexClaimScopeAdapterResponse,
+            provider_journal.response,
+        )
+        if not provider_response.candidates:
+            case_execution = RoleSlotCaseExecution(
+                case_id=case.spec.case_id,
+                state="no_candidates",
+                provider_journal=provider_journal,
+                model_calls=(),
+            )
+            _write_case_execution(output_dir, case_execution)
+            case_executions.append(case_execution)
+            continue
+
+        model_plan = _model_plan(case, provider_response)
+        _write_model_plan(output_dir, model_plan)
+        if model_adapter is None:
+            model_adapter = (
+                model_adapter_factory()
+                if model_adapter_factory is not None
+                else QwenRoleSlotJudgeAdapter()
+            )
+
+        model_journals: list[RoleSlotModelJournal] = []
+        raw_responses: list[str] = []
+        case_stop: StopReason | None = None
+        for request in model_plan.requests:
+            if known_model_cost + 1e-12 >= model_soft_stop_usd:
+                case_stop = "model_soft_stop"
+                break
+            try:
+                raw_model_response = model_adapter(request)
+                model_response = QwenRoleSlotResponse.model_validate(
+                    raw_model_response
+                )
+            except QwenRoleSlotJudgeError as exc:
+                model_journal = _failed_model_journal(
+                    request,
+                    failure_type=exc.failure_type,
+                    failure_detail=str(exc),
+                    failure_retryable=exc.retryable,
+                    request_may_have_spent=exc.request_may_have_spent,
+                    observed_returned_model=exc.observed_returned_model,
+                    observed_usage=exc.observed_usage,
+                    observed_latency_ms=exc.observed_latency_ms,
+                )
+                case_stop = "model_failed"
+            except ValidationError as exc:
+                model_journal = _failed_model_journal(
+                    request,
+                    failure_type="adapter_response_invalid",
+                    failure_detail=_safe_validation_detail(exc),
+                    failure_retryable=False,
+                    request_may_have_spent=True,
+                )
+                case_stop = "accounting_invalid"
+            else:
+                drift = _response_identity_drift(request, model_response)
+                if drift:
+                    model_journal = _failed_model_journal(
+                        request,
+                        failure_type="adapter_response_identity_mismatch",
+                        failure_detail="response identity drifted: " + ", ".join(drift),
+                        failure_retryable=False,
+                        request_may_have_spent=True,
+                        observed_returned_model=model_response.returned_model,
+                        observed_usage=model_response.usage,
+                        observed_latency_ms=model_response.latency_ms,
+                    )
+                    case_stop = "accounting_invalid"
+                else:
+                    model_journal = RoleSlotModelJournal(
+                        case_id=request.case_id,
+                        pass_number=request.pass_number,
+                        candidate_order=request.candidate_order,
+                        state="completed",
+                        request=request,
+                        response=model_response,
+                        request_may_have_spent=True,
+                    )
+                    raw_responses.append(model_response.raw_content)
+
+            # The response and safe usage are durable before another Qwen call.
+            _write_model_journal(output_dir, model_journal)
+            model_journals.append(model_journal)
+            usage = _model_journal_usage(model_journal)
+            if model_journal.request_may_have_spent and (
+                usage is None or usage.cost_usd is None
+            ):
+                case_stop = case_stop or "accounting_invalid"
+            elif usage is not None and usage.cost_usd is not None:
+                known_model_cost += usage.cost_usd
+            if model_journal.state != "completed":
+                break
+
+        if len(raw_responses) == 3 and case_stop is None:
+            audit = evaluate_role_slot_case(
+                case_id=case.spec.case_id,
+                topic=case.spec.topic,
+                profile=case.spec.roles.profile(),
+                selection_contract=challenge.selection_contract,
+                candidates=cast(
+                    tuple[OpenAlexClaimScopeCandidate, ...],
+                    provider_response.candidates,
+                ),
+                raw_responses=cast(tuple[str, str, str], tuple(raw_responses)),
+            )
+            _write_case_audit(output_dir, audit)
+            case_execution = RoleSlotCaseExecution(
+                case_id=case.spec.case_id,
+                state="completed",
+                provider_journal=provider_journal,
+                model_plan=model_plan,
+                model_calls=tuple(model_journals),
+                case_audit=audit,
+            )
+        else:
+            case_execution = RoleSlotCaseExecution(
+                case_id=case.spec.case_id,
+                state="model_incomplete",
+                provider_journal=provider_journal,
+                model_plan=model_plan,
+                model_calls=tuple(model_journals),
+            )
+        # The complete case boundary is durable before the next provider call.
+        _write_case_execution(output_dir, case_execution)
+        case_executions.append(case_execution)
+        if case_stop is not None:
+            stop_reason = case_stop
+            break
+
+    execution = _execution_artifact(
+        manifest_sha256=_sha256_bytes(manifest_text.encode("utf-8")),
+        stop_reason=stop_reason,
+        cases=case_executions,
+    )
+    _write_final_artifacts(output_dir, execution)
+    return execution
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--cohort", choices=("development", "unseen"), default="development")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE_PATH)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--openalex-soft-stop-usd", type=float)
+    parser.add_argument("--model-soft-stop-usd", type=float)
+    parser.add_argument("--acknowledge-anonymous-daily-budget", action="store_true")
+    parser.add_argument("--acknowledge-model-budget", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(_stdout_json(protocol_dry_run(fixture_path=args.fixture)))
+        return 0
+    if args.cohort != "development":
+        raise SystemExit("v6 live execution refuses the unseen cohort")
+    if (
+        args.output_dir is None
+        or args.openalex_soft_stop_usd is None
+        or args.model_soft_stop_usd is None
+    ):
+        raise SystemExit(
+            "--execute-live requires --output-dir and both provider soft stops"
+        )
+    execution = execute_development_study(
+        output_dir=args.output_dir,
+        openalex_soft_stop_usd=args.openalex_soft_stop_usd,
+        model_soft_stop_usd=args.model_soft_stop_usd,
+        acknowledge_anonymous_daily_budget=args.acknowledge_anonymous_daily_budget,
+        acknowledge_model_budget=args.acknowledge_model_budget,
+        fixture_path=args.fixture,
+    )
+    print(_stdout_json(execution))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/academic_agent/tools/qwen_role_slot_judge.py
+++ b/src/academic_agent/tools/qwen_role_slot_judge.py
@@ -1,0 +1,539 @@
+"""Strict one-request Qwen adapter for the disconnected role-slot v6 study.
+
+The production Qwen path retries selected transport failures and the sealed v5
+judge has historical request identities.  Neither boundary is suitable for a
+new experiment whose one adapter invocation must equal exactly one potentially
+billable request.  This module therefore owns a separate request and response
+contract while retaining the already tested direct-HTTP accounting rules.
+
+It performs no retry, redirect, repair, fallback, endpoint override, streaming,
+or model substitution.  Nothing in the production worker imports this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Literal, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.token_usage import cost_for, price_for
+
+
+QWEN_ROLE_SLOT_ENDPOINT = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+)
+QWEN_ROLE_SLOT_MODEL = "qwen3.5-plus"
+QWEN_ROLE_SLOT_TIMEOUT_SECONDS = 120.0
+QWEN_ROLE_SLOT_MAX_TOKENS = 8_000
+_MAX_RESPONSE_BYTES = 1_000_000
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+RoleSlotCandidateOrder = Literal[
+    "provider_order",
+    "reverse_provider_order",
+    "candidate_sha256_order",
+]
+
+
+class QwenRoleSlotJudgeError(RuntimeError):
+    """Credential-safe terminal failure from one v6 Qwen request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_type: str,
+        retryable: bool,
+        request_may_have_spent: bool,
+        observed_returned_model: str | None = None,
+        observed_usage: QwenRoleSlotUsageObservation | None = None,
+        observed_latency_ms: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failure_type = failure_type
+        self.retryable = retryable
+        self.request_may_have_spent = request_may_have_spent
+        # A rejected provider envelope may retain safe identity and accounting
+        # so an already-spent request cannot disappear into a false zero.  Raw
+        # semantic content is deliberately absent from this exception.
+        self.observed_returned_model = observed_returned_model
+        self.observed_usage = observed_usage
+        self.observed_latency_ms = observed_latency_ms
+
+
+class QwenRoleSlotRequest(BaseModel):
+    """Credential-free identity for one candidate-order quote extraction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    pass_number: Literal[1, 2, 3]
+    candidate_order: RoleSlotCandidateOrder
+    trace_id: str = Field(pattern=r"^openalex-v6-y0[1-8]-pass-[123]$")
+    requested_provider: Literal["qwen"] = "qwen"
+    requested_model: Literal["qwen3.5-plus"] = QWEN_ROLE_SLOT_MODEL
+    chat_completions_endpoint: Literal[
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+    ] = QWEN_ROLE_SLOT_ENDPOINT
+    system_prompt: str = Field(min_length=20, max_length=20_000)
+    user_prompt: str = Field(min_length=20, max_length=250_000)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    temperature: Literal[0.0] = 0.0
+    max_tokens: Literal[8000] = QWEN_ROLE_SLOT_MAX_TOKENS
+    transport_timeout_seconds: Literal[120.0] = QWEN_ROLE_SLOT_TIMEOUT_SECONDS
+
+    @model_validator(mode="after")
+    def _validate_request_identity(self) -> "QwenRoleSlotRequest":
+        expected_trace = (
+            f"openalex-v6-{self.case_id.casefold()}-pass-{self.pass_number}"
+        )
+        if self.trace_id != expected_trace:
+            raise ValueError("trace ID drifted from the case and pass")
+        expected_order = (
+            "provider_order",
+            "reverse_provider_order",
+            "candidate_sha256_order",
+        )[self.pass_number - 1]
+        if self.candidate_order != expected_order:
+            raise ValueError("candidate order drifted from the pass identity")
+        observed_prompt = prompt_sha256(self.system_prompt, self.user_prompt)
+        if observed_prompt != self.prompt_sha256:
+            raise ValueError("prompt SHA-256 does not match the request text")
+        return self
+
+    def body(self) -> bytes:
+        """Return exact wire bytes while keeping credentials out of artifacts."""
+
+        # ``extra_body`` is an OpenAI SDK argument, not a direct-HTTP field.
+        # The provider extension must therefore remain at the top level here.
+        return json.dumps(
+            {
+                "enable_thinking": False,
+                "max_tokens": self.max_tokens,
+                "messages": [
+                    {"content": self.system_prompt, "role": "system"},
+                    {"content": self.user_prompt, "role": "user"},
+                ],
+                "model": self.requested_model,
+                "response_format": {"type": "json_object"},
+                "stream": False,
+                "temperature": self.temperature,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+
+class QwenRoleSlotUsageObservation(BaseModel):
+    """Safe accounting retained even when semantic output is rejected."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    cached_prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    cost_usd: float | None = Field(default=None, ge=0.0, allow_inf_nan=False)
+    cost_basis: str | None = Field(default=None, min_length=5, max_length=300)
+
+    @model_validator(mode="after")
+    def _validate_accounting(self) -> "QwenRoleSlotUsageObservation":
+        if self.cached_prompt_tokens > self.prompt_tokens:
+            raise ValueError("cached tokens cannot exceed prompt tokens")
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            raise ValueError("total tokens do not match prompt plus completion")
+        if (self.cost_usd is None) != (self.cost_basis is None):
+            raise ValueError("cost and cost basis must be known or unknown together")
+        return self
+
+
+class QwenRoleSlotUsage(QwenRoleSlotUsageObservation):
+    """Successful request accounting with a reproducible local price."""
+
+    cost_usd: float = Field(ge=0.0, allow_inf_nan=False)
+    cost_basis: str = Field(min_length=5, max_length=300)
+
+
+class QwenRoleSlotResponse(BaseModel):
+    """Complete inspectable result from exactly one Qwen request."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^Y0[1-8]$")
+    pass_number: Literal[1, 2, 3]
+    candidate_order: RoleSlotCandidateOrder
+    trace_id: str = Field(pattern=r"^openalex-v6-y0[1-8]-pass-[123]$")
+    request_sha256: str = Field(pattern=_SHA256_PATTERN)
+    batch_input_sha256: str = Field(pattern=_SHA256_PATTERN)
+    prompt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    requested_model: Literal["qwen3.5-plus"] = QWEN_ROLE_SLOT_MODEL
+    returned_model: Literal["qwen3.5-plus"]
+    provider_response_id: str = Field(min_length=3, max_length=300)
+    provider_request_id: str | None = Field(default=None, max_length=300)
+    finish_reason: str = Field(min_length=1, max_length=100)
+    raw_content: str = Field(min_length=1, max_length=200_000)
+    raw_content_sha256: str = Field(pattern=_SHA256_PATTERN)
+    usage: QwenRoleSlotUsage
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_response_identity(self) -> "QwenRoleSlotResponse":
+        expected_trace = (
+            f"openalex-v6-{self.case_id.casefold()}-pass-{self.pass_number}"
+        )
+        if self.trace_id != expected_trace:
+            raise ValueError("response trace ID drifted from case and pass")
+        expected_order = (
+            "provider_order",
+            "reverse_provider_order",
+            "candidate_sha256_order",
+        )[self.pass_number - 1]
+        if self.candidate_order != expected_order:
+            raise ValueError("response candidate order drifted from pass")
+        if _sha256_text(self.raw_content) != self.raw_content_sha256:
+            raise ValueError("raw model content SHA-256 does not match")
+        return self
+
+
+@dataclass(frozen=True)
+class QwenRoleSlotTransportResponse:
+    """Raw body and headers from one transport invocation."""
+
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class QwenRoleSlotOneRequestTransport(Protocol):
+    """Injected seam whose one invocation equals one outbound request."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> QwenRoleSlotTransportResponse: ...
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects so one adapter call cannot spend twice."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _UrllibOneRequestTransport:
+    """Default direct transport with no redirect or retry behavior."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        body: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> QwenRoleSlotTransportResponse:
+        request = Request(
+            endpoint,
+            data=body,
+            headers=dict(headers),
+            method="POST",
+        )
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            response_headers = {
+                str(key): str(value) for key, value in response.headers.items()
+            }
+            return QwenRoleSlotTransportResponse(
+                body=response.read(_MAX_RESPONSE_BYTES + 1),
+                headers=response_headers,
+            )
+
+
+class _ProviderMessage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    content: str = Field(min_length=1, max_length=200_000)
+
+
+class _ProviderChoice(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    finish_reason: str = Field(min_length=1, max_length=100)
+    message: _ProviderMessage
+
+
+class _PromptTokenDetails(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    cached_tokens: int = Field(default=0, ge=0)
+
+
+class _ProviderUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    prompt_tokens_details: _PromptTokenDetails | None = None
+
+
+class _ProviderEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str = Field(min_length=3, max_length=300)
+    model: str = Field(min_length=3, max_length=200)
+    choices: tuple[_ProviderChoice, ...] = Field(min_length=1, max_length=1)
+    usage: _ProviderUsage
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return _sha256_text(canonical)
+
+
+def prompt_sha256(system_prompt: str, user_prompt: str) -> str:
+    """Bind both messages independently from provider wire formatting."""
+
+    return _sha256_json({"system": system_prompt, "user": user_prompt})
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str | None:
+    expected = name.casefold()
+    return next(
+        (value for key, value in headers.items() if key.casefold() == expected),
+        None,
+    )
+
+
+def _safe_validation_detail(exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "provider response schema invalid"
+
+
+def _usage_observation(
+    envelope: _ProviderEnvelope,
+) -> QwenRoleSlotUsageObservation:
+    """Validate counters before admitting any semantic response text."""
+
+    details = envelope.usage.prompt_tokens_details
+    cached_tokens = details.cached_tokens if details is not None else 0
+    metrics = SimpleNamespace(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=cached_tokens,
+        cache_creation_tokens=0,
+        completion_tokens=envelope.usage.completion_tokens,
+    )
+    # Deployment price overrides are useful operationally but cannot move a
+    # committed experiment's cost stop.  The runner also locks token_usage.py.
+    price = price_for(envelope.model, allow_env_override=False)
+    cost = (
+        cost_for(envelope.model, metrics, allow_env_override=False)
+        if price is not None
+        else None
+    )
+    return QwenRoleSlotUsageObservation(
+        prompt_tokens=envelope.usage.prompt_tokens,
+        cached_prompt_tokens=cached_tokens,
+        completion_tokens=envelope.usage.completion_tokens,
+        total_tokens=envelope.usage.total_tokens,
+        cost_usd=cost,
+        cost_basis=price.basis if price is not None else None,
+    )
+
+
+class QwenRoleSlotJudgeAdapter:
+    """Perform one fixed-endpoint, fixed-model v6 JSON request."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = QWEN_ROLE_SLOT_TIMEOUT_SECONDS,
+        transport: QwenRoleSlotOneRequestTransport | None = None,
+        monotonic_clock=None,  # noqa: ANN001
+    ) -> None:
+        resolved_key = (api_key or os.getenv("DASHSCOPE_API_KEY") or "").strip()
+        if not resolved_key:
+            raise ValueError("DASHSCOPE_API_KEY is required for the v6 Qwen judge")
+        if timeout != QWEN_ROLE_SLOT_TIMEOUT_SECONDS:
+            raise ValueError("v6 Qwen timeout must remain exactly 120 seconds")
+        self._api_key = resolved_key
+        self._timeout = timeout
+        self._transport = transport or _UrllibOneRequestTransport()
+        self._clock = monotonic_clock or time.perf_counter
+
+    def __call__(
+        self,
+        request: QwenRoleSlotRequest,
+    ) -> QwenRoleSlotResponse:
+        """Send one request; every transport or accounting failure is terminal."""
+
+        if request.transport_timeout_seconds != self._timeout:
+            raise QwenRoleSlotJudgeError(
+                "Qwen request timeout identity does not match the adapter",
+                failure_type="request_timeout_identity_mismatch",
+                retryable=False,
+                request_may_have_spent=False,
+            )
+        body = request.body()
+        request_sha256 = hashlib.sha256(body).hexdigest()
+        started_at = self._clock()
+        try:
+            transport_response = self._transport(
+                endpoint=request.chat_completions_endpoint,
+                body=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "AcademicAgentRoleSlotV6-Qwen/1.0",
+                    "X-Client-Request-ID": request.trace_id,
+                },
+                timeout=self._timeout,
+            )
+        except HTTPError as exc:
+            is_redirect = 300 <= exc.code < 400
+            raise QwenRoleSlotJudgeError(
+                f"Qwen HTTP {exc.code}",
+                failure_type=("provider_redirect" if is_redirect else "provider_http"),
+                retryable=exc.code in {408, 429} or 500 <= exc.code < 600,
+                request_may_have_spent=not is_redirect,
+                observed_latency_ms=max(
+                    (self._clock() - started_at) * 1000.0,
+                    0.0,
+                ),
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise QwenRoleSlotJudgeError(
+                f"Qwen transport failed: {type(exc).__name__}",
+                failure_type="provider_transport",
+                retryable=True,
+                request_may_have_spent=True,
+                observed_latency_ms=max(
+                    (self._clock() - started_at) * 1000.0,
+                    0.0,
+                ),
+            ) from exc
+        latency_ms = max((self._clock() - started_at) * 1000.0, 0.0)
+
+        if len(transport_response.body) > _MAX_RESPONSE_BYTES:
+            raise QwenRoleSlotJudgeError(
+                "Qwen response exceeded the byte limit",
+                failure_type="provider_response_too_large",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_latency_ms=latency_ms,
+            )
+        try:
+            decoded = json.loads(transport_response.body.decode("utf-8"))
+            envelope = _ProviderEnvelope.model_validate(decoded)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            detail = (
+                _safe_validation_detail(exc)
+                if isinstance(exc, ValidationError)
+                else type(exc).__name__
+            )
+            raise QwenRoleSlotJudgeError(
+                f"Qwen response failed schema validation: {detail}",
+                failure_type="provider_response_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_latency_ms=latency_ms,
+            ) from exc
+
+        try:
+            observed_usage = _usage_observation(envelope)
+        except ValidationError as exc:
+            raise QwenRoleSlotJudgeError(
+                "Qwen usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_latency_ms=latency_ms,
+            ) from exc
+
+        if envelope.model != request.requested_model:
+            raise QwenRoleSlotJudgeError(
+                "Qwen returned a model identity inconsistent with the request",
+                failure_type="provider_model_identity_mismatch",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
+                observed_latency_ms=latency_ms,
+            )
+        if observed_usage.cost_usd is None or observed_usage.cost_basis is None:
+            raise QwenRoleSlotJudgeError(
+                "Qwen token cost is not inspectable for the returned model",
+                failure_type="provider_cost_uninspectable",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_usage=observed_usage,
+                observed_latency_ms=latency_ms,
+            )
+        try:
+            usage = QwenRoleSlotUsage.model_validate(
+                observed_usage.model_dump(mode="python")
+            )
+        except ValidationError as exc:
+            raise QwenRoleSlotJudgeError(
+                "Qwen usage accounting failed schema validation",
+                failure_type="provider_usage_invalid",
+                retryable=False,
+                request_may_have_spent=True,
+                observed_returned_model=envelope.model,
+                observed_latency_ms=latency_ms,
+            ) from exc
+
+        choice = envelope.choices[0]
+        return QwenRoleSlotResponse(
+            case_id=request.case_id,
+            pass_number=request.pass_number,
+            candidate_order=request.candidate_order,
+            trace_id=request.trace_id,
+            request_sha256=request_sha256,
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model=envelope.model,
+            provider_response_id=envelope.id,
+            provider_request_id=(
+                _header_value(transport_response.headers, "x-request-id")
+                or _header_value(
+                    transport_response.headers,
+                    "x-dashscope-request-id",
+                )
+            ),
+            finish_reason=choice.finish_reason,
+            raw_content=choice.message.content,
+            raw_content_sha256=_sha256_text(choice.message.content),
+            usage=usage,
+            latency_ms=latency_ms,
+        )

--- a/tests/test_openalex_role_slot_development.py
+++ b/tests/test_openalex_role_slot_development.py
@@ -1,0 +1,514 @@
+"""Zero-network write-once seams for the role-slot v6 development runner."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import openalex_role_slot_development as development
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from academic_agent.tools.qwen_role_slot_judge import (
+    QwenRoleSlotJudgeError,
+    QwenRoleSlotResponse,
+    QwenRoleSlotUsage,
+)
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _implementation_hashes() -> dict[str, str]:
+    return {
+        name: _sha256(path.read_bytes())
+        for name, path in development._IMPLEMENTATION_PATHS.items()  # noqa: SLF001
+    }
+
+
+def _candidate(case_id: str, index: int) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{case_id} role-slot candidate {index} with direct source text",
+            url=f"https://openalex.org/W{case_id[1:]}{index}123456789",
+            doi=f"10.5555/{case_id.casefold()}.{index}",
+            publisher="Frozen OpenAlex Test Publisher",
+            published_date=date(2026, 8, 31),
+            evidence_summary=(
+                f"This abstract for {case_id} candidate {index} contains enough "
+                "public source text for every fixed role-slot parser boundary."
+            ),
+            summary_source="abstract",
+            citation_count=index,
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+class OrderedProviderAdapter:
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.calls = []
+
+    def __call__(self, call):  # noqa: ANN001, ANN204
+        case_number = len(self.calls) + 1
+        case_id = f"Y{case_number:02d}"
+        assert (self.output_dir / "manifest.json").is_file()
+        if case_number > 1:
+            previous = f"Y{case_number - 1:02d}"
+            assert (
+                self.output_dir / "case-executions" / f"{previous}.json"
+            ).is_file()
+        self.calls.append(call)
+        request_id = f"client-openalex-v6-{case_id.casefold()}"
+        usage = ToolProviderUsage(
+            provider="openalex",
+            request_id=request_id,
+            request_id_source="client_generated",
+            result_count=3,
+            cost_basis="reported_usd",
+            reported_cost_usd=0.001,
+        )
+        return OpenAlexClaimScopeAdapterResponse(
+            idempotency_key=call.idempotency_key,
+            candidates=(_candidate(case_id, 0), _candidate(case_id, 1)),
+            provider_rejections=(
+                ProviderResultRejection(
+                    provider_result_index=2,
+                    code="provider_result_schema_invalid",
+                    detail="frozen malformed provider row",
+                    title=f"{case_id} rejected row",
+                    url=f"https://openalex.org/W{case_number}999999999",
+                ),
+            ),
+            search_cost_usd=0.001,
+            provider_request_id=request_id,
+            provider_usage=usage,
+        )
+
+
+def _prompt_input(request) -> dict[str, object]:  # noqa: ANN001
+    return json.loads(request.user_prompt.split("INPUT:\n", 1)[1])
+
+
+def _abstain_content(request) -> str:  # noqa: ANN001
+    outbound = _prompt_input(request)
+    slots = outbound["roles"]
+    return json.dumps(
+        {
+            "case_id": request.case_id,
+            "candidates": [
+                {
+                    "candidate_sha256": candidate["candidate_sha256"],
+                    "slots": [
+                        {
+                            "slot_index": slot["slot_index"],
+                            "state": "ABSTAIN",
+                            "field": None,
+                            "quote": None,
+                        }
+                        for slot in slots
+                    ],
+                }
+                for candidate in outbound["candidates"]
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+
+class OrderedModelAdapter:
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.calls = []
+        self.outbound_orders: list[tuple[str, ...]] = []
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        assert (
+            self.output_dir / "provider-journals" / f"{request.case_id}.json"
+        ).is_file()
+        assert (
+            self.output_dir / "model-plans" / f"{request.case_id}.json"
+        ).is_file()
+        if request.pass_number > 1:
+            assert (
+                self.output_dir
+                / "model-journals"
+                / f"{request.case_id}-pass-{request.pass_number - 1}.json"
+            ).is_file()
+        outbound = _prompt_input(request)
+        candidate_order = tuple(
+            row["candidate_sha256"] for row in outbound["candidates"]
+        )
+        self.outbound_orders.append(candidate_order)
+        self.calls.append(request)
+        raw_content = _abstain_content(request)
+        usage = QwenRoleSlotUsage(
+            prompt_tokens=100,
+            cached_prompt_tokens=1,
+            completion_tokens=20,
+            total_tokens=120,
+            cost_usd=0.001,
+            cost_basis="frozen zero-network test cost",
+        )
+        return QwenRoleSlotResponse(
+            case_id=request.case_id,
+            pass_number=request.pass_number,
+            candidate_order=request.candidate_order,
+            trace_id=request.trace_id,
+            request_sha256=_sha256(request.body()),
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model="qwen3.5-plus",
+            provider_response_id=f"qwen-response-{len(self.calls)}",
+            provider_request_id=f"qwen-request-{len(self.calls)}",
+            finish_reason="stop",
+            raw_content=raw_content,
+            raw_content_sha256=_sha256(raw_content.encode("utf-8")),
+            usage=usage,
+            latency_ms=25.0,
+        )
+
+
+class ProviderFactory:
+    def __init__(self, output_dir: Path, adapter: OrderedProviderAdapter) -> None:
+        self.output_dir = output_dir
+        self.adapter = adapter
+        self.call_count = 0
+
+    def __call__(self):  # noqa: ANN204
+        self.call_count += 1
+        assert (self.output_dir / "manifest.json").is_file()
+        return self.adapter
+
+
+class ModelFactory:
+    def __init__(self, output_dir: Path, adapter: OrderedModelAdapter) -> None:
+        self.output_dir = output_dir
+        self.adapter = adapter
+        self.call_count = 0
+
+    def __call__(self):  # noqa: ANN204
+        self.call_count += 1
+        assert (self.output_dir / "manifest.json").is_file()
+        assert (self.output_dir / "provider-journals" / "Y01.json").is_file()
+        assert (self.output_dir / "model-plans" / "Y01.json").is_file()
+        return self.adapter
+
+
+def _run_complete(tmp_path: Path):  # noqa: ANN202
+    output = tmp_path / "result"
+    provider = OrderedProviderAdapter(output)
+    model = OrderedModelAdapter(output)
+    provider_factory = ProviderFactory(output, provider)
+    model_factory = ModelFactory(output, model)
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.25,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=provider_factory,
+        model_adapter_factory=model_factory,
+    )
+    return output, execution, provider, model, provider_factory, model_factory
+
+
+def test_dry_run_verifies_all_templates_without_constructing_a_client():
+    result = development.protocol_dry_run(
+        expected_implementation_sha256=_implementation_hashes()
+    )
+
+    assert result["case_count"] == 8
+    assert result["maximum_openalex_request_count"] == 8
+    assert result["maximum_model_call_count"] == 24
+    assert result["requested_model"] == "qwen3.5-plus"
+    assert result["model_transport_timeout_seconds"] == 120.0
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["unseen_cohort_opened"] is False
+    assert [case["case_id"] for case in result["cases"]] == [
+        f"Y{index:02d}" for index in range(1, 9)
+    ]
+    assert all(
+        len(set(case["judge_request_template_sha256s"])) == 3
+        for case in result["cases"]
+    )
+
+
+def test_complete_execution_persists_every_seam_and_actual_candidate_order(tmp_path):
+    """Values must reach durable clients, not merely exist inside the kernel."""
+
+    output, execution, provider, model, provider_factory, model_factory = (
+        _run_complete(tmp_path)
+    )
+
+    assert execution.overall_state == "completed"
+    assert execution.stop_reason == "completed"
+    assert execution.openalex_request_count == 8
+    assert execution.model_call_count == 24
+    assert execution.provider_row_count == 24
+    assert execution.provider_candidate_count == 16
+    assert execution.provider_rejection_count == 8
+    assert execution.completed_case_audit_count == 8
+    assert execution.top_level_valid_pass_rate == 1.0
+    assert execution.local_valid_row_rate == 1.0
+    assert execution.provisional_unanimity_rate == 1.0
+    assert execution.selected_case_count == 0
+    assert execution.mechanical_gate_state == "fail"
+    assert execution.source_lock_readiness == "ready"
+    assert execution.human_review_state == "not_prepared"
+    assert execution.source_value_state == "not_evaluated"
+    assert execution.openalex_cost_usd == pytest.approx(0.008)
+    assert execution.model_cost_usd == pytest.approx(0.024)
+    assert provider_factory.call_count == 1
+    assert model_factory.call_count == 1
+    assert len(provider.calls) == 8
+    assert len(model.calls) == 24
+
+    for offset in range(0, 24, 3):
+        provider_order, reverse_order, sha_order = model.outbound_orders[offset : offset + 3]
+        assert reverse_order == tuple(reversed(provider_order))
+        assert sha_order == tuple(sorted(provider_order))
+
+    payload = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert len(payload["cases"]) == 8
+    for case in payload["cases"]:
+        assert len(case["model_calls"]) == 3
+        assert len(case["case_audit"]["passes"]) == 3
+        assert len(case["case_audit"]["candidate_decisions"]) == 2
+        slot_count = len(case["model_plan"]["inputs"][0]["roles"])
+        for pass_audit in case["case_audit"]["passes"]:
+            assert len(pass_audit["candidate_rows"]) == 2
+            assert all(
+                len(candidate["slots"]) == slot_count
+                for candidate in pass_audit["candidate_rows"]
+            )
+    rows = list(
+        csv.DictReader((output / "provider-rows.csv").open(encoding="utf-8"))
+    )
+    assert len(rows) == 24
+    assert {row["adapter_disposition"] for row in rows} == {
+        "candidate",
+        "provider_rejected",
+    }
+    index = json.loads((output / "artifact-index.json").read_text(encoding="utf-8"))
+    assert len(index["files"]) == 60
+    assert "case-audits/Y08.json" in index["files"]
+    assert "model-journals/Y08-pass-3.json" in index["files"]
+
+
+class OneCaseProvider(OrderedProviderAdapter):
+    pass
+
+
+class TerminalModelFailure:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        self.calls.append(request)
+        raise QwenRoleSlotJudgeError(
+            "simulated uninspectable model timeout",
+            failure_type="provider_transport",
+            retryable=True,
+            request_may_have_spent=True,
+            observed_latency_ms=120_000.0,
+        )
+
+
+def test_model_failure_is_one_attempt_and_uninspectable_not_zero(tmp_path):
+    output = tmp_path / "failure"
+    provider = OneCaseProvider(output)
+    model = TerminalModelFailure()
+
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.25,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=lambda: provider,
+        model_adapter_factory=lambda: model,
+    )
+
+    assert execution.overall_state == "partial"
+    assert execution.stop_reason == "model_failed"
+    assert execution.model_call_count == 1
+    assert execution.model_completed_call_count == 0
+    assert execution.model_cost_state == "uninspectable"
+    assert execution.model_cost_usd is None
+    assert execution.mechanical_gate_state == "not_evaluated"
+    assert len(model.calls) == 1
+    journal = json.loads(
+        (output / "model-journals" / "Y01-pass-1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert journal["failure_type"] == "provider_transport"
+    assert journal["request_may_have_spent"] is True
+    assert "raw_content" not in journal
+
+
+class TerminalProviderFailure:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, call):  # noqa: ANN001, ANN204
+        del call
+        self.call_count += 1
+        raise ToolAdapterFailure(
+            "simulated provider timeout",
+            retryable=True,
+            failure_type="provider_transport",
+            search_cost_usd=None,
+        )
+
+
+def test_provider_failure_stops_before_model_factory_and_keeps_unknown_cost(tmp_path):
+    output = tmp_path / "provider-failure"
+    provider = TerminalProviderFailure()
+    model_factory_called = False
+
+    def model_factory():  # noqa: ANN202
+        nonlocal model_factory_called
+        model_factory_called = True
+        raise AssertionError("model factory must not run after provider failure")
+
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.25,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=lambda: provider,
+        model_adapter_factory=model_factory,
+    )
+
+    assert execution.stop_reason == "provider_failed"
+    assert execution.openalex_request_count == 1
+    assert execution.openalex_cost_state == "uninspectable"
+    assert execution.openalex_cost_usd is None
+    assert execution.model_cost_state == "not_observed"
+    assert provider.call_count == 1
+    assert model_factory_called is False
+
+
+def test_drift_existing_output_budget_and_key_fail_before_factories(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "existing"
+    output.mkdir()
+    factory_calls = 0
+
+    def factory():  # noqa: ANN202
+        nonlocal factory_calls
+        factory_calls += 1
+        raise AssertionError("factory must remain unreachable")
+
+    with pytest.raises(FileExistsError):
+        development.execute_development_study(
+            output_dir=output,
+            openalex_soft_stop_usd=0.01,
+            model_soft_stop_usd=0.25,
+            acknowledge_anonymous_daily_budget=True,
+            acknowledge_model_budget=True,
+            expected_implementation_sha256=_implementation_hashes(),
+            provider_adapter_factory=factory,
+        )
+    with pytest.raises(development.OpenAlexRoleSlotDevelopmentError, match="budget"):
+        development.execute_development_study(
+            output_dir=tmp_path / "missing-ack",
+            openalex_soft_stop_usd=0.01,
+            model_soft_stop_usd=0.25,
+            acknowledge_anonymous_daily_budget=False,
+            acknowledge_model_budget=True,
+            expected_implementation_sha256=_implementation_hashes(),
+            provider_adapter_factory=factory,
+        )
+    monkeypatch.setenv("OPENALEX_API_KEY", "configured-key-must-not-be-used")
+    with pytest.raises(development.OpenAlexRoleSlotDevelopmentError, match="refuses"):
+        development.execute_development_study(
+            output_dir=tmp_path / "configured-key",
+            openalex_soft_stop_usd=0.01,
+            model_soft_stop_usd=0.25,
+            acknowledge_anonymous_daily_budget=True,
+            acknowledge_model_budget=True,
+            expected_implementation_sha256=_implementation_hashes(),
+            provider_adapter_factory=factory,
+        )
+    assert factory_calls == 0
+
+
+def test_fixture_drift_stops_before_output_or_provider_construction(tmp_path):
+    output = tmp_path / "drift"
+    factory_calls = 0
+
+    def factory():  # noqa: ANN202
+        nonlocal factory_calls
+        factory_calls += 1
+        raise AssertionError("provider factory must not run after fixture drift")
+
+    with pytest.raises(
+        development.OpenAlexRoleSlotDevelopmentError,
+        match="fixture byte identity drifted",
+    ):
+        development.execute_development_study(
+            output_dir=output,
+            openalex_soft_stop_usd=0.01,
+            model_soft_stop_usd=0.25,
+            acknowledge_anonymous_daily_budget=True,
+            acknowledge_model_budget=True,
+            expected_fixture_sha256="0" * 64,
+            expected_implementation_sha256=_implementation_hashes(),
+            provider_adapter_factory=factory,
+        )
+    assert not output.exists()
+    assert factory_calls == 0
+
+
+def test_live_cli_refuses_unseen_before_execution(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["openalex_role_slot_development.py", "--execute-live", "--cohort", "unseen"],
+    )
+    with pytest.raises(SystemExit, match="refuses the unseen cohort"):
+        development.main()
+
+
+def test_production_worker_remains_disconnected_from_v6_runtime():
+    root = Path(development.__file__).resolve().parent
+    production_sources = (
+        root / "src/academic_agent/pipeline_worker.py",
+        root / "src/academic_agent/crew.py",
+        root / "api/main.py",
+    )
+    forbidden = (
+        "openalex_role_slot_development",
+        "qwen_role_slot_judge",
+        "openalex_role_slot",
+    )
+    for path in production_sources:
+        source = path.read_text(encoding="utf-8")
+        assert all(name not in source for name in forbidden)

--- a/tests/test_openalex_role_slot_development_edge_seams.py
+++ b/tests/test_openalex_role_slot_development_edge_seams.py
@@ -1,0 +1,263 @@
+"""Additional zero-network seams for v6 unavailable and empty-source states."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from pathlib import Path
+
+import openalex_role_slot_development as development
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import ToolEvidenceCandidate, ToolProviderUsage
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from academic_agent.tools.qwen_role_slot_judge import (
+    QwenRoleSlotResponse,
+    QwenRoleSlotUsage,
+)
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _implementation_hashes() -> dict[str, str]:
+    return {
+        name: _sha256(path.read_bytes())
+        for name, path in development._IMPLEMENTATION_PATHS.items()  # noqa: SLF001
+    }
+
+
+def _usage(case_id: str, result_count: int) -> ToolProviderUsage:
+    return ToolProviderUsage(
+        provider="openalex",
+        request_id=f"client-openalex-v6-{case_id.casefold()}",
+        request_id_source="client_generated",
+        result_count=result_count,
+        cost_basis="reported_usd",
+        reported_cost_usd=0.001,
+    )
+
+
+class EmptyProvider:
+    """Return eight accounted empty result sets without constructing Qwen."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.call_count = 0
+
+    def __call__(self, call):  # noqa: ANN001, ANN204
+        self.call_count += 1
+        case_id = f"Y{self.call_count:02d}"
+        assert (self.output_dir / "manifest.json").is_file()
+        if self.call_count > 1:
+            previous = f"Y{self.call_count - 1:02d}"
+            assert (
+                self.output_dir / "case-executions" / f"{previous}.json"
+            ).is_file()
+        return OpenAlexClaimScopeAdapterResponse(
+            idempotency_key=call.idempotency_key,
+            candidates=(),
+            provider_rejections=(),
+            search_cost_usd=0.001,
+            provider_request_id=f"client-openalex-v6-{case_id.casefold()}",
+            provider_usage=_usage(case_id, 0),
+        )
+
+
+def _candidate(case_id: str) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=f"{case_id} source-text candidate",
+            url=f"https://openalex.org/W{case_id[1:]}123456789",
+            doi=f"10.5555/{case_id.casefold()}",
+            publisher="Frozen OpenAlex Test Publisher",
+            published_date=date(2026, 9, 1),
+            evidence_summary=(
+                f"The public abstract for {case_id} is intentionally sufficient "
+                "to reach every parser boundary in this zero-network test."
+            ),
+            summary_source="abstract",
+            citation_count=1,
+            provider_result_index=0,
+        ),
+        aboutness=(),
+    )
+
+
+class OneCandidateProvider:
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.call_count = 0
+
+    def __call__(self, call):  # noqa: ANN001, ANN204
+        self.call_count += 1
+        case_id = f"Y{self.call_count:02d}"
+        assert (self.output_dir / "manifest.json").is_file()
+        if self.call_count > 1:
+            previous = f"Y{self.call_count - 1:02d}"
+            assert (
+                self.output_dir / "case-executions" / f"{previous}.json"
+            ).is_file()
+        return OpenAlexClaimScopeAdapterResponse(
+            idempotency_key=call.idempotency_key,
+            candidates=(_candidate(case_id),),
+            provider_rejections=(),
+            search_cost_usd=0.001,
+            provider_request_id=f"client-openalex-v6-{case_id.casefold()}",
+            provider_usage=_usage(case_id, 1),
+        )
+
+
+class MalformedSemanticModel:
+    """Return paid, accounted responses whose semantic JSON is unusable."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.calls = []
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        assert (
+            self.output_dir / "provider-journals" / f"{request.case_id}.json"
+        ).is_file()
+        assert (
+            self.output_dir / "model-plans" / f"{request.case_id}.json"
+        ).is_file()
+        if request.pass_number > 1:
+            assert (
+                self.output_dir
+                / "model-journals"
+                / f"{request.case_id}-pass-{request.pass_number - 1}.json"
+            ).is_file()
+        self.calls.append(request)
+        raw_content = "{}"
+        return QwenRoleSlotResponse(
+            case_id=request.case_id,
+            pass_number=request.pass_number,
+            candidate_order=request.candidate_order,
+            trace_id=request.trace_id,
+            request_sha256=_sha256(request.body()),
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model="qwen3.5-plus",
+            provider_response_id=f"qwen-malformed-response-{len(self.calls)}",
+            provider_request_id=f"qwen-malformed-request-{len(self.calls)}",
+            finish_reason="stop",
+            raw_content=raw_content,
+            raw_content_sha256=_sha256(raw_content.encode("utf-8")),
+            usage=QwenRoleSlotUsage(
+                prompt_tokens=100,
+                cached_prompt_tokens=0,
+                completion_tokens=2,
+                total_tokens=102,
+                cost_usd=0.001,
+                cost_basis="frozen zero-network test cost",
+            ),
+            latency_ms=20.0,
+        )
+
+
+def test_empty_provider_results_complete_without_constructing_qwen(tmp_path):
+    """No evidence means checked-but-empty, not a model call or silent pass."""
+
+    output = tmp_path / "empty-provider"
+    provider = EmptyProvider(output)
+    model_factory_called = False
+
+    def model_factory():  # noqa: ANN202
+        nonlocal model_factory_called
+        model_factory_called = True
+        raise AssertionError("Qwen must not be constructed without candidates")
+
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.25,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=lambda: provider,
+        model_adapter_factory=model_factory,
+    )
+
+    assert execution.overall_state == "completed"
+    assert execution.openalex_request_count == 8
+    assert execution.openalex_successful_case_count == 8
+    assert execution.provider_row_count == 0
+    assert execution.model_call_count == 0
+    assert execution.model_cost_state == "not_observed"
+    assert execution.top_level_valid_pass_denominator == 0
+    assert execution.top_level_contract_gate_passed is None
+    assert execution.mechanical_gate_state == "fail"
+    assert execution.source_lock_readiness == "ready"
+    assert all(case.state == "no_candidates" for case in execution.cases)
+    assert provider.call_count == 8
+    assert model_factory_called is False
+
+
+def test_malformed_semantic_json_is_accounted_unavailable_and_reaches_clients(tmp_path):
+    """A paid malformed answer remains visible and never becomes a repair/pass."""
+
+    output = tmp_path / "malformed-semantic"
+    provider = OneCandidateProvider(output)
+    model = MalformedSemanticModel(output)
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.25,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=lambda: provider,
+        model_adapter_factory=lambda: model,
+    )
+
+    assert execution.overall_state == "completed"
+    assert execution.model_call_count == 24
+    assert execution.model_completed_call_count == 24
+    assert execution.model_cost_state == "known"
+    assert execution.top_level_valid_pass_numerator == 0
+    assert execution.top_level_valid_pass_denominator == 24
+    assert execution.top_level_contract_gate_passed is False
+    assert execution.mechanical_gate_state == "fail"
+    assert len(model.calls) == 24
+    for case in execution.cases:
+        assert case.case_audit is not None
+        assert [item.state for item in case.case_audit.passes] == [
+            "malformed",
+            "malformed",
+            "malformed",
+        ]
+        for pass_audit in case.case_audit.passes:
+            assert len(pass_audit.candidate_rows) == 1
+            assert pass_audit.candidate_rows[0].row_state == "pass_unavailable"
+            assert all(
+                slot.state == "row_unavailable"
+                for slot in pass_audit.candidate_rows[0].slots
+            )
+        for call in case.model_calls:
+            assert call.response is not None
+            assert call.response.raw_content == "{}"
+
+    execution_payload = json.loads(
+        (output / "execution.json").read_text(encoding="utf-8")
+    )
+    aggregate = json.loads(
+        (output / "case-audits.json").read_text(encoding="utf-8")
+    )
+    expected_aggregate = [
+        case["case_audit"]
+        for case in execution_payload["cases"]
+        if case["case_audit"] is not None
+    ]
+    assert aggregate == expected_aggregate
+    for row in aggregate:
+        per_case = json.loads(
+            (output / "case-audits" / f"{row['case_id']}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert row == per_case

--- a/tests/test_qwen_role_slot_judge.py
+++ b/tests/test_qwen_role_slot_judge.py
@@ -1,0 +1,223 @@
+"""Zero-network wire and accounting seams for the role-slot v6 Qwen judge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from academic_agent.tools.qwen_role_slot_judge import (
+    QWEN_ROLE_SLOT_ENDPOINT,
+    QWEN_ROLE_SLOT_TIMEOUT_SECONDS,
+    QwenRoleSlotJudgeAdapter,
+    QwenRoleSlotJudgeError,
+    QwenRoleSlotRequest,
+    QwenRoleSlotTransportResponse,
+    prompt_sha256,
+)
+
+
+def _request() -> QwenRoleSlotRequest:
+    system = "Extract exact role quotes and return one strict JSON object only."
+    user = "Process every candidate and fixed slot in provider order as JSON."
+    return QwenRoleSlotRequest(
+        case_id="Y01",
+        pass_number=1,
+        candidate_order="provider_order",
+        trace_id="openalex-v6-y01-pass-1",
+        system_prompt=system,
+        user_prompt=user,
+        batch_input_sha256="1" * 64,
+        prompt_sha256=prompt_sha256(system, user),
+    )
+
+
+def _provider_body(*, model: str = "qwen3.5-plus") -> bytes:
+    return json.dumps(
+        {
+            "id": "qwen-role-slot-response-1",
+            "model": model,
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"content": '{"case_id":"Y01"}'},
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 120,
+                "prompt_tokens_details": {"cached_tokens": 20},
+                "completion_tokens": 10,
+                "total_tokens": 130,
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class RecordingTransport:
+    def __init__(self, body: bytes | None = None) -> None:
+        self.body = body or _provider_body()
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.calls.append(kwargs)
+        return QwenRoleSlotTransportResponse(
+            body=self.body,
+            headers={"X-DashScope-Request-ID": "qwen-role-slot-request-1"},
+        )
+
+
+def test_adapter_sends_exact_non_thinking_body_once(monkeypatch):
+    """The test observes the wire body, not an unused configuration field."""
+
+    monkeypatch.setenv("LLM_PRICE_PER_MTOK", "99:99:99")
+    transport = RecordingTransport()
+    adapter = QwenRoleSlotJudgeAdapter(
+        api_key="role-slot-secret",
+        transport=transport,
+        monotonic_clock=iter((1.0, 1.25)).__next__,
+    )
+
+    response = adapter(_request())
+
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call["endpoint"] == QWEN_ROLE_SLOT_ENDPOINT
+    assert call["timeout"] == QWEN_ROLE_SLOT_TIMEOUT_SECONDS
+    assert call["headers"]["Authorization"] == "Bearer role-slot-secret"
+    assert b"role-slot-secret" not in call["body"]
+    body = json.loads(call["body"])
+    assert body["enable_thinking"] is False
+    assert "extra_body" not in body
+    assert body["model"] == "qwen3.5-plus"
+    assert body["temperature"] == 0.0
+    assert body["stream"] is False
+    assert body["max_tokens"] == 8000
+    assert body["response_format"] == {"type": "json_object"}
+    assert response.case_id == "Y01"
+    assert response.candidate_order == "provider_order"
+    assert response.provider_request_id == "qwen-role-slot-request-1"
+    assert response.latency_ms == pytest.approx(250.0)
+    assert response.usage.cached_prompt_tokens == 20
+    assert response.usage.cost_usd > 0
+    assert "built-in Qwen3.5 Plus peak tier" in response.usage.cost_basis
+    assert "env" not in response.usage.cost_basis
+    assert response.request_sha256 == hashlib.sha256(call["body"]).hexdigest()
+
+
+class TimeoutTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.calls.append(kwargs)
+        raise TimeoutError("simulated v6 timeout")
+
+
+def test_timeout_is_one_terminal_attempt_with_visible_latency():
+    transport = TimeoutTransport()
+    adapter = QwenRoleSlotJudgeAdapter(
+        api_key="secret",
+        transport=transport,
+        monotonic_clock=iter((1.0, 121.25)).__next__,
+    )
+
+    with pytest.raises(QwenRoleSlotJudgeError) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_transport"
+    assert caught.value.request_may_have_spent is True
+    assert caught.value.observed_latency_ms == pytest.approx(120_250.0)
+    assert len(transport.calls) == 1
+
+
+def test_model_identity_failure_discards_semantic_content_but_keeps_usage():
+    transport = RecordingTransport(
+        _provider_body(model="qwen3.5-plus-2026-09-01")
+    )
+    adapter = QwenRoleSlotJudgeAdapter(api_key="secret", transport=transport)
+
+    with pytest.raises(QwenRoleSlotJudgeError) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_model_identity_mismatch"
+    assert caught.value.request_may_have_spent is True
+    assert caught.value.observed_returned_model == "qwen3.5-plus-2026-09-01"
+    assert caught.value.observed_usage.prompt_tokens == 120
+    assert not hasattr(caught.value, "raw_content")
+    assert len(transport.calls) == 1
+
+
+class RedirectTransport:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN204
+        self.call_count += 1
+        raise HTTPError(kwargs["endpoint"], 302, "redirect", {}, None)
+
+
+def test_redirect_is_rejected_without_retry_or_key_leak():
+    transport = RedirectTransport()
+    adapter = QwenRoleSlotJudgeAdapter(
+        api_key="do-not-persist-v6-key",
+        transport=transport,
+    )
+
+    with pytest.raises(QwenRoleSlotJudgeError) as caught:
+        adapter(_request())
+
+    assert caught.value.failure_type == "provider_redirect"
+    assert caught.value.request_may_have_spent is False
+    assert "do-not-persist-v6-key" not in str(caught.value)
+    assert transport.call_count == 1
+
+
+def test_missing_or_inconsistent_usage_never_becomes_zero_cost():
+    missing = json.loads(_provider_body())
+    del missing["usage"]
+    adapter = QwenRoleSlotJudgeAdapter(
+        api_key="secret",
+        transport=RecordingTransport(json.dumps(missing).encode("utf-8")),
+    )
+    with pytest.raises(QwenRoleSlotJudgeError) as missing_error:
+        adapter(_request())
+    assert missing_error.value.failure_type == "provider_response_invalid"
+
+    inconsistent = json.loads(_provider_body())
+    inconsistent["usage"]["total_tokens"] = 999
+    transport = RecordingTransport(json.dumps(inconsistent).encode("utf-8"))
+    adapter = QwenRoleSlotJudgeAdapter(api_key="secret", transport=transport)
+    with pytest.raises(QwenRoleSlotJudgeError) as total_error:
+        adapter(_request())
+    assert total_error.value.failure_type == "provider_usage_invalid"
+    assert total_error.value.request_may_have_spent is True
+    assert len(transport.calls) == 1
+
+
+def test_request_identity_rejects_wrong_pass_order_and_prompt_hash():
+    with pytest.raises(ValueError, match="candidate order"):
+        QwenRoleSlotRequest(
+            case_id="Y01",
+            pass_number=1,
+            candidate_order="reverse_provider_order",
+            trace_id="openalex-v6-y01-pass-1",
+            system_prompt="A sufficiently long role-slot system instruction.",
+            user_prompt="A sufficiently long role-slot user instruction in JSON.",
+            batch_input_sha256="2" * 64,
+            prompt_sha256="3" * 64,
+        )
+
+    with pytest.raises(ValueError, match="prompt SHA-256"):
+        QwenRoleSlotRequest(
+            case_id="Y01",
+            pass_number=1,
+            candidate_order="provider_order",
+            trace_id="openalex-v6-y01-pass-1",
+            system_prompt="A sufficiently long role-slot system instruction.",
+            user_prompt="A sufficiently long role-slot user instruction in JSON.",
+            batch_input_sha256="2" * 64,
+            prompt_sha256="3" * 64,
+        )


### PR DESCRIPTION
## Why

The phase-one v6 kernel proves local semantic containment but not the paid-call ordering, accounting, and durable client seams required before any Y development execution can be authorized. This stacked PR adds those contracts without connecting v6 to production.

## What

- add a write-once Y01-Y08 runner with a two-stage request identity boundary
- add an exact one-request qwen3.5-plus adapter with no retry, redirect, repair, fallback, or model substitution
- persist provider journals and derived three-request plans before Qwen construction
- keep OpenAlex and Qwen request ceilings, soft stops, costs, and failure states separate
- preserve empty and malformed states without false passes or false zero cost
- verify every provider row, model call, candidate row, and role slot at the final artifact boundary
- synchronize README, AGENTS.md, and an implementation result record

## Evidence

- 39/39 combined v6 focused tests
- 16/16 new runner and adapter tests
- 1,837 tests plus 657 subtests in the complete zero-network suite
- latest Ruff and narrow Pylint pass
- manifest-order and client-only Y08-drop defects were re-injected and observed red before restoration

## Boundaries

This PR is stacked on #82. It performs no OpenAlex or Qwen call, opens no private labels, imports nothing into pipeline_worker.py, and does not claim completed or production Tool Calling.