### PR TITLE
Record the bounded v7 AA development run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1878 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1879 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -671,23 +671,27 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md`, and
   `docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md`.
 
-  A separately pre-registered write-once AA runner is now implemented but has
-  not executed. It locks the fixture and six behavior dependencies before
-  output reservation, writes the complete 16-lane manifest before adapter
-  construction, commits each one-request lane journal before later work, and
-  commits each DOI-first/URL-second deduplicated portfolio before the next
-  case. Raw provider rows, rejections, duplicate occurrences, all lane
-  memberships, unique candidates, blank review rows, cost, latency and trace
-  identities reach hashed artifacts. Its focused suite passes 17/17 and the
-  combined v7 suite passes 27/27. Moving manifest persistence after adapter
-  construction and dropping a duplicate source's second lane membership were
-  each re-injected and made the intended seam test fail before restoration.
-  No OpenAlex request, model call or human review has occurred; AA remains
-  unconsumed, AB remains unopened, candidate value remains `not_evaluated`,
-  and production Tool Calling remains disconnected. See
-  `docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md`
+  The separately pre-registered write-once AA runner has now completed its one
+  permitted development execution on exact merged revision `2a61c32`. Sixteen
+  of sixteen one-attempt anonymous OpenAlex requests and all eight portfolios
+  committed for USD 0.016 of provider-reported cost. All 96 provider rows (84
+  candidates and 12 rejections) reached the aggregate boundary, producing 79
+  DOI/URL-deduplicated blank-review candidates. Independent recomputation found
+  zero mismatches across 29 indexed files; all request IDs, idempotency keys,
+  and costs were inspectable. No model or production/report/Planner/recovery
+  connection occurred. After every artifact committed, strict Windows GBK
+  stdout failed on U+2022 in one title. AA was not rerun: a zero-network test
+  reproduced the original exception, and only the stdout projection now uses
+  reversible ASCII JSON escapes while authoritative UTF-8 artifacts remain
+  unchanged. AA is consumed, AB is unopened, human review is not prepared,
+  candidate value remains `not_evaluated`, and production Tool Calling remains
+  disconnected. The next allowed work is an exact source lock and eligible
+  label-blind human review; do not rerun or tune on AA, open AB, or connect
+  production. See
+  `docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md`,
+  `docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md`,
   and
-  `docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md`.
+  `docs/results-2026-09-02-openalex-role-directed-retrieval-v7-development-live.md`.
 
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,

--- a/README.md
+++ b/README.md
@@ -910,26 +910,31 @@ execution, or model client. Its focused suite passes 10/10, including a
 re-injected boundary defect where the second lane existed internally but did
 not reach serialized output.
 
-A separately pre-registered write-once AA runner is now implemented but has not
-been executed. It locks the fixture and six behavior dependencies before output
-reservation, persists the complete 16-lane manifest before adapter
-construction, writes every one-request lane journal before later work, and
-persists each DOI-first/URL-second deduplicated portfolio before the next case.
-Raw provider rows, rejections, duplicate occurrences, all lane memberships,
-unique candidates, blank human-review rows, cost, latency, and trace identities
-reach hashed artifacts. The 17/17 runner suite and 27/27 combined v7 suite pass;
-moving the manifest after adapter construction and dropping a duplicate lane
-membership each made the intended seam test fail before restoration. No
-provider request or human review has occurred: AA is unconsumed, AB is unopened,
-candidate value is `not_evaluated`, and production Tool Calling remains
-disconnected. See the
+The separately pre-registered write-once AA runner has now completed its one
+permitted development execution on exact merged revision `2a61c32`. Sixteen of
+sixteen one-attempt anonymous OpenAlex requests and 8/8 case portfolios reached
+durable artifacts for provider-reported cost USD 0.016. All 96 provider rows
+(84 candidates and 12 rejections) reached the aggregate boundary; deterministic
+DOI/URL deduplication produced 79 unique blank-review candidates. Independent
+recomputation found zero mismatches across 29 indexed files, and all request
+IDs, idempotency keys, and per-request costs were inspectable. No model call or
+production/report/Planner/recovery connection occurred.
+
+After every artifact had committed, the final Windows GBK stdout projection
+failed on a U+2022 provider-title character. AA was not rerun: a zero-network
+regression reproduced the exception, and stdout now uses reversible ASCII JSON
+escapes while authoritative artifacts retain original UTF-8. AA is consumed,
+AB remains unopened, and candidate value remains `not_evaluated` until an exact
+source lock and eligible human review apply all five frozen gates. Production
+Tool Calling remains disconnected. See the
 [v7 pre-registration](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md),
 [pre-provider AB05 erratum](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md),
 the [offline implementation result](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md),
 the [live-runner pre-registration](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md),
-and the [live-runner implementation result](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md).
+the [live-runner implementation result](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md),
+and the [AA live result](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-development-live.md).
 
-Local verification now passes **1,878 tests plus 657 subtests**, latest Ruff,
+Local verification now passes **1,879 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2214,22 +2219,26 @@ metrics 缺失，4 个核心来源哈希与 56 份索引工件全部一致，且
 通过，其中包括一次接缝缺陷回注：第二条 lane 在内部存在却没有到达序列化输出
 时，边界测试会失败。
 
-另行预注册的 AA write-once runner 现已实现但尚未执行。它在预留输出目录前
-锁定 fixture 与 6 个行为依赖，在构造 adapter 前持久化完整 16-lane manifest，
-每个单请求 lane 日志落盘后才允许后续工作，并在进入下一案例前持久化按 DOI
-优先、OpenAlex URL 次优去重的双 lane portfolio。原始供应商行、拒绝项、重复
-出现记录、全部 lane 成员关系、唯一候选、空白人工评审行、成本、延迟与 trace
-身份均进入带哈希工件。runner 的 17/17 与 v7 组合 27/27 测试通过；将 manifest
-移到 adapter 构造之后、或丢失重复来源的第二条 lane 成员关系，都会使对应接缝
-测试失败。目前未发起供应商请求，也未进行人工评审，因此 AA 尚未消耗、AB
-保持未打开、候选价值为 `not_evaluated`，生产 Tool Calling 仍未连接。详见
+另行预注册的 AA write-once runner 已在精确合并版本 `2a61c32` 上完成唯一一次
+允许的开发集执行：16/16 次匿名 OpenAlex 单尝试请求与 8/8 个案例 portfolio
+全部落入持久化工件，供应商报告成本为 0.016 美元。96 条供应商行（84 条候选、
+12 条拒绝）均到达聚合边界，按 DOI/URL 确定性去重后得到 79 条唯一空白评审
+候选。独立重算 29 个索引文件得到 0 个哈希不一致，全部请求 ID、幂等键和单请求
+成本可检查；模型、生产、报告、Planner 与恢复连接均为 0。
+
+全部工件提交后，Windows GBK stdout 因供应商标题中的 U+2022 字符在最终打印
+阶段报错。项目没有重跑 AA：零网络回归测试复现了异常，stdout 改用可逆 ASCII
+JSON 转义，而权威工件仍保留原始 UTF-8。AA 现已消费，AB 保持未打开；在精确
+source lock 与合格人工评审应用全部五项冻结门槛前，候选价值仍为
+`not_evaluated`，生产 Tool Calling 继续断开。详见
 [v7 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7.md)、
 [AB05 供应商调用前勘误](docs/errata-2026-09-01-openalex-role-directed-v7-ab05-query.md)、
 [离线实现结果](docs/results-2026-09-01-openalex-role-directed-retrieval-v7-offline.md)、
-[live runner 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md)
-与[live runner 实现结果](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md)。
+[live runner 预注册](docs/prereg-2026-09-01-openalex-role-directed-retrieval-v7-live-runner.md)、
+[live runner 实现结果](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-live-runner.md)
+与[AA 真实运行结果](docs/results-2026-09-02-openalex-role-directed-retrieval-v7-development-live.md)。
 
-本地验证现通过 **1,878 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+本地验证现通过 **1,879 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/results-2026-09-02-openalex-role-directed-retrieval-v7-development-live.md
+++ b/docs/results-2026-09-02-openalex-role-directed-retrieval-v7-development-live.md
@@ -1,0 +1,121 @@
+# Result: role-directed retrieval v7 AA development live run
+
+Date: 2026-09-02 (Australia/Sydney)
+
+Status: provider and mechanical execution completed; source value not evaluated;
+AA01-AA08 consumed; AB01-AB08 unopened; production disconnected
+
+## Authorized identity and scope
+
+The owner separately authorized this run on merged revision
+`2a61c32d4693f4f9a44965312c378dc8f14fb308` and frozen fixture SHA-256
+`9a91746d0a77fee6d57bfc91ae4329ab78a89109fca6f35171d56c0f3ee95761`.
+The authorization permitted only the sixteen ordered AA01-AA08 anonymous
+OpenAlex Works requests, with a USD 0.02 provider-reported soft stop. It forbade
+retry, redirect, model calls, repair, recovery, supplementary search, access to
+AB01-AB08, and production connection.
+
+The default zero-network preflight first reproduced 8/8 cases, 16/16 lane
+identities, the exact fixture hash, and all six frozen implementation hashes.
+The combined v7 suite passed 27/27 immediately before the provider run. The
+environment contained no `OPENALEX_API_KEY`, and the write-once output directory
+was fresh.
+
+## Provider execution
+
+The live runner completed the frozen sequence without retry or recovery:
+
+| Measure | Observed |
+|---|---:|
+| Ordered OpenAlex requests | 16/16 |
+| Successful lane journals | 16/16 |
+| Completed case portfolios | 8/8 |
+| Provider rows | 96 |
+| Provider candidates | 84 |
+| Provider rejections | 12 |
+| DOI/URL-deduplicated candidates | 79 |
+| Blank human-review rows | 79 |
+| Provider-reported cost | USD 0.016 |
+| Total request latency | 23,540.564 ms |
+| Per-request latency, min / median / max | 708.016 / 1,523.273 / 2,503.959 ms |
+| Model calls | 0 |
+
+The candidate boundary by case was:
+
+| Case | Provider candidates | Provider rejections | Unique candidates |
+|---|---:|---:|---:|
+| AA01 | 11 | 1 | 11 |
+| AA02 | 11 | 1 | 10 |
+| AA03 | 9 | 3 | 7 |
+| AA04 | 10 | 2 | 9 |
+| AA05 | 10 | 2 | 10 |
+| AA06 | 12 | 0 | 12 |
+| AA07 | 11 | 1 | 10 |
+| AA08 | 10 | 2 | 10 |
+
+These are transport and portfolio counts, not relevance labels. In particular,
+the 79-row review boundary contains no populated relevance, novelty, role, or
+reviewer-note fields.
+
+## Artifact audit
+
+The artifact index covers 29 files: the manifest, final execution, three CSV
+boundaries, sixteen lane journals, and eight case portfolios. Independent local
+recomputation found zero SHA-256 mismatches. All sixteen provider request IDs
+and all sixteen idempotency keys were unique; every lane had inspectable
+provider cost. The execution reports `serialized_boundary_complete=true`,
+`source_lock_state=not_created`, `human_review_state=not_prepared`, and
+`source_value_state=not_evaluated`.
+
+Selected top-level hashes are:
+
+| Artifact | SHA-256 |
+|---|---|
+| `manifest.json` | `221e874252ea010fb60fe253a7aaa06a115f0dc2e38eb2dffac48ccfc6863d7d` |
+| `execution.json` | `50aeddf9ec2604b12cdc62eb8ae2949c056ce9feeb0a06a60cc3a68ccdcd2506` |
+| `provider-rows.csv` | `5f01e459e612d10778925da5f3a2b478eb1a492635212dc80e82b1712513ec0b` |
+| `unique-candidates.csv` | `1a11206970c8d751de01a896f8f36ef4f904d8ef146f9fbcdd87545b25bd21af` |
+| `review.csv` | `2a62f9b3367413c61f87553b184356eb4c3dfcbef2d25beac14fb859d0210719` |
+| `artifact-index.json` | `7ff4d2a86d19caac5e2a73177870f77540ec19a431bc42e3f321324830bf56bc` |
+
+The authoritative write-once directory remains local at
+`outputs/openalex-role-directed-v7-aa-live-2026-09-02/`. A later source-lock
+stage must bind these exact bytes rather than reconstructing or rerunning AA.
+
+## Post-artifact Windows stdout defect
+
+After `execute_live_study()` had written every aggregate and indexed artifact,
+the CLI attempted to print the returned object through a strict Windows GBK
+text stream. One provider title contained U+2022 BULLET, so the final
+`print()` raised `UnicodeEncodeError` and the process exited with code 1. The
+exception happened after the complete result was durably committed; the
+execution artifact itself is `completed` and no provider retry was attempted.
+AA must not be rerun to obtain a cosmetic zero exit code.
+
+A zero-network regression test now sends the same character through the CLI
+JSON projection under strict GBK. Re-injecting the original non-ASCII stdout
+projection made that test fail with the observed exception. The repair escapes
+non-ASCII code points only in stdout while preserving original UTF-8 text in the
+write-once artifacts. This operational repair does not alter the frozen query,
+provider result, portfolio, cost, or any artifact hash above.
+
+## Decision
+
+The frozen provider and mechanical gates passed: OpenAlex compatibility,
+bounded one-attempt accounting, durable request ordering, complete row and
+lineage serialization, zero model calls, and production isolation were all
+observed for this one AA run. This does not pass a human candidate-value gate.
+
+AA01-AA08 are now consumed development evidence and may not be tuned on or
+rerun as validation. AB01-AB08 remain unopened. The next permitted step is a
+separately implemented source lock and eligible label-blind human review of the
+79 frozen candidates. Only if all five pre-registered human gates pass may a
+separate AB evaluation be considered. This result does not authorize a semantic
+judge, Planner trigger study, report connection, or production Tool Calling.
+
+## Explicit non-claims
+
+This run does not establish source relevance, novelty, role coverability,
+candidate precision, evidence-lane incremental value, report improvement,
+planner-trigger precision, user value, recall, an SLO, or production readiness.
+The latency distribution contains sixteen observations and is not a p95 claim.

--- a/openalex_role_directed_live.py
+++ b/openalex_role_directed_live.py
@@ -1469,7 +1469,13 @@ def execute_live_study(
 
 
 def _stdout_json(value: object) -> str:
-    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+    """Render reversible CLI JSON independently of the caller's locale."""
+
+    # Authoritative write-once artifacts preserve original UTF-8 provider text.
+    # Stdout is only a projection and may still be strict GBK on Windows, so
+    # escaping non-ASCII code points prevents a completed live study from being
+    # reported as failed after every auditable artifact has already committed.
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/tests/test_openalex_role_directed_live.py
+++ b/tests/test_openalex_role_directed_live.py
@@ -526,6 +526,18 @@ def test_artifacts_expose_no_key_or_unrelated_process_secret(tmp_path, monkeypat
     assert '"api_key_used": false' in rendered
 
 
+def test_cli_json_projection_survives_strict_gbk_stdout():
+    """The completed AA run reached disk before a bullet broke GBK stdout."""
+
+    payload = {"title": "Role-directed evidence • completed"}
+
+    rendered = live._stdout_json(payload)
+    encoded = rendered.encode("gbk", errors="strict")
+
+    assert "\\u2022" in rendered
+    assert json.loads(encoded.decode("gbk")) == payload
+
+
 def test_production_worker_does_not_import_role_directed_components():
     worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Why

The separately authorized AA01-AA08 retrieval-first v7 run has now consumed the development cohort. The repository must record the mechanical result without presenting it as source-value or production Tool Calling validation.

The run also exposed a post-artifact Windows GBK stdout failure: all write-once artifacts were complete, but printing a provider title containing U+2022 returned exit code one. Rerunning consumed AA data for a cosmetic exit code would violate the frozen protocol.

## What changed

- records 16/16 one-attempt OpenAlex requests, 8/8 portfolios, USD 0.016 provider cost, 96 provider rows, 79 unique blank-review candidates, and zero mismatches across 29 indexed files
- marks AA consumed, AB unopened, human value not evaluated, and production disconnected
- makes only the CLI stdout projection use reversible ASCII JSON escapes while preserving original UTF-8 artifacts
- adds a regression test that failed with the observed UnicodeEncodeError before the repair
- updates README and AGENTS.md with the exact next boundary: source lock and eligible human review

## Verification

- `uv run pytest -q`: 1,879 passed + 657 subtests
- focused v7 suite: 28/28
- `uv run --with ruff ruff check .`: passed
- CI-equivalent narrow Pylint: passed

No provider request was made after the frozen AA execution, and no model, AB, Planner, report, recovery, or production connection was used.