### PR TITLE
Add the bounded role-directed v7 live runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1861 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1878 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -227,6 +227,8 @@ openalex_role_slot_failure_review.py
                         label-blind 64-row v6 failure diagnostic; zero-network
 openalex_role_directed_unseen.py
                         frozen AA/AB two-lane v7 preflight; zero-network only
+openalex_role_directed_live.py
+                        write-once AA v7 runner; CLI defaults to zero-network
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -660,7 +662,7 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   corrected before implementation or any request after a scope audit showed
   that a weak token had created a formal rather than meaningful overlap; the
   original commit and erratum remain visible. The focused suite passes 10/10
-  and the full suite passes 1861 tests plus 657 subtests. Dropping every second
+  and the full suite passes 1878 tests plus 657 subtests. Dropping every second
   lane only at serialization was re-injected and made the boundary test fail
   before restoration. No OpenAlex request or human review has occurred, so AA
   remains unconsumed, AB remains unopened, and candidate value is
@@ -668,6 +670,24 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md`,
   `docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md`, and
   `docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md`.
+
+  A separately pre-registered write-once AA runner is now implemented but has
+  not executed. It locks the fixture and six behavior dependencies before
+  output reservation, writes the complete 16-lane manifest before adapter
+  construction, commits each one-request lane journal before later work, and
+  commits each DOI-first/URL-second deduplicated portfolio before the next
+  case. Raw provider rows, rejections, duplicate occurrences, all lane
+  memberships, unique candidates, blank review rows, cost, latency and trace
+  identities reach hashed artifacts. Its focused suite passes 17/17 and the
+  combined v7 suite passes 27/27. Moving manifest persistence after adapter
+  construction and dropping a duplicate source's second lane membership were
+  each re-injected and made the intended seam test fail before restoration.
+  No OpenAlex request, model call or human review has occurred; AA remains
+  unconsumed, AB remains unopened, candidate value remains `not_evaluated`,
+  and production Tool Calling remains disconnected. See
+  `docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md`
+  and
+  `docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -908,14 +908,28 @@ The raw-byte-locked offline preflight expands 8/8 AA cases, 16/16 unique search
 identities, and 16/16 unique lane contracts while importing no network,
 execution, or model client. Its focused suite passes 10/10, including a
 re-injected boundary defect where the second lane existed internally but did
-not reach serialized output. No provider request or human review has occurred:
-AA is unconsumed, AB is unopened, candidate value is `not_evaluated`, and
-production Tool Calling remains disconnected. See the
+not reach serialized output.
+
+A separately pre-registered write-once AA runner is now implemented but has not
+been executed. It locks the fixture and six behavior dependencies before output
+reservation, persists the complete 16-lane manifest before adapter
+construction, writes every one-request lane journal before later work, and
+persists each DOI-first/URL-second deduplicated portfolio before the next case.
+Raw provider rows, rejections, duplicate occurrences, all lane memberships,
+unique candidates, blank human-review rows, cost, latency, and trace identities
+reach hashed artifacts. The 17/17 runner suite and 27/27 combined v7 suite pass;
+moving the manifest after adapter construction and dropping a duplicate lane
+membership each made the intended seam test fail before restoration. No
+provider request or human review has occurred: AA is unconsumed, AB is unopened,
+candidate value is `not_evaluated`, and production Tool Calling remains
+disconnected. See the
 [v7 pre-registration](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md),
 [pre-provider AB05 erratum](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md),
-and [offline implementation result](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md).
+the [offline implementation result](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md),
+the [live-runner pre-registration](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md),
+and the [live-runner implementation result](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md).
 
-Local verification now passes **1,861 tests plus 657 subtests**, latest Ruff,
+Local verification now passes **1,878 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2198,14 +2212,24 @@ metrics 缺失，4 个核心来源哈希与 56 份索引工件全部一致，且
 原始字节锁定的离线预检现已展开 8/8 个 AA 案例、16/16 个唯一检索身份与
 16/16 个唯一 lane 合约，且不导入网络、执行或模型客户端。10/10 个定向测试
 通过，其中包括一次接缝缺陷回注：第二条 lane 在内部存在却没有到达序列化输出
-时，边界测试会失败。目前未发起供应商请求，也未进行人工评审，因此 AA 尚未
-消耗、AB 保持未打开、候选价值为 `not_evaluated`，生产 Tool Calling 仍未
-连接。详见
-[v7 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md)、
-[AB05 供应商调用前勘误](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md)
-与[离线实现结果](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md)。
+时，边界测试会失败。
 
-本地验证现通过 **1,861 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+另行预注册的 AA write-once runner 现已实现但尚未执行。它在预留输出目录前
+锁定 fixture 与 6 个行为依赖，在构造 adapter 前持久化完整 16-lane manifest，
+每个单请求 lane 日志落盘后才允许后续工作，并在进入下一案例前持久化按 DOI
+优先、OpenAlex URL 次优去重的双 lane portfolio。原始供应商行、拒绝项、重复
+出现记录、全部 lane 成员关系、唯一候选、空白人工评审行、成本、延迟与 trace
+身份均进入带哈希工件。runner 的 17/17 与 v7 组合 27/27 测试通过；将 manifest
+移到 adapter 构造之后、或丢失重复来源的第二条 lane 成员关系，都会使对应接缝
+测试失败。目前未发起供应商请求，也未进行人工评审，因此 AA 尚未消耗、AB
+保持未打开、候选价值为 `not_evaluated`，生产 Tool Calling 仍未连接。详见
+[v7 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md)、
+[AB05 供应商调用前勘误](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md)、
+[离线实现结果](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md)、
+[live runner 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md)
+与[live runner 实现结果](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md)。
+
+本地验证现通过 **1,878 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md
+++ b/docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md
@@ -1,0 +1,198 @@
+# Pre-registration amendment: role-directed retrieval v7 live runner
+
+**Frozen:** 2026-09-01, on top of the merged zero-network v7 preflight
+revision `f28160305247df1235c5bd2b1bac63bcb04e2f46`, before implementing a
+network-capable runner, constructing an OpenAlex adapter for AA01-AA08, or
+making any provider request for AA01-AA08 or AB01-AB08.
+
+**Parent protocol:**
+[`prereg-2026-09-01-openalex-role-directed-retrieval-v7.md`](prereg-2026-09-01-openalex-role-directed-retrieval-v7.md)
+
+**Challenge fixture:**
+`tests/fixtures/openalex_role_directed_v7_challenge.json`
+
+**Raw fixture SHA-256:**
+`9a91746d0a77fee6d57bfc91ae4329ab78a89109fca6f35171d56c0f3ee95761`
+
+**Production connection authorized:** no
+
+**Live provider execution authorized:** no. This amendment authorizes only
+implementation and zero-network verification of the disconnected AA runner.
+A real AA run requires separate owner authorization naming the merged revision,
+the exact fixture hash, no more than sixteen requests, and a provider-reported
+cost soft stop no greater than USD 0.02. AB01-AB08 remain unavailable until AA
+passes every frozen mechanical and human gate without tuning.
+
+## Question
+
+Can the frozen AA01-AA08 two-lane retrieval method be executed through a
+durable, bounded boundary that preserves every spent request, provider row,
+rejection, lane membership, and deduplication decision without allowing an
+interrupted or uninspectable run to look complete?
+
+This phase does not ask whether the retrieved sources are relevant, novel, or
+jointly role-covering. Those are human-review questions and remain
+`not_evaluated` after runner implementation or provider execution.
+
+## Frozen execution scope
+
+Only the `development` cohort AA01-AA08 may enter this runner. The existing
+preflight may continue to byte-check and expand AB01-AB08 offline, but live
+execution must reject the unseen cohort before adapter construction.
+
+Each AA case owns exactly two sequential anonymous OpenAlex Works requests in
+the fixture order:
+
+1. `technology_scope`;
+2. `technology_evidence`.
+
+Each lane may return at most six provider rows with reconstructable abstracts.
+The complete AA run may therefore make at most sixteen one-attempt requests and
+observe at most 96 provider rows. Redirects, retries, fallback queries,
+supplementary search, result-page fetches, model calls, repair, recovery, and
+parallel requests are forbidden. A failed request, invalid response, identity
+mismatch, uninspectable cost, or reached soft stop ends the run before a later
+request begins.
+
+## Identity and authorization boundary
+
+Before output reservation or construction of any network-capable object, the
+runner must verify:
+
+- the raw challenge fixture bytes;
+- all eight ordered AA case identities and sixteen ordered lane identities;
+- the committed bytes of `openalex_role_directed_unseen.py`;
+- the committed bytes of `evidence.py`, `evidence_gap.py`, and
+  `evidence_search.py`;
+- the committed bytes of `domain_evidence_search.py` and
+  `anonymous_openalex_search.py`; and
+- the exact provider, portfolio, and qualification contracts expanded by the
+  preflight.
+
+The runner records its observed self SHA-256 in the manifest and final
+execution artifact. It cannot embed an expected hash of its own complete bytes
+without recursion, so a later live authorization must name the exact merged
+revision that owns that observed runner.
+
+The live path must also require an explicit `--execute-live` flag, a fresh
+write-once output directory, acknowledgement of the anonymous OpenAlex daily
+budget, and a positive soft stop no greater than USD 0.02. It must refuse to
+start when `OPENALEX_API_KEY` is configured. The CLI defaults to zero-network
+dry-run and may not infer live authority from the presence of an output path.
+
+## Write-once ordering
+
+After all identities and arguments pass, ordering is fixed:
+
+1. reserve the fresh output directory;
+2. persist `manifest.json` with every expanded source collection, validated
+   plan, role profile, lane contract, idempotency key, request ceiling, value
+   gate, and implementation identity;
+3. only then construct the adapter;
+4. issue at most one request for the next ordered AA lane;
+5. persist its complete `lane-executions/AAxx--lane.json` journal before a later
+   lane may start;
+6. after both lanes complete, deterministically create and persist the case
+   portfolio before the next case may start; and
+7. finish with write-once execution, provider-row, unique-candidate,
+   blank-review, and artifact-index files.
+
+An interrupted prefix is durable history, not resumable authority. This runner
+does not add checkpoint or retry semantics. If only one lane of a case was
+spent, its journal remains visible and no portfolio is fabricated for that
+case.
+
+## Frozen portfolio and deduplication contract
+
+Every valid candidate remains reviewable; there is no semantic source filter.
+Within one case, candidates are visited in frozen lane order and provider-rank
+order. The first candidate owns the unique-candidate record. A later candidate
+is merged only when it shares:
+
+1. the same non-empty normalized DOI, compared case-insensitively; otherwise
+2. the same canonical OpenAlex record URL.
+
+DOI identity has precedence over URL identity. A duplicate occurrence must
+retain its own lane ID, provider rank, request identity, candidate hash, and the
+deduplication key and owner that caused the merge. The unique record must retain
+all originating lane memberships and occurrences. Two candidates with
+different non-empty DOIs do not merge merely because a malformed provider
+response points them at one URL; that ambiguity is retained for human review.
+
+Every provider rejection remains attached to its request and provider row. It
+does not enter the unique candidate denominator, but it must reach the raw-row
+CSV and final accounting.
+
+## Final states and mechanical gates
+
+`completed` means all sixteen ordered requests reached durable completed
+journals and all eight case portfolios were persisted. It does not mean source
+value passed. The final artifact must distinguish:
+
+- provider state: `not_observed`, `known`, or `uninspectable` cost;
+- execution state: `completed` or `partial`;
+- review-packet state: `eligible_for_source_lock` only after all mechanical
+  gates, otherwise `incomplete` or `mechanical_gate_failed`;
+- human review: always `not_prepared` in this phase; and
+- source value: always `not_evaluated` in this phase.
+
+Mechanical eligibility requires exactly eight ordered portfolios, sixteen
+one-attempt completed requests with inspectable accounting, complete serialized
+coverage of every provider row and rejection, complete occurrence-to-unique
+candidate lineage, and zero model calls. Production, reports, Planner,
+checkpoint recovery, and supplementary-search connections remain false.
+
+The human gates from the parent protocol are unchanged. In particular, a
+complete provider run does not calculate relevance, novelty, role support,
+candidate precision, evidence-lane incremental value, or union coverability.
+All blank review rows must expose both frozen baseline context and complete
+source title/abstract content without exposing a hidden answer or model label.
+
+## Required zero-network verification
+
+Before a real AA authorization, tests must prove that:
+
+1. dry-run locks eight AA cases, sixteen lanes, dependency hashes, and all
+   request ceilings while constructing no adapter and opening no socket;
+2. fixture, implementation, order, or authorization drift fails before output
+   reservation and adapter construction;
+3. `manifest.json` exists before an injected adapter factory can run;
+4. each prior lane journal exists before a later injected request can run;
+5. both lane journals and the portfolio exist before the next case request;
+6. every provider candidate and rejection reaches the raw-row CSV;
+7. every duplicate occurrence and all lane memberships reach the unique-source
+   and blank-review boundaries;
+8. provider failure, invalid accounting, identity mismatch, unknown cost, and
+   soft stop remain distinct partial states with no retry;
+9. no environment secret reaches any artifact;
+10. the production worker imports no v7 preflight, runner, or experimental
+    adapter; and
+11. the full zero-network suite, latest Ruff, and narrow Pylint pass.
+
+Two defects must be re-injected and observed red before restoration: moving
+manifest persistence after adapter construction, and dropping one duplicate
+occurrence or lane membership from the final serialized boundary. Existing
+assertions may not be weakened or skipped.
+
+## Stop and falsification rules
+
+Runner implementation fails if a network-capable object can exist before the
+manifest, if a later request can begin before the previous spent-request
+journal, if a later case can begin before its predecessor portfolio, if any
+provider row or deduplication lineage disappears before the client artifact,
+or if production imports a v7 component.
+
+A later AA run fails mechanically if it does not complete all sixteen requests
+and eight portfolios with inspectable accounting. A mechanically complete run
+still requires a separate source lock and eligible human review. AA failure
+seals v7; it does not authorize tuning on AA, rerunning it as validation,
+opening AB, lowering a gate, or connecting the method to production.
+
+## Explicit non-claims
+
+Passing this implementation stage would establish only a durable, bounded,
+inspectable and production-disconnected execution contract. It would not
+establish OpenAlex compatibility on AA, source relevance, novelty, precision,
+recall, role coverability, incremental value of the second lane, report
+improvement, planner-trigger precision, user utility, an SLO, autonomous tool
+choice, or completed production Tool Calling.

