### PR TITLE
Record the bounded role-slot v6 development failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,18 +587,28 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   1837 tests plus 657 subtests. Moving manifest persistence after adapter
   construction and dropping Y08 only from the final aggregate were each
   re-injected and made their exact seam tests fail before restoration. The
-  default CLI remains zero-network dry-run, `pipeline_worker.py` imports none of
-  v6, and this phase made no OpenAlex or Qwen request, paid call, label read or
-  production connection. Y01-Y08 and Z01-Y08 therefore remain unused. A live Y
-  attempt requires a separate authorization naming an exact merged revision,
-  request ceilings and provider-specific cost stops; Z remains unavailable until
-  every frozen Y gate passes. See
+  default CLI remains zero-network dry-run and `pipeline_worker.py` imports none
+  of v6. See
   `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md`,
   `docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md`,
   `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md`,
   `docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-runner-identity-clarification.md`
   and
   `docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md`.
+
+  A separately authorized Y run on merged revision `d23ffd5` completed 8/8
+  anonymous OpenAlex requests and 21/24 exact `qwen3.5-plus` calls before the
+  model soft stop. It recorded 64 candidates, 56/56 hash-valid artifacts, USD
+  0.008 OpenAlex cost and USD 0.204363 Qwen cost. The serialized state is
+  correctly `partial / model_soft_stop`: Y08 has a provider journal and model
+  plan but no model call. This is already an irrecoverable v6 failure rather
+  than a reason to buy three more calls. Even perfect Y08 outcomes could raise
+  provisional unanimity only from 34/56 to 42/64 (65.625%), below 80%, and
+  selected-case coverage only from 4/8 to 5/8, below 6/8. Y is consumed, Z stays
+  unopened, and v6 is sealed. The original protocol still requires a label-
+  blind review of all 64 provider candidates after mechanical failure; that
+  review is diagnostic only and cannot rescue v6 or authorize production. See
+  `docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -852,12 +852,23 @@ The combined v6 subset passes 39/39 focused tests and the new runner/adapter
 subset passes 16/16. Two additional re-injections proved that the manifest must
 precede client construction and that a correctly computed Y08 audit cannot be
 dropped only at the aggregate client artifact. The default CLI remains a
-zero-network dry-run; no live request, private-label read, paid call or
-production connection occurred, so Y01-Y08 and Z01-Z08 remain unused. See the
+zero-network dry-run. See the
 [v6 pre-registration](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md),
 [offline implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md),
 [runner amendment](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md)
 and [runner implementation result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md).
+
+A separately authorized run on merged revision `d23ffd5` completed all eight
+anonymous OpenAlex requests and 21/24 sequential Qwen calls before the USD 0.20
+model soft stop. It retained 64 provider candidates, exact `qwen3.5-plus`
+identity, 56/56 hash-valid artifacts and USD 0.008 / USD 0.204363 inspectable
+OpenAlex/Qwen cost. The execution is explicitly partial, but extra spending
+cannot rescue it: candidate-disposition unanimity can reach at most 42/64
+(65.625%) against the frozen 80% gate, and selected-case coverage can reach at
+most 5/8 against the frozen 6/8 gate. Y is consumed, Z remains unopened, v6 is
+sealed, and production remains disconnected. The required next step is a
+label-blind review of all 64 provider candidates for failure diagnosis only.
+See the [bounded live result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md).
 
 Local verification now passes **1,837 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
@@ -2097,12 +2108,20 @@ write-once manifest 会在客户端构造前冻结 8 个 OpenAlex 请求身份�
 v6 内核、预检、适配器与运行器合计通过 39/39 个定向测试，其中新增运行器与
 适配器为 16/16。两次新增缺陷回注证明 manifest 必须先于客户端构造，且内部
 正确计算并写入单案文件的 Y08 不能只在最终聚合中消失。默认 CLI 仍为零网络
-dry-run；本阶段没有真实请求、私有标签读取、付费调用或生产连接，因此
-Y01–Y08 与 Z01–Z08 仍未使用。详见
+dry-run。详见
 [v6 预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6.md)、
 [离线实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-offline.md)、
 [运行器补充预注册](docs/prereg-2026-09-01-openalex-role-slot-consensus-v6-development-runner.md)
 与[运行器实现结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-runner-implementation.md)。
+
+随后在合并版本 `d23ffd5` 上获授权执行的真实运行完成了全部 8 次匿名 OpenAlex
+请求，并在 0.20 美元模型软停止线前完成 21/24 次顺序 Qwen 调用。运行保留
+64 条候选、精确 `qwen3.5-plus` 身份、56/56 份哈希一致工件，以及 OpenAlex
+0.008 美元、Qwen 0.204363 美元的可审计成本。执行状态明确为 partial，且继续
+付费也无法挽救：候选 disposition 一致率最多只能达到 42/64（65.625%），低于
+冻结的 80%；选中证据集的案例最多只能达到 5/8，低于 6/8。Y 已被消耗，Z
+保持未打开，v6 已封存且生产仍断开。下一步只应对全部 64 条候选做标签盲化人工
+评审以诊断失败面。详见[受限真实运行结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md)。
 
 本地验证现通过 **1,837 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。

--- a/docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md
+++ b/docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md
@@ -1,0 +1,119 @@
+# Result: role-slot consensus v6 Y development run
+
+**Executed:** 2026-09-01
+
+**Authorized merged revision:**
+`d23ffd54bb171d1030f5531a7d57bd6eedc5d853`
+
+**Production connection authorized:** no
+
+**Private labels opened:** none
+
+**Unseen Z01-Z08 opened:** no
+
+## Outcome
+
+The bounded Y01-Y08 run stopped correctly at the Qwen soft-cost boundary. It
+completed all eight anonymous OpenAlex requests and 21 of the possible 24
+sequential `qwen3.5-plus` requests. The 21st in-flight request took the known
+model estimate from below the USD 0.20 stop to USD 0.204363; the runner then
+stopped before constructing the first Y08 model request. No retry, redirect,
+repair, fallback, recovery, supplementary search or model substitution ran.
+
+The serialized execution is therefore `partial / model_soft_stop`, and its
+mechanical state correctly remains `not_evaluated`. This is not merely an
+unfinished run that could become a pass by buying three more calls. Two frozen
+gates are already mathematically unreachable:
+
+- provisional disposition unanimity is 34/56 (60.714%) for Y01-Y07. Even if
+  all eight Y08 candidates were unanimous, the maximum would be 42/64
+  (65.625%), below the pre-registered 80% minimum; and
+- four completed cases selected an evidence set. Even if Y08 selected one,
+  the maximum would be 5/8, below the pre-registered 6/8 minimum.
+
+The v6 development hypothesis therefore cannot pass. Y01-Y08 are consumed
+development evidence, Z01-Z08 remain unopened, and v6 must not be rerun or
+tuned into a pass. The production worker, report workflow and planner trigger
+remain disconnected.
+
+## Authorized and observed limits
+
+| Boundary | Authorized | Observed |
+|---|---:|---:|
+| Anonymous OpenAlex requests | at most 8 | 8 completed |
+| OpenAlex soft stop | USD 0.01 | USD 0.008 known |
+| Sequential Qwen calls | at most 24 | 21 completed |
+| Qwen soft stop | USD 0.20 | USD 0.204363 known |
+| Requested / returned model | exact `qwen3.5-plus` | 21/21 exact |
+| Retry, repair, fallback or recovery | forbidden | none |
+| Production, report or planner connection | forbidden | false |
+
+The small Qwen overage is within the explicitly authorized one-in-flight-call
+allowance. The runner checked the stop before each later request and made no
+22nd call.
+
+## Mechanical observations
+
+| Frozen observation | Result |
+|---|---:|
+| OpenAlex successful cases | 8/8 |
+| Provider candidates / rejections | 64 / 0 |
+| Completed case audits | 7/8 |
+| Top-level valid model passes | 21/21 (100%) |
+| Locally valid candidate-pass rows | 160/168 (95.238%) |
+| Provisional unanimous dispositions | 34/56 (60.714%) |
+| Cases with a selected evidence set | 4 completed cases |
+| Prompt / completion / total tokens | 61,844 / 49,106 / 110,950 |
+| Cached prompt tokens | 0 |
+
+The top-level response-contract gate and the 95% local-row gate passed on the
+attempted model calls. The 80% unanimity gate failed. Selected-set coverage
+cannot reach 6/8. Because Y08 has no model audit, the complete audit boundary,
+source-lock readiness and human-value gates remain unavailable rather than
+being reported as passes.
+
+### Per-case boundary
+
+| Case | Provider rows | Model calls | Deterministic action | Selected sources | Unanimous candidates |
+|---|---:|---:|---|---:|---:|
+| Y01 | 8 | 3 | `ABSTAIN` | 0 | 4/8 |
+| Y02 | 8 | 3 | `ABSTAIN` | 0 | 4/8 |
+| Y03 | 8 | 3 | `SELECT` | 1 | 4/8 |
+| Y04 | 8 | 3 | `SELECT` | 1 | 4/8 |
+| Y05 | 8 | 3 | `SELECT` | 1 | 8/8 |
+| Y06 | 8 | 3 | `SELECT` | 1 | 2/8 |
+| Y07 | 8 | 3 | `ABSTAIN` | 0 | 8/8 |
+| Y08 | 8 | 0 | not evaluated | not evaluated | not evaluated |
+
+## Artifact and request audit
+
+The final `execution.json` passed its committed Pydantic model. The artifact
+index named 56 files; all 56 existed and every recorded SHA-256 matched. The
+eight provider journals preserved the frozen Y01-Y08 order and each recorded
+exactly one outbound attempt. The 21 model journals were all completed, had 21
+unique trace identities, and requested and returned only `qwen3.5-plus`.
+
+The provider calls accumulated 12.372 seconds of recorded latency. The model
+calls accumulated 920.490 seconds; their median recorded latency was 45.101
+seconds and the maximum was 53.952 seconds. These are one bounded run's
+transport observations, not an SLO or latency distribution.
+
+## Required follow-up
+
+The original pre-registration requires every provider candidate to receive a
+label-blind human source review even after a mechanical failure. A separate,
+production-disconnected packet should therefore expose the 64 frozen titles
+and abstracts plus the frozen baseline and role descriptions while hiding
+model slots, consensus decisions and selected sets. That review may diagnose
+retrieval and role-assignment failure surfaces; it cannot rescue v6, authorize
+Z01-Z08 or connect Tool Calling to production.
+
+Any successor semantic method must use a new identity and fresh challenge. It
+must not tune on Y01-Y08 and retain the v6 name.
+
+## Explicit non-claims
+
+This run does not establish source truth, OpenAlex-wide precision or recall,
+literature-wide novelty, human-confirmed role support, report improvement,
+decision correctness, user utility, cost stability, an SLO, autonomous tool
+choice or completed production Tool Calling.


### PR DESCRIPTION
Records the separately authorized Y01-Y08 development execution at merged revision d23ffd54bb171d1030f5531a7d57bd6eedc5d853. The run completed 8/8 anonymous OpenAlex requests and 21/24 exact qwen3.5-plus calls before the model soft stop, preserved inspectable request, cost, token, latency, and artifact-hash evidence, and remained disconnected from production. The frozen unanimity and selected-case gates are already mathematically unreachable even under a perfect Y08 outcome, so the result seals v6 without spending on three calls that cannot change the decision. Y is consumed, Z remains unopened, and the required 64-row label-blind follow-up is diagnostic only. Verification: 1,837 tests plus 657 subtests, latest Ruff, and the CI-equivalent narrow Pylint checks pass.