### PR TITLE
Pre-register retrieval-first Tool Calling v7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1851 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1861 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -225,6 +225,8 @@ openalex_role_slot_development.py
                         write-once Y runner; CLI defaults to zero-network dry-run
 openalex_role_slot_failure_review.py
                         label-blind 64-row v6 failure diagnostic; zero-network
+openalex_role_directed_unseen.py
+                        frozen AA/AB two-lane v7 preflight; zero-network only
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -641,6 +643,32 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   plus
   `docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md`.
 
+  A separately pre-registered retrieval-first v7 now tests the bottleneck that
+  the v6 human diagnostic actually measured. It freezes fresh AA01-AA08
+  development and AB01-AB08 unseen cohorts, with one `technology_scope` and
+  one `technology_evidence` OpenAlex query per case. Both queries must target
+  all required roles; the first must target scope and the second supporting
+  evidence. Each query is limited to one read-only request and six rows. No
+  semantic model is permitted until the candidate portfolio passes frozen
+  relevance, role-coverability, pool-precision and second-lane incremental-value
+  gates. Z remains unopened under v6 and is not reused.
+
+  The raw-byte-locked zero-network preflight is now implemented. It expands
+  8/8 AA cases, 16/16 unique call identities and 16/16 unique lane-contract
+  identities, exposes every query and target role at the serialized boundary,
+  and advertises zero model calls and no live authority. One AB05 query was
+  corrected before implementation or any request after a scope audit showed
+  that a weak token had created a formal rather than meaningful overlap; the
+  original commit and erratum remain visible. The focused suite passes 10/10
+  and the full suite passes 1861 tests plus 657 subtests. Dropping every second
+  lane only at serialization was re-injected and made the boundary test fail
+  before restoration. No OpenAlex request or human review has occurred, so AA
+  remains unconsumed, AB remains unopened, and candidate value is
+  `not_evaluated`. See
+  `docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md`,
+  `docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md`, and
+  `docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md`.
+
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus
@@ -649,7 +677,7 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   and
   docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md.
   Keep
-  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5/v6
+  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5/v6/v7
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,

--- a/README.md
+++ b/README.md
@@ -895,8 +895,27 @@ Calling remains disconnected. See the
 [implementation result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md),
 and [human-review result](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md).
 
+A separately pre-registered **retrieval-first v7** now addresses that measured
+bottleneck without reopening Y or Z. Fresh AA01-AA08 development and AB01-AB08
+unseen cohorts each freeze two code-owned OpenAlex lanes: one binds the core
+technology to application scope, and one binds it to decision evidence. Each
+lane is capped at one read-only request and six rows. Before any semantic model
+can be justified, the merged candidate portfolio must pass frozen relevance,
+human role-coverability, pool-precision, and second-lane incremental-value
+gates.
 
-Local verification now passes **1,851 tests plus 657 subtests**, latest Ruff,
+The raw-byte-locked offline preflight expands 8/8 AA cases, 16/16 unique search
+identities, and 16/16 unique lane contracts while importing no network,
+execution, or model client. Its focused suite passes 10/10, including a
+re-injected boundary defect where the second lane existed internally but did
+not reach serialized output. No provider request or human review has occurred:
+AA is unconsumed, AB is unopened, candidate value is `not_evaluated`, and
+production Tool Calling remains disconnected. See the
+[v7 pre-registration](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md),
+[pre-provider AB05 erratum](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md),
+and [offline implementation result](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md).
+
+Local verification now passes **1,861 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2169,8 +2188,24 @@ metrics 缺失，4 个核心来源哈希与 56 份索引工件全部一致，且
 [实现结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-implementation.md)
 与[人工评审结果](docs/results-2026-09-01-openalex-role-slot-v6-failure-diagnostic-review.md)。
 
+项目随后另行预注册了 **retrieval-first v7**，只针对上述已测得的检索瓶颈，
+不重新打开 Y 或 Z。全新的 AA01–AA08 开发集和 AB01–AB08 未见集为每个主题
+冻结两条代码所有的 OpenAlex lane：第一条把核心技术绑定到应用范围，第二条把
+核心技术绑定到决策证据；每条最多一次只读请求和 6 条结果。只有合并候选池通过
+冻结的相关性、人工角色可覆盖性、候选池精度及第二条 lane 增量价值门槛，后续
+语义模型调用才值得考虑。
 
-本地验证现通过 **1,851 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+原始字节锁定的离线预检现已展开 8/8 个 AA 案例、16/16 个唯一检索身份与
+16/16 个唯一 lane 合约，且不导入网络、执行或模型客户端。10/10 个定向测试
+通过，其中包括一次接缝缺陷回注：第二条 lane 在内部存在却没有到达序列化输出
+时，边界测试会失败。目前未发起供应商请求，也未进行人工评审，因此 AA 尚未
+消耗、AB 保持未打开、候选价值为 `not_evaluated`，生产 Tool Calling 仍未
+连接。详见
+[v7 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md)、
+[AB05 供应商调用前勘误](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md)
+与[离线实现结果](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md)。
+
+本地验证现通过 **1,861 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md
+++ b/docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md
@@ -1,0 +1,35 @@
+# Erratum: v7 AB05 evidence-lane query
+
+Date: 2026-09-01 (Australia/Sydney)
+
+This correction was made after pre-registration commit `e0d9155` and before
+the v7 preflight implementation, any OpenAlex request, any model call, or any
+human label.
+
+## What the zero-network audit found
+
+The original AB05 `technology_evidence` query was:
+
+```text
+phage loaded hydrogel pathogen reduction in vivo survival
+```
+
+The existing evidence-gap scope tokenizer counted only `loaded` and `in` as
+exact overlaps with the frozen topic. That technically met the two-token
+authorization rule while failing to bind the query robustly to the
+`bacteriophage_delivery` and `hydrogel_carrier` roles. Treating that formal
+pass as a meaningful scope pass would reproduce the precise retrieval-noise
+problem that v7 is intended to test.
+
+## Bounded correction
+
+The query is replaced with:
+
+```text
+bacteriophage loaded hydrogels bacterial fish pathogen reduction survival
+```
+
+No case identity, topic, role, lane target, request limit, qualification gate,
+cohort order, or production boundary changed. AB01-AB08 remain unopened. The
+corrected fixture receives a new raw-byte hash and becomes the only fixture
+identity accepted by the implementation.

--- a/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md
+++ b/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md
@@ -31,6 +31,10 @@ planner-trigger precision, source truth, production reliability, or user value.
 - Both cohorts, their role definitions, query text, lane targets, order, and
   baseline identities live in
   `tests/fixtures/openalex_role_directed_v7_challenge.json`.
+- One AB05 evidence-lane query was corrected before implementation or any
+  provider request after the zero-network scope audit exposed a weak token
+  overlap. The original committed bytes and the bounded correction are recorded
+  in `docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md`.
 - Y01-Y08 remain consumed diagnostic evidence. Z01-Z08 remain unopened under
   the v6 protocol and must not be repurposed for v7.
 - AA becomes consumed after any provider request. AB must remain unopened until