--- a/docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md
+++ b/docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md
@@ -1,0 +1,107 @@
+# Result: role-directed retrieval v7 live runner implementation
+
+Date: 2026-09-02 (Australia/Sydney)
+
+Status: implemented and mechanically qualified offline; no OpenAlex request,
+model call, human review, unseen-cohort access, or production connection
+
+## Scope
+
+This stage implements the write-once runner pre-registered in
+`prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md`. It does
+not execute AA01-AA08. The exact fixture remains:
+
+```text
+9a91746d0a77fee6d57bfc91ae4329ab78a89109fca6f35171d56c0f3ee95761
+```
+
+AA therefore remains unconsumed, and AB01-AB08 remains unopened.
+
+## Implemented execution boundary
+
+`openalex_role_directed_live.py` now provides a production-disconnected CLI
+that defaults to the existing zero-network dry-run. Its live path accepts only
+the AA development cohort and requires a fresh output directory, an explicit
+live flag, anonymous-budget acknowledgement, no configured OpenAlex key, and a
+positive provider-reported soft stop no greater than USD 0.02.
+
+Before a network-capable adapter can exist, the runner checks the raw fixture
+and six behavior-bearing dependency hashes, expands all eight ordered cases and
+sixteen ordered lane identities, records its own observed hash, reserves the
+output directory, and writes the complete manifest. Each attempted lane then
+owns one request and one durable journal. A second lane cannot start before the
+first journal exists, and a later case cannot start before the preceding
+two-lane portfolio exists.
+
+A provider failure, invalid OpenAlex accounting shape, idempotency mismatch,
+uninspectable cost, or reached soft stop creates an explicit partial result and
+starts no later request. A structurally parseable but provider-unidentified
+response remains visible in its failed lane journal without being promoted to
+the provider-row table. This distinction was found by the new test suite rather
+than being hidden as a zero-row provider pass.
+
+## Portfolio and review boundary
+
+Completed lane candidates are visited in frozen lane and provider-rank order.
+The deterministic portfolio merges the same normalized DOI first, then an
+unambiguous canonical OpenAlex work URL. Conflicting non-empty DOIs do not merge
+solely because their URLs collide. Every candidate occurrence retains:
+
+- case and lane identity;
+- provider rank and request identity;
+- candidate, occurrence, owner, and unique-source hashes;
+- the exact deduplication basis and value; and
+- all originating lane memberships.
+
+Every valid provider candidate and indexed rejection reaches
+`provider-rows.csv`. First-seen sources and complete occurrence membership reach
+`unique-candidates.csv`. The blank `review.csv` exposes the topic, frozen
+baseline, full role profile, title, abstract, DOI, URL, provider ranks, and lane
+memberships, while relevance, novelty, supported roles, and notes remain blank.
+No model predicts or filters those labels.
+
+The artifact index hashes the manifest, execution, all lane journals, all case
+portfolios, and all three CSV boundaries. Final models recompute request,
+candidate, rejection, occurrence, unique-source, portfolio, cost, and latency
+totals from their child artifacts. `completed` means sixteen durable completed
+requests and eight portfolios only; source value remains `not_evaluated`.
+
+## Verification
+
+- new live-runner focused suite: 17/17 passed;
+- combined v7 preflight and runner suite: 27/27 passed;
+- full zero-network suite: 1,878 tests plus 657 subtests passed;
+- latest Ruff across the repository and the CI-equivalent narrow Pylint gate:
+  passed; and
+- default CLI dry-run: 8/8 cases, 16/16 lanes, zero live authority, zero model
+  calls, and no provider client construction.
+
+Two pre-registered boundary defects were re-injected and observed red:
+
+1. manifest persistence was moved after adapter construction; the injected
+   factory failed immediately because durable authority did not yet exist;
+2. the serialized unique-source boundary was changed to retain only the first
+   lane; the CSV seam test failed for all shared two-lane candidates.
+
+Both defects were restored, after which the combined v7 suite returned to
+27/27. The broader suite also caught one implementation issue during normal
+development: a generic response without provider usage was durable as a failed
+journal but could not be serialized as an identified OpenAlex row. The runner
+now preserves that failure without inventing provider lineage.
+
+## What this establishes
+
+This result establishes a bounded, write-once, identity-locked execution
+contract for a future separately authorized AA run. It preserves the exact
+relationship between spent requests, raw provider rows, duplicate occurrences,
+unique candidates, and blank human-review rows. It also keeps model calls,
+production reports, Planner triggers, supplementary search, retries, and
+recovery structurally disconnected.
+
+It does not establish live OpenAlex compatibility for AA, candidate relevance,
+novelty, precision, role coverability, incremental value of the evidence lane,
+report improvement, user value, autonomous tool choice, or production Tool
+Calling. A real run still requires separate authorization naming the merged
+revision, this fixture hash, no more than sixteen sequential anonymous OpenAlex
+requests, and a cost soft stop no greater than USD 0.02. Even a mechanically
+complete run requires a separately source-locked, eligible human review.

