### PR TITLE
Record the completed role-slot v6 human failure diagnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,17 +620,26 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   is complete at 8/8 cases and 64/64 candidates. It exposes baseline context,
   code-owned role descriptions, titles and abstracts while hiding all model
   passes, consensus roles, candidate actions and selected sets. The real local
-  blank packet is `incomplete / not_evaluated` with 0/64 completed rows,
+  blank packet was `incomplete / not_evaluated` with 0/64 completed rows,
   `metrics=null`, and no network or model call.
 
   Its focused suite passes 14/14. Removing the explicit
   `candidate_action` block and dropping the final candidate only from the
   labels CSV were each re-injected and made their client-boundary tests fail
-  before restoration. No human label has returned, so retrieval value and role
-  accuracy remain unobserved; the diagnostic cannot rescue v6, open
-  Z01-Z08, validate a successor or connect production. See
+  before restoration. One eligible human reviewer later completed 64/64 rows,
+  declared no substantive generative-AI use and did not check external sources.
+  Thirteen candidates were directly relevant and 51 were retrieval noise. Six
+  of eight cases contained baseline-novel relevant evidence, but only Y04-Y06
+  were human-coverable as complete role sets. Candidate admission was 9 TP,
+  7 FP, 38 TN and 2 FN; role-level precision/recall were 86.92%/90.29%.
+  Candidate-pool quality and missing role coverage therefore dominate the
+  failure, while semantic consensus errors remain a secondary contributor.
+  The diagnostic cannot rescue v6, open Z01-Z08, validate a successor or
+  connect production. See
   `docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md` and