--- a/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md
+++ b/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md
@@ -1,0 +1,123 @@
+# Pre-registration: OpenAlex role-directed retrieval portfolio v7
+
+Date: 2026-09-01 (Australia/Sydney)
+
+Status: pre-registered before implementation, provider requests, model calls,
+or human labels for AA01-AA08 or AB01-AB08
+
+## Decision being tested
+
+The failed role-slot consensus v6 study cannot be repaired by buying more
+semantic-judge calls. Its eligible human diagnostic found 13 directly relevant
+candidates among 64 provider rows, but only AA-independent predecessor cases
+Y04-Y06 (3/8) contained a human-coverable evidence set. Y01, Y02, and Y08 had
+core-technology evidence without the required application or decision-evidence
+roles; Y03 and Y07 had no directly relevant candidate. Candidate-pool quality
+and missing role coverage therefore precede semantic-judge quality.
+
+V7 tests one narrower hypothesis:
+
+> Two separately budgeted, role-directed OpenAlex searches can produce a
+> candidate portfolio that is sufficiently relevant, baseline-novel, and
+> human-coverable to justify a later semantic judge.
+
+This is a retrieval qualification study. It does not test Qwen, report quality,
+planner-trigger precision, source truth, production reliability, or user value.
+
+## Frozen cohorts
+
+- `AA01`-`AA08` are the development cohort.
+- `AB01`-`AB08` are the unopened unseen cohort.
+- Both cohorts, their role definitions, query text, lane targets, order, and
+  baseline identities live in
+  `tests/fixtures/openalex_role_directed_v7_challenge.json`.
+- Y01-Y08 remain consumed diagnostic evidence. Z01-Z08 remain unopened under
+  the v6 protocol and must not be repurposed for v7.
+- AA becomes consumed after any provider request. AB must remain unopened until
+  AA passes every frozen mechanical and human gate without tuning on AB.
+
+## Retrieval contract
+
+Every case contains the same two ordered read-only lanes:
+
+1. `technology_scope` binds every required technology role to at least one
+   application/scope role.
+2. `technology_evidence` binds every required technology role to at least one
+   supporting performance, validation, durability, or outcome role.
+
+The exact query is code-owned and frozen in the fixture. A model does not write,
+rewrite, expand, or choose either query. Each lane may make exactly one
+anonymous OpenAlex Works request and return at most six rows with reconstructable
+abstracts. Therefore one case authorizes at most two requests and twelve raw
+provider rows; AA01-AA08 authorize at most sixteen requests. Redirects, retries,
+fallback search, supplementary search, result-page fetching, and model calls are
+forbidden.
+
+The future runner must preserve lane identity and provider rank, then deduplicate
+by normalized DOI before canonical OpenAlex URL while retaining all lane
+memberships. No source may be filtered by a semantic model before the retrieval
+qualification review. Every provider row, row-level rejection, lane membership,
+deduplication decision, request identity, latency, and provider-reported cost
+must reach the serialized audit boundary.
+
+## Role-coverability definition
+
+A case is human-coverable only when at most three directly relevant,
+baseline-novel candidates jointly support:
+
+- every required role;
+- at least one scope role; and
+- at least one supporting role.
+
+The reviewer must derive role support from the frozen title and abstract. This
+is not external source verification. `not_checked`, incomplete review, or an
+ineligible reviewer is distinct from a failed value gate.
+
+## Frozen gates
+
+All gates are conjunctive. Silence or an unavailable denominator is not a pass.
+
+### Mechanical gates
+
+1. AA expands exactly eight ordered case identities and sixteen ordered lane
+   identities before any client can be constructed.
+2. A live AA run, if separately authorized later, completes exactly sixteen
+   one-attempt OpenAlex requests with inspectable per-request accounting.
+3. Every provider row and rejection reaches the aggregate boundary; all
+   deduplication decisions retain their originating lane identities.
+4. No Qwen or other model request occurs. Production, reports, recovery, and
+   planner-trigger connections remain false.
+
+### Human candidate-value gates
+
+1. At least 6/8 cases contain one directly relevant, baseline-novel candidate.
+2. At least 6/8 cases are human-coverable under the maximum-three-source rule.
+3. Directly relevant candidates are at least 25% of all reviewable unique
+   candidates. This is a candidate-pool floor, not the <=5% wrong-source gate
+   required of a final production-selected set.
+4. `technology_evidence` contributes at least one unique directly relevant
+   candidate not returned by `technology_scope` in at least 4/8 cases.
+5. The two-lane union makes at least two more cases human-coverable than the
+   `technology_scope` lane alone. If one lane is already sufficient, the second
+   paid request has not justified its place in the production budget.
+
+## Stop and falsification rules
+
+- The zero-network preflight alone cannot pass any provider or human gate.
+- A provider run requires a new explicit authorization naming the merged
+  revision, AA fixture hash, maximum sixteen requests, and a cost soft stop.
+- Any fixture, implementation, query, lane-target, request-budget, or ordering
+  drift after authorization stops before client construction.
+- A mechanical failure still requires all safely persisted provider rows to
+  remain inspectable, but it cannot be called a value pass.
+- AA failure seals v7. Do not tune on AA, rerun it, lower a gate, or open AB and
+  call the result validation.
+- AA success permits only a separately pre-registered AB evaluation. It does
+  not authorize production Tool Calling.
+
+## Production boundary
+
+The preflight and any later runner must remain outside `pipeline_worker.py`.
+No production source collection, report, Planner decision, checkpoint, retry,
+or recovery path imports v7. A production connection would require a separate
+decision after an eligible AB result and a report-level value study.

--- a/docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md
+++ b/docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md
@@ -1,0 +1,94 @@
+# Result: OpenAlex role-directed retrieval portfolio v7 offline preflight
+
+Date: 2026-09-01 (Australia/Sydney)
+
+Status: implemented and mechanically qualified offline; no provider request,
+model call, human review, or production connection
+
+## Why this successor exists
+
+The eligible v6 failure diagnostic was re-measured before implementation. Among
+the eight consumed Y cases:
+
+- Y04, Y05, and Y06 were human-coverable under the frozen maximum-three-source
+  role rule;
+- Y01, Y02, and Y08 contained core-technology evidence but lacked scope or
+  supporting evidence;
+- Y03 and Y07 contained no directly relevant candidate; and
+- the complete pool contained 13 relevant and 51 irrelevant rows.
+
+Only 3/8 candidate pools could therefore support the task even if the semantic
+judge were perfect. V7 tests retrieval before buying another semantic run.
+
+## Frozen method
+
+Commit `e0d9155` froze new AA01-AA08 development and AB01-AB08 unseen
+cohorts, two ordered role-directed queries per case, a maximum of six rows per
+query, and conjunctive human-value gates. Commit `605d20f` transparently
+corrected one AB05 evidence query before implementation or any provider request
+after the existing scope tokenizer exposed a weak formal overlap. The corrected
+fixture hash is:
+
+```text
+9a91746d0a77fee6d57bfc91ae4329ab78a89109fca6f35171d56c0f3ee95761
+```
+
+Each case now expands:
+
+1. one `technology_scope` academic-search call that targets every required
+   role and at least one scope role; and
+2. one `technology_evidence` call that targets every required role and at
+   least one supporting role.
+
+The ordinary evidence-gap validator authorizes and hashes both calls. The v7
+module adds case, profile, plan, lane, provider, portfolio, and qualification
+contract identities. All 16 development idempotency keys and all 16 lane
+contract hashes are distinct.
+
+## Observable dry-run boundary
+
+`openalex_role_directed_unseen.py` emits the exact two lanes for every case,
+including query text, target role IDs, result limit, idempotency key, and lane
+contract hash. It also states separately that:
+
+- the maximum AA request count is 16;
+- the maximum raw provider-row count is 96;
+- the maximum model-call count is zero;
+- human qualification has not run;
+- provider and model calls are not authorized; and
+- production, reports, planner triggers, recovery, private labels, network, and
+  model clients remain disconnected.
+
+The module imports no provider adapter, execution kernel, HTTP library, CrewAI,
+or model client. Its default CLI is therefore structurally zero-network rather
+than relying on an operator remembering a dry-run flag.
+
+## Verification
+
+- focused v7 suite: 10/10 passed;
+- full zero-network suite: 1,861 tests plus 657 subtests passed;
+- latest Ruff: passed;
+- narrow Pylint `E0701`: passed; and
+- fixture JSON, cohort order, topic uniqueness, query uniqueness, query scope,
+  role targets, and raw-byte identity: passed.
+
+The protocol-mandated seam defect was also re-injected. The dry-run serializer
+was temporarily changed to emit only the first lane even though both validated
+calls still existed internally. The boundary test failed because eight
+`technology_evidence` lanes were absent. Restoring the complete zip returned
+the focused suite to 10/10.
+
+## What this result does and does not establish
+
+This result establishes a deterministic, auditable, two-call retrieval
+preflight that cannot silently open a socket. It does not establish OpenAlex
+compatibility for these queries, candidate relevance, role coverability,
+incremental value from the second lane, report improvement, or production Tool
+Calling.
+
+AA remains unconsumed because no provider request has occurred. AB remains
+unopened. A live AA run requires separate authorization naming the merged
+revision, exact fixture hash, maximum 16 sequential anonymous OpenAlex requests,
+and a cost soft stop. Even a mechanically complete run must then undergo an
+eligible, source-locked human review before any semantic model experiment can
+be considered.