--- a/openalex_role_directed_live.py
+++ b/openalex_role_directed_live.py
@@ -1,0 +1,1501 @@
+"""Write-once live runner for the frozen AA01-AA08 v7 retrieval study.
+
+The production pipeline never imports this module.  It exists to determine
+whether two code-owned OpenAlex searches produce a reviewable evidence
+portfolio before any semantic judge or production Planner is considered.  The
+CLI defaults to a zero-network protocol check; provider work requires an
+explicit live flag, budget acknowledgement, fresh output path, and a separate
+owner authorization naming the merged revision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import re
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence import canonicalize_url, normalize_doi
+from academic_agent.evidence_gap import (
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    source_collection_sha256,
+)
+from academic_agent.source_pipeline import SourceCollection
+from academic_agent.tools.anonymous_openalex_search import (
+    AnonymousOpenAlexEvidenceSearchAdapter,
+)
+from academic_agent.tools.evidence_search import (
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+from openalex_role_directed_unseen import (
+    EXPECTED_FIXTURE_SHA256,
+    PreparedRoleDirectedCase,
+    RetrievalLaneId,
+    RoleDirectedCaseSpec,
+    RoleDirectedPortfolioContract,
+    RoleDirectedProviderContract,
+    RoleDirectedQualificationContract,
+    dry_run,
+    load_frozen_cases,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_RUNNER_PATH = Path(__file__).resolve()
+_IMPLEMENTATION_PATHS = {
+    "anonymous_openalex_search.py": (_ROOT / "src/academic_agent/tools/anonymous_openalex_search.py"),
+    "domain_evidence_search.py": (_ROOT / "src/academic_agent/tools/domain_evidence_search.py"),
+    "evidence.py": _ROOT / "src/academic_agent/evidence.py",
+    "evidence_gap.py": _ROOT / "src/academic_agent/evidence_gap.py",
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_role_directed_unseen.py": (_ROOT / "openalex_role_directed_unseen.py"),
+}
+# These hashes bind behavior-bearing dependencies before output reservation or
+# adapter construction.  The runner records its own observed hash instead of
+# recursively trying to embed an expected hash of its complete bytes.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "anonymous_openalex_search.py": ("bcaa201622fe5241115661cd9d5a6f7616761eddfedb9acf364b3693e7a044c9"),
+    "domain_evidence_search.py": ("ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab"),
+    "evidence.py": ("8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5"),
+    "evidence_gap.py": ("f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25"),
+    "evidence_search.py": ("2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"),
+    "openalex_role_directed_unseen.py": ("c69b67add9b0eee0ce3a19cd25213dab339b8e0d75e3828ab9cf161856622b7a"),
+}
+
+MAXIMUM_REQUESTS = 16
+MAXIMUM_PROVIDER_ROWS = 96
+MAXIMUM_SOFT_STOP_USD = 0.02
+ANONYMOUS_DAILY_BUDGET_USD = 0.10
+_CASE_ORDER = tuple(f"AA{index:02d}" for index in range(1, 9))
+_LANE_ORDER: tuple[RetrievalLaneId, RetrievalLaneId] = (
+    "technology_scope",
+    "technology_evidence",
+)
+_AGGREGATE_SOURCE_FILES = (
+    "manifest.json",
+    "execution.json",
+    "provider-rows.csv",
+    "unique-candidates.csv",
+    "review.csv",
+)
+_PROVIDER_ROW_COLUMNS = (
+    "case_id",
+    "lane_id",
+    "lane_index",
+    "provider",
+    "tool",
+    "provider_request_id",
+    "provider_request_id_source",
+    "provider_cost_basis",
+    "provider_result_index",
+    "adapter_disposition",
+    "candidate_sha256",
+    "occurrence_sha256",
+    "unique_candidate_sha256",
+    "deduplication_basis",
+    "deduplication_value",
+    "owner_occurrence_sha256",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+    "provider_rejection_code",
+    "rejection_detail",
+    "latency_ms",
+    "trace_id",
+)
+_UNIQUE_CANDIDATE_COLUMNS = (
+    "case_id",
+    "unique_candidate_sha256",
+    "owner_occurrence_sha256",
+    "lane_memberships",
+    "occurrence_sha256s",
+    "provider_ranks",
+    "candidate_sha256",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+)
+_REVIEW_COLUMNS = (
+    "case_id",
+    "topic",
+    "unique_candidate_sha256",
+    "lane_memberships",
+    "occurrence_count",
+    "provider_ranks",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+    "frozen_baseline_sources",
+    "frozen_role_profile",
+    "directly_relevant",
+    "baseline_novel",
+    "supported_role_ids",
+    "review_note",
+)
+
+
+RoleDirectedAdapter = Callable[
+    [ValidatedGapCall],
+    ToolAdapterResponse | dict[str, Any],
+]
+AdapterFactory = Callable[[], RoleDirectedAdapter]
+Clock = Callable[[], float]
+StopReason = Literal[
+    "completed",
+    "soft_stop",
+    "cost_uninspectable",
+    "request_failed",
+    "accounting_invalid",
+]
+ReviewPacketEligibility = Literal[
+    "eligible_for_source_lock",
+    "mechanical_gate_failed",
+    "incomplete",
+]
+CostState = Literal["known", "uninspectable", "not_observed"]
+DeduplicationBasis = Literal[
+    "new_unique",
+    "normalized_doi",
+    "canonical_openalex_url",
+]
+
+
+class OpenAlexRoleDirectedLiveError(ValueError):
+    """Raised when the frozen live boundary cannot be represented safely."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _plan_sha256(value: ValidatedGapPlan) -> str:
+    return _model_sha256(value)
+
+
+def _candidate_sha256(value: ToolEvidenceCandidate) -> str:
+    return _model_sha256(value)
+
+
+def _normalized_doi(value: str | None) -> str | None:
+    normalized = normalize_doi(value)
+    return normalized.casefold() if normalized else None
+
+
+def _canonical_openalex_url(value: str) -> str:
+    """Return a stable OpenAlex work identity, rejecting non-record URLs."""
+
+    canonical = canonicalize_url(value)
+    parsed = urlsplit(canonical)
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").casefold() != "openalex.org"
+        or parsed.query
+        or re.fullmatch(r"/W[0-9]+", parsed.path, flags=re.IGNORECASE) is None
+    ):
+        raise OpenAlexRoleDirectedLiveError("role-directed candidate URL is not a canonical OpenAlex work")
+    return f"https://openalex.org/{parsed.path.lstrip('/').upper()}"
+
+
+class RoleDirectedFrozenCaseArtifact(BaseModel):
+    """Complete deterministic case expansion persisted before provider work."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: RoleDirectedCaseSpec
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    lane_contract_sha256s: tuple[str, str]
+    source_collection: SourceCollection
+    validated_plan: ValidatedGapPlan
+
+    @model_validator(mode="after")
+    def _validate_expanded_identities(self) -> "RoleDirectedFrozenCaseArtifact":
+        if source_collection_sha256(self.source_collection) != self.collection_sha256:
+            raise ValueError("expanded source collection hash does not match")
+        if _plan_sha256(self.validated_plan) != self.plan_sha256:
+            raise ValueError("expanded validated plan hash does not match")
+        if self.spec.roles.profile().sha256() != self.profile_sha256:
+            raise ValueError("expanded role profile hash does not match")
+        if tuple(lane.lane_id for lane in self.spec.lanes) != _LANE_ORDER:
+            raise ValueError("manifest lane order drifted")
+        if len(self.validated_plan.calls) != 2:
+            raise ValueError("manifest case must retain two validated calls")
+        if any(len(value) != 64 for value in self.lane_contract_sha256s):
+            raise ValueError("manifest lane contract identity is malformed")
+        return self
+
+
+class RoleDirectedManifestArtifact(BaseModel):
+    """Write-once method, input, budget, and disconnection boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_role_directed_v7_manifest"] = "openalex_role_directed_v7_manifest"
+    cohort: Literal["development"] = "development"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    recovery_connected: Literal[False] = False
+    model_calls_authorized: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[16] = MAXIMUM_REQUESTS
+    maximum_provider_rows: Literal[96] = MAXIMUM_PROVIDER_ROWS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    provider_contract: RoleDirectedProviderContract
+    portfolio_contract: RoleDirectedPortfolioContract
+    qualification_contract: RoleDirectedQualificationContract
+    cases: tuple[RoleDirectedFrozenCaseArtifact, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_frozen_contract(self) -> "RoleDirectedManifestArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("manifest fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("manifest implementation identities do not match")
+        if tuple(case.spec.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("manifest cases must remain ordered AA01 through AA08")
+        lane_count = sum(len(case.validated_plan.calls) for case in self.cases)
+        if lane_count != MAXIMUM_REQUESTS:
+            raise ValueError("manifest must commit all sixteen lane requests")
+        return self
+
+
+class RoleDirectedLaneExecution(BaseModel):
+    """One spent-request journal with explicit identity and accounting state."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AA0[1-8]$")
+    lane_id: RetrievalLaneId
+    lane_index: int = Field(ge=0, le=1)
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    lane_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trace_id: str = Field(
+        pattern=(
+            r"^openalex-role-directed-v7-aa0[1-8]-"
+            r"(?:technology-scope|technology-evidence)$"
+        )
+    )
+    state: Literal["completed", "failed"]
+    outbound_attempt_count: Literal[1] = 1
+    response: ToolAdapterResponse | None = None
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    search_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_state_and_response(self) -> "RoleDirectedLaneExecution":
+        if self.lane_id != _LANE_ORDER[self.lane_index]:
+            raise ValueError("lane identity and index drifted")
+        if self.state == "completed":
+            if self.response is None:
+                raise ValueError("completed lane requires an adapter response")
+            if any(
+                value is not None
+                for value in (
+                    self.failure_type,
+                    self.failure_detail,
+                    self.failure_retryable,
+                )
+            ):
+                raise ValueError("completed lane cannot carry failure metadata")
+            if self.response.idempotency_key != self.idempotency_key:
+                raise ValueError("response idempotency identity drifted")
+            if self.response.search_cost_usd != self.search_cost_usd:
+                raise ValueError("lane cost drifted from provider response")
+            usage = self.response.provider_usage
+            if (
+                self.response.tool != "academic_search"
+                or usage is None
+                or usage.provider != "openalex"
+                or usage.cost_basis != "reported_usd"
+                or usage.result_count > 6
+            ):
+                raise ValueError("completed lane lacks the frozen OpenAlex accounting")
+        else:
+            if self.failure_type is None or self.failure_detail is None:
+                raise ValueError("failed lane requires explicit failure metadata")
+            if self.response is not None and (self.response.search_cost_usd != self.search_cost_usd):
+                raise ValueError("failed lane cost drifted from provider response")
+        return self
+
+
+class RoleDirectedCandidateOccurrence(BaseModel):
+    """One provider candidate and its deterministic portfolio lineage."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AA0[1-8]$")
+    lane_id: RetrievalLaneId
+    lane_index: int = Field(ge=0, le=1)
+    provider_result_index: int = Field(ge=0, le=5)
+    candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    unique_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    owner_occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    deduplication_basis: DeduplicationBasis
+    deduplication_value: str = Field(min_length=1, max_length=2000)
+    normalized_doi: str | None = Field(default=None, max_length=300)
+    canonical_openalex_url: str = Field(min_length=20, max_length=2000)
+    candidate: ToolEvidenceCandidate
+
+    @model_validator(mode="after")
+    def _validate_occurrence_identity(self) -> "RoleDirectedCandidateOccurrence":
+        if self.lane_id != _LANE_ORDER[self.lane_index]:
+            raise ValueError("occurrence lane identity and index drifted")
+        if _candidate_sha256(self.candidate) != self.candidate_sha256:
+            raise ValueError("occurrence candidate identity drifted")
+        if self.candidate.provider_result_index != self.provider_result_index:
+            raise ValueError("occurrence provider rank drifted")
+        is_owner = self.occurrence_sha256 == self.owner_occurrence_sha256
+        if is_owner != (self.deduplication_basis == "new_unique"):
+            raise ValueError("occurrence owner and deduplication basis disagree")
+        if self.normalized_doi != _normalized_doi(self.candidate.doi):
+            raise ValueError("occurrence DOI normalization drifted")
+        if self.canonical_openalex_url != _canonical_openalex_url(self.candidate.url):
+            raise ValueError("occurrence OpenAlex URL normalization drifted")
+        return self
+
+
+class RoleDirectedUniqueCandidate(BaseModel):
+    """One first-seen source retaining every lane and provider occurrence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AA0[1-8]$")
+    unique_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    owner_occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    primary_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    primary_candidate: ToolEvidenceCandidate
+    lane_memberships: tuple[RetrievalLaneId, ...] = Field(min_length=1, max_length=2)
+    occurrence_sha256s: tuple[str, ...] = Field(min_length=1, max_length=12)
+
+    @model_validator(mode="after")
+    def _validate_unique_identity(self) -> "RoleDirectedUniqueCandidate":
+        expected = _sha256_json(
+            {
+                "case_id": self.case_id,
+                "owner_occurrence_sha256": self.owner_occurrence_sha256,
+            }
+        )
+        if self.unique_candidate_sha256 != expected:
+            raise ValueError("unique candidate identity drifted")
+        if _candidate_sha256(self.primary_candidate) != self.primary_candidate_sha256:
+            raise ValueError("primary candidate identity drifted")
+        expected_lanes = tuple(lane for lane in _LANE_ORDER if lane in self.lane_memberships)
+        if self.lane_memberships != expected_lanes:
+            raise ValueError("unique candidate lane memberships are not canonical")
+        if len(set(self.occurrence_sha256s)) != len(self.occurrence_sha256s):
+            raise ValueError("unique candidate occurrences must be unique")
+        return self
+
+
+class RoleDirectedCasePortfolio(BaseModel):
+    """Two completed lane journals joined without semantic source filtering."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AA0[1-8]$")
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    lane_execution_sha256s: tuple[str, str]
+    occurrences: tuple[RoleDirectedCandidateOccurrence, ...] = Field(max_length=12)
+    unique_candidates: tuple[RoleDirectedUniqueCandidate, ...] = Field(max_length=12)
+
+    @model_validator(mode="after")
+    def _validate_portfolio_lineage(self) -> "RoleDirectedCasePortfolio":
+        if any(item.case_id != self.case_id for item in self.occurrences):
+            raise ValueError("portfolio occurrence belongs to another case")
+        occurrence_ids = tuple(item.occurrence_sha256 for item in self.occurrences)
+        if len(set(occurrence_ids)) != len(occurrence_ids):
+            raise ValueError("portfolio occurrence identities must be unique")
+        unique_ids = {item.unique_candidate_sha256 for item in self.unique_candidates}
+        if len(unique_ids) != len(self.unique_candidates):
+            raise ValueError("portfolio unique candidate identities must be unique")
+        if any(item.unique_candidate_sha256 not in unique_ids for item in self.occurrences):
+            raise ValueError("portfolio occurrence lost its unique-source owner")
+        by_unique = {
+            unique_id: tuple(
+                occurrence.occurrence_sha256
+                for occurrence in self.occurrences
+                if occurrence.unique_candidate_sha256 == unique_id
+            )
+            for unique_id in unique_ids
+        }
+        for candidate in self.unique_candidates:
+            if by_unique[candidate.unique_candidate_sha256] != (candidate.occurrence_sha256s):
+                raise ValueError("unique candidate occurrence lineage drifted")
+            lanes = tuple(
+                lane
+                for lane in _LANE_ORDER
+                if any(
+                    occurrence.lane_id == lane
+                    and occurrence.unique_candidate_sha256 == candidate.unique_candidate_sha256
+                    for occurrence in self.occurrences
+                )
+            )
+            if lanes != candidate.lane_memberships:
+                raise ValueError("unique candidate lane lineage drifted")
+        return self
+
+
+class RoleDirectedProviderSummary(BaseModel):
+    """Provider accounting where missing observations cannot become zero cost."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["openalex"] = "openalex"
+    access_mode: Literal["anonymous_no_key"] = "anonymous_no_key"
+    authorized_case_count: Literal[8] = 8
+    authorized_lane_count: Literal[16] = MAXIMUM_REQUESTS
+    attempted_lane_count: int = Field(ge=0, le=16)
+    successful_lane_count: int = Field(ge=0, le=16)
+    request_count: int = Field(ge=0, le=16)
+    cost_state: CostState
+    reported_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    total_latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+    stopped_reason: StopReason
+
+    @model_validator(mode="after")
+    def _validate_accounting(self) -> "RoleDirectedProviderSummary":
+        if self.successful_lane_count > self.attempted_lane_count:
+            raise ValueError("successful lanes cannot exceed attempted lanes")
+        if self.request_count != self.attempted_lane_count:
+            raise ValueError("every attempted lane must own exactly one request")
+        if self.cost_state == "known" and self.reported_cost_usd is None:
+            raise ValueError("known provider cost requires a numeric total")
+        if self.cost_state != "known" and self.reported_cost_usd is not None:
+            raise ValueError("unknown provider cost must keep USD null")
+        completed = self.successful_lane_count == MAXIMUM_REQUESTS
+        if (self.stopped_reason == "completed") != completed:
+            raise ValueError("provider completion does not match successful lanes")
+        return self
+
+
+class RoleDirectedExecutionArtifact(BaseModel):
+    """Final execution state; source value remains a later human judgment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_role_directed_v7_execution"] = "openalex_role_directed_v7_execution"
+    cohort: Literal["development"] = "development"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    recovery_connected: Literal[False] = False
+    model_call_count: Literal[0] = 0
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[16] = MAXIMUM_REQUESTS
+    maximum_provider_rows: Literal[96] = MAXIMUM_PROVIDER_ROWS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    request_count: int = Field(ge=0, le=16)
+    attempted_lane_count: int = Field(ge=0, le=16)
+    successful_lane_count: int = Field(ge=0, le=16)
+    completed_portfolio_count: int = Field(ge=0, le=8)
+    provider_row_count: int = Field(ge=0, le=96)
+    provider_candidate_count: int = Field(ge=0, le=96)
+    provider_rejection_count: int = Field(ge=0, le=96)
+    unique_candidate_count: int = Field(ge=0, le=96)
+    serialized_boundary_complete: Literal[True] = True
+    overall_state: Literal["completed", "partial"]
+    review_packet_eligibility: ReviewPacketEligibility
+    source_lock_state: Literal["not_created"] = "not_created"
+    human_review_state: Literal["not_prepared"] = "not_prepared"
+    source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    provider_summary: RoleDirectedProviderSummary
+    lane_executions: tuple[RoleDirectedLaneExecution, ...] = Field(max_length=16)
+    portfolios: tuple[RoleDirectedCasePortfolio, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_totals_and_states(self) -> "RoleDirectedExecutionArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("execution fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("execution implementation identities do not match")
+        expected_lanes = tuple((case_id, lane_id) for case_id in _CASE_ORDER for lane_id in _LANE_ORDER)
+        observed_lanes = tuple((item.case_id, item.lane_id) for item in self.lane_executions)
+        if observed_lanes != expected_lanes[: len(observed_lanes)]:
+            raise ValueError("lane executions must preserve the frozen prefix")
+        if len(self.lane_executions) != self.attempted_lane_count:
+            raise ValueError("attempted lanes must equal persisted journals")
+        if self.request_count != sum(item.outbound_attempt_count for item in self.lane_executions):
+            raise ValueError("request count must equal lane journal attempts")
+        successful = sum(item.state == "completed" for item in self.lane_executions)
+        if successful != self.successful_lane_count:
+            raise ValueError("successful-lane count drifted")
+        expected_portfolios = _CASE_ORDER[: len(self.portfolios)]
+        if tuple(item.case_id for item in self.portfolios) != expected_portfolios:
+            raise ValueError("case portfolios must preserve the frozen prefix")
+        if len(self.portfolios) != self.completed_portfolio_count:
+            raise ValueError("completed-portfolio count drifted")
+        for portfolio in self.portfolios:
+            lane_items = tuple(item for item in self.lane_executions if item.case_id == portfolio.case_id)
+            if len(lane_items) != 2 or any(item.state != "completed" for item in lane_items):
+                raise ValueError("portfolio requires two completed lane journals")
+            if tuple(_model_sha256(item) for item in lane_items) != (portfolio.lane_execution_sha256s):
+                raise ValueError("portfolio lane-journal identities drifted")
+        responses = tuple(item.response for item in self.lane_executions if item.response is not None)
+        provider_candidates = sum(len(item.candidates) for item in responses)
+        provider_rejections = sum(len(item.provider_rejections) for item in responses)
+        if provider_candidates != self.provider_candidate_count:
+            raise ValueError("provider-candidate count drifted")
+        if provider_rejections != self.provider_rejection_count:
+            raise ValueError("provider-rejection count drifted")
+        if provider_candidates + provider_rejections != self.provider_row_count:
+            raise ValueError("provider-row count drifted")
+        unique_candidates = sum(len(item.unique_candidates) for item in self.portfolios)
+        if unique_candidates != self.unique_candidate_count:
+            raise ValueError("unique-candidate count drifted")
+        portfolio_occurrences = sum(len(item.occurrences) for item in self.portfolios)
+        portfolio_case_ids = {item.case_id for item in self.portfolios}
+        completed_candidates = sum(
+            len(item.response.candidates)
+            for item in self.lane_executions
+            if item.state == "completed" and item.response is not None and item.case_id in portfolio_case_ids
+        )
+        if portfolio_occurrences != completed_candidates:
+            raise ValueError("completed provider candidate lost portfolio lineage")
+        if self.provider_summary.request_count != self.request_count:
+            raise ValueError("provider request count drifted from execution")
+        if self.provider_summary.attempted_lane_count != self.attempted_lane_count:
+            raise ValueError("provider attempted-lane count drifted")
+        if self.provider_summary.successful_lane_count != self.successful_lane_count:
+            raise ValueError("provider successful-lane count drifted")
+        expected_latency = sum(item.latency_ms for item in self.lane_executions)
+        if not math.isclose(
+            self.provider_summary.total_latency_ms,
+            expected_latency,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise ValueError("provider latency total drifted from lane journals")
+        completed = self.successful_lane_count == MAXIMUM_REQUESTS and self.completed_portfolio_count == len(
+            _CASE_ORDER
+        )
+        if (self.overall_state == "completed") != completed:
+            raise ValueError("overall state does not match durable completion")
+        expected_eligibility: ReviewPacketEligibility = "eligible_for_source_lock" if completed else "incomplete"
+        if self.review_packet_eligibility != expected_eligibility:
+            raise ValueError("review-packet eligibility drifted")
+        return self
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects because one lane authorizes one outbound request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _OneRequestTransport:
+    """Concrete transport with neither redirect following nor internal retry."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(endpoint, data=body, headers=dict(headers), method=method)
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read()
+
+
+def _file_sha256(path: Path) -> str:
+    try:
+        return _sha256_bytes(path.read_bytes())
+    except OSError as exc:
+        raise OpenAlexRoleDirectedLiveError(f"could not read frozen implementation file {path.name}: {exc}") from exc
+
+
+def verify_frozen_implementation() -> dict[str, str]:
+    """Reject dependency drift before output or adapter construction."""
+
+    if set(_IMPLEMENTATION_PATHS) != set(EXPECTED_IMPLEMENTATION_SHA256):
+        raise OpenAlexRoleDirectedLiveError("role-directed implementation lock names are inconsistent")
+    observed = {name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()}
+    if observed != EXPECTED_IMPLEMENTATION_SHA256:
+        changed = sorted(
+            name for name, digest in observed.items() if EXPECTED_IMPLEMENTATION_SHA256.get(name) != digest
+        )
+        raise OpenAlexRoleDirectedLiveError("role-directed implementation identity drifted: " + ", ".join(changed))
+    return observed
+
+
+def protocol_dry_run() -> dict[str, Any]:
+    """Expose frozen AA and dependency identities while opening zero sockets."""
+
+    result = dry_run("development")
+    result["implementation_sha256"] = verify_frozen_implementation()
+    result["runner_sha256"] = _file_sha256(_RUNNER_PATH)
+    result["live_runner_maximum_requests"] = MAXIMUM_REQUESTS
+    result["live_runner_maximum_soft_stop_usd"] = MAXIMUM_SOFT_STOP_USD
+    return result
+
+
+def _manifest_artifact(
+    cases: tuple[PreparedRoleDirectedCase, ...],
+    *,
+    fixture_sha256: str,
+    implementation_sha256: dict[str, str],
+    runner_sha256: str,
+    soft_stop_usd: float,
+    provider_contract: RoleDirectedProviderContract,
+    portfolio_contract: RoleDirectedPortfolioContract,
+    qualification_contract: RoleDirectedQualificationContract,
+) -> RoleDirectedManifestArtifact:
+    return RoleDirectedManifestArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        provider_contract=provider_contract,
+        portfolio_contract=portfolio_contract,
+        qualification_contract=qualification_contract,
+        cases=tuple(
+            RoleDirectedFrozenCaseArtifact(
+                spec=case.spec,
+                collection_sha256=case.collection_sha256,
+                plan_sha256=case.plan_sha256,
+                profile_sha256=case.profile_sha256,
+                case_contract_sha256=case.case_contract_sha256,
+                lane_contract_sha256s=case.lane_contract_sha256s,
+                source_collection=case.collection,
+                validated_plan=case.plan,
+            )
+            for case in cases
+        ),
+    )
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise OpenAlexRoleDirectedLiveError(f"could not create write-once artifact {path}: {exc}") from exc
+
+
+def _json_text(value: BaseModel | dict[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def _write_lane_journal(
+    output_dir: Path,
+    execution: RoleDirectedLaneExecution,
+) -> None:
+    journal_dir = output_dir / "lane-executions"
+    journal_dir.mkdir(exist_ok=True)
+    filename = f"{execution.case_id}--{execution.lane_id}.json"
+    _write_new(journal_dir / filename, _json_text(execution))
+
+
+def _write_case_portfolio(
+    output_dir: Path,
+    portfolio: RoleDirectedCasePortfolio,
+) -> None:
+    portfolio_dir = output_dir / "case-portfolios"
+    portfolio_dir.mkdir(exist_ok=True)
+    _write_new(
+        portfolio_dir / f"{portfolio.case_id}.json",
+        _json_text(portfolio),
+    )
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    """Describe invalid structure without copying potentially unsafe input."""
+
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "adapter response failed validation"
+
+
+def _trace_id(case_id: str, lane_id: RetrievalLaneId) -> str:
+    return f"openalex-role-directed-v7-{case_id.casefold()}-{lane_id.replace('_', '-')}"
+
+
+def _failure_execution(
+    case: PreparedRoleDirectedCase,
+    lane_id: RetrievalLaneId,
+    lane_index: int,
+    call: ValidatedGapCall,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool | None,
+    latency_ms: float,
+    response: ToolAdapterResponse | None = None,
+    search_cost_usd: float | None = None,
+) -> RoleDirectedLaneExecution:
+    return RoleDirectedLaneExecution(
+        case_id=case.spec.case_id,
+        lane_id=lane_id,
+        lane_index=lane_index,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        lane_contract_sha256=case.lane_contract_sha256s[lane_index],
+        idempotency_key=call.idempotency_key,
+        trace_id=_trace_id(case.spec.case_id, lane_id),
+        state="failed",
+        response=response,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        search_cost_usd=search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _completed_execution(
+    case: PreparedRoleDirectedCase,
+    lane_id: RetrievalLaneId,
+    lane_index: int,
+    call: ValidatedGapCall,
+    response: ToolAdapterResponse,
+    latency_ms: float,
+) -> RoleDirectedLaneExecution:
+    return RoleDirectedLaneExecution(
+        case_id=case.spec.case_id,
+        lane_id=lane_id,
+        lane_index=lane_index,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        lane_contract_sha256=case.lane_contract_sha256s[lane_index],
+        idempotency_key=call.idempotency_key,
+        trace_id=_trace_id(case.spec.case_id, lane_id),
+        state="completed",
+        response=response,
+        search_cost_usd=response.search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _occurrence_sha256(
+    case_id: str,
+    lane_id: RetrievalLaneId,
+    provider_result_index: int,
+    candidate_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "case_id": case_id,
+            "lane_id": lane_id,
+            "provider_result_index": provider_result_index,
+            "candidate_sha256": candidate_sha256,
+        }
+    )
+
+
+def _compatible_url_owner(
+    owners: list[dict[str, Any]],
+    normalized_doi: str | None,
+) -> dict[str, Any] | None:
+    """Return one unambiguous owner without merging conflicting non-empty DOIs."""
+
+    compatible = [
+        owner
+        for owner in owners
+        if owner["normalized_doi"] is None or normalized_doi is None or owner["normalized_doi"] == normalized_doi
+    ]
+    return compatible[0] if len(compatible) == 1 else None
+
+
+def build_case_portfolio(
+    case: PreparedRoleDirectedCase,
+    lane_executions: tuple[RoleDirectedLaneExecution, RoleDirectedLaneExecution],
+) -> RoleDirectedCasePortfolio:
+    """Join two lanes in deterministic order while retaining every occurrence."""
+
+    if tuple(item.lane_id for item in lane_executions) != _LANE_ORDER or any(
+        item.state != "completed" or item.response is None for item in lane_executions
+    ):
+        raise OpenAlexRoleDirectedLiveError("case portfolio requires both ordered completed lane journals")
+
+    owner_records: list[dict[str, Any]] = []
+    seen_dois: dict[str, dict[str, Any]] = {}
+    seen_urls: dict[str, list[dict[str, Any]]] = {}
+    occurrences: list[RoleDirectedCandidateOccurrence] = []
+
+    for lane_execution in lane_executions:
+        response = lane_execution.response
+        if response is None:  # pragma: no cover - guarded above and by Pydantic
+            raise OpenAlexRoleDirectedLiveError("completed lane lost its response")
+        for candidate in response.candidates:
+            provider_index = candidate.provider_result_index
+            if provider_index is None:
+                raise OpenAlexRoleDirectedLiveError("provider-accounted candidate lost its result index")
+            candidate_digest = _candidate_sha256(candidate)
+            occurrence_digest = _occurrence_sha256(
+                case.spec.case_id,
+                lane_execution.lane_id,
+                provider_index,
+                candidate_digest,
+            )
+            normalized_doi = _normalized_doi(candidate.doi)
+            canonical_url = _canonical_openalex_url(candidate.url)
+            owner = seen_dois.get(normalized_doi) if normalized_doi else None
+            basis: DeduplicationBasis = "normalized_doi"
+            deduplication_value = normalized_doi or canonical_url
+            if owner is None:
+                owner = _compatible_url_owner(
+                    seen_urls.get(canonical_url, []),
+                    normalized_doi,
+                )
+                basis = "canonical_openalex_url"
+                deduplication_value = canonical_url
+            if owner is None:
+                unique_digest = _sha256_json(
+                    {
+                        "case_id": case.spec.case_id,
+                        "owner_occurrence_sha256": occurrence_digest,
+                    }
+                )
+                owner = {
+                    "unique_candidate_sha256": unique_digest,
+                    "owner_occurrence_sha256": occurrence_digest,
+                    "primary_candidate_sha256": candidate_digest,
+                    "primary_candidate": candidate,
+                    "normalized_doi": normalized_doi,
+                    "canonical_openalex_url": canonical_url,
+                    "lane_memberships": [],
+                    "occurrence_sha256s": [],
+                }
+                owner_records.append(owner)
+                if normalized_doi:
+                    seen_dois[normalized_doi] = owner
+                seen_urls.setdefault(canonical_url, []).append(owner)
+                basis = "new_unique"
+                deduplication_value = normalized_doi or canonical_url
+            # Every occurrence can introduce a useful secondary identity.  For
+            # example, a no-DOI first row may be followed by the same OpenAlex
+            # record with a DOI.  Registering both identities here lets later
+            # occurrences join the same owner without changing the first-seen
+            # source or erasing the path by which it was discovered.
+            if normalized_doi and normalized_doi not in seen_dois:
+                seen_dois[normalized_doi] = owner
+            url_owners = seen_urls.setdefault(canonical_url, [])
+            if not any(existing is owner for existing in url_owners):
+                url_owners.append(owner)
+            if lane_execution.lane_id not in owner["lane_memberships"]:
+                owner["lane_memberships"].append(lane_execution.lane_id)
+            owner["occurrence_sha256s"].append(occurrence_digest)
+            occurrences.append(
+                RoleDirectedCandidateOccurrence(
+                    case_id=case.spec.case_id,
+                    lane_id=lane_execution.lane_id,
+                    lane_index=lane_execution.lane_index,
+                    provider_result_index=provider_index,
+                    candidate_sha256=candidate_digest,
+                    occurrence_sha256=occurrence_digest,
+                    unique_candidate_sha256=owner["unique_candidate_sha256"],
+                    owner_occurrence_sha256=owner["owner_occurrence_sha256"],
+                    deduplication_basis=basis,
+                    deduplication_value=deduplication_value,
+                    normalized_doi=normalized_doi,
+                    canonical_openalex_url=canonical_url,
+                    candidate=candidate,
+                )
+            )
+
+    unique_candidates = tuple(
+        RoleDirectedUniqueCandidate(
+            case_id=case.spec.case_id,
+            unique_candidate_sha256=owner["unique_candidate_sha256"],
+            owner_occurrence_sha256=owner["owner_occurrence_sha256"],
+            primary_candidate_sha256=owner["primary_candidate_sha256"],
+            primary_candidate=owner["primary_candidate"],
+            lane_memberships=tuple(owner["lane_memberships"]),
+            occurrence_sha256s=tuple(owner["occurrence_sha256s"]),
+        )
+        for owner in owner_records
+    )
+    return RoleDirectedCasePortfolio(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        plan_sha256=case.plan_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        lane_execution_sha256s=tuple(_model_sha256(item) for item in lane_executions),
+        occurrences=tuple(occurrences),
+        unique_candidates=unique_candidates,
+    )
+
+
+def _provider_cost(
+    executions: list[RoleDirectedLaneExecution],
+) -> tuple[CostState, float | None]:
+    if not executions:
+        return "not_observed", None
+    values = [item.search_cost_usd for item in executions]
+    if any(value is None for value in values):
+        return "uninspectable", None
+    return "known", sum(value for value in values if value is not None)
+
+
+def _elapsed_ms(clock: Clock, started_at: float) -> float:
+    """Keep a spent request journal even if an injected clock goes backwards."""
+
+    elapsed_ms = (clock() - started_at) * 1000.0
+    if not math.isfinite(elapsed_ms):
+        raise OpenAlexRoleDirectedLiveError("request clock produced non-finite latency")
+    return max(0.0, elapsed_ms)
+
+
+def _json_compact(value: object) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def _occurrence_by_provider_row(
+    portfolios: tuple[RoleDirectedCasePortfolio, ...],
+) -> dict[tuple[str, RetrievalLaneId, int], RoleDirectedCandidateOccurrence]:
+    return {
+        (item.case_id, item.lane_id, item.provider_result_index): item
+        for portfolio in portfolios
+        for item in portfolio.occurrences
+    }
+
+
+def _provider_rows(
+    executions: tuple[RoleDirectedLaneExecution, ...],
+    portfolios: tuple[RoleDirectedCasePortfolio, ...],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    occurrence_map = _occurrence_by_provider_row(portfolios)
+    for execution in executions:
+        response = execution.response
+        if response is None:
+            continue
+        usage = response.provider_usage
+        if usage is None:
+            # A generically parseable ToolAdapterResponse can still fail the
+            # frozen OpenAlex accounting contract.  Its safe shape remains in
+            # the failed lane journal, but rows without a provider request
+            # identity cannot be promoted into the auditable provider table.
+            if execution.state == "failed":
+                continue
+            raise OpenAlexRoleDirectedLiveError("persisted OpenAlex response lost provider accounting")
+        for candidate in response.candidates:
+            index = candidate.provider_result_index
+            if index is None:
+                raise OpenAlexRoleDirectedLiveError("provider candidate lost its result index")
+            occurrence = occurrence_map.get((execution.case_id, execution.lane_id, index))
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "lane_id": execution.lane_id,
+                    "lane_index": str(execution.lane_index),
+                    "provider": usage.provider,
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id or "",
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(index),
+                    "adapter_disposition": "candidate",
+                    "candidate_sha256": _candidate_sha256(candidate),
+                    "occurrence_sha256": (occurrence.occurrence_sha256 if occurrence else ""),
+                    "unique_candidate_sha256": (occurrence.unique_candidate_sha256 if occurrence else ""),
+                    "deduplication_basis": (occurrence.deduplication_basis if occurrence else "NOT_EVALUATED"),
+                    "deduplication_value": (occurrence.deduplication_value if occurrence else ""),
+                    "owner_occurrence_sha256": (occurrence.owner_occurrence_sha256 if occurrence else ""),
+                    "title": candidate.title,
+                    "url": candidate.url,
+                    "normalized_doi": _normalized_doi(candidate.doi) or "",
+                    "publisher": candidate.publisher,
+                    "published_date": (candidate.published_date.isoformat() if candidate.published_date else ""),
+                    "evidence_summary": candidate.evidence_summary,
+                    "summary_source": candidate.summary_source,
+                    "citation_count": (str(candidate.citation_count) if candidate.citation_count is not None else ""),
+                    "provider_rejection_code": "",
+                    "rejection_detail": "",
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+        for rejection in response.provider_rejections:
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "lane_id": execution.lane_id,
+                    "lane_index": str(execution.lane_index),
+                    "provider": usage.provider,
+                    "tool": response.tool,
+                    "provider_request_id": response.provider_request_id or "",
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(rejection.provider_result_index),
+                    "adapter_disposition": "provider_rejected",
+                    "candidate_sha256": "",
+                    "occurrence_sha256": "",
+                    "unique_candidate_sha256": "",
+                    "deduplication_basis": "NOT_APPLICABLE",
+                    "deduplication_value": "",
+                    "owner_occurrence_sha256": "",
+                    "title": rejection.title or "",
+                    "url": rejection.url or "",
+                    "normalized_doi": "",
+                    "publisher": "",
+                    "published_date": "",
+                    "evidence_summary": "",
+                    "summary_source": "",
+                    "citation_count": "",
+                    "provider_rejection_code": rejection.code,
+                    "rejection_detail": rejection.detail,
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+    rows.sort(
+        key=lambda row: (
+            _CASE_ORDER.index(row["case_id"]),
+            int(row["lane_index"]),
+            int(row["provider_result_index"]),
+        )
+    )
+    return rows
+
+
+def _unique_and_review_rows(
+    manifest: RoleDirectedManifestArtifact,
+    portfolios: tuple[RoleDirectedCasePortfolio, ...],
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    case_inputs = {item.spec.case_id: item for item in manifest.cases}
+    unique_rows: list[dict[str, str]] = []
+    review_rows: list[dict[str, str]] = []
+    for portfolio in portfolios:
+        occurrences = {item.occurrence_sha256: item for item in portfolio.occurrences}
+        frozen = case_inputs[portfolio.case_id]
+        for item in portfolio.unique_candidates:
+            candidate = item.primary_candidate
+            provider_ranks = [
+                {
+                    "lane_id": occurrences[occurrence_id].lane_id,
+                    "provider_result_index": (occurrences[occurrence_id].provider_result_index),
+                }
+                for occurrence_id in item.occurrence_sha256s
+            ]
+            lane_memberships = _json_compact(item.lane_memberships)
+            unique_rows.append(
+                {
+                    "case_id": item.case_id,
+                    "unique_candidate_sha256": item.unique_candidate_sha256,
+                    "owner_occurrence_sha256": item.owner_occurrence_sha256,
+                    "lane_memberships": lane_memberships,
+                    "occurrence_sha256s": _json_compact(item.occurrence_sha256s),
+                    "provider_ranks": _json_compact(provider_ranks),
+                    "candidate_sha256": item.primary_candidate_sha256,
+                    "title": candidate.title,
+                    "url": candidate.url,
+                    "normalized_doi": _normalized_doi(candidate.doi) or "",
+                    "publisher": candidate.publisher,
+                    "published_date": (candidate.published_date.isoformat() if candidate.published_date else ""),
+                    "evidence_summary": candidate.evidence_summary,
+                    "summary_source": candidate.summary_source,
+                    "citation_count": (str(candidate.citation_count) if candidate.citation_count is not None else ""),
+                }
+            )
+            review_rows.append(
+                {
+                    "case_id": item.case_id,
+                    "topic": frozen.spec.topic,
+                    "unique_candidate_sha256": item.unique_candidate_sha256,
+                    "lane_memberships": lane_memberships,
+                    "occurrence_count": str(len(item.occurrence_sha256s)),
+                    "provider_ranks": _json_compact(provider_ranks),
+                    "title": candidate.title,
+                    "url": candidate.url,
+                    "normalized_doi": _normalized_doi(candidate.doi) or "",
+                    "publisher": candidate.publisher,
+                    "published_date": (candidate.published_date.isoformat() if candidate.published_date else ""),
+                    "evidence_summary": candidate.evidence_summary,
+                    "summary_source": candidate.summary_source,
+                    "citation_count": (str(candidate.citation_count) if candidate.citation_count is not None else ""),
+                    "frozen_baseline_sources": _json_compact(
+                        [source.model_dump(mode="json") for source in frozen.source_collection.academic_sources]
+                    ),
+                    "frozen_role_profile": _json_compact(frozen.spec.roles.profile().model_dump(mode="json")),
+                    "directly_relevant": "",
+                    "baseline_novel": "",
+                    "supported_role_ids": "",
+                    "review_note": "",
+                }
+            )
+    return unique_rows, review_rows
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    manifest: RoleDirectedManifestArtifact,
+    artifact: RoleDirectedExecutionArtifact,
+) -> None:
+    provider_rows = _provider_rows(artifact.lane_executions, artifact.portfolios)
+    unique_rows, review_rows = _unique_and_review_rows(manifest, artifact.portfolios)
+    if len(provider_rows) != artifact.provider_row_count:
+        raise OpenAlexRoleDirectedLiveError("provider row disappeared before the aggregate boundary")
+    if len(unique_rows) != artifact.unique_candidate_count:
+        raise OpenAlexRoleDirectedLiveError("unique candidate disappeared before the aggregate boundary")
+    if len(review_rows) != artifact.unique_candidate_count:
+        raise OpenAlexRoleDirectedLiveError("candidate disappeared before the blank review boundary")
+    _write_new(output_dir / "execution.json", _json_text(artifact))
+    _write_new(
+        output_dir / "provider-rows.csv",
+        _csv_text(_PROVIDER_ROW_COLUMNS, provider_rows),
+    )
+    _write_new(
+        output_dir / "unique-candidates.csv",
+        _csv_text(_UNIQUE_CANDIDATE_COLUMNS, unique_rows),
+    )
+    _write_new(
+        output_dir / "review.csv",
+        _csv_text(_REVIEW_COLUMNS, review_rows),
+    )
+    source_paths = [output_dir / name for name in _AGGREGATE_SOURCE_FILES]
+    source_paths.extend(sorted((output_dir / "lane-executions").glob("*.json")))
+    source_paths.extend(sorted((output_dir / "case-portfolios").glob("*.json")))
+    file_hashes = {path.relative_to(output_dir).as_posix(): _sha256_bytes(path.read_bytes()) for path in source_paths}
+    _write_new(
+        output_dir / "artifact-index.json",
+        _json_text(
+            {
+                "schema_version": 1,
+                "mode": "openalex_role_directed_v7_artifact_index",
+                "production_connected": False,
+                "report_workflow_connected": False,
+                "planner_trigger_connected": False,
+                "recovery_connected": False,
+                "model_call_count": 0,
+                "source_file_sha256": file_hashes,
+            }
+        ),
+    )
+
+
+def execute_live_study(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    acknowledge_anonymous_daily_budget: bool,
+    adapter_factory: AdapterFactory | None = None,
+    monotonic_clock: Clock | None = None,
+) -> RoleDirectedExecutionArtifact:
+    """Run AA01-AA08 under a provider-reported write-once budget boundary."""
+
+    if not 0.0 < soft_stop_usd <= MAXIMUM_SOFT_STOP_USD:
+        raise OpenAlexRoleDirectedLiveError("role-directed v7 soft stop must be greater than zero and at most USD 0.02")
+    if not acknowledge_anonymous_daily_budget:
+        raise OpenAlexRoleDirectedLiveError("role-directed v7 execution requires daily-budget acknowledgement")
+    if (os.getenv("OPENALEX_API_KEY") or "").strip():
+        raise OpenAlexRoleDirectedLiveError("anonymous role-directed v7 study refuses a configured OPENALEX_API_KEY")
+    if output_dir.exists():
+        raise FileExistsError(f"role-directed v7 output already exists: {output_dir}")
+
+    fixture_sha256, challenge, cases = load_frozen_cases("development")
+    implementation_sha256 = verify_frozen_implementation()
+    runner_sha256 = _file_sha256(_RUNNER_PATH)
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest_artifact(
+        cases,
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        provider_contract=challenge.provider_contract,
+        portfolio_contract=challenge.portfolio_contract,
+        qualification_contract=challenge.qualification_contract,
+    )
+    # This file is durable authority for the exact calls.  Constructing the
+    # adapter before it exists would make a crash leave an unaudited spender.
+    adapter: RoleDirectedAdapter
+    _write_new(output_dir / "manifest.json", _json_text(manifest))
+    if adapter_factory is not None:
+        adapter = adapter_factory()
+    else:
+        adapter = AnonymousOpenAlexEvidenceSearchAdapter(transport=_OneRequestTransport())
+
+    executions: list[RoleDirectedLaneExecution] = []
+    portfolios: list[RoleDirectedCasePortfolio] = []
+    clock = monotonic_clock or time.perf_counter
+    known_cost = 0.0
+    stopped_reason: StopReason = "completed"
+    stop = False
+    for case in cases:
+        case_executions: list[RoleDirectedLaneExecution] = []
+        for lane_index, (lane, call) in enumerate(zip(case.spec.lanes, case.plan.calls, strict=True)):
+            if known_cost + 1e-12 >= soft_stop_usd:
+                stopped_reason = "soft_stop"
+                stop = True
+                break
+            lane_stop_reason: StopReason | None = None
+            started_at = clock()
+            try:
+                raw_response = adapter(call)
+            except ToolAdapterFailure as exc:
+                latency_ms = _elapsed_ms(clock, started_at)
+                execution = _failure_execution(
+                    case,
+                    lane.lane_id,
+                    lane_index,
+                    call,
+                    failure_type=exc.failure_type,
+                    failure_detail=str(exc),
+                    failure_retryable=exc.retryable,
+                    latency_ms=latency_ms,
+                    search_cost_usd=exc.search_cost_usd,
+                )
+                lane_stop_reason = "request_failed"
+            else:
+                latency_ms = _elapsed_ms(clock, started_at)
+                try:
+                    response = ToolAdapterResponse.model_validate(raw_response)
+                except ValidationError as exc:
+                    execution = _failure_execution(
+                        case,
+                        lane.lane_id,
+                        lane_index,
+                        call,
+                        failure_type="adapter_response_invalid",
+                        failure_detail=_validation_detail(exc),
+                        failure_retryable=False,
+                        latency_ms=latency_ms,
+                    )
+                    lane_stop_reason = "accounting_invalid"
+                else:
+                    if response.idempotency_key != call.idempotency_key:
+                        execution = _failure_execution(
+                            case,
+                            lane.lane_id,
+                            lane_index,
+                            call,
+                            failure_type="adapter_identity_mismatch",
+                            failure_detail=("adapter response idempotency key does not match the authorized lane"),
+                            failure_retryable=False,
+                            latency_ms=latency_ms,
+                            response=response,
+                            search_cost_usd=response.search_cost_usd,
+                        )
+                        lane_stop_reason = "accounting_invalid"
+                    else:
+                        try:
+                            execution = _completed_execution(
+                                case,
+                                lane.lane_id,
+                                lane_index,
+                                call,
+                                response,
+                                latency_ms,
+                            )
+                        except ValidationError as exc:
+                            execution = _failure_execution(
+                                case,
+                                lane.lane_id,
+                                lane_index,
+                                call,
+                                failure_type="adapter_response_invalid",
+                                failure_detail=_validation_detail(exc),
+                                failure_retryable=False,
+                                latency_ms=latency_ms,
+                                response=response,
+                                search_cost_usd=response.search_cost_usd,
+                            )
+                            lane_stop_reason = "accounting_invalid"
+
+            # The spent request reaches durable storage before any later lane
+            # can begin.  This also preserves a one-lane partial case without
+            # pretending that a two-lane portfolio exists.
+            _write_lane_journal(output_dir, execution)
+            executions.append(execution)
+            case_executions.append(execution)
+            if execution.search_cost_usd is None:
+                stopped_reason = lane_stop_reason or "cost_uninspectable"
+                stop = True
+                break
+            known_cost += execution.search_cost_usd
+            if lane_stop_reason is not None:
+                stopped_reason = lane_stop_reason
+                stop = True
+                break
+
+        if len(case_executions) == 2 and all(item.state == "completed" for item in case_executions):
+            portfolio = build_case_portfolio(
+                case,
+                (case_executions[0], case_executions[1]),
+            )
+            _write_case_portfolio(output_dir, portfolio)
+            portfolios.append(portfolio)
+        if stop:
+            break
+
+    cost_state, reported_cost = _provider_cost(executions)
+    successful_lane_count = sum(item.state == "completed" for item in executions)
+    provider_candidate_count = sum(len(item.response.candidates) for item in executions if item.response is not None)
+    provider_rejection_count = sum(
+        len(item.response.provider_rejections) for item in executions if item.response is not None
+    )
+    completed = successful_lane_count == MAXIMUM_REQUESTS and len(portfolios) == len(_CASE_ORDER)
+    if completed:
+        stopped_reason = "completed"
+    provider_summary = RoleDirectedProviderSummary(
+        attempted_lane_count=len(executions),
+        successful_lane_count=successful_lane_count,
+        request_count=len(executions),
+        cost_state=cost_state,
+        reported_cost_usd=reported_cost,
+        total_latency_ms=sum(item.latency_ms for item in executions),
+        stopped_reason=stopped_reason,
+    )
+    artifact = RoleDirectedExecutionArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        request_count=len(executions),
+        attempted_lane_count=len(executions),
+        successful_lane_count=successful_lane_count,
+        completed_portfolio_count=len(portfolios),
+        provider_row_count=provider_candidate_count + provider_rejection_count,
+        provider_candidate_count=provider_candidate_count,
+        provider_rejection_count=provider_rejection_count,
+        unique_candidate_count=sum(len(item.unique_candidates) for item in portfolios),
+        overall_state="completed" if completed else "partial",
+        review_packet_eligibility=("eligible_for_source_lock" if completed else "incomplete"),
+        provider_summary=provider_summary,
+        lane_executions=tuple(executions),
+        portfolios=tuple(portfolios),
+    )
+    _write_final_artifacts(output_dir, manifest, artifact)
+    return artifact
+
+
+def _stdout_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Frozen OpenAlex role-directed retrieval v7 live harness.")
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    parser.add_argument("--acknowledge-anonymous-daily-budget", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(_stdout_json(protocol_dry_run()))
+        return 0
+    if args.output_dir is None or args.soft_stop_usd is None:
+        raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
+    artifact = execute_live_study(
+        output_dir=args.output_dir,
+        soft_stop_usd=args.soft_stop_usd,
+        acknowledge_anonymous_daily_budget=(args.acknowledge_anonymous_daily_budget),
+    )
+    print(_stdout_json(artifact.model_dump(mode="json")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_role_directed_live.py
+++ b/tests/test_openalex_role_directed_live.py
@@ -1,0 +1,534 @@
+"""Zero-network seams for the frozen role-directed retrieval v7 live runner."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import socket
+
+import pytest
+
+import openalex_role_directed_live as live
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from openalex_role_directed_unseen import (
+    PreparedRoleDirectedCase,
+    RetrievalLaneId,
+    load_frozen_cases,
+)
+
+
+def _work_id(case_id: str, suffix: int) -> str:
+    return f"https://openalex.org/W{int(case_id[2:]):02d}{suffix:06d}"
+
+
+def _candidate(
+    case_id: str,
+    lane_id: RetrievalLaneId,
+    index: int,
+    *,
+    shared: bool,
+) -> ToolEvidenceCandidate:
+    if shared:
+        # Deliberately use a different OpenAlex record in the second lane.  The
+        # shared DOI, rather than a coincident URL, must own this merge.
+        suffix = 1 if lane_id == "technology_scope" else 9
+        doi = f"10.5555/{case_id.casefold()}.shared"
+        label = "shared DOI candidate"
+    else:
+        suffix = 2 if lane_id == "technology_scope" else 3
+        doi = None
+        label = f"{lane_id} unique candidate"
+    return ToolEvidenceCandidate(
+        title=f"{case_id} {label} for role-directed retrieval",
+        url=_work_id(case_id, suffix),
+        doi=doi,
+        publisher="OpenAlex zero-network role-directed fixture",
+        evidence_summary=(
+            f"This synthetic {lane_id} abstract for {case_id} preserves enough "
+            "content to exercise portfolio persistence without asserting source value."
+        ),
+        summary_source="abstract",
+        citation_count=index + 1,
+        provider_result_index=index,
+    )
+
+
+def _response(
+    case: PreparedRoleDirectedCase,
+    lane_id: RetrievalLaneId,
+    call: ValidatedGapCall,
+    *,
+    reported_cost_usd: float,
+    include_rejection: bool,
+    identity_mismatch: bool,
+) -> ToolAdapterResponse:
+    candidates = (
+        _candidate(case.spec.case_id, lane_id, 0, shared=True),
+        _candidate(case.spec.case_id, lane_id, 1, shared=False),
+    )
+    rejections = (
+        (
+            ProviderResultRejection(
+                provider_result_index=2,
+                code="provider_result_not_object",
+                detail="zero-network fixture row is not an object",
+            ),
+        )
+        if include_rejection
+        else ()
+    )
+    idempotency_key = "0" * 64 if identity_mismatch else call.idempotency_key
+    usage = ToolProviderUsage(
+        provider="openalex",
+        request_id=f"client-v7-{call.idempotency_key[:16]}",
+        request_id_source="client_generated",
+        result_count=len(candidates) + len(rejections),
+        cost_basis="reported_usd",
+        reported_cost_usd=reported_cost_usd,
+    )
+    return ToolAdapterResponse(
+        tool="academic_search",
+        idempotency_key=idempotency_key,
+        candidates=candidates,
+        provider_rejections=rejections,
+        search_cost_usd=reported_cost_usd,
+        provider_request_id=usage.request_id,
+        provider_usage=usage,
+    )
+
+
+class RecordingFactory:
+    """Injected adapter proving construction, request, and portfolio ordering."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        *,
+        reported_cost_usd: float = 0.001,
+        include_rejection: bool = False,
+        fail_at: int | None = None,
+        invalid_at: int | None = None,
+        identity_mismatch_at: int | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.reported_cost_usd = reported_cost_usd
+        self.include_rejection = include_rejection
+        self.fail_at = fail_at
+        self.invalid_at = invalid_at
+        self.identity_mismatch_at = identity_mismatch_at
+        self.constructed = 0
+        self.calls: list[tuple[str, RetrievalLaneId]] = []
+        _, _, cases = load_frozen_cases("development")
+        self.by_key = {
+            call.idempotency_key: (case, lane.lane_id)
+            for case in cases
+            for lane, call in zip(case.spec.lanes, case.plan.calls, strict=True)
+        }
+
+    def __call__(self):
+        # A socket-capable object cannot predate the complete durable method.
+        assert (self.output_dir / "manifest.json").is_file()
+        self.constructed += 1
+
+        def run(call: ValidatedGapCall):
+            case, lane_id = self.by_key[call.idempotency_key]
+            for previous_case, previous_lane in self.calls:
+                assert (self.output_dir / "lane-executions" / f"{previous_case}--{previous_lane}.json").is_file()
+            if self.calls and self.calls[-1][0] != case.spec.case_id:
+                assert (self.output_dir / "case-portfolios" / f"{self.calls[-1][0]}.json").is_file()
+            ordinal = len(self.calls)
+            self.calls.append((case.spec.case_id, lane_id))
+            if ordinal == self.fail_at:
+                raise ToolAdapterFailure(
+                    "offline injected provider failure",
+                    retryable=False,
+                    failure_type="provider_authentication",
+                    search_cost_usd=None,
+                )
+            if ordinal == self.invalid_at:
+                return {
+                    "tool": "academic_search",
+                    "idempotency_key": call.idempotency_key,
+                    "outbound_request_count": 1,
+                }
+            return _response(
+                case,
+                lane_id,
+                call,
+                reported_cost_usd=self.reported_cost_usd,
+                include_rejection=self.include_rejection,
+                identity_mismatch=ordinal == self.identity_mismatch_at,
+            )
+
+        return run
+
+
+def _run(tmp_path: Path, *, monotonic_clock=None, **factory_options):
+    output = tmp_path / "role-directed-v7"
+    factory = RecordingFactory(output, **factory_options)
+    artifact = live.execute_live_study(
+        output_dir=output,
+        soft_stop_usd=0.02,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=factory,
+        monotonic_clock=monotonic_clock,
+    )
+    return output, factory, artifact
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_protocol_dry_run_locks_sixteen_lanes_without_live_authority(monkeypatch):
+    def block_socket(*args, **kwargs):
+        raise AssertionError("dry-run attempted to create a socket")
+
+    monkeypatch.setattr(socket, "socket", block_socket)
+    result = live.protocol_dry_run()
+
+    assert result["case_count"] == 8
+    assert sum(len(case["lanes"]) for case in result["cases"]) == 16
+    assert result["implementation_sha256"] == live.EXPECTED_IMPLEMENTATION_SHA256
+    assert len(result["runner_sha256"]) == 64
+    assert result["live_runner_maximum_requests"] == 16
+    assert result["live_runner_maximum_soft_stop_usd"] == 0.02
+    assert result["live_provider_requests_authorized"] is False
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["production_connected"] is False
+
+
+def test_complete_run_reaches_all_write_once_boundaries(tmp_path):
+    output, factory, artifact = _run(tmp_path)
+    expected_calls = [
+        (f"AA{index:02d}", lane_id)
+        for index in range(1, 9)
+        for lane_id in live._LANE_ORDER  # noqa: SLF001
+    ]
+
+    assert factory.constructed == 1
+    assert factory.calls == expected_calls
+    assert artifact.overall_state == "completed"
+    assert artifact.request_count == 16
+    assert artifact.successful_lane_count == 16
+    assert artifact.completed_portfolio_count == 8
+    assert artifact.provider_candidate_count == 32
+    assert artifact.unique_candidate_count == 24
+    assert artifact.model_call_count == 0
+    assert artifact.review_packet_eligibility == "eligible_for_source_lock"
+    assert artifact.provider_summary.reported_cost_usd == pytest.approx(0.016)
+    assert len(list((output / "lane-executions").glob("*.json"))) == 16
+    assert len(list((output / "case-portfolios").glob("*.json"))) == 8
+    assert (output / "artifact-index.json").is_file()
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    execution = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert manifest["runner_sha256"] == artifact.runner_sha256
+    assert execution["runner_sha256"] == artifact.runner_sha256
+
+
+def test_every_provider_row_occurrence_and_lane_membership_reaches_csv(tmp_path):
+    output, _, artifact = _run(tmp_path, include_rejection=True)
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    unique_rows = _read_csv(output / "unique-candidates.csv")
+    review_rows = _read_csv(output / "review.csv")
+
+    assert artifact.provider_row_count == 48
+    assert len(provider_rows) == 48
+    assert len(unique_rows) == len(review_rows) == 24
+    candidates = [row for row in provider_rows if row["adapter_disposition"] == "candidate"]
+    rejections = [row for row in provider_rows if row["adapter_disposition"] == "provider_rejected"]
+    assert len(candidates) == 32
+    assert len(rejections) == 16
+    assert all(row["occurrence_sha256"] for row in candidates)
+    assert all(row["unique_candidate_sha256"] for row in candidates)
+    assert all(not row["occurrence_sha256"] for row in rejections)
+    shared = [row for row in unique_rows if len(json.loads(row["occurrence_sha256s"])) == 2]
+    assert len(shared) == 8
+    assert all(json.loads(row["lane_memberships"]) == ["technology_scope", "technology_evidence"] for row in shared)
+    assert all(
+        not row["directly_relevant"]
+        and not row["baseline_novel"]
+        and not row["supported_role_ids"]
+        and not row["review_note"]
+        for row in review_rows
+    )
+    assert all(row["frozen_baseline_sources"] for row in review_rows)
+    assert all(row["frozen_role_profile"] for row in review_rows)
+
+
+def test_doi_precedes_url_and_conflicting_nonempty_dois_do_not_merge():
+    _, _, cases = load_frozen_cases("development")
+    case = cases[0]
+    scope_call, evidence_call = case.plan.calls
+
+    scope_candidates = (
+        ToolEvidenceCandidate(
+            title="No DOI owner candidate",
+            url="https://openalex.org/W100000001",
+            publisher="OpenAlex fixture",
+            evidence_summary="A sufficiently long synthetic abstract for URL identity testing.",
+            summary_source="abstract",
+            provider_result_index=0,
+        ),
+        ToolEvidenceCandidate(
+            title="DOI owner candidate",
+            url="https://openalex.org/W100000002",
+            doi="10.5555/doi-owner",
+            publisher="OpenAlex fixture",
+            evidence_summary="A sufficiently long synthetic abstract for DOI identity testing.",
+            summary_source="abstract",
+            provider_result_index=1,
+        ),
+    )
+    evidence_candidates = (
+        ToolEvidenceCandidate(
+            title="URL duplicate gains DOI",
+            url="https://openalex.org/W100000001",
+            doi="10.5555/url-owner-later-doi",
+            publisher="OpenAlex fixture",
+            evidence_summary="A sufficiently long synthetic abstract for URL fallback testing.",
+            summary_source="abstract",
+            provider_result_index=0,
+        ),
+        ToolEvidenceCandidate(
+            title="DOI duplicate has another URL",
+            url="https://openalex.org/W100000003",
+            doi="10.5555/doi-owner",
+            publisher="OpenAlex fixture",
+            evidence_summary="A sufficiently long synthetic abstract for DOI precedence testing.",
+            summary_source="abstract",
+            provider_result_index=1,
+        ),
+        ToolEvidenceCandidate(
+            title="Conflicting DOI on owner URL",
+            url="https://openalex.org/W100000002",
+            doi="10.5555/conflicting-doi",
+            publisher="OpenAlex fixture",
+            evidence_summary="A sufficiently long synthetic abstract for DOI conflict testing.",
+            summary_source="abstract",
+            provider_result_index=2,
+        ),
+    )
+
+    def response(call, candidates):
+        usage = ToolProviderUsage(
+            provider="openalex",
+            request_id=f"request-{call.idempotency_key[:12]}",
+            request_id_source="client_generated",
+            result_count=len(candidates),
+            cost_basis="reported_usd",
+            reported_cost_usd=0.001,
+        )
+        return ToolAdapterResponse(
+            tool="academic_search",
+            idempotency_key=call.idempotency_key,
+            candidates=candidates,
+            search_cost_usd=0.001,
+            provider_request_id=usage.request_id,
+            provider_usage=usage,
+        )
+
+    scope_execution = live._completed_execution(  # noqa: SLF001
+        case,
+        "technology_scope",
+        0,
+        scope_call,
+        response(scope_call, scope_candidates),
+        1.0,
+    )
+    evidence_execution = live._completed_execution(  # noqa: SLF001
+        case,
+        "technology_evidence",
+        1,
+        evidence_call,
+        response(evidence_call, evidence_candidates),
+        1.0,
+    )
+    portfolio = live.build_case_portfolio(
+        case,
+        (scope_execution, evidence_execution),
+    )
+
+    assert len(portfolio.occurrences) == 5
+    assert len(portfolio.unique_candidates) == 3
+    assert [item.deduplication_basis for item in portfolio.occurrences] == [
+        "new_unique",
+        "new_unique",
+        "canonical_openalex_url",
+        "normalized_doi",
+        "new_unique",
+    ]
+
+
+def test_request_latency_reaches_journal_csv_and_provider_summary(tmp_path):
+    ticks = iter(float(value) for value in range(32))
+    output, _, artifact = _run(
+        tmp_path,
+        monotonic_clock=lambda: next(ticks),
+    )
+
+    assert artifact.provider_summary.total_latency_ms == pytest.approx(16000.0)
+    assert {item.latency_ms for item in artifact.lane_executions} == {1000.0}
+    first_journal = (output / "lane-executions" / "AA01--technology_scope.json").read_text(encoding="utf-8")
+    assert '"latency_ms": 1000.0' in first_journal
+    assert {row["latency_ms"] for row in _read_csv(output / "provider-rows.csv")} == {"1000.0"}
+
+
+@pytest.mark.parametrize(
+    ("soft_stop", "acknowledge"),
+    [(0.0, True), (0.0201, True), (0.02, False)],
+)
+def test_invalid_authorization_fails_before_adapter_and_output(
+    tmp_path,
+    soft_stop,
+    acknowledge,
+):
+    output = tmp_path / "forbidden"
+    factory = RecordingFactory(output)
+
+    with pytest.raises(live.OpenAlexRoleDirectedLiveError):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=soft_stop,
+            acknowledge_anonymous_daily_budget=acknowledge,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_configured_key_fails_before_adapter_and_output(tmp_path, monkeypatch):
+    output = tmp_path / "configured-key"
+    factory = RecordingFactory(output)
+    monkeypatch.setenv("OPENALEX_API_KEY", "configured-secret")
+
+    with pytest.raises(live.OpenAlexRoleDirectedLiveError, match="refuses"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_existing_output_fails_before_adapter_construction(tmp_path):
+    output = tmp_path / "existing"
+    output.mkdir()
+    factory = RecordingFactory(output)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+
+
+def test_implementation_hash_drift_fails_before_factory_and_output(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "hash-drift"
+    factory = RecordingFactory(output)
+    monkeypatch.setitem(
+        live.EXPECTED_IMPLEMENTATION_SHA256,
+        "openalex_role_directed_unseen.py",
+        "0" * 64,
+    )
+
+    with pytest.raises(live.OpenAlexRoleDirectedLiveError, match="identity drifted"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_soft_stop_commits_one_lane_without_fabricating_a_portfolio(tmp_path):
+    output, factory, artifact = _run(tmp_path, reported_cost_usd=0.02)
+
+    assert factory.calls == [("AA01", "technology_scope")]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "soft_stop"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert len(artifact.lane_executions) == 1
+    assert not artifact.portfolios
+    assert (output / "lane-executions" / "AA01--technology_scope.json").is_file()
+    assert not (output / "case-portfolios" / "AA01.json").exists()
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    assert len(provider_rows) == 2
+    assert {row["deduplication_basis"] for row in provider_rows} == {"NOT_EVALUATED"}
+
+
+def test_provider_failure_remains_an_inspectable_partial_result(tmp_path):
+    output, factory, artifact = _run(tmp_path, fail_at=0)
+
+    assert factory.calls == [("AA01", "technology_scope")]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "request_failed"
+    assert artifact.provider_summary.cost_state == "uninspectable"
+    assert artifact.lane_executions[0].failure_type == "provider_authentication"
+    assert (output / "lane-executions" / "AA01--technology_scope.json").is_file()
+
+
+def test_invalid_response_is_not_reported_as_a_provider_pass(tmp_path):
+    output, factory, artifact = _run(tmp_path, invalid_at=0)
+
+    assert factory.calls == [("AA01", "technology_scope")]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.lane_executions[0].failure_type == "adapter_response_invalid"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "execution.json").is_file()
+
+
+def test_identity_mismatch_preserves_response_but_blocks_portfolio(tmp_path):
+    output, factory, artifact = _run(tmp_path, identity_mismatch_at=0)
+
+    assert factory.calls == [("AA01", "technology_scope")]
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.lane_executions[0].response is not None
+    assert artifact.lane_executions[0].failure_type == "adapter_identity_mismatch"
+    assert not artifact.portfolios
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    assert len(provider_rows) == 2
+    assert {row["deduplication_basis"] for row in provider_rows} == {"NOT_EVALUATED"}
+
+
+def test_artifacts_expose_no_key_or_unrelated_process_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNRELATED_PROCESS_SECRET", "must-not-reach-artifacts")
+    output, _, _ = _run(tmp_path)
+
+    rendered = "\n".join(path.read_text(encoding="utf-8") for path in output.rglob("*") if path.is_file())
+    assert "must-not-reach-artifacts" not in rendered
+    assert "configured-secret" not in rendered
+    assert '"api_key_used": false' in rendered
+
+
+def test_production_worker_does_not_import_role_directed_components():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
+
+    assert "openalex_role_directed_live" not in worker
+    assert "openalex_role_directed_unseen" not in worker
+    assert "AnonymousOpenAlexEvidenceSearchAdapter" not in worker


### PR DESCRIPTION
## Why\n\nThe v7 offline preflight froze two role-directed OpenAlex lanes per AA case, but it did not yet provide a crash-auditable execution boundary. A later live value study needs to preserve every request and candidate relationship before any provider result is visible.\n\n## What changed\n\n- pre-register the bounded AA-only live protocol before implementation\n- add a write-once runner that persists the full manifest before adapter construction\n- commit each one-request lane journal before later work and each two-lane portfolio before the next case\n- deduplicate by normalized DOI first and unambiguous OpenAlex URL second while preserving every occurrence and lane membership\n- expose complete provider-row, rejection, candidate, blank-review, cost, latency, trace, and artifact-hash boundaries\n- add 17 focused runner tests and synchronize English/Chinese README plus AGENTS.md\n\n## Verification\n\n- 17/17 focused live-runner tests\n- 27/27 combined v7 tests\n- 1,878 tests + 657 subtests\n- latest Ruff\n- CI-equivalent narrow Pylint\n- zero-network default dry-run: 8 cases / 16 lanes\n- defect reinjection: late manifest persistence and truncated duplicate lineage both make their seam tests fail\n\n## Limits\n\nNo OpenAlex request, model call, human review, unseen AB access, planner/report connection, retry, redirect, recovery, or production Tool Calling is authorized by this PR. AA remains unconsumed and source value remains 
ot_evaluated.