-  `docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md`.
+  `docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md`,
+  plus
+  `docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -875,16 +875,25 @@ boundary are now implemented. The packet preserves all 64 frozen Y01-Y08
 provider candidates while hiding model passes, consensus roles, candidate
 actions and selected sets until the post-return summary seam.
 
-The real local blank packet is correctly `incomplete / not_evaluated`: 0/64
-rows are complete, metrics are absent, the four core source hashes and all 56
-indexed artifacts match, and no network or model call occurs. The focused
+The real local blank packet was correctly `incomplete / not_evaluated`: 0/64
+rows were complete, metrics were absent, the four core source hashes and all 56
+indexed artifacts matched, and no network or model call occurred. The focused
 suite passes 14/14; one hidden-decision leak and one missing serialized
 candidate were each re-injected and made their boundary tests fail.
 
-No human label has been returned, so source value and role accuracy remain
-unobserved. This diagnostic cannot rescue v6, open Z or authorize production.
-See the [diagnostic pre-registration](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md)
-and [implementation result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md).
+One eligible human reviewer later completed 64/64 rows without substantive
+generative-AI use or external-source checks. Thirteen candidates were directly
+relevant and 51 were retrieval noise; six of eight cases contained at least one
+baseline-novel relevant candidate, but only Y04, Y05 and Y06 had a human-
+coverable role set. Candidate admission therefore produced 9 TP, 7 FP, 38 TN
+and 2 FN, while role-level precision/recall were 86.92%/90.29%. The diagnostic
+attributes the dominant failure to candidate-pool quality and role coverage,
+with semantic consensus errors as a secondary contributor. It is diagnostic
+only: v6 remains failed and sealed, Z remains unopened, and production Tool
+Calling remains disconnected. See the
+[diagnostic pre-registration](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md),
+[implementation result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md),
+and [human-review result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md).
 
 
 Local verification now passes **1,851 tests plus 657 subtests**, latest Ruff,
@@ -2144,15 +2153,21 @@ dry-run。详见
 Y01–Y08 冻结供应商候选，同时在回传后的汇总接缝之前隐藏模型 pass、共识角色、
 候选动作和已选证据集。
 
-真实本地空白包被正确判为 `incomplete / not_evaluated`：完成行为 0/64，
+真实本地空白包曾被正确判为 `incomplete / not_evaluated`：完成行为 0/64，
 metrics 缺失，4 个核心来源哈希与 56 份索引工件全部一致，且不发生网络或模型
 调用。14/14 个定向测试通过；隐藏决策泄露和少序列化一条候选两个缺陷均被
 重新注入，并分别使边界测试失败。
 
-目前尚未返回任何人工标签，因此来源价值与角色准确性仍未观测。该诊断不能
-挽救 v6、打开 Z 或授权生产接入。详见
-[诊断预注册](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md)
-与[实现结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md)。
+随后一名合格人工评审者完成 64/64 条，声明未使用实质生成式 AI、未检查外部
+来源。13 条候选被判为直接相关，51 条属于检索噪声；6/8 个案例至少存在一条
+基线外相关候选，但只有 Y04、Y05、Y06 能由人工组成角色完整的证据集。候选
+准入混淆矩阵为 9 TP、7 FP、38 TN、2 FN，角色级 precision / recall 为
+86.92% / 90.29%。诊断因此把主要失败归因于候选池质量与角色覆盖不足，把语义
+共识误差列为次要因素。该结果只用于归因：v6 仍然失败并封存，Z 保持未打开，
+生产 Tool Calling 继续断开。详见
+[诊断预注册](docs/prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md)、
+[实现结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md)
+与[人工评审结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md)。
 
 
 本地验证现通过 **1,851 项测试与 657 个 subtests**、最新版 Ruff、CI 同款

--- a/docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md
+++ b/docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md
@@ -1,0 +1,143 @@
+# Result: role-slot v6 failure diagnostic human review
+
+**Completed:** 2026-09-01
+
+**Status:** `complete / evaluated_diagnostic_only`.
+
+**Authority:** descriptive interpretation of the 64 frozen Y01-Y08 OpenAlex
+titles and abstracts by one independent human reviewer. This result cannot
+repair the failed v6 gates, open Z01-Z08, validate a successor, establish
+source truth, or authorize production Tool Calling.
+
+## Why this review exists
+
+The v6 development run was already irrecoverably failed after 21 of 24 Qwen
+calls. Even perfect Y08 outputs could not reach either the frozen candidate
+unanimity or selected-case coverage gate. The OpenAlex boundary was complete,
+however, so the original protocol still required a label-blind review of all
+64 provider candidates to distinguish retrieval, role-assignment, admission,
+and incomplete-execution failure surfaces.
+
+The packet exposed each frozen topic, query, synthetic baseline, code-owned
+role description, title, abstract, and bibliographic identity. It hid every
+Qwen pass, consensus role, candidate action, selected set, and automated
+failure attribution until after the completed return was validated.
+
+## Eligible return
+
+One anonymous human reviewer completed all 64 rows in 40 minutes and declared:
+
+- all rows reviewed: `YES`;
+- substantive generative-AI use: `NONE`;
+- external sources checked: `NONE`;
+- expertise: not supplied; and
+- limitations: not supplied.
+
+The project owner explicitly confirmed that the return was completed by a
+human. The returned declaration used `2026/9/1`, while the strict schema
+requires ISO `YYYY-MM-DD`. The two returned files were preserved byte for byte
+in the private audit archive before only that date was normalized to
+`2026-09-01`. No label, note, candidate identity, reviewer identity, elapsed
+time, AI-use declaration, external-source declaration, expertise field, or
+limitation field was changed.
+
+The zero-network summarizer revalidated the exact source lock, 56 indexed
+artifacts, packet manifest, all 64 candidate identities, allowed role IDs, and
+title-role subset rule. The result is complete with no method issue and no
+incomplete row.
+
+## Frozen-text source result
+
+| Measure | Result |
+|---|---:|
+| Completed rows | 64 / 64 |
+| Directly relevant | 13 / 64 (20.31%) |
+| Directly irrelevant retrieval noise | 51 / 64 (79.69%) |
+| Unverifiable from frozen text | 0 / 64 |
+| Relevant and baseline-novel candidates | 13 |
+| Cases with a baseline-novel relevant candidate | 6 / 8 |
+| Cases with a human-covering evidence set | 3 / 8 |
+| Human-coverable cases | Y04, Y05, Y06 |
+| Model-observed candidates | 56 / 64 |
+
+Only Y04, Y05, and Y06 contained a set of at most three candidates that met
+the frozen role-coverage contract under the human labels. Each of those cases
+was coverable by one candidate. Five cases had no human-covering set, so the
+frozen run could not have met its 6/8 selected-case gate even with perfect
+model judgments over the same candidate pool.
+
+The 13 relevant and baseline-novel candidates occurred in Y01, Y02, Y04, Y05,
+Y06, and Y08. A relevant paper is therefore not automatically a sufficient
+role-covering evidence set. Y08 was not observed by the model because the
+pre-registered soft stop ended the run before its three calls.
+
+## Hidden-trace comparison
+
+The hidden v6 traces were joined only after the eligible return.
+
+| Candidate admission over 56 observed rows | Count |
+|---|---:|
+| True positive | 9 |
+| False positive | 7 |
+| True negative | 38 |
+| False negative | 2 |
+
+This is a derived 56.25% candidate-admission precision and 81.82% recall on
+the consumed diagnostic set. The model selected Y03, Y04, Y05, and Y06. It
+covered all three human-coverable cases but also selected Y03, for which the
+human labels found no valid covering set.
+
+| Role assignment over observed candidate-role slots | Count |
+|---|---:|
+| True positive | 93 |
+| False positive | 14 |
+| True negative | 163 |
+| False negative | 10 |
+| Precision | 86.92% |
+| Recall | 90.29% |
+
+Fourteen observed candidates contained at least one consensus role unsupported
+by the reviewer, while ten omitted at least one human-supported role. These
+counts may overlap and are candidate-level diagnostics, not independent error
+rates.
+
+Title anchors were precision-first but incomplete: 27 true positives, two
+false positives, 229 true negatives, and 22 false negatives produced 93.10%
+precision and 55.10% recall. This supports retaining title evidence as a
+high-precision signal, but not using it as the sole role-support requirement.
+
+## Interpretation
+
+The dominant observed bottleneck is upstream candidate quality. Nearly four
+out of five OpenAlex rows were directly irrelevant, and five of eight cases
+did not contain a human-covering set. Buying the three missing Qwen calls,
+adding more consensus passes, or lowering the frozen thresholds could not fix
+that missing candidate evidence.
+
+The role-slot judge was not error-free: it produced role false positives and
+false negatives, and candidate admission had seven false positives. Those are
+real secondary failure surfaces. They do not outweigh the more basic fact that
+the frozen retrieval pool itself made the coverage gate mathematically
+unreachable under human labels.
+
+Because the reviewer did not open external sources, this measures only the
+supplied title-and-abstract text. One reviewer provides no inter-rater
+agreement, and the 40-minute duration does not establish expert review cost.
+
+## Decision
+
+Role-slot consensus v6 remains failed and sealed. Y01-Y08 stay consumed,
+Z01-Z08 stay unopened, and every experimental adapter remains disconnected
+from `pipeline_worker.py` and the production report path.
+
+A successor should treat candidate retrieval and semantic role judgment as
+separate hypotheses. The next pre-registered development method may use Y only
+as disclosed failure-analysis evidence, but must face a newly frozen unseen
+cohort before any production claim. It should not spend on more consensus
+passes until the candidate pool can meet a human-coverability gate.
+
+See the
+[diagnostic pre-registration](prereg-2026-09-01-openalex-role-slot-v6-failure-diagnostic.md),
+[blank-packet implementation result](results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md),
+and
+[original bounded live result](results-2026-09-01-openalex-role-slot-consensus-v6-development-live.md).


### PR DESCRIPTION
## Summary
- records the completed 64-row human failure diagnostic and its strict zero-network aggregation
- updates the English and Chinese current-state indexes with retrieval, coverability, admission, and role metrics
- preserves the diagnostic-only boundary: v6 remains failed, Y is consumed, Z is unopened, and production Tool Calling stays disconnected

## Validation
- 14 focused diagnostic tests passed
- 1851 tests and 657 subtests passed
- latest Ruff passed
- CI-equivalent narrow Pylint passed
- reproduced summary SHA-256 matches the private audit archive