--- a/openalex_role_directed_unseen.py
+++ b/openalex_role_directed_unseen.py
@@ -1,0 +1,590 @@
+"""Zero-network preflight for the frozen role-directed retrieval v7 study.
+
+The v6 human diagnostic found that candidate retrieval, not semantic consensus,
+was the first bottleneck. AA01-AA08 and AB01-AB08 therefore freeze two
+role-directed search lanes per case before this implementation exists. This
+module validates the raw fixture bytes before parsing, expands both evidence-gap
+calls, and publishes every immutable identity a future separately authorised
+runner would need. It imports no provider, execution, or model client, so its
+CLI cannot spend either a search or model budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceSetRoleProfile,
+    EvidenceSetRoleSpec,
+)
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = (
+    _ROOT / "tests/fixtures/openalex_role_directed_v7_challenge.json"
+)
+EXPECTED_FIXTURE_SHA256 = (
+    "9a91746d0a77fee6d57bfc91ae4329ab78a89109fca6f35171d56c0f3ee95761"
+)
+_DEVELOPMENT_ORDER = tuple(f"AA{index:02d}" for index in range(1, 9))
+_UNSEEN_ORDER = tuple(f"AB{index:02d}" for index in range(1, 9))
+_LANE_ORDER = ("technology_scope", "technology_evidence")
+_COLLECTED_AT = datetime(2026, 9, 1, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 9, 1)
+
+RetrievalLaneId = Literal["technology_scope", "technology_evidence"]
+
+
+class OpenAlexRoleDirectedPreflightError(ValueError):
+    """Raised before live authority when the frozen v7 contract drifts."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+class RoleDirectedProviderContract(BaseModel):
+    """Exact two-request OpenAlex boundary without a transport import."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["anonymous_openalex"] = "anonymous_openalex"
+    requests_per_case: Literal[2] = 2
+    result_limit_per_request: Literal[6] = 6
+    require_abstract: Literal[True] = True
+    allow_redirects: Literal[False] = False
+    allow_retries: Literal[False] = False
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleDirectedPortfolioContract(BaseModel):
+    """Deterministic merge rules for a future provider result portfolio."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    lane_order: tuple[str, str]
+    deduplicate_by: tuple[str, str]
+    preserve_lane_memberships: Literal[True] = True
+    preserve_provider_rank: Literal[True] = True
+    maximum_unique_candidates_per_case: Literal[12] = 12
+    maximum_cover_sources_per_case: Literal[3] = 3
+    semantic_filter_before_human_qualification: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_exact_merge_contract(self) -> "RoleDirectedPortfolioContract":
+        if self.lane_order != _LANE_ORDER:
+            raise ValueError("v7 retrieval lane order drifted")
+        if self.deduplicate_by != (
+            "normalized_doi",
+            "canonical_openalex_url",
+        ):
+            raise ValueError("v7 deduplication precedence drifted")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleDirectedQualificationContract(BaseModel):
+    """Frozen gates that decide whether later semantic judging is justified."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    minimum_cases_with_relevant_novel_candidate: Literal[6] = 6
+    minimum_human_coverable_cases: Literal[6] = 6
+    minimum_candidate_pool_precision: Literal[0.25] = 0.25
+    minimum_cases_with_unique_evidence_lane_value: Literal[4] = 4
+    minimum_coverability_gain_over_scope_lane: Literal[2] = 2
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleDirectedRoleGroups(BaseModel):
+    """Fixture roles converted to the existing immutable role profile."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required: tuple[EvidenceSetRoleSpec, ...] = Field(min_length=2, max_length=4)
+    scope: tuple[EvidenceSetRoleSpec, ...] = Field(min_length=1, max_length=4)
+    supporting: tuple[EvidenceSetRoleSpec, ...] = Field(
+        min_length=2,
+        max_length=8,
+    )
+
+    def profile(self) -> EvidenceSetRoleProfile:
+        # The shared profile owns duplicate-ID validation. Reusing it avoids a
+        # subtly different v7 role grammar that later code could misinterpret.
+        return EvidenceSetRoleProfile(
+            required_roles=self.required,
+            scope_roles=self.scope,
+            supporting_roles=self.supporting,
+        )
+
+
+class RoleDirectedLaneSpec(BaseModel):
+    """One code-owned query tied to explicit semantic role identifiers."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    lane_id: RetrievalLaneId
+    query: str = Field(min_length=20, max_length=500)
+    target_role_ids: tuple[str, ...] = Field(min_length=3, max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_unique_targets(self) -> "RoleDirectedLaneSpec":
+        if len(self.target_role_ids) != len(set(self.target_role_ids)):
+            raise ValueError("retrieval lane target role IDs must be unique")
+        return self
+
+
+class RoleDirectedCaseSpec(BaseModel):
+    """One topic, one role profile, and the two ordered retrieval lanes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^A[AB]0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    roles: RoleDirectedRoleGroups
+    lanes: tuple[RoleDirectedLaneSpec, RoleDirectedLaneSpec]
+
+    @model_validator(mode="after")
+    def _validate_role_bound_lanes(self) -> "RoleDirectedCaseSpec":
+        if tuple(lane.lane_id for lane in self.lanes) != _LANE_ORDER:
+            raise ValueError("case lanes must remain technology_scope then technology_evidence")
+        if self.lanes[0].query.casefold() == self.lanes[1].query.casefold():
+            raise ValueError("case retrieval queries must be distinct")
+
+        profile = self.roles.profile()
+        required_ids = {role.role_id for role in profile.required_roles}
+        scope_ids = {role.role_id for role in profile.scope_roles}
+        supporting_ids = {role.role_id for role in profile.supporting_roles}
+        known_ids = required_ids | scope_ids | supporting_ids
+
+        for lane in self.lanes:
+            target_ids = set(lane.target_role_ids)
+            unknown = sorted(target_ids - known_ids)
+            if unknown:
+                raise ValueError(
+                    f"{self.case_id} {lane.lane_id}: unknown target roles {unknown}"
+                )
+            if not required_ids.issubset(target_ids):
+                raise ValueError(
+                    f"{self.case_id} {lane.lane_id}: every lane must target "
+                    "all required roles"
+                )
+            if lane.lane_id == "technology_scope" and not target_ids & scope_ids:
+                raise ValueError(
+                    f"{self.case_id}: technology_scope must target a scope role"
+                )
+            if (
+                lane.lane_id == "technology_evidence"
+                and not target_ids & supporting_ids
+            ):
+                raise ValueError(
+                    f"{self.case_id}: technology_evidence must target a "
+                    "supporting role"
+                )
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleDirectedChallengeManifest(BaseModel):
+    """Complete raw-byte-frozen v7 development and unseen input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    method_id: Literal["openalex-role-directed-retrieval-portfolio-v7"]
+    provider_contract: RoleDirectedProviderContract
+    portfolio_contract: RoleDirectedPortfolioContract
+    qualification_contract: RoleDirectedQualificationContract
+    development_cases: tuple[RoleDirectedCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+    unseen_cases: tuple[RoleDirectedCaseSpec, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_cross_contracts(self) -> "RoleDirectedChallengeManifest":
+        if tuple(case.case_id for case in self.development_cases) != (
+            _DEVELOPMENT_ORDER
+        ):
+            raise ValueError("development cases must remain AA01 through AA08")
+        if tuple(case.case_id for case in self.unseen_cases) != _UNSEEN_ORDER:
+            raise ValueError("unseen cases must remain AB01 through AB08")
+
+        all_cases = (*self.development_cases, *self.unseen_cases)
+        if len({case.topic for case in all_cases}) != len(all_cases):
+            raise ValueError("topic strings must be unique across both cohorts")
+        queries = tuple(lane.query for case in all_cases for lane in case.lanes)
+        if len(set(query.casefold() for query in queries)) != len(queries):
+            raise ValueError("retrieval queries must be unique across both cohorts")
+        if (
+            self.provider_contract.requests_per_case
+            * self.provider_contract.result_limit_per_request
+            != self.portfolio_contract.maximum_unique_candidates_per_case
+        ):
+            raise ValueError("provider row ceiling and portfolio ceiling drifted")
+        if (
+            self.portfolio_contract.maximum_cover_sources_per_case
+            > self.portfolio_contract.maximum_unique_candidates_per_case
+        ):
+            raise ValueError("cover-source ceiling exceeds the candidate ceiling")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedRoleDirectedCase:
+    """Deterministic identities for a future separately locked live runner."""
+
+    spec: RoleDirectedCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    plan: ValidatedGapPlan
+    collection_sha256: str
+    plan_sha256: str
+    profile_sha256: str
+    case_contract_sha256: str
+    lane_contract_sha256s: tuple[str, str]
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _case_contract_sha256(
+    spec: RoleDirectedCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    portfolio_contract_sha256: str,
+    qualification_contract_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "method_id": method_id,
+            "spec": spec.model_dump(mode="json"),
+            "provider_contract_sha256": provider_contract_sha256,
+            "portfolio_contract_sha256": portfolio_contract_sha256,
+            "qualification_contract_sha256": qualification_contract_sha256,
+        }
+    )
+
+
+def _lane_contract_sha256(
+    spec: RoleDirectedCaseSpec,
+    lane: RoleDirectedLaneSpec,
+    call: ValidatedGapCall,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    portfolio_contract_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "method_id": method_id,
+            "case_id": spec.case_id,
+            "topic": spec.topic,
+            "profile_sha256": spec.roles.profile().sha256(),
+            "lane": lane.model_dump(mode="json"),
+            "validated_call": call.model_dump(mode="json"),
+            "provider_contract_sha256": provider_contract_sha256,
+            "portfolio_contract_sha256": portfolio_contract_sha256,
+        }
+    )
+
+
+def _seed_source(spec: RoleDirectedCaseSpec) -> EvidenceSource:
+    """Create a valid gap context without pretending retrieval already ran."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen role-directed v7 baseline context",
+        url=(
+            "https://doi.org/10.5555/openalex-role-directed-v7."
+            f"{spec.case_id.casefold()}"
+        ),
+        publisher="Frozen Role-directed v7 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider candidate and does not satisfy the explicit "
+            "academic retrieval gap used by this disconnected study."
+        ),
+        summary_source="abstract",
+    )
+
+
+def build_case(
+    spec: RoleDirectedCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    portfolio_contract_sha256: str,
+    qualification_contract_sha256: str,
+    result_limit: int,
+) -> PreparedRoleDirectedCase:
+    """Expand one two-call plan without network, clocks, randomness, or labels."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen role-directed v7 retrieval challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexRoleDirectedPreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+
+    plan = validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=(
+                "The frozen role-directed case authorizes two complementary "
+                "read-only academic requests for its explicit evidence gap."
+            ),
+            calls=tuple(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=lane.query,
+                    trigger_ids=(trigger.signal_id,),
+                    result_limit=result_limit,
+                )
+                for lane in spec.lanes
+            ),
+        ),
+    )
+    if len(plan.calls) != len(_LANE_ORDER):
+        raise OpenAlexRoleDirectedPreflightError(
+            f"{spec.case_id}: validated plan did not retain both retrieval lanes"
+        )
+
+    lane_contract_sha256s = tuple(
+        _lane_contract_sha256(
+            spec,
+            lane,
+            call,
+            method_id=method_id,
+            provider_contract_sha256=provider_contract_sha256,
+            portfolio_contract_sha256=portfolio_contract_sha256,
+        )
+        for lane, call in zip(spec.lanes, plan.calls, strict=True)
+    )
+    return PreparedRoleDirectedCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        plan=plan,
+        collection_sha256=source_collection_sha256(collection),
+        plan_sha256=_plan_sha256(plan),
+        profile_sha256=spec.roles.profile().sha256(),
+        case_contract_sha256=_case_contract_sha256(
+            spec,
+            method_id=method_id,
+            provider_contract_sha256=provider_contract_sha256,
+            portfolio_contract_sha256=portfolio_contract_sha256,
+            qualification_contract_sha256=qualification_contract_sha256,
+        ),
+        lane_contract_sha256s=lane_contract_sha256s,
+    )
+
+
+def load_frozen_cases(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    RoleDirectedChallengeManifest,
+    tuple[PreparedRoleDirectedCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding either cohort."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexRoleDirectedPreflightError(
+            "role-directed v7 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = RoleDirectedChallengeManifest.model_validate_json(raw)
+    specs = (
+        manifest.development_cases
+        if cohort == "development"
+        else manifest.unseen_cases
+    )
+    provider_sha256 = manifest.provider_contract.sha256()
+    portfolio_sha256 = manifest.portfolio_contract.sha256()
+    qualification_sha256 = manifest.qualification_contract.sha256()
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(
+            build_case(
+                spec,
+                method_id=manifest.method_id,
+                provider_contract_sha256=provider_sha256,
+                portfolio_contract_sha256=portfolio_sha256,
+                qualification_contract_sha256=qualification_sha256,
+                result_limit=manifest.provider_contract.result_limit_per_request,
+            )
+            for spec in specs
+        ),
+    )
+
+
+def dry_run(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose all frozen lane identities while constructing no live client."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        cohort,
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    flattened_calls = sum(len(case.plan.calls) for case in cases)
+    return {
+        "mode": "openalex_role_directed_v7_dry_run",
+        "cohort": cohort,
+        "method_id": manifest.method_id,
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "recovery_connected": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "private_labels_opened": False,
+        "human_qualification_performed": False,
+        "live_provider_requests_authorized": False,
+        "live_model_calls_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "maximum_search_request_count": flattened_calls,
+        "maximum_provider_row_count": (
+            flattened_calls * manifest.provider_contract.result_limit_per_request
+        ),
+        "maximum_model_call_count": 0,
+        "provider_contract": manifest.provider_contract.model_dump(mode="json"),
+        "portfolio_contract": manifest.portfolio_contract.model_dump(mode="json"),
+        "qualification_contract": manifest.qualification_contract.model_dump(
+            mode="json"
+        ),
+        "provider_contract_sha256": manifest.provider_contract.sha256(),
+        "portfolio_contract_sha256": manifest.portfolio_contract.sha256(),
+        "qualification_contract_sha256": (
+            manifest.qualification_contract.sha256()
+        ),
+        "cases": [
+            {
+                "case_id": case.spec.case_id,
+                "case_spec_sha256": case.spec.sha256(),
+                "collection_sha256": case.collection_sha256,
+                "plan_sha256": case.plan_sha256,
+                "profile_sha256": case.profile_sha256,
+                "case_contract_sha256": case.case_contract_sha256,
+                "lanes": [
+                    {
+                        "lane_id": lane.lane_id,
+                        "query": lane.query,
+                        "target_role_ids": list(lane.target_role_ids),
+                        "idempotency_key": call.idempotency_key,
+                        "lane_contract_sha256": lane_sha256,
+                        "result_limit": call.result_limit,
+                    }
+                    for lane, call, lane_sha256 in zip(
+                        case.spec.lanes,
+                        case.plan.calls,
+                        case.lane_contract_sha256s,
+                        strict=True,
+                    )
+                ],
+            }
+            for case in cases
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cohort",
+        choices=("development", "unseen"),
+        default="development",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(json.dumps(dry_run(args.cohort), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/openalex_role_directed_v7_challenge.json
+++ b/tests/fixtures/openalex_role_directed_v7_challenge.json
@@ -713,7 +713,7 @@
         },
         {
           "lane_id": "technology_evidence",
-          "query": "phage loaded hydrogel pathogen reduction in vivo survival",
+          "query": "bacteriophage loaded hydrogels bacterial fish pathogen reduction survival",
           "target_role_ids": [
             "bacteriophage_delivery",
             "hydrogel_carrier",

--- a/tests/fixtures/openalex_role_directed_v7_challenge.json
+++ b/tests/fixtures/openalex_role_directed_v7_challenge.json
@@ -1,0 +1,886 @@
+{
+  "schema_version": 1,
+  "method_id": "openalex-role-directed-retrieval-portfolio-v7",
+  "provider_contract": {
+    "provider": "anonymous_openalex",
+    "requests_per_case": 2,
+    "result_limit_per_request": 6,
+    "require_abstract": true,
+    "allow_redirects": false,
+    "allow_retries": false
+  },
+  "portfolio_contract": {
+    "lane_order": [
+      "technology_scope",
+      "technology_evidence"
+    ],
+    "deduplicate_by": [
+      "normalized_doi",
+      "canonical_openalex_url"
+    ],
+    "preserve_lane_memberships": true,
+    "preserve_provider_rank": true,
+    "maximum_unique_candidates_per_case": 12,
+    "maximum_cover_sources_per_case": 3,
+    "semantic_filter_before_human_qualification": false
+  },
+  "qualification_contract": {
+    "minimum_cases_with_relevant_novel_candidate": 6,
+    "minimum_human_coverable_cases": 6,
+    "minimum_candidate_pool_precision": 0.25,
+    "minimum_cases_with_unique_evidence_lane_value": 4,
+    "minimum_coverability_gain_over_scope_lane": 2
+  },
+  "development_cases": [
+    {
+      "case_id": "AA01",
+      "topic": "Electrochemical phosphorus recovery from municipal wastewater as struvite using magnesium-air cells",
+      "roles": {
+        "required": [
+          {
+            "role_id": "electrochemical_phosphorus_recovery",
+            "description": "Evidence that phosphorus is recovered through an electrochemical process."
+          },
+          {
+            "role_id": "magnesium_air_cell",
+            "description": "Evidence that a magnesium-air cell supplies magnesium, energy, or both."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "municipal_wastewater",
+            "description": "Evidence that municipal wastewater, sewage, or a comparable wastewater stream is treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "struvite_product",
+            "description": "Evidence that recovered phosphorus forms struvite or another reusable phosphate product."
+          },
+          {
+            "role_id": "phosphorus_recovery_performance",
+            "description": "Evidence reporting phosphorus removal, recovery efficiency, purity, or energy demand."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "magnesium air electrochemical phosphorus recovery municipal wastewater",
+          "target_role_ids": [
+            "electrochemical_phosphorus_recovery",
+            "magnesium_air_cell",
+            "municipal_wastewater"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "magnesium air cell phosphorus recovery struvite efficiency",
+          "target_role_ids": [
+            "electrochemical_phosphorus_recovery",
+            "magnesium_air_cell",
+            "struvite_product",
+            "phosphorus_recovery_performance"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA02",
+      "topic": "Nanobody-functionalized paper microfluidics for rapid aflatoxin detection in grain",
+      "roles": {
+        "required": [
+          {
+            "role_id": "nanobody_recognition",
+            "description": "Evidence that a nanobody or single-domain antibody provides molecular recognition."
+          },
+          {
+            "role_id": "paper_microfluidic",
+            "description": "Evidence that detection occurs on a paper-based microfluidic or lateral-flow platform."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "grain_aflatoxin",
+            "description": "Evidence that aflatoxin in grain, cereal, feed, or a closely related food matrix is targeted."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "rapid_detection",
+            "description": "Evidence reporting rapid, point-of-use, or short-turnaround detection."
+          },
+          {
+            "role_id": "analytical_performance",
+            "description": "Evidence reporting detection limit, selectivity, sensitivity, or recovery."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "nanobody paper microfluidic aflatoxin grain sensor",
+          "target_role_ids": [
+            "nanobody_recognition",
+            "paper_microfluidic",
+            "grain_aflatoxin"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "nanobody paper aflatoxin rapid detection sensitivity limit",
+          "target_role_ids": [
+            "nanobody_recognition",
+            "paper_microfluidic",
+            "rapid_detection",
+            "analytical_performance"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA03",
+      "topic": "Supercritical-solvent recycling of carbon-fibre epoxy composites for fibre reuse",
+      "roles": {
+        "required": [
+          {
+            "role_id": "supercritical_solvolysis",
+            "description": "Evidence that a supercritical or near-critical solvent depolymerises a thermoset matrix."
+          },
+          {
+            "role_id": "carbon_fibre_epoxy",
+            "description": "Evidence that the treated material is a carbon-fibre epoxy composite."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "fibre_reuse",
+            "description": "Evidence that recovered carbon fibres are intended or demonstrated for reuse."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "resin_depolymerisation",
+            "description": "Evidence reporting resin removal, depolymerisation, or recovered chemical products."
+          },
+          {
+            "role_id": "retained_fibre_properties",
+            "description": "Evidence reporting retained strength, modulus, surface quality, or composite performance."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "supercritical solvent carbon fibre epoxy composite recycling reuse",
+          "target_role_ids": [
+            "supercritical_solvolysis",
+            "carbon_fibre_epoxy",
+            "fibre_reuse"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "supercritical solvolysis carbon fiber epoxy recovered fibre strength",
+          "target_role_ids": [
+            "supercritical_solvolysis",
+            "carbon_fibre_epoxy",
+            "resin_depolymerisation",
+            "retained_fibre_properties"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA04",
+      "topic": "Organic electrochemical transistor sensors for non-invasive sweat cortisol monitoring",
+      "roles": {
+        "required": [
+          {
+            "role_id": "organic_electrochemical_transistor",
+            "description": "Evidence that sensing uses an organic electrochemical transistor."
+          },
+          {
+            "role_id": "cortisol_sensing",
+            "description": "Evidence that cortisol is the measured analyte."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "sweat_monitoring",
+            "description": "Evidence that cortisol is measured non-invasively in sweat or a wearable sweat sample."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "sensitivity_selectivity",
+            "description": "Evidence reporting sensitivity, selectivity, detection limit, or interference."
+          },
+          {
+            "role_id": "wearable_operation",
+            "description": "Evidence of wearable, continuous, on-body, or real-time operation."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "organic electrochemical transistor cortisol sweat wearable sensor",
+          "target_role_ids": [
+            "organic_electrochemical_transistor",
+            "cortisol_sensing",
+            "sweat_monitoring"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "OECT cortisol sensor sensitivity selectivity wearable monitoring",
+          "target_role_ids": [
+            "organic_electrochemical_transistor",
+            "cortisol_sensing",
+            "sensitivity_selectivity",
+            "wearable_operation"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA05",
+      "topic": "Bio-based phase-change composites for passive cold-chain food packaging",
+      "roles": {
+        "required": [
+          {
+            "role_id": "bio_based_phase_change_material",
+            "description": "Evidence that the phase-change medium or its encapsulation is bio-based."
+          },
+          {
+            "role_id": "latent_heat_storage",
+            "description": "Evidence that thermal control uses latent-heat phase-change storage."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "cold_chain_food_packaging",
+            "description": "Evidence of food, pharmaceutical, or comparable cold-chain packaging use."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "thermal_buffering",
+            "description": "Evidence reporting temperature buffering, holdover time, or latent heat."
+          },
+          {
+            "role_id": "cycling_or_leakage",
+            "description": "Evidence addressing thermal cycling, leakage, encapsulation, or material stability."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "bio based phase change material cold chain food packaging",
+          "target_role_ids": [
+            "bio_based_phase_change_material",
+            "latent_heat_storage",
+            "cold_chain_food_packaging"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "bio composite phase change cold storage thermal cycling leakage",
+          "target_role_ids": [
+            "bio_based_phase_change_material",
+            "latent_heat_storage",
+            "thermal_buffering",
+            "cycling_or_leakage"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA06",
+      "topic": "Monovalent-selective electrodialysis for lithium recovery from spent LFP battery leachate",
+      "roles": {
+        "required": [
+          {
+            "role_id": "monovalent_selective_membrane",
+            "description": "Evidence that a monovalent-selective ion-exchange membrane provides separation."
+          },
+          {
+            "role_id": "electrodialysis_lithium_recovery",
+            "description": "Evidence that electrodialysis or an electro-membrane process recovers lithium."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "lfp_battery_leachate",
+            "description": "Evidence that spent lithium-iron-phosphate battery leachate or a comparable battery stream is treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "lithium_selectivity",
+            "description": "Evidence reporting lithium selectivity against sodium, magnesium, iron, or other ions."
+          },
+          {
+            "role_id": "recovery_efficiency",
+            "description": "Evidence reporting lithium recovery, purity, current efficiency, or energy use."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "monovalent selective electrodialysis lithium LFP battery leachate",
+          "target_role_ids": [
+            "monovalent_selective_membrane",
+            "electrodialysis_lithium_recovery",
+            "lfp_battery_leachate"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "electrodialysis lithium recovery spent LFP selectivity efficiency",
+          "target_role_ids": [
+            "monovalent_selective_membrane",
+            "electrodialysis_lithium_recovery",
+            "lithium_selectivity",
+            "recovery_efficiency"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA07",
+      "topic": "Methanotrophic ectoine production from biogas for cosmetic ingredients",
+      "roles": {
+        "required": [
+          {
+            "role_id": "methanotrophic_bioconversion",
+            "description": "Evidence that methane-oxidising microorganisms convert methane or biogas."
+          },
+          {
+            "role_id": "ectoine_production",
+            "description": "Evidence that ectoine or hydroxyectoine is the target product."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "biogas_feedstock",
+            "description": "Evidence that biogas, biomethane, or methane-rich waste gas is used as feedstock."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "product_yield",
+            "description": "Evidence reporting ectoine titre, yield, productivity, or extraction."
+          },
+          {
+            "role_id": "cosmetic_or_high_value_use",
+            "description": "Evidence of cosmetic, dermatological, pharmaceutical, or other high-value product use."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "methanotroph ectoine production biogas methane feedstock",
+          "target_role_ids": [
+            "methanotrophic_bioconversion",
+            "ectoine_production",
+            "biogas_feedstock"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "methane biogas ectoine yield productivity cosmetic",
+          "target_role_ids": [
+            "methanotrophic_bioconversion",
+            "ectoine_production",
+            "product_yield",
+            "cosmetic_or_high_value_use"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AA08",
+      "topic": "Passive daytime radiative-cooling coatings for refrigerated warehouse roofs",
+      "roles": {
+        "required": [
+          {
+            "role_id": "passive_daytime_radiative_cooling",
+            "description": "Evidence that a surface rejects heat through daytime radiative cooling without active power."
+          },
+          {
+            "role_id": "cooling_coating",
+            "description": "Evidence that the cooling material is applied as a coating, paint, or roof surface."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "refrigerated_warehouse_roof",
+            "description": "Evidence of a refrigerated, cold-storage, warehouse, or comparable building-roof application."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "cooling_performance",
+            "description": "Evidence reporting cooling power, surface temperature reduction, or energy savings."
+          },
+          {
+            "role_id": "outdoor_durability",
+            "description": "Evidence addressing weathering, fouling, adhesion, aging, or outdoor durability."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "passive daytime radiative cooling coating warehouse roof cold storage",
+          "target_role_ids": [
+            "passive_daytime_radiative_cooling",
+            "cooling_coating",
+            "refrigerated_warehouse_roof"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "radiative cooling roof coating cooling power outdoor durability",
+          "target_role_ids": [
+            "passive_daytime_radiative_cooling",
+            "cooling_coating",
+            "cooling_performance",
+            "outdoor_durability"
+          ]
+        }
+      ]
+    }
+  ],
+  "unseen_cases": [
+    {
+      "case_id": "AB01",
+      "topic": "Electrocatalytic nitrate conversion from agricultural runoff into ammonium fertilizer",
+      "roles": {
+        "required": [
+          {
+            "role_id": "electrochemical_nitrate_reduction",
+            "description": "Evidence that nitrate is electrochemically reduced."
+          },
+          {
+            "role_id": "ammonium_product",
+            "description": "Evidence that ammonia or ammonium is the intended recovered product."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "agricultural_runoff",
+            "description": "Evidence that agricultural runoff, drainage, or nitrate-rich water is treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "selectivity_or_faradaic_efficiency",
+            "description": "Evidence reporting ammonia selectivity, yield, or Faradaic efficiency."
+          },
+          {
+            "role_id": "fertilizer_reuse",
+            "description": "Evidence that recovered nitrogen is reused or assessed as fertilizer."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "electrochemical nitrate reduction agricultural runoff ammonium recovery",
+          "target_role_ids": [
+            "electrochemical_nitrate_reduction",
+            "ammonium_product",
+            "agricultural_runoff"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "electrocatalytic nitrate ammonia Faradaic efficiency fertilizer reuse",
+          "target_role_ids": [
+            "electrochemical_nitrate_reduction",
+            "ammonium_product",
+            "selectivity_or_faradaic_efficiency",
+            "fertilizer_reuse"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB02",
+      "topic": "Piezoelectric textile insoles for gait monitoring during stroke rehabilitation",
+      "roles": {
+        "required": [
+          {
+            "role_id": "piezoelectric_textile",
+            "description": "Evidence that a textile, fibre, or flexible piezoelectric material senses pressure or motion."
+          },
+          {
+            "role_id": "gait_sensing",
+            "description": "Evidence that the device measures gait, plantar pressure, steps, or walking mechanics."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "stroke_rehabilitation",
+            "description": "Evidence of stroke, neurological, or clinical gait rehabilitation use."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "pressure_mapping",
+            "description": "Evidence reporting spatial or temporal plantar-pressure or gait parameters."
+          },
+          {
+            "role_id": "wearable_validation",
+            "description": "Evidence of on-body testing, patient testing, repeatability, or clinical validation."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "piezoelectric textile insole gait monitoring stroke rehabilitation",
+          "target_role_ids": [
+            "piezoelectric_textile",
+            "gait_sensing",
+            "stroke_rehabilitation"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "piezoelectric smart insole plantar pressure gait clinical validation",
+          "target_role_ids": [
+            "piezoelectric_textile",
+            "gait_sensing",
+            "pressure_mapping",
+            "wearable_validation"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB03",
+      "topic": "Enzyme-responsive intelligent food packaging for real-time meat spoilage detection",
+      "roles": {
+        "required": [
+          {
+            "role_id": "enzyme_responsive_indicator",
+            "description": "Evidence that an enzyme-mediated or enzyme-responsive reaction changes a spoilage indicator."
+          },
+          {
+            "role_id": "intelligent_packaging",
+            "description": "Evidence that the indicator is integrated into packaging, a label, or a film."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "meat_spoilage",
+            "description": "Evidence that meat, poultry, fish, or comparable protein-food spoilage is monitored."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "freshness_correlation",
+            "description": "Evidence correlating the signal with microbial load, metabolites, pH, or freshness."
+          },
+          {
+            "role_id": "shelf_life_validation",
+            "description": "Evidence of storage trials, shelf-life tracking, or real-time package validation."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "enzyme responsive intelligent packaging meat spoilage indicator",
+          "target_role_ids": [
+            "enzyme_responsive_indicator",
+            "intelligent_packaging",
+            "meat_spoilage"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "enzymatic freshness label food packaging shelf life microbial correlation",
+          "target_role_ids": [
+            "enzyme_responsive_indicator",
+            "intelligent_packaging",
+            "freshness_correlation",
+            "shelf_life_validation"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB04",
+      "topic": "Metal-organic-framework adsorption heat pumps for low-grade industrial waste-heat cooling",
+      "roles": {
+        "required": [
+          {
+            "role_id": "metal_organic_framework_adsorbent",
+            "description": "Evidence that a metal-organic framework is the active adsorbent."
+          },
+          {
+            "role_id": "adsorption_heat_pump",
+            "description": "Evidence of an adsorption chiller, heat pump, or thermally driven cooling cycle."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "industrial_waste_heat",
+            "description": "Evidence that low-grade industrial waste heat or process heat drives the system."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "cooling_performance",
+            "description": "Evidence reporting coefficient of performance, cooling capacity, or specific cooling power."
+          },
+          {
+            "role_id": "cyclic_stability",
+            "description": "Evidence reporting adsorption cycling, water stability, or long-term material performance."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "metal organic framework adsorption heat pump industrial waste heat",
+          "target_role_ids": [
+            "metal_organic_framework_adsorbent",
+            "adsorption_heat_pump",
+            "industrial_waste_heat"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "MOF adsorption chiller cooling performance cyclic stability",
+          "target_role_ids": [
+            "metal_organic_framework_adsorbent",
+            "adsorption_heat_pump",
+            "cooling_performance",
+            "cyclic_stability"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB05",
+      "topic": "Bacteriophage-loaded hydrogels for treating bacterial infections in farmed fish",
+      "roles": {
+        "required": [
+          {
+            "role_id": "bacteriophage_delivery",
+            "description": "Evidence that bacteriophages are delivered as the antibacterial agent."
+          },
+          {
+            "role_id": "hydrogel_carrier",
+            "description": "Evidence that a hydrogel or gel matrix carries or releases the phages."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "aquaculture_infection",
+            "description": "Evidence that a bacterial disease of farmed fish or another aquaculture species is treated."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "pathogen_reduction",
+            "description": "Evidence reporting bacterial-load or disease-severity reduction."
+          },
+          {
+            "role_id": "in_vivo_outcome",
+            "description": "Evidence reporting survival, healing, protection, or another in-vivo outcome."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "bacteriophage hydrogel aquaculture fish bacterial infection treatment",
+          "target_role_ids": [
+            "bacteriophage_delivery",
+            "hydrogel_carrier",
+            "aquaculture_infection"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "phage loaded hydrogel pathogen reduction in vivo survival",
+          "target_role_ids": [
+            "bacteriophage_delivery",
+            "hydrogel_carrier",
+            "pathogen_reduction",
+            "in_vivo_outcome"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB06",
+      "topic": "Membrane-aerated biofilm reactors for nitrous-oxide mitigation in decentralized wastewater treatment",
+      "roles": {
+        "required": [
+          {
+            "role_id": "membrane_aerated_biofilm_reactor",
+            "description": "Evidence that treatment uses a membrane-aerated biofilm reactor."
+          },
+          {
+            "role_id": "nitrous_oxide_mitigation",
+            "description": "Evidence that nitrous-oxide formation, emission, or consumption is measured or controlled."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "decentralized_wastewater",
+            "description": "Evidence of decentralized, small-scale, onsite, or low-energy wastewater treatment."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "nitrogen_removal",
+            "description": "Evidence reporting nitrification, denitrification, or total-nitrogen removal."
+          },
+          {
+            "role_id": "greenhouse_gas_performance",
+            "description": "Evidence reporting emission factors, dissolved gas, carbon footprint, or mitigation efficiency."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "membrane aerated biofilm reactor nitrous oxide decentralized wastewater",
+          "target_role_ids": [
+            "membrane_aerated_biofilm_reactor",
+            "nitrous_oxide_mitigation",
+            "decentralized_wastewater"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "MABR nitrogen removal nitrous oxide greenhouse gas emissions",
+          "target_role_ids": [
+            "membrane_aerated_biofilm_reactor",
+            "nitrous_oxide_mitigation",
+            "nitrogen_removal",
+            "greenhouse_gas_performance"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB07",
+      "topic": "Printed perovskite X-ray detectors for low-dose dental imaging",
+      "roles": {
+        "required": [
+          {
+            "role_id": "printed_perovskite_detector",
+            "description": "Evidence that a perovskite X-ray detector is fabricated by printing or another scalable coating process."
+          },
+          {
+            "role_id": "xray_detection",
+            "description": "Evidence of direct or indirect X-ray detection."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "dental_imaging",
+            "description": "Evidence of dental, oral, or comparable low-dose medical imaging."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "low_dose_sensitivity",
+            "description": "Evidence reporting sensitivity, detection limit, dose, or signal-to-noise performance."
+          },
+          {
+            "role_id": "imaging_or_stability",
+            "description": "Evidence of image formation, spatial resolution, operational stability, or repeated exposure."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "printed perovskite X ray detector low dose dental imaging",
+          "target_role_ids": [
+            "printed_perovskite_detector",
+            "xray_detection",
+            "dental_imaging"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "printed perovskite X ray detector sensitivity imaging stability",
+          "target_role_ids": [
+            "printed_perovskite_detector",
+            "xray_detection",
+            "low_dose_sensitivity",
+            "imaging_or_stability"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "AB08",
+      "topic": "Hyperspectral-guided laser weeding robots for selective herbicide-free crop management",
+      "roles": {
+        "required": [
+          {
+            "role_id": "hyperspectral_weed_discrimination",
+            "description": "Evidence that hyperspectral or imaging spectroscopy distinguishes crops from weeds."
+          },
+          {
+            "role_id": "robotic_laser_weeding",
+            "description": "Evidence that a robot or automated platform uses laser energy to control weeds."
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "field_crop_management",
+            "description": "Evidence of field, row-crop, horticultural, or comparable crop-management operation."
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "weed_control_accuracy",
+            "description": "Evidence reporting classification, targeting, or weed-kill performance."
+          },
+          {
+            "role_id": "crop_safety_or_throughput",
+            "description": "Evidence reporting crop damage, treatment speed, energy, or field throughput."
+          }
+        ]
+      },
+      "lanes": [
+        {
+          "lane_id": "technology_scope",
+          "query": "hyperspectral crop weed discrimination robotic laser weeding field",
+          "target_role_ids": [
+            "hyperspectral_weed_discrimination",
+            "robotic_laser_weeding",
+            "field_crop_management"
+          ]
+        },
+        {
+          "lane_id": "technology_evidence",
+          "query": "hyperspectral laser weeding robot targeting accuracy crop damage throughput",
+          "target_role_ids": [
+            "hyperspectral_weed_discrimination",
+            "robotic_laser_weeding",
+            "weed_control_accuracy",
+            "crop_safety_or_throughput"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_openalex_role_directed_unseen.py
+++ b/tests/test_openalex_role_directed_unseen.py
@@ -1,0 +1,306 @@
+"""Zero-network seams for the frozen role-directed retrieval v7 preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import socket
+
+import pytest
+
+import openalex_role_directed_unseen as unseen
+
+
+def _write_fixture(tmp_path: Path, payload: dict[str, object]) -> tuple[Path, str]:
+    fixture = tmp_path / "challenge.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return fixture, unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+
+def test_development_dry_run_expands_two_unique_calls_per_case_without_authority():
+    result = unseen.dry_run("development")
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [item["case_id"] for item in result["cases"]] == [
+        f"AA{index:02d}" for index in range(1, 9)
+    ]
+    for key in (
+        "case_spec_sha256",
+        "collection_sha256",
+        "plan_sha256",
+        "profile_sha256",
+        "case_contract_sha256",
+    ):
+        assert len({item[key] for item in result["cases"]}) == 8
+
+    lanes = [lane for case in result["cases"] for lane in case["lanes"]]
+    assert len(lanes) == 16
+    assert len({lane["idempotency_key"] for lane in lanes}) == 16
+    assert len({lane["lane_contract_sha256"] for lane in lanes}) == 16
+    assert {lane["result_limit"] for lane in lanes} == {6}
+    assert [
+        tuple(lane["lane_id"] for lane in case["lanes"])
+        for case in result["cases"]
+    ] == [("technology_scope", "technology_evidence")] * 8
+
+    assert result["maximum_search_request_count"] == 16
+    assert result["maximum_provider_row_count"] == 96
+    assert result["maximum_model_call_count"] == 0
+    assert result["provider_contract"] == {
+        "provider": "anonymous_openalex",
+        "requests_per_case": 2,
+        "result_limit_per_request": 6,
+        "require_abstract": True,
+        "allow_redirects": False,
+        "allow_retries": False,
+    }
+    assert result["portfolio_contract"] == {
+        "lane_order": ["technology_scope", "technology_evidence"],
+        "deduplicate_by": ["normalized_doi", "canonical_openalex_url"],
+        "preserve_lane_memberships": True,
+        "preserve_provider_rank": True,
+        "maximum_unique_candidates_per_case": 12,
+        "maximum_cover_sources_per_case": 3,
+        "semantic_filter_before_human_qualification": False,
+    }
+    assert result["qualification_contract"] == {
+        "minimum_cases_with_relevant_novel_candidate": 6,
+        "minimum_human_coverable_cases": 6,
+        "minimum_candidate_pool_precision": 0.25,
+        "minimum_cases_with_unique_evidence_lane_value": 4,
+        "minimum_coverability_gain_over_scope_lane": 2,
+    }
+    for flag in (
+        "production_connected",
+        "report_workflow_connected",
+        "planner_trigger_connected",
+        "recovery_connected",
+        "real_network_calls_performed",
+        "real_model_calls_performed",
+        "private_labels_opened",
+        "human_qualification_performed",
+        "live_provider_requests_authorized",
+        "live_model_calls_authorized",
+    ):
+        assert result[flag] is False
+
+
+def test_every_frozen_lane_reaches_the_serialized_dry_run_boundary():
+    """A valid plan is useless if one lane disappears before the client seam."""
+
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    result = unseen.dry_run("development")
+
+    expected = [
+        {
+            "case_id": case["case_id"],
+            "lane_id": lane["lane_id"],
+            "query": lane["query"],
+            "target_role_ids": lane["target_role_ids"],
+        }
+        for case in payload["development_cases"]
+        for lane in case["lanes"]
+    ]
+    observed = [
+        {
+            "case_id": case["case_id"],
+            "lane_id": lane["lane_id"],
+            "query": lane["query"],
+            "target_role_ids": lane["target_role_ids"],
+        }
+        for case in result["cases"]
+        for lane in case["lanes"]
+    ]
+
+    assert observed == expected
+    assert all(
+        len(lane["idempotency_key"]) == 64
+        and len(lane["lane_contract_sha256"]) == 64
+        for case in result["cases"]
+        for lane in case["lanes"]
+    )
+
+
+def test_unseen_cohort_has_distinct_identities_and_zero_live_authority():
+    development = unseen.dry_run("development")
+    challenge = unseen.dry_run("unseen")
+
+    assert [item["case_id"] for item in challenge["cases"]] == [
+        f"AB{index:02d}" for index in range(1, 9)
+    ]
+    assert {
+        item["case_contract_sha256"] for item in development["cases"]
+    }.isdisjoint(item["case_contract_sha256"] for item in challenge["cases"])
+    assert {
+        lane["idempotency_key"]
+        for case in development["cases"]
+        for lane in case["lanes"]
+    }.isdisjoint(
+        lane["idempotency_key"]
+        for case in challenge["cases"]
+        for lane in case["lanes"]
+    )
+    assert challenge["real_network_calls_performed"] is False
+    assert challenge["real_model_calls_performed"] is False
+    assert challenge["live_provider_requests_authorized"] is False
+    assert challenge["live_model_calls_authorized"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path, monkeypatch):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    def must_not_expand(*args, **kwargs):
+        raise AssertionError("case expansion ran before the raw hash check")
+
+    monkeypatch.setattr(unseen, "build_case", must_not_expand)
+    with pytest.raises(
+        unseen.OpenAlexRoleDirectedPreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases("development", fixture)
+
+
+def test_case_order_drift_is_rejected_with_a_matching_test_hash(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0], payload["development_cases"][1] = (
+        payload["development_cases"][1],
+        payload["development_cases"][0],
+    )
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="AA01 through AA08"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_lane_order_and_role_binding_drift_fail_closed(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["lanes"].reverse()
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="case lanes must remain"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["lanes"][0]["target_role_ids"] = [
+        "electrochemical_phosphorus_recovery",
+        "magnesium_air_cell",
+        "struvite_product",
+    ]
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="technology_scope must target a scope role"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_query_drift_changes_only_query_bound_identities(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["lanes"][1]["query"] += " validation"
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    original = unseen.dry_run("development")
+    drifted = unseen.dry_run(
+        "development",
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+    original_case = original["cases"][0]
+    drifted_case = drifted["cases"][0]
+
+    assert drifted_case["collection_sha256"] == original_case["collection_sha256"]
+    assert drifted_case["profile_sha256"] == original_case["profile_sha256"]
+    assert drifted_case["case_spec_sha256"] != original_case["case_spec_sha256"]
+    assert drifted_case["plan_sha256"] != original_case["plan_sha256"]
+    assert (
+        drifted_case["case_contract_sha256"]
+        != original_case["case_contract_sha256"]
+    )
+    assert (
+        drifted_case["lanes"][0]["idempotency_key"]
+        == original_case["lanes"][0]["idempotency_key"]
+    )
+    assert (
+        drifted_case["lanes"][0]["lane_contract_sha256"]
+        == original_case["lanes"][0]["lane_contract_sha256"]
+    )
+    assert (
+        drifted_case["lanes"][1]["idempotency_key"]
+        != original_case["lanes"][1]["idempotency_key"]
+    )
+    assert (
+        drifted_case["lanes"][1]["lane_contract_sha256"]
+        != original_case["lanes"][1]["lane_contract_sha256"]
+    )
+
+
+def test_role_drift_changes_role_bound_identities_but_not_search_plan(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["roles"]["scope"][0][
+        "description"
+    ] += " under documented plant operating conditions"
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    original = unseen.dry_run("development")
+    drifted = unseen.dry_run(
+        "development",
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+    original_case = original["cases"][0]
+    drifted_case = drifted["cases"][0]
+
+    assert drifted_case["plan_sha256"] == original_case["plan_sha256"]
+    assert drifted_case["profile_sha256"] != original_case["profile_sha256"]
+    assert (
+        drifted_case["case_contract_sha256"]
+        != original_case["case_contract_sha256"]
+    )
+    assert [
+        lane["idempotency_key"] for lane in drifted_case["lanes"]
+    ] == [lane["idempotency_key"] for lane in original_case["lanes"]]
+    assert [
+        lane["lane_contract_sha256"] for lane in drifted_case["lanes"]
+    ] != [lane["lane_contract_sha256"] for lane in original_case["lanes"]]
+
+
+def test_dry_run_opens_no_socket_even_when_socket_creation_is_blocked(monkeypatch):
+    def block_socket(*args, **kwargs):
+        raise AssertionError("preflight attempted to create a socket")
+
+    monkeypatch.setattr(socket, "socket", block_socket)
+
+    result = unseen.dry_run("development")
+
+    assert result["case_count"] == 8
+    assert result["real_network_calls_performed"] is False
+
+
+def test_preflight_imports_no_provider_model_or_execution_client():
+    source = Path("openalex_role_directed_unseen.py").read_text(encoding="utf-8")
+
+    for forbidden in (
+        "anonymous_openalex_search",
+        "OpenAlexEvidenceSearchAdapter",
+        "execute_gap_plan",
+        "qwen",
+        "litellm",
+        "crewai",
+        "urllib",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## Why

The role-slot v6 human diagnostic showed that only 3/8 cases had a human-coverable role portfolio. Semantic consensus was therefore downstream of a retrieval bottleneck, and spending more Qwen calls could not manufacture missing evidence.

## What

- freeze separate AA01-AA08 development and AB01-AB08 unseen cohorts
- define two code-owned OpenAlex lanes per case: technology plus scope, and technology plus supporting evidence
- bind fixture, case, lane, role, plan, idempotency, request, and contract identities before provider construction
- add a zero-network preflight that expands all 16 development lane identities while keeping model, Planner, recovery, report, and production connections disabled
- preserve the AB05 query correction as a pre-implementation erratum rather than silently changing a frozen challenge
- document conjunctive coverage, precision, incremental-value, and union-gain qualification gates

## Verification

- 1,861 tests passed plus 657 subtests
- latest Ruff passed
- narrow Pylint E0701 check rated 10.00/10
- serialized-lane defect reinjection failed at the client boundary before restoration
- zero OpenAlex requests and zero model calls

This PR establishes offline eligibility only. AA remains unconsumed, AB remains unopened, source value is not evaluated, and production Tool Calling remains disconnected.