### PR TITLE
Implement the label-blind role-slot v6 failure diagnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1837 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1851 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -175,7 +175,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  105 test modules plus conftest, organised by subject
+tests/                  106 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -223,6 +223,8 @@ openalex_role_slot_unseen.py
                         frozen Y/Z role-slot identity preflight; zero-network only
 openalex_role_slot_development.py
                         write-once Y runner; CLI defaults to zero-network dry-run
+openalex_role_slot_failure_review.py
+                        label-blind 64-row v6 failure diagnostic; zero-network
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -584,7 +586,7 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
 
   The combined v6 kernel/preflight/adapter/runner subset passes 39/39 tests; the
   new runner/adapter subset passes 16/16, and the full zero-network suite passes
-  1837 tests plus 657 subtests. Moving manifest persistence after adapter
+  1851 tests plus 657 subtests. Moving manifest persistence after adapter
   construction and dropping Y08 only from the final aggregate were each
   re-injected and made their exact seam tests fail before restoration. The
   default CLI remains zero-network dry-run and `pipeline_worker.py` imports none
@@ -609,6 +611,26 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   blind review of all 64 provider candidates after mechanical failure; that
   review is diagnostic only and cannot rescue v6 or authorize production. See
   `docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md`.
+
+  The separately pre-registered post-outcome v6 failure diagnostic is now
+  implemented. Its diagnostic-only owner lock preserves the original
+  `source_lock_readiness=not_ready`, verifies the four exact core hashes and
+  all 56 indexed child artifacts, cross-checks the eight provider journals and
+  eight case executions, and permits review only because the provider boundary
+  is complete at 8/8 cases and 64/64 candidates. It exposes baseline context,
+  code-owned role descriptions, titles and abstracts while hiding all model
+  passes, consensus roles, candidate actions and selected sets. The real local
+  blank packet is `incomplete / not_evaluated` with 0/64 completed rows,
+  `metrics=null`, and no network or model call.
+
+  Its focused suite passes 14/14. Removing the explicit
+  `candidate_action` block and dropping the final candidate only from the
+  labels CSV were each re-injected and made their client-boundary tests fail
+  before restoration. No human label has returned, so retrieval value and role
+  accuracy remain unobserved; the diagnostic cannot rescue v6, open
+  Z01-Z08, validate a successor or connect production. See
+  `docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md` and
+  `docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -870,7 +870,24 @@ sealed, and production remains disconnected. The required next step is a
 label-blind review of all 64 provider candidates for failure diagnosis only.
 See the [bounded live result](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md).
 
-Local verification now passes **1,837 tests plus 657 subtests**, latest Ruff,
+The separately pre-registered v6 failure diagnostic and label-blind review
+boundary are now implemented. The packet preserves all 64 frozen Y01-Y08
+provider candidates while hiding model passes, consensus roles, candidate
+actions and selected sets until the post-return summary seam.
+
+The real local blank packet is correctly `incomplete / not_evaluated`: 0/64
+rows are complete, metrics are absent, the four core source hashes and all 56
+indexed artifacts match, and no network or model call occurs. The focused
+suite passes 14/14; one hidden-decision leak and one missing serialized
+candidate were each re-injected and made their boundary tests fail.
+
+No human label has been returned, so source value and role accuracy remain
+unobserved. This diagnostic cannot rescue v6, open Z or authorize production.
+See the [diagnostic pre-registration](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md)
+and [implementation result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md).
+
+
+Local verification now passes **1,851 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2123,7 +2140,22 @@ dry-run。详见
 保持未打开，v6 已封存且生产仍断开。下一步只应对全部 64 条候选做标签盲化人工
 评审以诊断失败面。详见[受限真实运行结果](docs/results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md)。
 
-本地验证现通过 **1,837 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+另行预注册的 v6 失败诊断与标签盲化评审边界现已实现。评审包保留全部 64 条
+Y01–Y08 冻结供应商候选，同时在回传后的汇总接缝之前隐藏模型 pass、共识角色、
+候选动作和已选证据集。
+
+真实本地空白包被正确判为 `incomplete / not_evaluated`：完成行为 0/64，
+metrics 缺失，4 个核心来源哈希与 56 份索引工件全部一致，且不发生网络或模型
+调用。14/14 个定向测试通过；隐藏决策泄露和少序列化一条候选两个缺陷均被
+重新注入，并分别使边界测试失败。
+
+目前尚未返回任何人工标签，因此来源价值与角色准确性仍未观测。该诊断不能
+挽救 v6、打开 Z 或授权生产接入。详见
+[诊断预注册](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md)
+与[实现结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md)。
+
+
+本地验证现通过 **1,851 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md
+++ b/docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md
@@ -1,0 +1,179 @@
+# Pre-registration: role-slot v6 failure diagnostic
+
+Date: 2026-09-01
+
+## Decision recorded before implementation
+
+The bounded Y01-Y08 role-slot v6 development run is already falsified. It
+stopped at the registered Qwen cost boundary after 21 of 24 calls, and two
+mechanical gates are mathematically unreachable even under an optimistic Y08
+completion. This diagnostic cannot change that result, reopen Y01-Y08, open
+Z01-Z08, or authorize production Tool Calling.
+
+The original v6 pre-registration nevertheless requires every provider
+candidate to receive a label-blind human review after a mechanical failure.
+The provider layer is complete even though the model layer is not: eight
+anonymous OpenAlex requests returned eight candidate rows per case, for 64
+candidate rows and zero provider rejections. This follow-up therefore measures
+the value and role coverage of the frozen provider population already on disk.
+It performs no search and no model call.
+
+This document is committed before the diagnostic implementation. The
+implementation may enforce this contract; it may not change the questions or
+turn descriptive observations into a qualification gate after labels arrive.
+
+## Frozen source identity
+
+The source execution was produced from merged revision
+`d23ffd54bb171d1030f5531a7d57bd6eedc5d853` and recorded on public parent
+revision `9b5c9524a42ae3e3f73055314246cdfca649919d`. Its local source directory is:
+
+`outputs/experiments/2026-09-01-openalex-role-slot-v6-Y-live-d23ffd54`
+
+The diagnostic must reject any byte drift from these core artifacts:
+
+| Artifact | SHA-256 |
+|---|---|
+| `manifest.json` | `543c5300f36e7e1f498f66cb51fba88eebefea07e93ada817de15e7291178e17` |
+| `execution.json` | `fbd5f42adffeb714937845fcf5f887bd6291989d308fce587da227be63f6754c` |
+| `provider-rows.csv` | `c7926e4ae228d3fc16580885ce5b6208a0dc176c39b2650aba6ff833b22bbb8b` |
+| `artifact-index.json` | `c7a6472d3d32d990e7f3de5470f8eec3af1963bc15207144e7f994e4f844d38a` |
+
+The implementation must also verify every file named by the 56-entry artifact
+index before parsing semantic content. A matching index file without matching
+indexed bytes is not a valid source. The eight provider journals and eight
+case-execution journals must agree with the aggregate execution and CSV.
+
+The original execution correctly reports `source_lock_readiness=not_ready`
+because its full model audit is incomplete. The diagnostic may create a new,
+explicitly diagnostic-only source lock only when the provider boundary itself
+is complete at 8/8 cases and 64/64 candidates. That exception must never be
+accepted by the v6 qualification source-lock path or production code.
+
+## Frozen diagnostic questions
+
+The diagnostic asks only these questions:
+
+1. How many frozen OpenAlex candidates directly address each declared topic,
+   and how much retrieval noise is present among inspectable rows?
+2. Which code-owned required, scope and supporting roles are supported by each
+   frozen title and abstract, and which of those roles have title support?
+3. Relative to the synthetic frozen baseline exposed in the packet, which
+   directly relevant rows add material evidence?
+4. For the 56 candidates with three completed model passes, where do the hidden
+   v6 consensus roles disagree with the returned human role labels?
+5. Using only returned human role labels and the already frozen deterministic
+   selection contract, in how many cases did the retrieved population contain
+   a covering set of at most three sources?
+6. Are failed cases better explained by retrieval noise, unsupported consensus
+   roles, missed supported roles, or an absent covering set?
+
+These are descriptive failure-surface measurements. There is no diagnostic
+pass threshold, and no answer can rescue v6 or qualify a successor method.
+
+## Label-blind reviewer boundary
+
+The packet must expose every provider candidate exactly once and include:
+
+- case ID, topic and frozen query;
+- the synthetic frozen baseline context;
+- the code-owned required, scope and supporting role IDs and descriptions;
+- provider result index and candidate SHA-256;
+- title, abstract, URL, DOI, publisher, publication date and summary source;
+- blank fields for direct relevance, baseline-relative novelty, frozen-text
+  sufficiency, supported role IDs, title-supported role IDs and a grounded
+  review note; and
+- one reviewer declaration covering completeness, generative-AI use, external
+  source checks, elapsed time, expertise, date and limitations.
+
+Until labels are returned, the packet and its manifest must hide:
+
+- every model request, pass, slot, quote and response;
+- consensus-supported roles and support counts;
+- provisional or final candidate actions and abstention reasons;
+- selected sources, case actions and gate outcomes; and
+- OpenAlex aboutness metadata or any diagnostic attribution derived from the
+  hidden execution.
+
+Reviewer-visible identity and context fields are immutable. Rows may be
+reordered, but missing, duplicated, extra or altered identities must fail the
+summary boundary. Supported-role values must be JSON arrays containing only
+role IDs declared for that case; title-supported roles must be a subset of
+supported roles. Every non-empty row requires a substantive review note.
+
+## Review eligibility and observable states
+
+The review evaluates the exact frozen title and abstract text. Opening external
+sources is encouraged and must be declared, but it is not required for this
+text-bound diagnostic. The resulting claims must distinguish frozen-text
+judgment from external source truth.
+
+Only `NONE` or `LANGUAGE_ONLY` substantive generative-AI use is eligible. The
+summary must expose mutually distinct states:
+
+- blank or partially returned rows/declaration: `incomplete / not_evaluated`;
+- substantive generated judgments: `excluded_substantive_ai / not_evaluated`;
+- reviewer did not confirm all rows: `not_inspectable / not_evaluated`; and
+- complete eligible return: `complete / evaluated_diagnostic_only`.
+
+No state may be named `pass`, and every result must keep
+`production_connection_authorized=false`, `z_cohort_authorized=false`, and
+`v6_rescue_authorized=false`.
+
+## Frozen aggregation rules
+
+Metrics may be computed only after a complete eligible review. They must retain
+all 64 rows in the population and report at least:
+
+- inspectable, directly relevant, directly irrelevant and unverifiable counts;
+- retrieval-noise and frozen-text-insufficiency rates with explicit
+  denominators;
+- relevant and baseline-novel candidate and case counts;
+- human-supported role and title-supported role counts;
+- for the 56 model-observed candidates, role-level true-positive,
+  false-positive, false-negative and true-negative counts plus precision and
+  recall when their denominators exist;
+- human-coverable case IDs under the frozen one-required, one-context,
+  one-title-anchor candidate admission and three-source set-cover contract;
+- hidden v6 selected case IDs, missed human-coverable cases, model-selected
+  cases without human cover, and model-unobserved cases; and
+- an attribution count that keeps retrieval noise, frozen-text insufficiency,
+  consensus false positives, consensus false negatives and absent covering
+  sets distinct.
+
+The deterministic human set-cover projection must use the same maximum of
+three sources and the same smallest-set, provider-index, candidate-SHA ordering
+as v6. It is a diagnostic projection from human labels, not a rerun of the
+model and not an alternative qualification result.
+
+## Implementation and falsification requirements
+
+Before a packet is handed to a reviewer, the zero-network implementation must:
+
+- verify the four exact core hashes and all 56 indexed file hashes;
+- validate the committed Pydantic manifest, execution and provider journals;
+- prove all eight cases and all 64 provider candidates reach both the packet
+  manifest and labels CSV;
+- prove model, consensus and selected-set fields cannot cross the reviewer
+  boundary;
+- report a blank packet as `not_evaluated`, never zero-error success;
+- reject source drift, artifact-index drift, context drift, duplicate rows,
+  unknown role IDs, invalid role subsets and substantive-AI review;
+- join hidden model traces only inside the post-return summary seam;
+- assert that `pipeline_worker.py` cannot import the diagnostic; and
+- re-inject at least one hidden-decision leak and one computed-but-not-
+  serialized candidate defect, confirm their tests fail, then restore the
+  implementation.
+
+The implementation phase must run the focused tests, complete zero-network
+suite, latest Ruff and narrow Pylint. It may generate a blank packet locally,
+but no private human label may be invented or inferred by code.
+
+## Explicit non-claims
+
+This diagnostic does not establish source truth, OpenAlex-wide precision or
+recall, literature-wide novelty, inter-rater agreement, a successor method,
+report improvement, decision correctness, user utility, stable cost or
+latency, an SLO, autonomous tool choice, or completed production Tool Calling.
+It sends no data off the machine and imports nothing into the production
+workflow.

--- a/docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md
+++ b/docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md
@@ -1,0 +1,126 @@
+# Result: role-slot v6 failure diagnostic implementation
+
+Date: 2026-09-01
+
+## Outcome
+
+The pre-registered post-outcome diagnostic is implemented and its real blank
+review packet has been generated locally. The implementation makes no network
+or model call. It source-locks the provider-complete part of the already failed
+Y01-Y08 execution, exposes all 64 frozen OpenAlex title-and-abstract rows to a
+label-blind reviewer, and keeps every Qwen pass, consensus role, candidate
+action, abstention reason and selected set hidden until the post-return summary
+boundary.
+
+The blank real packet is correctly reported as
+`incomplete / not_evaluated`: 0/64 rows are complete, metrics are absent, and
+the result keeps `v6_rescue_authorized=false`,
+`z_cohort_authorized=false` and
+`production_connection_authorized=false`. This is implementation readiness for
+a diagnostic review, not a source-value result and not Tool Calling
+qualification.
+
+## Frozen source verification
+
+`openalex_role_slot_failure_review.py` rejects drift in the four pre-registered
+core files before semantic parsing and then verifies every child named by the
+56-entry artifact index. It also cross-checks the committed Pydantic manifest,
+aggregate execution, provider rows, eight provider journals and eight case
+executions. The real source passed with:
+
+- executed revision
+  `d23ffd54bb171d1030f5531a7d57bd6eedc5d853`;
+- 8/8 provider-complete cases and exactly 8 candidates per case;
+- 64/64 provider candidates with non-empty title and abstract text;
+- 56/56 indexed files matching their recorded SHA-256 values; and
+- the original model execution retained as `partial / model_soft_stop`, rather
+  than silently relabelled complete.
+
+The owner-authorized diagnostic lock is a separate, narrowly named exception
+over this provider-complete population. It preserves the original
+`source_lock_readiness=not_ready` and cannot be consumed by the v6
+qualification path or production worker.
+
+## Reviewer and summary boundaries
+
+The generated packet contains immutable topic, query, baseline, role
+descriptions, candidate identity, title, abstract and bibliographic context,
+plus blank human-label fields. The return validator:
+
+- requires every candidate exactly once while allowing row reordering;
+- rejects missing, duplicate, extra or context-modified rows;
+- accepts only declared role IDs and requires title-supported roles to be a
+  subset of supported roles;
+- requires a grounded note for every completed row;
+- distinguishes incomplete, substantive-AI-excluded, not-inspectable and
+  complete diagnostic states; and
+- joins hidden model traces only after an eligible complete return.
+
+Only a complete eligible return can compute the frozen descriptive metrics:
+retrieval noise, frozen-text insufficiency, baseline-relative novelty,
+role-level confusion for the 56 model-observed candidates, human-only
+three-source coverability, and failure-surface attribution. No result state is
+called a pass.
+
+## Real blank artifact observation
+
+The local, gitignored diagnostic directory is:
+
+`outputs/experiments/2026-09-01-openalex-role-slot-v6-Y-failure-diagnostic`
+
+The real write-once artifacts are:
+
+| Artifact | Rows / bytes | SHA-256 |
+|---|---:|---|
+| `source_lock.json` | 7,908 bytes | `72c63a42e2c79cdbb96bd5bf555d9bce8cc342bc1759b9a606231e073d388c23` |
+| `packet/packet_manifest.json` | 226,898 bytes | `f2c5748e6bcf0e9bb7ffd19fc2cee88c94a31719797f1f2a4154bd96b7ebf841` |
+| `packet/labels.csv` | 64 rows / 194,850 bytes | `4a7f017704bb44e8de9423da1115f9f16e3b9cf71a31b9c4a9bbceae8d8045cb` |
+| `packet/reviewer_declaration.csv` | 131 bytes | `eb17b0ae23599575afcd9a68ad6a6d64644d4c0001fd10cdabb853a3f3ee1a31` |
+| `packet/README.md` | 2,209 bytes | `6d4f9688a92c6ea34f97289bc9c2341467c926c9362a4ebf010b8d623a028fd4` |
+| `blank_summary.json` | 3,259 bytes | `74762918d38018ec1fa2adee6e5a20205346c4a319e67466c3c441bc64c1bb66` |
+
+The packet contains 64 rows across all eight cases. Its blank summary reports
+all 64 row IDs as incomplete, `metrics=null`, and no method issue. No private
+label was generated or inferred by code.
+
+## Tests and defect re-injection
+
+The first focused run produced 12 passes and two failures. One was a real
+review-boundary omission: `candidate_action` was not yet an explicitly
+forbidden manifest key. The implementation now rejects it. The second exposed
+a weak test fixture rather than a weak validator: the fixture had first marked
+every declared role supported, so its intended title-only role was actually a
+valid subset. The fixture now empties the parent role set before injecting the
+invalid title role.
+
+After those corrections, the focused suite passes 14/14. The two
+protocol-required defects were then re-injected independently:
+
+1. Removing `candidate_action` from the forbidden reviewer-key set made
+   `test_packet_manifest_rejects_hidden_decision_leak` fail because the
+   injected automated action crossed the packet boundary.
+2. Serializing `snapshot.candidates[:-1]` into `labels.csv` made
+   `test_packet_preserves_all_candidates_and_hides_every_v6_outcome` fail with
+   63 rows instead of 64.
+
+Both defects were restored before the focused suite was rerun successfully.
+Final local verification passes:
+
+- **1,851 tests plus 657 subtests** in the full zero-network suite;
+- 14/14 focused diagnostic tests;
+- latest Ruff over the complete repository; and
+- the CI-equivalent narrow Pylint categories on the new root module.
+
+## What this does not establish
+
+No human label has been returned, so retrieval precision, role accuracy,
+human-coverable case count and attribution metrics remain unobserved. A later
+eligible reviewer may diagnose the frozen failure surface, but cannot rescue
+v6, tune on or rerun Y01-Y08, open Z01-Z08, validate a successor, improve a
+production report, or authorize production Tool Calling.
+
+The next legitimate step is to copy only the generated reviewer packet into
+the private notes repository, obtain an independent human return, preserve the
+raw declaration, and run this zero-network summarizer. Until then the project
+must continue to describe Tool Calling as production-disconnected experimental
+work.

--- a/openalex_role_slot_failure_review.py
+++ b/openalex_role_slot_failure_review.py
@@ -1,0 +1,1620 @@
+"""Review all frozen role-slot v6 provider candidates after mechanical failure.
+
+The Y01-Y08 v6 run was already falsified before its human-value gates opened.
+Its OpenAlex layer is nevertheless complete, so the original pre-registration
+still requires a label-blind review of every provider candidate.  This module
+locks those exact bytes, emits a reviewer packet without model decisions, and
+joins the hidden role-slot trace only after an eligible review returns.
+
+This root-level experimental utility opens no socket, invokes no model,
+registers no evidence, and is never imported by the production worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from itertools import combinations
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.openalex_role_slot import RoleSlotCaseAudit
+from evidence_gap_phase4_review import (
+    DECLARATION_FIELDS,
+    ELIGIBLE_AI_USE,
+    Phase4ReviewError as RoleSlotFailureReviewError,
+    _file_sha256,
+    _read_csv,
+    _read_json_object,
+    _validated_declaration,
+    _write_csv_new,
+    _write_text_new,
+)
+from openalex_role_slot_development import (
+    EXPECTED_IMPLEMENTATION_SHA256,
+    RoleSlotCaseExecution,
+    RoleSlotDevelopmentExecution,
+    RoleSlotDevelopmentManifest,
+    RoleSlotModelJournal,
+    RoleSlotModelPlan,
+    RoleSlotProviderJournal,
+    _PROVIDER_ROW_COLUMNS,
+    _provider_rows,
+)
+from openalex_role_slot_unseen import (
+    EXPECTED_FIXTURE_SHA256,
+    load_frozen_cases,
+)
+
+
+EXPECTED_EXECUTED_REVISION = "d23ffd54bb171d1030f5531a7d57bd6eedc5d853"
+EXPECTED_SOURCE_FILE_SHA256 = {
+    "manifest.json": (
+        "543c5300f36e7e1f498f66cb51fba88eebefea07e93ada817de15e7291178e17"
+    ),
+    "execution.json": (
+        "fbd5f42adffeb714937845fcf5f887bd6291989d308fce587da227be63f6754c"
+    ),
+    "provider-rows.csv": (
+        "c7926e4ae228d3fc16580885ce5b6208a0dc176c39b2650aba6ff833b22bbb8b"
+    ),
+    "artifact-index.json": (
+        "c7a6472d3d32d990e7f3de5470f8eec3af1963bc15207144e7f994e4f844d38a"
+    ),
+}
+EXPECTED_EXECUTION_OBSERVATIONS: dict[str, Any] = {
+    "overall_state": "partial",
+    "stop_reason": "model_soft_stop",
+    "openalex_request_count": 8,
+    "openalex_successful_case_count": 8,
+    "openalex_cost_state": "known",
+    "openalex_cost_usd": 0.008,
+    "model_call_count": 21,
+    "model_completed_call_count": 21,
+    "model_cost_state": "known",
+    "model_cost_usd": 0.204363,
+    "prompt_tokens": 61_844,
+    "cached_prompt_tokens": 0,
+    "completion_tokens": 49_106,
+    "total_tokens": 110_950,
+    "provider_row_count": 64,
+    "provider_candidate_count": 64,
+    "provider_rejection_count": 0,
+    "completed_case_audit_count": 7,
+    "selected_case_count": 4,
+    "provisional_unanimity_numerator": 34,
+    "provisional_unanimity_denominator": 56,
+    "audit_boundary_complete": False,
+    "mechanical_gate_state": "not_evaluated",
+    "source_lock_readiness": "not_ready",
+    "human_review_state": "not_prepared",
+    "source_value_state": "not_evaluated",
+}
+CASE_IDS = tuple(f"Y{index:02d}" for index in range(1, 9))
+EXPECTED_CANDIDATES_PER_CASE = {case_id: 8 for case_id in CASE_IDS}
+EXPECTED_CANDIDATE_COUNT = 64
+EXPECTED_INDEXED_FILE_COUNT = 56
+CORE_SOURCE_FILES = tuple(EXPECTED_SOURCE_FILE_SHA256)
+
+# Context is intentionally repeated on every label row.  A separate context
+# table would be smaller, but it would add a fragile human join at exactly the
+# seam where prior project bugs silently lost correct values before the client.
+CONTEXT_FIELDS = (
+    "case_id",
+    "provider_result_index",
+    "candidate_sha256",
+    "topic",
+    "query",
+    "baseline_sources_json",
+    "required_roles_json",
+    "scope_roles_json",
+    "supporting_roles_json",
+    "title",
+    "url",
+    "doi",
+    "publisher",
+    "published_date",
+    "abstract",
+    "summary_source",
+)
+LABEL_VALUE_FIELDS = (
+    "direct_relevance",
+    "baseline_novelty",
+    "abstract_sufficient",
+    "supported_role_ids_json",
+    "title_supported_role_ids_json",
+    "review_note",
+)
+LABEL_FIELDS = (*CONTEXT_FIELDS, *LABEL_VALUE_FIELDS)
+VALID_LABEL_COMBINATIONS = {
+    ("YES", novelty, "YES") for novelty in ("YES", "NO")
+} | {
+    ("NO", "N/A", "YES"),
+    ("UNVERIFIABLE", "UNVERIFIABLE", "NO"),
+}
+MEASUREMENT_LIMIT = (
+    "This post-outcome diagnostic measures human interpretation of the frozen "
+    "title and abstract text for all 64 Y01-Y08 provider candidates. It cannot "
+    "change the failed v6 result, validate a successor, open Z01-Z08, or "
+    "authorize production Tool Calling."
+)
+_FORBIDDEN_REVIEWER_KEYS = {
+    "action",
+    "abstention_reasons",
+    "candidate_action",
+    "candidate_decisions",
+    "case_audit",
+    "consensus_supported",
+    "covered_required_role_ids",
+    "covered_scope_role_ids",
+    "covered_supporting_role_ids",
+    "model_calls",
+    "model_plan",
+    "observations",
+    "pass_row_states",
+    "passes",
+    "provisional_actions",
+    "provisional_disposition_unanimous",
+    "quote",
+    "role_consensus",
+    "selected_sources",
+    "support_count",
+    "title_anchor_role_ids",
+    "title_support_count",
+}
+
+
+class RoleSlotFailureDiagnosticLock(BaseModel):
+    """Owner attestation over the exact provider-complete failed execution."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_role_slot_v6_failure_diagnostic_lock"] = (
+        "openalex_role_slot_v6_failure_diagnostic_lock"
+    )
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    diagnostic_only: Literal[True] = True
+    original_source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    original_source_lock_readiness: Literal["not_ready"] = "not_ready"
+    authorized_output: Literal[True] = True
+    executed_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    source_file_sha256: dict[str, str]
+    indexed_file_sha256: dict[str, str]
+    study_owner_id: str = Field(min_length=2, max_length=200)
+    authorized_at: datetime
+    note: str | None = Field(default=None, max_length=1000)
+
+    @model_validator(mode="after")
+    def _validate_frozen_identity(self) -> "RoleSlotFailureDiagnosticLock":
+        if self.executed_revision != EXPECTED_EXECUTED_REVISION:
+            raise ValueError("diagnostic lock executed revision does not match")
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("diagnostic lock fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("diagnostic lock implementation identities do not match")
+        if self.source_file_sha256 != EXPECTED_SOURCE_FILE_SHA256:
+            raise ValueError("diagnostic lock does not identify the frozen v6 run")
+        if len(self.indexed_file_sha256) != EXPECTED_INDEXED_FILE_COUNT:
+            raise ValueError("diagnostic lock indexed-file count does not match")
+        for mapping in (self.source_file_sha256, self.indexed_file_sha256):
+            if any(not _is_sha256(value) for value in mapping.values()):
+                raise ValueError(
+                    "diagnostic lock hashes must be complete lowercase SHA-256 values"
+                )
+        if self.authorized_at.tzinfo is None:
+            raise ValueError("diagnostic lock timestamp must be timezone-aware")
+        return self
+
+
+@dataclass(frozen=True)
+class RoleSlotFailureCandidate:
+    """One reviewer-visible candidate without any v6 model outcome."""
+
+    case_id: str
+    provider_result_index: int
+    candidate_sha256: str
+    topic: str
+    query: str
+    baseline_sources_json: str
+    required_roles_json: str
+    scope_roles_json: str
+    supporting_roles_json: str
+    title: str
+    url: str
+    doi: str
+    publisher: str
+    published_date: str
+    abstract: str
+    summary_source: str
+
+    @property
+    def key(self) -> tuple[str, int, str]:
+        return self.case_id, self.provider_result_index, self.candidate_sha256
+
+    @property
+    def row_id(self) -> str:
+        return (
+            f"{self.case_id}/{self.provider_result_index}/"
+            f"{self.candidate_sha256[:12]}"
+        )
+
+    @property
+    def identity_sha256(self) -> str:
+        return _sha256_json(asdict(self))
+
+    @property
+    def role_groups(self) -> dict[str, tuple[str, ...]]:
+        return {
+            "required": _role_ids_from_context(self.required_roles_json),
+            "scope": _role_ids_from_context(self.scope_roles_json),
+            "supporting": _role_ids_from_context(self.supporting_roles_json),
+        }
+
+    @property
+    def declared_role_ids(self) -> tuple[str, ...]:
+        groups = self.role_groups
+        return (*groups["required"], *groups["scope"], *groups["supporting"])
+
+
+@dataclass(frozen=True)
+class RoleSlotFailureSnapshot:
+    """Exact source projection shared by lock, packet, and summary seams."""
+
+    source_file_hashes: dict[str, str]
+    indexed_file_hashes: dict[str, str]
+    manifest: RoleSlotDevelopmentManifest
+    execution: RoleSlotDevelopmentExecution
+    candidates: tuple[RoleSlotFailureCandidate, ...]
+    hidden_traces: dict[tuple[str, int, str], dict[str, Any]]
+    selection_contract: Any
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _sha256_json(value: object) -> str:
+    rendered = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(rendered).hexdigest()
+
+
+def _json_text(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json_value(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RoleSlotFailureReviewError(
+            f"could not read JSON artifact {path}: {exc}"
+        ) from exc
+
+
+def _role_context_json(roles: Sequence[Any]) -> str:
+    return json.dumps(
+        [
+            {"role_id": role.role_id, "description": role.description}
+            for role in roles
+        ],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _role_ids_from_context(value: str) -> tuple[str, ...]:
+    try:
+        rows = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise RoleSlotFailureReviewError(
+            "reviewer-visible role context is not valid JSON"
+        ) from exc
+    if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+        raise RoleSlotFailureReviewError("role context must be a JSON object array")
+    role_ids = tuple(row.get("role_id") for row in rows)
+    if any(not isinstance(role_id, str) or not role_id for role_id in role_ids):
+        raise RoleSlotFailureReviewError("role context contains an invalid role ID")
+    if len(role_ids) != len(set(role_ids)):
+        raise RoleSlotFailureReviewError("role context contains duplicate role IDs")
+    return role_ids
+
+
+def _baseline_sources_json(case: Any) -> str:
+    return json.dumps(
+        [source.model_dump(mode="json") for source in case.source_collection.academic_sources],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _expected_index_paths(
+    execution: RoleSlotDevelopmentExecution,
+) -> set[str]:
+    paths = {
+        "manifest.json",
+        "execution.json",
+        "provider-rows.csv",
+        "case-audits.json",
+    }
+    for case in execution.cases:
+        paths.add(f"provider-journals/{case.case_id}.json")
+        paths.add(f"case-executions/{case.case_id}.json")
+        if case.model_plan is not None:
+            paths.add(f"model-plans/{case.case_id}.json")
+        paths.update(
+            f"model-journals/{call.case_id}-pass-{call.pass_number}.json"
+            for call in case.model_calls
+        )
+        if case.case_audit is not None:
+            paths.add(f"case-audits/{case.case_id}.json")
+    return paths
+
+
+def _validate_artifact_index(
+    source_dir: Path,
+    execution: RoleSlotDevelopmentExecution,
+) -> dict[str, str]:
+    payload = _read_json_object(source_dir / "artifact-index.json")
+    expected_header = {
+        "schema_version": 1,
+        "mode": "openalex_role_slot_v6_development_artifact_index",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+    }
+    if any(payload.get(key) != value for key, value in expected_header.items()):
+        raise RoleSlotFailureReviewError("v6 artifact index header drifted")
+    files = payload.get("files")
+    if not isinstance(files, dict) or any(
+        not isinstance(name, str) or not _is_sha256(value)
+        for name, value in files.items()
+    ):
+        raise RoleSlotFailureReviewError("v6 artifact index file map is invalid")
+    expected_paths = _expected_index_paths(execution)
+    if set(files) != expected_paths:
+        missing = sorted(expected_paths - set(files))
+        extra = sorted(set(files) - expected_paths)
+        raise RoleSlotFailureReviewError(
+            f"v6 artifact index paths drifted; missing={missing}, extra={extra}"
+        )
+    if len(files) != EXPECTED_INDEXED_FILE_COUNT:
+        raise RoleSlotFailureReviewError("v6 artifact index count drifted")
+    for name, expected_hash in files.items():
+        path = PurePosixPath(name)
+        if path.is_absolute() or ".." in path.parts or path.as_posix() != name:
+            raise RoleSlotFailureReviewError(
+                f"v6 artifact index contains an unsafe path: {name}"
+            )
+        observed = _file_sha256(source_dir / Path(*path.parts))
+        if observed != expected_hash:
+            raise RoleSlotFailureReviewError(
+                f"indexed artifact identity drifted: {name}"
+            )
+    return dict(files)
+
+
+def _validate_execution_observations(
+    manifest: RoleSlotDevelopmentManifest,
+    execution: RoleSlotDevelopmentExecution,
+    manifest_sha256: str,
+) -> None:
+    if execution.manifest_sha256 != manifest_sha256:
+        raise RoleSlotFailureReviewError("execution manifest identity drifted")
+    if manifest.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+        raise RoleSlotFailureReviewError("v6 fixture identity drifted")
+    if manifest.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+        raise RoleSlotFailureReviewError("v6 implementation identity drifted")
+    if tuple(case.spec.case_id for case in manifest.cases) != CASE_IDS:
+        raise RoleSlotFailureReviewError("manifest cases are not frozen Y01-Y08")
+    if tuple(case.case_id for case in execution.cases) != CASE_IDS:
+        raise RoleSlotFailureReviewError("execution cases are not frozen Y01-Y08")
+    observed = execution.model_dump(mode="json")
+    for field, expected in EXPECTED_EXECUTION_OBSERVATIONS.items():
+        value = observed.get(field)
+        if isinstance(expected, float):
+            equal = isinstance(value, (int, float)) and math.isclose(
+                float(value), expected, abs_tol=1e-12
+            )
+        else:
+            equal = value == expected
+        if not equal:
+            raise RoleSlotFailureReviewError(
+                f"v6 execution observation drifted for {field}: "
+                f"expected {expected!r}, got {value!r}"
+            )
+    if any(
+        (
+            case.provider_journal.state != "completed"
+            or case.provider_journal.response is None
+            or len(case.provider_journal.response.candidates)
+            != EXPECTED_CANDIDATES_PER_CASE[case.case_id]
+            or case.provider_journal.response.provider_rejections
+        )
+        for case in execution.cases
+    ):
+        raise RoleSlotFailureReviewError(
+            "provider-complete diagnostic requires every Y case and candidate"
+        )
+    if any(
+        getattr(manifest, field) is not False
+        for field in (
+            "production_connected",
+            "report_workflow_connected",
+            "planner_trigger_connected",
+            "private_labels_opened",
+            "unseen_cohort_opened",
+        )
+    ) or any(
+        getattr(execution, field) is not False
+        for field in (
+            "production_connected",
+            "report_workflow_connected",
+            "planner_trigger_connected",
+            "private_labels_opened",
+            "unseen_cohort_opened",
+        )
+    ):
+        raise RoleSlotFailureReviewError("v6 diagnostic source is not disconnected")
+
+
+def _validate_child_artifacts(
+    source_dir: Path,
+    execution: RoleSlotDevelopmentExecution,
+) -> None:
+    aggregate_audits = _read_json_value(source_dir / "case-audits.json")
+    expected_audits = [
+        case.case_audit.model_dump(mode="json")
+        for case in execution.cases
+        if case.case_audit is not None
+    ]
+    if aggregate_audits != expected_audits:
+        raise RoleSlotFailureReviewError("aggregate case audits drifted from execution")
+    for case in execution.cases:
+        provider = RoleSlotProviderJournal.model_validate(
+            _read_json_object(
+                source_dir / "provider-journals" / f"{case.case_id}.json"
+            )
+        )
+        if provider != case.provider_journal:
+            raise RoleSlotFailureReviewError(
+                f"{case.case_id} provider journal drifted from execution"
+            )
+        child = RoleSlotCaseExecution.model_validate(
+            _read_json_object(
+                source_dir / "case-executions" / f"{case.case_id}.json"
+            )
+        )
+        if child != case:
+            raise RoleSlotFailureReviewError(
+                f"{case.case_id} case journal drifted from execution"
+            )
+        if case.model_plan is not None:
+            plan = RoleSlotModelPlan.model_validate(
+                _read_json_object(
+                    source_dir / "model-plans" / f"{case.case_id}.json"
+                )
+            )
+            if plan != case.model_plan:
+                raise RoleSlotFailureReviewError(
+                    f"{case.case_id} model plan drifted from execution"
+                )
+        for call in case.model_calls:
+            journal = RoleSlotModelJournal.model_validate(
+                _read_json_object(
+                    source_dir
+                    / "model-journals"
+                    / f"{call.case_id}-pass-{call.pass_number}.json"
+                )
+            )
+            if journal != call:
+                raise RoleSlotFailureReviewError(
+                    f"{case.case_id} model journal drifted from execution"
+                )
+        if case.case_audit is not None:
+            audit = RoleSlotCaseAudit.model_validate(
+                _read_json_object(
+                    source_dir / "case-audits" / f"{case.case_id}.json"
+                )
+            )
+            if audit != case.case_audit:
+                raise RoleSlotFailureReviewError(
+                    f"{case.case_id} case audit drifted from execution"
+                )
+
+
+def _project_candidates(
+    manifest: RoleSlotDevelopmentManifest,
+    execution: RoleSlotDevelopmentExecution,
+) -> tuple[
+    tuple[RoleSlotFailureCandidate, ...],
+    dict[tuple[str, int, str], dict[str, Any]],
+]:
+    manifest_cases = {case.spec.case_id: case for case in manifest.cases}
+    candidates: list[RoleSlotFailureCandidate] = []
+    hidden: dict[tuple[str, int, str], dict[str, Any]] = {}
+    for execution_case in execution.cases:
+        frozen = manifest_cases[execution_case.case_id]
+        response = execution_case.provider_journal.response
+        if response is None:
+            raise RoleSlotFailureReviewError(
+                f"{execution_case.case_id} has no provider response"
+            )
+        audit = execution_case.case_audit
+        decisions = (
+            {item.candidate_sha256: item for item in audit.candidate_decisions}
+            if audit is not None
+            else {}
+        )
+        selected_ids = (
+            {item.candidate_sha256 for item in audit.selected_sources}
+            if audit is not None
+            else set()
+        )
+        for provider_candidate in sorted(
+            response.candidates,
+            key=lambda item: int(item.evidence.provider_result_index or 0),
+        ):
+            evidence = provider_candidate.evidence
+            index = evidence.provider_result_index
+            if index is None:
+                raise RoleSlotFailureReviewError(
+                    "provider candidate lost its result index"
+                )
+            candidate = RoleSlotFailureCandidate(
+                case_id=execution_case.case_id,
+                provider_result_index=index,
+                candidate_sha256=provider_candidate.sha256(),
+                topic=frozen.spec.topic,
+                query=frozen.spec.query,
+                baseline_sources_json=_baseline_sources_json(frozen),
+                required_roles_json=_role_context_json(frozen.spec.roles.required),
+                scope_roles_json=_role_context_json(frozen.spec.roles.scope),
+                supporting_roles_json=_role_context_json(
+                    frozen.spec.roles.supporting
+                ),
+                title=evidence.title,
+                url=evidence.url,
+                doi=evidence.doi or "",
+                publisher=evidence.publisher,
+                published_date=(
+                    evidence.published_date.isoformat()
+                    if evidence.published_date is not None
+                    else ""
+                ),
+                abstract=evidence.evidence_summary,
+                summary_source=evidence.summary_source,
+            )
+            candidates.append(candidate)
+            decision = decisions.get(candidate.candidate_sha256)
+            trace: dict[str, Any] = {
+                "model_observed": decision is not None,
+                "case_action": audit.action if audit is not None else None,
+                "case_selected": bool(audit is not None and audit.action == "SELECT"),
+                "candidate_action": decision.action if decision is not None else None,
+                "consensus_supported_role_ids": (
+                    sorted(
+                        role.role_id
+                        for role in decision.role_consensus
+                        if role.consensus_supported
+                    )
+                    if decision is not None
+                    else []
+                ),
+                "title_anchor_role_ids": (
+                    sorted(decision.title_anchor_role_ids)
+                    if decision is not None
+                    else []
+                ),
+                "provisional_disposition_unanimous": (
+                    decision.provisional_disposition_unanimous
+                    if decision is not None
+                    else None
+                ),
+                "selected_source": candidate.candidate_sha256 in selected_ids,
+                "candidate_abstention_reasons": (
+                    list(decision.abstention_reasons)
+                    if decision is not None
+                    else []
+                ),
+            }
+            hidden[candidate.key] = trace
+    ordered = tuple(
+        sorted(
+            candidates,
+            key=lambda item: (
+                item.case_id,
+                item.provider_result_index,
+                item.candidate_sha256,
+            ),
+        )
+    )
+    if len(ordered) != EXPECTED_CANDIDATE_COUNT:
+        raise RoleSlotFailureReviewError("v6 provider candidate count drifted")
+    counts = Counter(item.case_id for item in ordered)
+    if dict(counts) != EXPECTED_CANDIDATES_PER_CASE:
+        raise RoleSlotFailureReviewError("v6 per-case candidate counts drifted")
+    if len({item.key for item in ordered}) != len(ordered):
+        raise RoleSlotFailureReviewError("v6 provider candidate identities repeat")
+    if set(hidden) != {item.key for item in ordered}:
+        raise RoleSlotFailureReviewError(
+            "computed hidden traces did not reach every candidate boundary"
+        )
+    return ordered, hidden
+
+
+def validate_finalized_source(
+    source_dir: Path,
+    *,
+    expected_hashes: Mapping[str, str] | None = None,
+) -> RoleSlotFailureSnapshot:
+    """Validate exact bytes and project a model-decision-blind population."""
+
+    if not source_dir.is_dir():
+        raise RoleSlotFailureReviewError(
+            f"source directory does not exist: {source_dir}"
+        )
+    source_hashes = {
+        name: _file_sha256(source_dir / name) for name in CORE_SOURCE_FILES
+    }
+    expected = (
+        dict(EXPECTED_SOURCE_FILE_SHA256)
+        if expected_hashes is None
+        else dict(expected_hashes)
+    )
+    if set(expected) != set(CORE_SOURCE_FILES):
+        raise RoleSlotFailureReviewError(
+            "expected hashes must identify every v6 diagnostic core file"
+        )
+    if source_hashes != expected:
+        drift = {
+            name: {"expected": expected[name], "observed": source_hashes[name]}
+            for name in CORE_SOURCE_FILES
+            if source_hashes[name] != expected[name]
+        }
+        raise RoleSlotFailureReviewError(
+            f"source artifact identity drifted after locking: {drift}"
+        )
+    manifest = RoleSlotDevelopmentManifest.model_validate(
+        _read_json_object(source_dir / "manifest.json")
+    )
+    execution = RoleSlotDevelopmentExecution.model_validate(
+        _read_json_object(source_dir / "execution.json")
+    )
+    _validate_execution_observations(
+        manifest,
+        execution,
+        source_hashes["manifest.json"],
+    )
+    indexed_hashes = _validate_artifact_index(source_dir, execution)
+    _validate_child_artifacts(source_dir, execution)
+    provider_rows = _read_csv(
+        source_dir / "provider-rows.csv",
+        _PROVIDER_ROW_COLUMNS,
+    )
+    if provider_rows != _provider_rows(execution.cases):
+        raise RoleSlotFailureReviewError(
+            "provider CSV does not preserve every execution candidate"
+        )
+    fixture_sha256, challenge, prepared_cases = load_frozen_cases("development")
+    if fixture_sha256 != manifest.fixture_sha256:
+        raise RoleSlotFailureReviewError("current fixture drifted from source manifest")
+    if tuple(item.spec for item in prepared_cases) != tuple(
+        item.spec for item in manifest.cases
+    ):
+        raise RoleSlotFailureReviewError("frozen case context drifted")
+    if challenge.selection_contract.sha256() != manifest.selection_contract_sha256:
+        raise RoleSlotFailureReviewError("selection contract drifted")
+    candidates, hidden = _project_candidates(manifest, execution)
+    return RoleSlotFailureSnapshot(
+        source_file_hashes=source_hashes,
+        indexed_file_hashes=indexed_hashes,
+        manifest=manifest,
+        execution=execution,
+        candidates=candidates,
+        hidden_traces=hidden,
+        selection_contract=challenge.selection_contract,
+    )
+
+def _walk_mapping_keys(value: object) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if isinstance(key, str):
+                keys.add(key)
+            keys.update(_walk_mapping_keys(child))
+    elif isinstance(value, list | tuple):
+        for child in value:
+            keys.update(_walk_mapping_keys(child))
+    return keys
+
+
+def _packet_rows(snapshot: RoleSlotFailureSnapshot) -> list[dict[str, Any]]:
+    rows = [
+        {**asdict(candidate), "identity_sha256": candidate.identity_sha256}
+        for candidate in snapshot.candidates
+    ]
+    leaked = sorted(_FORBIDDEN_REVIEWER_KEYS.intersection(_walk_mapping_keys(rows)))
+    if leaked:
+        raise RoleSlotFailureReviewError(
+            f"reviewer packet leaks v6 decision fields: {leaked}"
+        )
+    return rows
+
+
+def _packet_manifest(
+    snapshot: RoleSlotFailureSnapshot,
+    source_lock_path: Path,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "mode": "openalex_role_slot_v6_failure_diagnostic_packet",
+        "prepared_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.source_file_hashes,
+        "row_count": len(snapshot.candidates),
+        "case_count": len(CASE_IDS),
+        "rows": _packet_rows(snapshot),
+        "valid_label_combinations": [
+            list(values) for values in sorted(VALID_LABEL_COMBINATIONS)
+        ],
+        "role_label_contract": {
+            "supported_role_ids_json": (
+                "JSON array containing only role IDs declared for the case"
+            ),
+            "title_supported_role_ids_json": (
+                "JSON array that must be a subset of supported_role_ids_json"
+            ),
+        },
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def _packet_readme(snapshot: RoleSlotFailureSnapshot) -> str:
+    counts = Counter(candidate.case_id for candidate in snapshot.candidates)
+    cases = "\n".join(
+        f"| {case_id} | {counts[case_id]} |" for case_id in CASE_IDS
+    )
+    return f"""# Frozen role-slot candidate review
+
+This packet contains {len(snapshot.candidates)} OpenAlex title-and-abstract rows
+from eight frozen research questions. Preparing and summarizing it makes zero
+API or model calls.
+
+Do not edit packet_manifest.json. Complete only labels.csv and
+reviewer_declaration.csv. Rows may be reordered, but every context and identity
+field must remain unchanged. Do not inspect the source execution, automated
+model outputs, consensus decisions, selected sets, or the separate source-lock
+file until after returning the completed packet.
+
+| Case | Candidate rows |
+|---|---:|
+{cases}
+
+For each row:
+
+1. Set direct_relevance to YES when the frozen title and abstract directly
+   address the topic, NO when they only share a broad field, or UNVERIFIABLE
+   when the frozen text is insufficient.
+2. Set baseline_novelty to YES or NO only for a directly relevant row, N/A for
+   a directly irrelevant row, and UNVERIFIABLE otherwise. Novelty is relative
+   only to baseline_sources_json, not the whole literature.
+3. Set abstract_sufficient to YES for a relevance judgment and NO only with
+   the UNVERIFIABLE combination.
+4. Enter every supported code-owned role ID as a JSON array in
+   supported_role_ids_json, for example ["role_one","role_two"]. Use [] when no
+   declared role is supported. Enter the subset supported by title text in
+   title_supported_role_ids_json.
+5. Give a source-grounded review_note explaining the judgment.
+
+Allowed relevance combinations are YES / YES-or-NO / YES,
+NO / N/A / YES, and UNVERIFIABLE / UNVERIFIABLE / NO in
+direct_relevance / baseline_novelty / abstract_sufficient order.
+
+Every row must be reviewed. Declare any generative-AI use honestly in
+reviewer_declaration.csv; NONE and LANGUAGE_ONLY are eligible, while
+substantive generated judgments are retained but not evaluated. External URL
+checks are encouraged but optional because this diagnostic concerns the exact
+frozen text; record ALL_ATTEMPTED, SOME, or NONE.
+
+The review is diagnostic only. It cannot reverse the failed v6 experiment,
+open the unseen cohort, validate a successor, or authorize production Tool
+Calling.
+"""
+
+
+def prepare_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Create a separate packet whose rows contain no automated outcome."""
+
+    if packet_dir.exists():
+        raise RoleSlotFailureReviewError(
+            f"refusing to overwrite diagnostic packet: {packet_dir}"
+        )
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    if snapshot.indexed_file_hashes != source_lock.indexed_file_sha256:
+        raise RoleSlotFailureReviewError(
+            "indexed source identities drifted after diagnostic locking"
+        )
+    try:
+        packet_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise RoleSlotFailureReviewError(
+            f"could not create diagnostic packet {packet_dir}: {exc}"
+        ) from exc
+    manifest = _packet_manifest(snapshot, source_lock_path)
+    label_rows = [
+        {
+            **asdict(candidate),
+            **{field: "" for field in LABEL_VALUE_FIELDS},
+        }
+        for candidate in snapshot.candidates
+    ]
+    _write_csv_new(packet_dir / "labels.csv", LABEL_FIELDS, label_rows)
+    _write_csv_new(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [{}],
+    )
+    _write_text_new(packet_dir / "README.md", _packet_readme(snapshot))
+    _write_text_new(
+        packet_dir / "packet_manifest.json",
+        _json_text(manifest),
+    )
+    return manifest
+
+
+def _mapping_string(value: Mapping[str, Any], field: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str):
+        raise RoleSlotFailureReviewError(f"{field} must be a string")
+    return item
+
+
+def _candidate_from_mapping(
+    value: Mapping[str, Any],
+) -> RoleSlotFailureCandidate:
+    raw_index = value.get("provider_result_index")
+    try:
+        provider_result_index = int(raw_index)
+    except (TypeError, ValueError) as exc:
+        raise RoleSlotFailureReviewError(
+            "provider_result_index must be an integer"
+        ) from exc
+    return RoleSlotFailureCandidate(
+        case_id=_mapping_string(value, "case_id"),
+        provider_result_index=provider_result_index,
+        candidate_sha256=_mapping_string(value, "candidate_sha256"),
+        topic=_mapping_string(value, "topic"),
+        query=_mapping_string(value, "query"),
+        baseline_sources_json=_mapping_string(value, "baseline_sources_json"),
+        required_roles_json=_mapping_string(value, "required_roles_json"),
+        scope_roles_json=_mapping_string(value, "scope_roles_json"),
+        supporting_roles_json=_mapping_string(value, "supporting_roles_json"),
+        title=_mapping_string(value, "title"),
+        url=_mapping_string(value, "url"),
+        doi=_mapping_string(value, "doi"),
+        publisher=_mapping_string(value, "publisher"),
+        published_date=_mapping_string(value, "published_date"),
+        abstract=_mapping_string(value, "abstract"),
+        summary_source=_mapping_string(value, "summary_source"),
+    )
+
+
+def _manifest_candidates(
+    manifest: dict[str, Any],
+    snapshot: RoleSlotFailureSnapshot,
+    source_lock_path: Path,
+) -> dict[tuple[str, int, str], RoleSlotFailureCandidate]:
+    expected_header = {
+        "schema_version": 1,
+        "mode": "openalex_role_slot_v6_failure_diagnostic_packet",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.source_file_hashes,
+        "row_count": EXPECTED_CANDIDATE_COUNT,
+        "case_count": len(CASE_IDS),
+        "valid_label_combinations": [
+            list(values) for values in sorted(VALID_LABEL_COMBINATIONS)
+        ],
+        "role_label_contract": {
+            "supported_role_ids_json": (
+                "JSON array containing only role IDs declared for the case"
+            ),
+            "title_supported_role_ids_json": (
+                "JSON array that must be a subset of supported_role_ids_json"
+            ),
+        },
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+    for key, expected in expected_header.items():
+        if manifest.get(key) != expected:
+            raise RoleSlotFailureReviewError(
+                f"diagnostic packet manifest drifted for {key}"
+            )
+    leaked = sorted(
+        _FORBIDDEN_REVIEWER_KEYS.intersection(_walk_mapping_keys(manifest))
+    )
+    if leaked:
+        raise RoleSlotFailureReviewError(
+            f"diagnostic packet manifest leaks v6 decision fields: {leaked}"
+        )
+    rows = manifest.get("rows")
+    if not isinstance(rows, list) or len(rows) != EXPECTED_CANDIDATE_COUNT:
+        raise RoleSlotFailureReviewError(
+            "diagnostic packet manifest row count is not inspectable"
+        )
+    candidates: dict[tuple[str, int, str], RoleSlotFailureCandidate] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise RoleSlotFailureReviewError("packet rows must be objects")
+        candidate = _candidate_from_mapping(row)
+        if row.get("identity_sha256") != candidate.identity_sha256:
+            raise RoleSlotFailureReviewError(
+                f"packet identity hash drifted for {candidate.row_id}"
+            )
+        if candidate.key in candidates:
+            raise RoleSlotFailureReviewError(
+                f"packet contains duplicate identity {candidate.row_id}"
+            )
+        candidates[candidate.key] = candidate
+    expected = {candidate.key: candidate for candidate in snapshot.candidates}
+    if candidates != expected:
+        raise RoleSlotFailureReviewError(
+            "packet candidates do not match source-locked rows"
+        )
+    return candidates
+
+
+def _parse_review_role_ids(
+    value: str,
+    *,
+    candidate: RoleSlotFailureCandidate,
+    field: str,
+) -> tuple[str, ...]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise RoleSlotFailureReviewError(
+            f"{candidate.row_id} {field} must be a JSON array"
+        ) from exc
+    if not isinstance(parsed, list) or any(
+        not isinstance(item, str) for item in parsed
+    ):
+        raise RoleSlotFailureReviewError(
+            f"{candidate.row_id} {field} must contain only role IDs"
+        )
+    role_ids = tuple(parsed)
+    if len(role_ids) != len(set(role_ids)):
+        raise RoleSlotFailureReviewError(
+            f"{candidate.row_id} {field} contains duplicate role IDs"
+        )
+    unknown = sorted(set(role_ids) - set(candidate.declared_role_ids))
+    if unknown:
+        raise RoleSlotFailureReviewError(
+            f"{candidate.row_id} {field} contains unknown role IDs: {unknown}"
+        )
+    return tuple(sorted(role_ids))
+
+
+def _validated_label(
+    row: dict[str, str],
+    expected: RoleSlotFailureCandidate,
+) -> dict[str, Any] | None:
+    observed = _candidate_from_mapping(row)
+    if observed != expected:
+        raise RoleSlotFailureReviewError(
+            f"{expected.row_id} context or identity drifted"
+        )
+    values = [row[field].strip() for field in LABEL_VALUE_FIELDS]
+    if not any(values):
+        return None
+    if not all(values):
+        raise RoleSlotFailureReviewError(
+            f"{expected.row_id} is partially completed"
+        )
+    relevance = row["direct_relevance"].strip().upper()
+    novelty = row["baseline_novelty"].strip().upper()
+    sufficient = row["abstract_sufficient"].strip().upper()
+    if (relevance, novelty, sufficient) not in VALID_LABEL_COMBINATIONS:
+        raise RoleSlotFailureReviewError(
+            f"{expected.row_id} has invalid diagnostic labels: "
+            f"{relevance}/{novelty}/{sufficient}"
+        )
+    supported = _parse_review_role_ids(
+        row["supported_role_ids_json"].strip(),
+        candidate=expected,
+        field="supported_role_ids_json",
+    )
+    title_supported = _parse_review_role_ids(
+        row["title_supported_role_ids_json"].strip(),
+        candidate=expected,
+        field="title_supported_role_ids_json",
+    )
+    if not set(title_supported).issubset(supported):
+        raise RoleSlotFailureReviewError(
+            f"{expected.row_id} title-supported roles must be supported roles"
+        )
+    note = row["review_note"].strip()
+    if len("".join(note.split())) < 12:
+        raise RoleSlotFailureReviewError(
+            f"{expected.row_id} review_note is too short to ground the judgment"
+        )
+    return {
+        "case_id": expected.case_id,
+        "provider_result_index": expected.provider_result_index,
+        "candidate_sha256": expected.candidate_sha256,
+        "row_id": expected.row_id,
+        "direct_relevance": relevance,
+        "baseline_novelty": novelty,
+        "abstract_sufficient": sufficient,
+        "supported_role_ids": list(supported),
+        "title_supported_role_ids": list(title_supported),
+        "review_note": note,
+    }
+
+def _human_candidate_eligible(
+    candidate: RoleSlotFailureCandidate,
+    label: Mapping[str, Any],
+    contract: Any,
+) -> bool:
+    if (
+        label["direct_relevance"] != "YES"
+        or label["abstract_sufficient"] != "YES"
+    ):
+        return False
+    groups = candidate.role_groups
+    supported = set(label["supported_role_ids"])
+    required = len(supported.intersection(groups["required"]))
+    context = len(
+        supported.intersection((*groups["scope"], *groups["supporting"]))
+    )
+    title = len(label["title_supported_role_ids"])
+    return (
+        required >= contract.minimum_candidate_required_roles
+        and context >= contract.minimum_candidate_context_roles
+        and title >= contract.minimum_candidate_title_anchor_roles
+    )
+
+
+def _human_covering_set(
+    case_candidates: Sequence[RoleSlotFailureCandidate],
+    labels: Mapping[tuple[str, int, str], Mapping[str, Any]],
+    contract: Any,
+) -> tuple[RoleSlotFailureCandidate, ...]:
+    if not case_candidates:
+        return ()
+    groups = case_candidates[0].role_groups
+    eligible = tuple(
+        sorted(
+            (
+                candidate
+                for candidate in case_candidates
+                if _human_candidate_eligible(
+                    candidate,
+                    labels[candidate.key],
+                    contract,
+                )
+            ),
+            key=lambda item: (item.provider_result_index, item.candidate_sha256),
+        )
+    )
+    for size in range(1, contract.maximum_selected_sources_per_case + 1):
+        valid: list[tuple[RoleSlotFailureCandidate, ...]] = []
+        for group in combinations(eligible, size):
+            supported = set().union(
+                *(
+                    set(labels[candidate.key]["supported_role_ids"])
+                    for candidate in group
+                )
+            )
+            if (
+                set(groups["required"]).issubset(supported)
+                and len(supported.intersection(groups["scope"]))
+                >= contract.minimum_scope_roles
+                and len(supported.intersection(groups["supporting"]))
+                >= contract.minimum_supporting_roles
+            ):
+                valid.append(group)
+        if valid:
+            return min(
+                valid,
+                key=lambda group: (
+                    tuple(item.provider_result_index for item in group),
+                    tuple(item.candidate_sha256 for item in group),
+                ),
+            )
+    return ()
+
+
+def _safe_rate(numerator: int, denominator: int) -> float | None:
+    return numerator / denominator if denominator else None
+
+
+def _diagnostic_metrics(
+    snapshot: RoleSlotFailureSnapshot,
+    completed: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    labels = {
+        (
+            str(row["case_id"]),
+            int(row["provider_result_index"]),
+            str(row["candidate_sha256"]),
+        ): row
+        for row in completed
+    }
+    inspectable = [
+        row for row in completed if row["direct_relevance"] != "UNVERIFIABLE"
+    ]
+    relevant = [row for row in completed if row["direct_relevance"] == "YES"]
+    irrelevant = [row for row in completed if row["direct_relevance"] == "NO"]
+    unverifiable = [
+        row for row in completed if row["direct_relevance"] == "UNVERIFIABLE"
+    ]
+    novel_relevant = [
+        row
+        for row in completed
+        if row["direct_relevance"] == "YES"
+        and row["baseline_novelty"] == "YES"
+    ]
+
+    role_confusion = Counter()
+    title_confusion = Counter()
+    admission_confusion = Counter()
+    model_observed_candidate_count = 0
+    attribution = Counter()
+    for candidate in snapshot.candidates:
+        label = labels[candidate.key]
+        trace = snapshot.hidden_traces[candidate.key]
+        if label["direct_relevance"] == "NO":
+            attribution["retrieval_noise"] += 1
+        elif label["direct_relevance"] == "UNVERIFIABLE":
+            attribution["frozen_text_insufficient"] += 1
+        if not trace["model_observed"]:
+            attribution["model_not_observed"] += 1
+            continue
+        model_observed_candidate_count += 1
+        model_roles = set(trace["consensus_supported_role_ids"])
+        human_roles = set(label["supported_role_ids"])
+        for role_id in candidate.declared_role_ids:
+            model_positive = role_id in model_roles
+            human_positive = role_id in human_roles
+            role_confusion[
+                (
+                    "true_positive"
+                    if model_positive and human_positive
+                    else "false_positive"
+                    if model_positive
+                    else "false_negative"
+                    if human_positive
+                    else "true_negative"
+                )
+            ] += 1
+        model_title = set(trace["title_anchor_role_ids"])
+        human_title = set(label["title_supported_role_ids"])
+        for role_id in candidate.declared_role_ids:
+            model_positive = role_id in model_title
+            human_positive = role_id in human_title
+            title_confusion[
+                (
+                    "true_positive"
+                    if model_positive and human_positive
+                    else "false_positive"
+                    if model_positive
+                    else "false_negative"
+                    if human_positive
+                    else "true_negative"
+                )
+            ] += 1
+        model_keep = trace["candidate_action"] == "KEEP"
+        human_keep = _human_candidate_eligible(
+            candidate,
+            label,
+            snapshot.selection_contract,
+        )
+        admission_confusion[
+            (
+                "true_positive"
+                if model_keep and human_keep
+                else "false_positive"
+                if model_keep
+                else "false_negative"
+                if human_keep
+                else "true_negative"
+            )
+        ] += 1
+        if model_roles - human_roles:
+            attribution["candidate_with_consensus_false_positive"] += 1
+        if human_roles - model_roles:
+            attribution["candidate_with_consensus_false_negative"] += 1
+
+    candidates_by_case = {
+        case_id: tuple(
+            candidate
+            for candidate in snapshot.candidates
+            if candidate.case_id == case_id
+        )
+        for case_id in CASE_IDS
+    }
+    human_sets = {
+        case_id: _human_covering_set(
+            candidates,
+            labels,
+            snapshot.selection_contract,
+        )
+        for case_id, candidates in candidates_by_case.items()
+    }
+    human_coverable = sorted(
+        case_id for case_id, group in human_sets.items() if group
+    )
+    model_selected = sorted(
+        case.case_id
+        for case in snapshot.execution.cases
+        if case.case_audit is not None and case.case_audit.action == "SELECT"
+    )
+    model_unobserved = sorted(
+        case.case_id
+        for case in snapshot.execution.cases
+        if case.case_audit is None
+    )
+    attribution["case_without_human_covering_set"] = (
+        len(CASE_IDS) - len(human_coverable)
+    )
+
+    role_positive = (
+        role_confusion["true_positive"] + role_confusion["false_positive"]
+    )
+    human_role_positive = (
+        role_confusion["true_positive"] + role_confusion["false_negative"]
+    )
+    title_positive = (
+        title_confusion["true_positive"] + title_confusion["false_positive"]
+    )
+    human_title_positive = (
+        title_confusion["true_positive"] + title_confusion["false_negative"]
+    )
+    return {
+        "candidate_count": len(snapshot.candidates),
+        "inspectable_candidate_count": len(inspectable),
+        "direct_relevant_count": len(relevant),
+        "direct_irrelevant_count": len(irrelevant),
+        "unverifiable_count": len(unverifiable),
+        "retrieval_noise_rate_among_inspectable": _safe_rate(
+            len(irrelevant), len(inspectable)
+        ),
+        "frozen_text_insufficiency_rate": _safe_rate(
+            len(unverifiable), len(snapshot.candidates)
+        ),
+        "novel_relevant_candidate_count": len(novel_relevant),
+        "novel_relevant_case_ids": sorted(
+            {str(row["case_id"]) for row in novel_relevant}
+        ),
+        "human_supported_role_assignment_count": sum(
+            len(row["supported_role_ids"]) for row in completed
+        ),
+        "human_title_supported_role_assignment_count": sum(
+            len(row["title_supported_role_ids"]) for row in completed
+        ),
+        "model_observed_candidate_count": model_observed_candidate_count,
+        "model_unobserved_candidate_count": (
+            len(snapshot.candidates) - model_observed_candidate_count
+        ),
+        "role_confusion": dict(sorted(role_confusion.items())),
+        "role_precision": _safe_rate(
+            role_confusion["true_positive"], role_positive
+        ),
+        "role_recall": _safe_rate(
+            role_confusion["true_positive"], human_role_positive
+        ),
+        "unsupported_consensus_role_rate": _safe_rate(
+            role_confusion["false_positive"], role_positive
+        ),
+        "title_anchor_confusion": dict(sorted(title_confusion.items())),
+        "title_anchor_precision": _safe_rate(
+            title_confusion["true_positive"], title_positive
+        ),
+        "title_anchor_recall": _safe_rate(
+            title_confusion["true_positive"], human_title_positive
+        ),
+        "candidate_admission_confusion": dict(
+            sorted(admission_confusion.items())
+        ),
+        "human_coverable_case_ids": human_coverable,
+        "human_covering_sets": {
+            case_id: [candidate.row_id for candidate in group]
+            for case_id, group in human_sets.items()
+            if group
+        },
+        "model_selected_case_ids": model_selected,
+        "model_unobserved_case_ids": model_unobserved,
+        "model_missed_human_coverable_case_ids": sorted(
+            set(human_coverable) - set(model_selected)
+        ),
+        "model_selected_without_human_cover_case_ids": sorted(
+            set(model_selected) - set(human_coverable)
+        ),
+        "attribution_counts": dict(sorted(attribution.items())),
+    }
+
+
+def summarize_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Validate returned labels and join hidden v6 traces only here."""
+
+    if not packet_dir.is_dir():
+        raise RoleSlotFailureReviewError(
+            f"diagnostic packet directory does not exist: {packet_dir}"
+        )
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    if snapshot.indexed_file_hashes != source_lock.indexed_file_sha256:
+        raise RoleSlotFailureReviewError(
+            "indexed source identities drifted after diagnostic locking"
+        )
+    manifest = _read_json_object(packet_dir / "packet_manifest.json")
+    expected_candidates = _manifest_candidates(
+        manifest,
+        snapshot,
+        source_lock_path,
+    )
+    label_rows = _read_csv(packet_dir / "labels.csv", LABEL_FIELDS)
+    observed_keys = [_candidate_from_mapping(row).key for row in label_rows]
+    if len(observed_keys) != len(set(observed_keys)):
+        raise RoleSlotFailureReviewError(
+            "diagnostic labels contain duplicate candidate identities"
+        )
+    if set(observed_keys) != set(expected_candidates):
+        missing = sorted(set(expected_candidates) - set(observed_keys))
+        extra = sorted(set(observed_keys) - set(expected_candidates))
+        raise RoleSlotFailureReviewError(
+            f"diagnostic label identities drifted; missing={missing}, "
+            f"extra={extra}"
+        )
+    completed: dict[tuple[str, int, str], dict[str, Any]] = {}
+    incomplete_row_ids: list[str] = []
+    for row in label_rows:
+        candidate = _candidate_from_mapping(row)
+        validated = _validated_label(row, expected_candidates[candidate.key])
+        if validated is None:
+            incomplete_row_ids.append(candidate.row_id)
+        else:
+            completed[candidate.key] = validated
+
+    declaration_rows = _read_csv(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+    )
+    if len(declaration_rows) != 1:
+        raise RoleSlotFailureReviewError(
+            "reviewer_declaration.csv must contain exactly one row"
+        )
+    declaration = _validated_declaration(declaration_rows[0])
+    method_issues: list[str] = []
+    if declaration is not None and declaration["reviewed_all"] != "YES":
+        method_issues.append("reviewer_did_not_confirm_all_rows")
+    if incomplete_row_ids or declaration is None:
+        protocol_status = "incomplete"
+    elif declaration["generative_ai_use"] not in ELIGIBLE_AI_USE:
+        protocol_status = "excluded_substantive_ai"
+    elif method_issues:
+        protocol_status = "not_inspectable"
+    else:
+        protocol_status = "complete"
+    ordered = [completed[key] for key in sorted(completed)]
+    metrics = (
+        _diagnostic_metrics(snapshot, ordered)
+        if protocol_status == "complete"
+        else None
+    )
+    return {
+        "schema_version": 1,
+        "mode": "openalex_role_slot_v6_failure_diagnostic_result",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "diagnostic_only": True,
+        "original_v6_result": "irrecoverably_failed",
+        "original_source_lock_readiness": "not_ready",
+        "original_source_value_state": "not_evaluated",
+        "v6_rescue_authorized": False,
+        "z_cohort_authorized": False,
+        "production_connection_authorized": False,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.source_file_hashes,
+        "packet_manifest_sha256": _file_sha256(
+            packet_dir / "packet_manifest.json"
+        ),
+        "protocol_status": protocol_status,
+        "diagnostic_state": (
+            "evaluated_diagnostic_only"
+            if protocol_status == "complete"
+            else "not_evaluated"
+        ),
+        "expected_row_count": EXPECTED_CANDIDATE_COUNT,
+        "completed_row_count": len(completed),
+        "incomplete_row_ids": sorted(incomplete_row_ids),
+        "method_issues": method_issues,
+        "declaration": declaration,
+        "metrics": metrics,
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def write_summary(path: Path, result: dict[str, Any]) -> None:
+    """Persist one interpretation without replacing prior human evidence."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RoleSlotFailureReviewError(
+            f"could not create summary parent {path.parent}: {exc}"
+        ) from exc
+    _write_text_new(path, _json_text(result))
+
+
+def _write_json_stdout(value: object) -> None:
+    """Emit UTF-8 even when a legacy Windows console advertises GBK."""
+
+    text = _json_text(value)
+    stdout_buffer = getattr(sys.stdout, "buffer", None)
+    if stdout_buffer is None:
+        sys.stdout.write(text)
+        return
+    stdout_buffer.write(text.encode("utf-8"))
+    stdout_buffer.flush()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Lock, prepare, or summarize the zero-network v6 diagnostic."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    lock = commands.add_parser("lock")
+    lock.add_argument("--source-dir", type=Path, required=True)
+    lock.add_argument("--output", type=Path, required=True)
+    lock.add_argument("--owner", required=True)
+    lock.add_argument("--note")
+    lock.add_argument("--confirm-authorized-output", action="store_true")
+
+    prepare = commands.add_parser("prepare")
+    prepare.add_argument("--source-dir", type=Path, required=True)
+    prepare.add_argument("--source-lock", type=Path, required=True)
+    prepare.add_argument("--packet-dir", type=Path, required=True)
+
+    summarize = commands.add_parser("summarize")
+    summarize.add_argument("--source-dir", type=Path, required=True)
+    summarize.add_argument("--source-lock", type=Path, required=True)
+    summarize.add_argument("--packet-dir", type=Path, required=True)
+    summarize.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "lock":
+        result: object = create_source_lock(
+            args.source_dir,
+            args.output,
+            study_owner_id=args.owner,
+            confirm_authorized_output=args.confirm_authorized_output,
+            note=args.note,
+        )
+        result = result.model_dump(mode="json")
+    elif args.command == "prepare":
+        result = prepare_packet(
+            args.source_dir,
+            args.source_lock,
+            args.packet_dir,
+        )
+    else:
+        result = summarize_packet(
+            args.source_dir,
+            args.source_lock,
+            args.packet_dir,
+        )
+        if args.output is not None:
+            write_summary(args.output, result)
+    _write_json_stdout(result)
+    return 0
+
+
+
+
+def create_source_lock(
+    source_dir: Path,
+    output_path: Path,
+    *,
+    study_owner_id: str,
+    confirm_authorized_output: bool,
+    note: str | None = None,
+    authorized_at: datetime | None = None,
+) -> RoleSlotFailureDiagnosticLock:
+    """Bind the provider-complete failed run before a packet exists."""
+
+    if not confirm_authorized_output:
+        raise RoleSlotFailureReviewError(
+            "diagnostic locking requires authorized-output confirmation"
+        )
+    if output_path.exists():
+        raise RoleSlotFailureReviewError(
+            f"refusing to overwrite diagnostic lock: {output_path}"
+        )
+    snapshot = validate_finalized_source(source_dir)
+    lock = RoleSlotFailureDiagnosticLock(
+        executed_revision=EXPECTED_EXECUTED_REVISION,
+        fixture_sha256=snapshot.manifest.fixture_sha256,
+        implementation_sha256=snapshot.manifest.implementation_sha256,
+        source_file_sha256=snapshot.source_file_hashes,
+        indexed_file_sha256=snapshot.indexed_file_hashes,
+        study_owner_id=study_owner_id.strip(),
+        authorized_at=authorized_at or datetime.now(UTC),
+        note=note.strip() if note and note.strip() else None,
+    )
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RoleSlotFailureReviewError(
+            f"could not create diagnostic-lock parent {output_path.parent}: {exc}"
+        ) from exc
+    _write_text_new(output_path, _json_text(lock.model_dump(mode="json")))
+    return lock
+
+
+def _load_source_lock(path: Path) -> RoleSlotFailureDiagnosticLock:
+    try:
+        return RoleSlotFailureDiagnosticLock.model_validate(
+            _read_json_object(path)
+        )
+    except ValueError as exc:
+        if isinstance(exc, RoleSlotFailureReviewError):
+            raise
+        raise RoleSlotFailureReviewError(
+            f"diagnostic source lock is invalid: {exc}"
+        ) from exc
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_role_slot_failure_review.py
+++ b/tests/test_openalex_role_slot_failure_review.py
@@ -1,0 +1,495 @@
+"""Zero-network review seams for the failed role-slot v6 provider population."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import shutil
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import openalex_role_slot_development as development
+import openalex_role_slot_failure_review as diagnostic
+from academic_agent.openalex_claim_scope import OpenAlexClaimScopeCandidate
+from academic_agent.tools.evidence_search import (
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from academic_agent.tools.openalex_claim_scope_search import (
+    OpenAlexClaimScopeAdapterResponse,
+)
+from academic_agent.tools.qwen_role_slot_judge import (
+    QwenRoleSlotResponse,
+    QwenRoleSlotUsage,
+)
+from openalex_role_slot_failure_review import (
+    LABEL_FIELDS,
+    RoleSlotFailureReviewError,
+    create_source_lock,
+    prepare_packet,
+    summarize_packet,
+)
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _implementation_hashes() -> dict[str, str]:
+    return {
+        name: _sha256(path.read_bytes())
+        for name, path in development._IMPLEMENTATION_PATHS.items()  # noqa: SLF001
+    }
+
+
+def _candidate(case_id: str, index: int) -> OpenAlexClaimScopeCandidate:
+    return OpenAlexClaimScopeCandidate(
+        evidence=ToolEvidenceCandidate(
+            title=(
+                f"{case_id} candidate {index} frozen title with role evidence"
+            ),
+            url=f"https://openalex.org/W{case_id[1:]}{index}123456789",
+            doi=f"10.5555/{case_id.casefold()}.{index}",
+            publisher="Frozen OpenAlex Test Publisher",
+            published_date=date(2026, 8, 31),
+            evidence_summary=(
+                f"This abstract for {case_id} candidate {index} contains "
+                "sufficient public text for the deterministic role review seam."
+            ),
+            summary_source="abstract",
+            citation_count=index,
+            provider_result_index=index,
+        ),
+        aboutness=(),
+    )
+
+
+class _ProviderAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, call):  # noqa: ANN001, ANN204
+        self.call_count += 1
+        case_id = f"Y{self.call_count:02d}"
+        request_id = f"client-openalex-v6-review-{case_id.casefold()}"
+        usage = ToolProviderUsage(
+            provider="openalex",
+            request_id=request_id,
+            request_id_source="client_generated",
+            result_count=8,
+            cost_basis="reported_usd",
+            reported_cost_usd=0.001,
+        )
+        return OpenAlexClaimScopeAdapterResponse(
+            idempotency_key=call.idempotency_key,
+            candidates=tuple(_candidate(case_id, index) for index in range(8)),
+            provider_rejections=(),
+            search_cost_usd=0.001,
+            provider_request_id=request_id,
+            provider_usage=usage,
+        )
+
+
+def _prompt_input(request) -> dict[str, object]:  # noqa: ANN001
+    return json.loads(request.user_prompt.split("INPUT:\n", 1)[1])
+
+
+class _ModelAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self, request):  # noqa: ANN001, ANN204
+        self.call_count += 1
+        outbound = _prompt_input(request)
+        raw_content = json.dumps(
+            {
+                "case_id": request.case_id,
+                "candidates": [
+                    {
+                        "candidate_sha256": candidate["candidate_sha256"],
+                        "slots": [
+                            {
+                                "slot_index": role["slot_index"],
+                                "state": "ABSTAIN",
+                                "field": None,
+                                "quote": None,
+                            }
+                            for role in outbound["roles"]
+                        ],
+                    }
+                    for candidate in outbound["candidates"]
+                ],
+            },
+            separators=(",", ":"),
+        )
+        usage = QwenRoleSlotUsage(
+            prompt_tokens=100,
+            cached_prompt_tokens=0,
+            completion_tokens=20,
+            total_tokens=120,
+            cost_usd=0.001,
+            cost_basis="frozen zero-network review test cost",
+        )
+        return QwenRoleSlotResponse(
+            case_id=request.case_id,
+            pass_number=request.pass_number,
+            candidate_order=request.candidate_order,
+            trace_id=request.trace_id,
+            request_sha256=_sha256(request.body()),
+            batch_input_sha256=request.batch_input_sha256,
+            prompt_sha256=request.prompt_sha256,
+            requested_model=request.requested_model,
+            returned_model="qwen3.5-plus",
+            provider_response_id=f"qwen-response-{self.call_count}",
+            provider_request_id=f"qwen-request-{self.call_count}",
+            finish_reason="stop",
+            raw_content=raw_content,
+            raw_content_sha256=_sha256(raw_content.encode("utf-8")),
+            usage=usage,
+            latency_ms=25.0,
+        )
+
+
+@pytest.fixture(scope="module")
+def _frozen_source(tmp_path_factory):  # noqa: ANN001, ANN202
+    output = tmp_path_factory.mktemp("v6-review-source") / "result"
+    provider = _ProviderAdapter()
+    model = _ModelAdapter()
+    execution = development.execute_development_study(
+        output_dir=output,
+        openalex_soft_stop_usd=0.01,
+        model_soft_stop_usd=0.021,
+        acknowledge_anonymous_daily_budget=True,
+        acknowledge_model_budget=True,
+        expected_implementation_sha256=_implementation_hashes(),
+        provider_adapter_factory=lambda: provider,
+        model_adapter_factory=lambda: model,
+    )
+    assert execution.overall_state == "partial"
+    assert execution.stop_reason == "model_soft_stop"
+    assert execution.openalex_request_count == 8
+    assert execution.provider_candidate_count == 64
+    assert execution.model_call_count == 21
+    assert len(json.loads((output / "artifact-index.json").read_text())["files"]) == 56
+    source_hashes = {
+        name: _sha256((output / name).read_bytes())
+        for name in diagnostic.CORE_SOURCE_FILES
+    }
+    observations = {
+        field: getattr(execution, field)
+        for field in diagnostic.EXPECTED_EXECUTION_OBSERVATIONS
+    }
+    return output, source_hashes, observations
+
+
+@pytest.fixture
+def source(tmp_path, monkeypatch, _frozen_source):  # noqa: ANN001, ANN202
+    frozen, source_hashes, observations = _frozen_source
+    copied = tmp_path / "source"
+    shutil.copytree(frozen, copied)
+    monkeypatch.setattr(
+        diagnostic,
+        "EXPECTED_SOURCE_FILE_SHA256",
+        source_hashes,
+    )
+    monkeypatch.setattr(
+        diagnostic,
+        "EXPECTED_EXECUTION_OBSERVATIONS",
+        observations,
+    )
+    return copied
+
+
+def _lock(source: Path, tmp_path: Path) -> Path:
+    path = tmp_path / "private" / "source-lock.json"
+    create_source_lock(
+        source,
+        path,
+        study_owner_id="offline-owner",
+        confirm_authorized_output=True,
+    )
+    return path
+
+
+def _packet(source: Path, tmp_path: Path) -> tuple[Path, Path]:
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "reviewer-packet"
+    prepare_packet(source, source_lock, packet)
+    return source_lock, packet
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_csv(
+    path: Path,
+    fieldnames: tuple[str, ...],
+    rows: list[dict[str, str]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _complete_labels(packet: Path) -> list[dict[str, str]]:
+    rows = _read_csv(packet / "labels.csv")
+    for row in rows:
+        required = json.loads(row["required_roles_json"])
+        scope = json.loads(row["scope_roles_json"])
+        supporting = json.loads(row["supporting_roles_json"])
+        role_ids = [
+            item["role_id"] for item in (*required, *scope, *supporting)
+        ]
+        row.update(
+            {
+                "direct_relevance": "YES",
+                "baseline_novelty": "YES",
+                "abstract_sufficient": "YES",
+                "supported_role_ids_json": json.dumps(role_ids),
+                "title_supported_role_ids_json": json.dumps(
+                    [required[0]["role_id"]]
+                ),
+                "review_note": (
+                    "The frozen title and abstract directly support the listed "
+                    "roles and add evidence beyond the synthetic baseline."
+                ),
+            }
+        )
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    return rows
+
+
+def _complete_declaration(
+    packet: Path,
+    *,
+    ai_use: str = "NONE",
+    reviewed_all: str = "YES",
+) -> None:
+    _write_csv(
+        packet / "reviewer_declaration.csv",
+        diagnostic.DECLARATION_FIELDS,
+        [
+            {
+                "reviewer_id": "human-reviewer-01",
+                "reviewed_all": reviewed_all,
+                "generative_ai_use": ai_use,
+                "external_sources_checked": "NONE",
+                "elapsed_minutes": "45",
+                "expertise": "Academic evidence synthesis",
+                "completed_date": "2026-09-01",
+                "limitations": "Frozen title and abstract text only.",
+            }
+        ],
+    )
+
+
+def test_packet_preserves_all_candidates_and_hides_every_v6_outcome(
+    source,
+    tmp_path,
+):
+    source_lock, packet = _packet(source, tmp_path)
+    lock = json.loads(source_lock.read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (packet / "packet_manifest.json").read_text(encoding="utf-8")
+    )
+    labels = _read_csv(packet / "labels.csv")
+
+    assert lock["original_source_lock_readiness"] == "not_ready"
+    assert lock["production_connected"] is False
+    assert len(lock["indexed_file_sha256"]) == 56
+    assert manifest["row_count"] == 64
+    assert len(labels) == 64
+    assert all(
+        sum(row["case_id"] == case_id for row in labels) == 8
+        for case_id in diagnostic.CASE_IDS
+    )
+    assert all(row["baseline_sources_json"] for row in labels)
+    assert all(row["required_roles_json"] for row in labels)
+    assert all(row["abstract"] for row in labels)
+    assert not diagnostic._FORBIDDEN_REVIEWER_KEYS.intersection(  # noqa: SLF001
+        diagnostic._walk_mapping_keys(manifest)  # noqa: SLF001
+    )
+
+
+def test_blank_packet_is_incomplete_not_a_zero_error_result(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "incomplete"
+    assert result["diagnostic_state"] == "not_evaluated"
+    assert result["completed_row_count"] == 0
+    assert len(result["incomplete_row_ids"]) == 64
+    assert result["metrics"] is None
+    assert result["v6_rescue_authorized"] is False
+    assert result["z_cohort_authorized"] is False
+
+
+def test_complete_review_joins_hidden_trace_only_at_summary(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+    _complete_labels(packet)
+    _complete_declaration(packet)
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "complete"
+    assert result["diagnostic_state"] == "evaluated_diagnostic_only"
+    assert result["production_connection_authorized"] is False
+    metrics = result["metrics"]
+    assert metrics["candidate_count"] == 64
+    assert metrics["model_observed_candidate_count"] == 56
+    assert metrics["model_unobserved_candidate_count"] == 8
+    assert metrics["model_unobserved_case_ids"] == ["Y08"]
+    assert metrics["human_coverable_case_ids"] == list(diagnostic.CASE_IDS)
+    assert metrics["model_selected_case_ids"] == []
+    assert metrics["model_missed_human_coverable_case_ids"] == list(
+        diagnostic.CASE_IDS
+    )
+    assert metrics["role_confusion"]["false_negative"] == 280
+
+
+def test_substantive_ai_review_is_retained_but_not_evaluated(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+    _complete_labels(packet)
+    _complete_declaration(packet, ai_use="MOST_OR_ALL")
+
+    result = summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "excluded_substantive_ai"
+    assert result["diagnostic_state"] == "not_evaluated"
+    assert result["metrics"] is None
+    assert result["declaration"]["generative_ai_use"] == "MOST_OR_ALL"
+
+
+def test_source_lock_requires_explicit_owner_confirmation(source, tmp_path):
+    with pytest.raises(
+        RoleSlotFailureReviewError,
+        match="authorized-output confirmation",
+    ):
+        create_source_lock(
+            source,
+            tmp_path / "lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=False,
+        )
+
+
+def test_source_drift_after_lock_blocks_packet_preparation(source, tmp_path):
+    source_lock = _lock(source, tmp_path)
+    rows = source / "provider-rows.csv"
+    rows.write_text(rows.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(RoleSlotFailureReviewError, match="identity drifted"):
+        prepare_packet(source, source_lock, tmp_path / "packet")
+
+
+def test_indexed_child_drift_blocks_source_validation(source, tmp_path):
+    journal = source / "provider-journals" / "Y01.json"
+    journal.write_text(
+        journal.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RoleSlotFailureReviewError, match="indexed artifact"):
+        create_source_lock(
+            source,
+            tmp_path / "lock.json",
+            study_owner_id="offline-owner",
+            confirm_authorized_output=True,
+        )
+
+
+def test_label_context_drift_is_rejected_even_with_all_identities(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _complete_labels(packet)
+    rows[0]["abstract"] += " altered"
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    _complete_declaration(packet)
+
+    with pytest.raises(RoleSlotFailureReviewError, match="context or identity"):
+        summarize_packet(source, source_lock, packet)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "supported_role_ids_json",
+            '["unknown_role"]',
+            "unknown role IDs",
+        ),
+        (
+            "title_supported_role_ids_json",
+            '["automotive_composite"]',
+            "title-supported roles must be supported roles",
+        ),
+    ],
+)
+def test_unknown_or_non_subset_role_labels_are_rejected(
+    source,
+    tmp_path,
+    field,
+    value,
+    message,
+):
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _complete_labels(packet)
+    if field == "title_supported_role_ids_json":
+        # The default completed fixture marks every declared role as supported.
+        # Empty the parent set so this case actually re-injects the forbidden
+        # title-only support relation instead of accidentally constructing a
+        # valid subset and weakening the seam test.
+        rows[0]["supported_role_ids_json"] = "[]"
+    rows[0][field] = value
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows)
+    _complete_declaration(packet)
+
+    with pytest.raises(RoleSlotFailureReviewError, match=message):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_packet_manifest_rejects_hidden_decision_leak(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["rows"][0]["candidate_action"] = "KEEP"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RoleSlotFailureReviewError, match="leaks v6 decision"):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_missing_serialized_candidate_fails_at_return_boundary(source, tmp_path):
+    source_lock, packet = _packet(source, tmp_path)
+    rows = _read_csv(packet / "labels.csv")
+    _write_csv(packet / "labels.csv", LABEL_FIELDS, rows[:-1])
+
+    with pytest.raises(RoleSlotFailureReviewError, match="identities drifted"):
+        summarize_packet(source, source_lock, packet)
+
+
+def test_frozen_real_source_identity_uses_complete_sha256_values():
+    assert set(diagnostic.EXPECTED_SOURCE_FILE_SHA256) == set(
+        diagnostic.CORE_SOURCE_FILES
+    )
+    assert all(
+        len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+        for value in diagnostic.EXPECTED_SOURCE_FILE_SHA256.values()
+    )
+
+
+def test_production_worker_cannot_import_the_failure_review():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(
+        encoding="utf-8"
+    )
+    assert "openalex_role_slot_failure_review" not in worker


### PR DESCRIPTION
## Why
The bounded v6 experiment is already irrecoverably failed, but its registered protocol still requires a label-blind review of all 64 provider candidates. This PR implements that diagnostic without reopening Y, spending on missing model calls, opening Z, or connecting production Tool Calling.

## What changed
- locks the exact provider-complete execution and all 56 indexed artifacts
- exports 64 reviewer-visible title-and-abstract rows while hiding automated outcomes
- validates identities, context, role subsets, reviewer eligibility, and distinct not-evaluated states
- joins hidden traces only after an eligible complete return
- records the real blank packet and updates the bilingual project documentation

## Verification
- 1,851 tests and 657 subtests passed
- 14 focused diagnostic tests passed
- latest Ruff passed
- narrow Pylint categories passed
- hidden-decision and missing-row defects were each re-injected and made their seam tests fail

No human label has returned. This PR does not rescue v6 or authorize production Tool Calling.