### PR TITLE
Add bounded adaptive role-gap routing for Tool Calling v8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1894 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1909 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -175,7 +175,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  106 test modules plus conftest, organised by subject
+tests/                  107 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -715,6 +715,33 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/results-2026-09-02-openalex-role-directed-v7-human-review-boundary.md`,
   and `docs/results-2026-09-02-openalex-role-directed-v7-human-review.md`.
 
+
+  A separately pre-registered adaptive role-gap closure v8 now targets the
+  measured v7 failure instead of adding a third fixed broad query. Fresh
+  AC01-AC08 development and AD01-AD08 unseen cohorts each freeze one anchor
+  query, five candidate-local role-signal portfolios, one closure priority and
+  five mutually exclusive role-bound closure queries. The router may select
+  only the first mechanically missing role in frozen priority order, or emit
+  `abstain_no_mechanical_role_gap`; a future case can execute at most one
+  anchor and one closure request, with no model-written query.
+
+  The raw-byte-locked zero-network preflight is implemented and passes 15/15
+  focused tests. It exposes 48 potential call identities per cohort while
+  capping future execution at 16 requests and zero model calls. The first run
+  stopped because six closure queries failed the existing two-token topic-
+  scope authorization through lexical inflection. The authorization rule was
+  retained; a narrow pre-provider erratum appended one existing topic token to
+  each query and preserves both fixture hashes. Cross-candidate phrase pooling
+  and dropping one valid closure only at serialization were separately
+  re-injected and made their seam tests fail before restoration. AC and AD
+  remain unopened; provider compatibility, routing correctness, source value,
+  role coverability and report value are `not_evaluated`. Do not build or run a
+  live AC harness without a separate identity-locked runner and explicit owner
+  authorization, do not open AD before AC passes every frozen gate, and do not
+  connect v8 to production. See
+  `docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`,
+  `docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md`, and
+  `docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md`.
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus
@@ -723,7 +750,8 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   and
   docs/results-2026-08-30-openalex-evidence-set-v5-provider-contract-amendment-implementation.md.
   Keep
-  `pipeline_worker.py` disconnected from the executor, adapters, v2/v3/v4/v5/v6/v7
+  `pipeline_worker.py` disconnected from the executor, adapters,
+  v2/v3/v4/v5/v6/v7/v8
   candidates, live runners and review modules.
   See `docs/results-2026-08-25-evidence-gap-tool-execution-phase2.md`,
   `docs/results-2026-08-25-evidence-gap-live-adapter-phase3-implementation.md`,

--- a/README.md
+++ b/README.md
@@ -952,7 +952,29 @@ the [human-review pre-registration](docs/prereg-2026-09-02-openalex-role-directe
 the [human-review boundary result](docs/results-2026-09-02-openalex-role-directed-v7-human-review-boundary.md),
 and the [human-review result](docs/results-2026-09-02-openalex-role-directed-v7-human-review.md).
 
-Local verification now passes **1,894 tests plus 657 subtests**, latest Ruff,
+A separately pre-registered **adaptive role-gap v8** now targets the measured
+reason v7 failed: its second fixed lane found useful papers but closed none of
+the three missing role sets. Fresh AC01-AC08 development and AD01-AD08 unseen
+cohorts freeze one anchor plus five mutually exclusive role-closure queries per
+case. After the anchor, a deterministic candidate-local screen may select only
+the first missing role in frozen priority order; if no role is missing it must
+explicitly abstain, so a future case can spend one or two searches but never
+more than two.
+
+The corrected raw-byte-locked preflight exposes 48 potential call identities
+per cohort while capping execution at 16 requests and zero model calls. It
+passes 15/15 focused tests. Cross-candidate phrase pooling and a closure option
+lost only at serialization were each re-injected and made their seam test fail.
+The first preflight also caught six frozen queries that failed the existing
+topic-scope authorization because of lexical variants; the safety rule was not
+weakened, and the narrow pre-provider correction preserves both fixture hashes
+in an erratum. No OpenAlex request, model call, human review or production
+connection has occurred, so routing accuracy and source value remain
+`not_evaluated`. See the [v8 protocol](docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md),
+[query-scope erratum](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md),
+and [offline result](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md).
+
+Local verification now passes **1,909 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2271,7 +2293,24 @@ scope/union 混用两次缺陷回注。
 [人工评审边界结果](docs/results-2026-09-02-openalex-role-directed-v7-human-review-boundary.md)
 与[人工评审结果](docs/results-2026-09-02-openalex-role-directed-v7-human-review.md)。
 
-本地验证现通过 **1,894 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+项目又另行预注册了 **adaptive role-gap v8**，直接针对 v7 已测得的失败原因：
+第二条固定检索虽能找到有用论文，却没有补齐三个案例中缺失的角色。全新的
+AC01–AC08 开发集和 AD01–AD08 未见集为每个案例冻结一条 anchor 与五条互斥的
+角色补缺查询。anchor 返回后，确定性的候选内信号检查只能按冻结优先级选择第一
+个缺失角色；若不存在缺口则必须显式弃权，因此未来每个案例只能花费一次或两次
+检索，绝不会超过两次。
+
+修正后按原始字节锁定的预检为每个 cohort 暴露 48 个潜在调用身份，同时把可执行
+请求限制为 16 次、模型调用为 0，15/15 个定向测试通过。跨候选拼接信号词和仅在
+序列化时丢失一个 closure option 两项缺陷均被重新注入，并分别使接缝测试失败。
+第一次预检还发现六条冻结查询因词形差异无法通过既有主题范围授权；项目没有放宽
+安全规则，而是以勘误形式保留修正前后哈希并做最小的供应商调用前修正。目前没有
+发生 OpenAlex 请求、模型调用、人工评审或生产连接，因此路由正确率和来源价值仍为
+`not_evaluated`。详见 [v8 预注册](docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md)、
+[查询范围勘误](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md)与
+[离线结果](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md)。
+
+本地验证现通过 **1,909 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md
+++ b/docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md
@@ -1,0 +1,44 @@
+# Erratum: adaptive role-gap v8 frozen query scope
+
+**Date:** 2026-09-02 (Australia/Sydney)
+
+**Status:** corrected before any provider request, model call, private label,
+live runner, or production connection
+
+## What the zero-network preflight found
+
+The original v8 fixture was committed with raw SHA-256
+`ebdaf5da97a941abf7499b87bfcd3602db117a1be054ed3d13ef4ca3906f88f2`.
+The first implementation test stopped while expanding the frozen closure
+portfolio because six of 80 closure queries shared only one exact token with
+their case topic. The existing evidence-gap authorization boundary requires at
+least two exact non-stop-word topic tokens. The cause was lexical inflection or
+number rather than a different search intent: for example, `hydrolases` in the
+topic did not equal `hydrolase` or `hydrolysis` in the query.
+
+This was a useful preflight failure. The authorization rule was not weakened or
+bypassed, and no synthetic context was substituted for the frozen case topic.
+
+## Narrow correction
+
+One existing exact topic token was appended to each affected query:
+
+| Case | Role | Added topic token |
+|---|---|---|
+| AC01 | `enzymatic_pet_depolymerization` | `polyester` |
+| AC01 | `monomer_yield` | `polyester` |
+| AC01 | `enzyme_thermal_stability` | `polyester` |
+| AD01 | `polyurethane_hydrolase` | `depolymerization` |
+| AD01 | `enzyme_durability` | `depolymerization` |
+| AD05 | `cycling_stability` | `carbon` |
+
+The corrected fixture SHA-256 is
+`0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`.
+
+## What did not change
+
+The 16 topics, 80 semantic roles, 80 signal-group portfolios, role priorities,
+anchor queries, intended closure meanings, AC/AD split, request and cost caps,
+human gates, and falsification rules are unchanged. AC and AD were still
+unopened when this correction was made. This erratum does not authorize a live
+run and does not turn the corrected queries into evidence of retrieval value.

--- a/docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md
+++ b/docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md
@@ -31,8 +31,12 @@ truth, recall, user value, latency SLOs, or autonomous model-written tools.
 
 ## Frozen cohorts
 
-- The raw fixture SHA-256 is
-  `ebdaf5da97a941abf7499b87bfcd3602db117a1be054ed3d13ef4ca3906f88f2`.
+- The authoritative corrected raw fixture SHA-256 is
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`.
+  The original pre-implementation hash and six topic-scope token corrections
+  are preserved in `errata-2026-09-02-openalex-role-gap-v8-query-scope.md`;
+  no provider request, model call, private label, cohort, role, signal,
+  priority, or gate changed.
 - `AC01`-`AC08` are a new development cohort.
 - `AD01`-`AD08` are a new unopened unseen cohort.
 - The exact topics, role descriptions, candidate-local signal groups, anchor

--- a/docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md
+++ b/docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md
@@ -1,0 +1,162 @@
+# Pre-registration: adaptive role-gap closure v8
+
+**Date:** 2026-09-02 (Australia/Sydney)
+
+**Status:** frozen before implementation, provider requests, model calls, or
+human labels for AC01-AC08 or AD01-AD08
+
+**Production connection authorized:** no
+
+## Decision being tested
+
+Role-directed retrieval v7 established that broad relevance was not enough.
+Its eligible AA human review found directly relevant, baseline-novel material
+in 8/8 cases and 37/79 relevant candidates, but only 5/8 cases were jointly
+role-coverable. The second fixed query lane contributed unique relevant rows in
+7/8 cases while making zero additional cases coverable. The three failed cases
+each lacked one narrow role: a magnesium-air cell, cold-chain packaging use, or
+a monovalent-selective membrane. A second broad query therefore spent a request
+without targeting the role that actually blocked the evidence set.
+
+V8 tests one narrower hypothesis:
+
+> After one anchor search, a deterministic candidate-local role screen can
+> select at most one pre-frozen closure query for the highest-priority missing
+> role, improving human role coverability without allowing a model to invent or
+> expand a query.
+
+This is a disconnected retrieval-and-routing qualification study. It does not
+test report quality, planner-trigger precision on production reports, source
+truth, recall, user value, latency SLOs, or autonomous model-written tools.
+
+## Frozen cohorts
+
+- The raw fixture SHA-256 is
+  `ebdaf5da97a941abf7499b87bfcd3602db117a1be054ed3d13ef4ca3906f88f2`.
+- `AC01`-`AC08` are a new development cohort.
+- `AD01`-`AD08` are a new unopened unseen cohort.
+- The exact topics, role descriptions, candidate-local signal groups, anchor
+  queries, closure priorities, and every possible closure query live in
+  `tests/fixtures/openalex_role_gap_v8_challenge.json`.
+- AA01-AA08 remain consumed v7 evidence. AB01-AB08 remain sealed under the
+  failed v7 protocol. Neither cohort may be reused by v8.
+- AC becomes consumed after any provider request. AD must remain unopened until
+  AC passes every frozen mechanical and human gate without tuning on AD.
+
+## Bounded routing contract
+
+Each case starts with exactly one code-owned `anchor_search` query and at most
+six abstract-bearing OpenAlex rows. No second request is preselected.
+
+After the anchor response, each frozen role is screened independently. A role
+is mechanically observed only when all phrases in one of that role's frozen
+signal groups occur within the title-and-abstract text of the same candidate.
+Phrases may not be pooled across candidates, and OpenAlex topics, keywords,
+citation counts, or other provider metadata may not establish role coverage.
+These signals route a bounded request; they are not source-truth labels.
+
+If every role is mechanically observed, the router returns
+`abstain_no_mechanical_role_gap` and spends no second request. Otherwise it
+chooses the first missing role in the case's frozen closure-priority order and
+may issue exactly that role's pre-frozen `role_closure` query. It may not build,
+rewrite, broaden, or substitute a query at runtime. The complete case therefore
+uses one or two requests, never more than two, and returns at most twelve raw
+provider rows.
+
+The future runner must preserve the anchor observations, every matched signal
+group and candidate index, all missing roles, the selected role and frozen query
+identity, the explicit abstention reason, provider rank, request accounting,
+and all raw rows at the serialized boundary. Human review receives source text
+and role definitions but not the mechanical routing decision until its labels
+are locked.
+
+## Portfolio contract
+
+Provider rows are deduplicated within a case by normalized DOI before canonical
+OpenAlex URL. Every occurrence retains its request identity, route identity,
+provider rank, and deduplication owner. No semantic model may filter candidates
+before human qualification. At most three directly relevant, baseline-novel
+sources may form a human role-covering set.
+
+## Frozen gates
+
+All gates are conjunctive. An unavailable denominator is `not_evaluated`, not a
+pass.
+
+### Mechanical gates
+
+1. The zero-network preflight expands exactly eight ordered cases per cohort,
+   one anchor identity and five mutually exclusive closure-option identities
+   per case, while authorizing at most two executed requests per case.
+2. Every possible closure option is query- and role-bound before any provider
+   client can exist; unselected options are never sent.
+3. A later AC live run, if separately authorized, durably records every spent
+   request and provider row before a later request.
+4. No retry, redirect, fallback, supplementary search, result-page fetch,
+   recovery, or model call occurs.
+5. Production, reports, checkpoints, and the current shadow Planner remain
+   disconnected.
+
+### Human routing-and-value gates
+
+1. At least 6/8 cases contain a directly relevant, baseline-novel candidate.
+2. Directly relevant candidates are at least 25% of all reviewable unique
+   candidates.
+3. At least 6/8 routing decisions are human-correct: a closure call must target
+   a role absent from the human-labeled anchor portfolio, while an abstention is
+   correct only when the anchor portfolio is already human-coverable.
+4. In at least four executed closure cases, the closure request contributes a
+   directly relevant, baseline-novel candidate supporting the selected role.
+5. At least 6/8 union portfolios are human-coverable with no more than three
+   sources.
+6. The union makes at least two more cases human-coverable than the anchor
+   portfolio alone.
+
+The 25% candidate-pool floor is not the final production-selected-set
+wrong-source gate. Passing AC would only justify a separately pre-registered AD
+evaluation.
+
+## Required zero-network implementation evidence
+
+Before any live authorization, implementation tests must prove that:
+
+1. raw fixture bytes are checked before JSON parsing or case expansion;
+2. AC and AD topics, role profiles, priorities, anchor calls, and every closure
+   option have distinct content-addressed identities;
+3. a role signal cannot be completed by phrases split across two candidates;
+4. the first missing role in frozen priority order is selected even when a
+   different missing role appears first in serialized role order;
+5. no-gap input produces an explicit abstention and no closure call;
+6. the selected query is byte-for-byte one frozen closure option;
+7. every route observation and closure option reaches the dry-run client
+   boundary;
+8. the preflight imports no provider, execution, model, or private-review code;
+9. all live-authority, model, production, report, and recovery flags remain
+   false; and
+10. the full zero-network suite, latest Ruff, and narrow Pylint pass.
+
+Two defects must be re-injected and observed red before restoration: pooling
+signal phrases across candidates, and dropping one valid closure option before
+the serialized dry-run boundary. Assertions may not be weakened or skipped.
+
+## Stop and falsification rules
+
+- This pre-registration authorizes implementation and zero-network verification
+  only. It authorizes no OpenAlex or model request.
+- A live AC run requires new explicit owner authorization naming the merged
+  revision, exact fixture hash, no more than sixteen sequential OpenAlex
+  requests, and a provider-reported cost soft stop no greater than USD 0.02.
+- Fixture, signal, priority, query, implementation, order, or budget drift stops
+  before client construction.
+- AC failure seals v8. Do not tune on AC and call a rerun validation, lower a
+  gate, or open AD.
+- AC success permits only a separately pre-registered AD evaluation. AD success
+  would still require a report-level value and disabled-path study before any
+  production connection.
+
+## Explicit non-claims
+
+Passing the zero-network stage would establish only a deterministic, bounded,
+inspectable routing contract. It would not establish provider compatibility,
+source relevance, routing accuracy, closure value, role coverability, report
+improvement, user utility, production reliability, or completed Tool Calling.

--- a/docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md
+++ b/docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md
@@ -1,0 +1,104 @@
+# Adaptive role-gap closure v8: zero-network implementation result
+
+**Date:** 2026-09-02 (Australia/Sydney)
+
+**Protocol:**
+`prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`
+
+**Live provider requests:** 0
+
+**Model calls:** 0
+
+**Production connection:** false
+
+## Why this method exists
+
+The eligible v7 human review found relevant, baseline-novel candidates in 8/8
+cases and 37/79 relevant candidates, but only 5/8 cases were jointly
+role-coverable. Its second fixed query lane added uniquely relevant material in
+7/8 cases while closing zero additional role sets. V8 therefore tests a more
+specific mechanism: spend the optional second request only on the highest-
+priority role that a candidate-local screen did not observe after the anchor.
+
+## Implemented boundary
+
+The new zero-network preflight:
+
+- raw-byte checks the AC01-AC08 development and AD01-AD08 unseen fixture before
+  JSON parsing or case expansion;
+- expands one anchor identity and five mutually exclusive closure identities
+  per case, while capping future execution at one anchor plus one closure;
+- matches all phrases in one frozen signal group within one candidate's title
+  and abstract, never across candidates and never from provider metadata;
+- selects the first missing role in the frozen per-case priority, rather than
+  serialized role order;
+- returns `abstain_no_mechanical_role_gap` with no selected call when all roles
+  are observed;
+- binds every option to a validated academic-search call, idempotency key,
+  plan hash, role kind, query and route-contract hash; and
+- serializes all observations and all closure options while importing no
+  provider, executor, model, CrewAI or private-review code.
+
+The empty-anchor route embedded in dry-run output is explicitly marked as a
+synthetic seam probe, not a provider observation. It proves that checked
+negative observations and the selected route identity reach the client-facing
+serialization boundary.
+
+## Preflight correction
+
+The first focused run stopped before any network-capable object existed. Six of
+80 closure queries failed the existing evidence-gap topic-scope rule because
+lexical variants shared only one exact topic token. The scope rule was retained.
+One existing topic token was appended to each affected query, with both raw
+fixture identities and every correction preserved in
+`errata-2026-09-02-openalex-role-gap-v8-query-scope.md`.
+
+The authoritative corrected fixture SHA-256 is
+`0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`.
+No cohort, role, signal group, priority, intended query meaning, experimental
+gate or budget changed.
+
+## Mechanical result
+
+Both cohort dry-runs report:
+
+| Measure | Development AC | Unseen AD |
+|---|---:|---:|
+| Cases | 8 | 8 |
+| Potential call identities | 48 | 48 |
+| Maximum executable requests | 16 | 16 |
+| Maximum provider rows | 96 | 96 |
+| Maximum model calls | 0 | 0 |
+
+Shared contract hashes are:
+
+- provider: `26ebc0e138d7b40e26556ea61232c078a8e145649d9cb6168aa3bc4347b5bff3`;
+- routing: `c00c93afb38662d2b4eae66f55f1aaa591e43c2d0c8f46f52d5a0cb2d8d783b5`;
+- portfolio: `c857fce7c183544bd3971f348ca2de141ffcfa63b60b97a812bbbe18e4a5389a`;
+  and
+- qualification: `19a17bfe778d7b503cc8a2093687832be7b3be29848cf41109259da893ac2791`.
+
+The focused suite passes **15/15**. Two protocol-mandated defects were then
+injected separately:
+
+1. pooling signal phrases across candidates changed the engineered-PET-
+   hydrolase observation from false to true and made the candidate-local seam
+   test fail; and
+2. dropping the final valid closure option only during serialization made the
+   exact fixture-to-boundary comparison fail.
+
+Both defects were removed and the 15/15 focused suite passed again. No assertion
+was relaxed and no test was skipped.
+
+## Strict interpretation
+
+This stage passes the frozen zero-network mechanical gates only. AC and AD are
+still unopened, provider compatibility and cost are unobserved, and source
+relevance, routing correctness, selected-role closure value, role coverability,
+report improvement and user utility are all `not_evaluated`.
+
+V8 remains disconnected from the production worker, reports, checkpoints,
+recovery and the phase-1 shadow Planner. A separately implemented, identity-
+locked write-once AC runner plus new explicit authorization would be required
+before any OpenAlex request. Even an AC pass would justify only a separately
+pre-registered AD evaluation, not production Tool Calling.

--- a/openalex_role_gap_unseen.py
+++ b/openalex_role_gap_unseen.py
@@ -1,0 +1,898 @@
+"""Zero-network preflight for adaptive role-gap closure v8.
+
+Role-directed retrieval v7 showed that a second fixed broad query could add
+relevant papers without closing the role that blocked a usable evidence set.
+V8 therefore freezes one anchor query plus five mutually exclusive closure
+options per case.  This module checks those identities and exercises the
+candidate-local router without importing a provider, executor, model, or
+private review artifact.  Running its CLI cannot spend a search or model
+budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from academic_agent.evidence import EvidenceSource
+from academic_agent.evidence_gap import (
+    GapContext,
+    GapPlanProposal,
+    GapSearchIntent,
+    ValidatedGapCall,
+    ValidatedGapPlan,
+    build_gap_context,
+    source_collection_sha256,
+    validate_gap_plan,
+)
+from academic_agent.openalex_evidence_set import (
+    EvidenceRoleKind,
+    EvidenceSetRoleProfile,
+    EvidenceSetRoleSpec,
+)
+from academic_agent.source_pipeline import SourceCollection
+
+
+_ROOT = Path(__file__).resolve().parent
+DEFAULT_FIXTURE_PATH = _ROOT / "tests/fixtures/openalex_role_gap_v8_challenge.json"
+EXPECTED_FIXTURE_SHA256 = (
+    "0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7"
+)
+_DEVELOPMENT_ORDER = tuple(f"AC{index:02d}" for index in range(1, 9))
+_UNSEEN_ORDER = tuple(f"AD{index:02d}" for index in range(1, 9))
+_ROLE_KIND_ORDER: tuple[EvidenceRoleKind, ...] = (
+    "required",
+    "scope",
+    "supporting",
+)
+_COLLECTED_AT = datetime(2026, 9, 2, tzinfo=UTC)
+_ACCESSED_DATE = date(2026, 9, 2)
+_TOKEN_BOUNDARY = re.compile(r"[^a-z0-9]+")
+
+
+class OpenAlexRoleGapPreflightError(ValueError):
+    """Raised before live authority when the frozen v8 contract drifts."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+class RoleGapProviderContract(BaseModel):
+    """Exact bounded OpenAlex boundary without importing its transport."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["anonymous_openalex"] = "anonymous_openalex"
+    maximum_requests_per_case: Literal[2] = 2
+    result_limit_per_request: Literal[6] = 6
+    require_abstract: Literal[True] = True
+    allow_redirects: Literal[False] = False
+    allow_retries: Literal[False] = False
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleGapRoutingContract(BaseModel):
+    """Frozen router semantics; every boolean is part of the experiment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    anchor_lane_id: Literal["anchor_search"] = "anchor_search"
+    closure_lane_id: Literal["role_closure"] = "role_closure"
+    candidate_local_signals: Literal[True] = True
+    group_match_requires_all_phrases: Literal[True] = True
+    provider_metadata_may_establish_role: Literal[False] = False
+    missing_role_tiebreak: Literal["frozen_case_priority"] = (
+        "frozen_case_priority"
+    )
+    closure_query_must_be_frozen: Literal[True] = True
+    maximum_closure_calls: Literal[1] = 1
+    stop_when_no_gap: Literal[True] = True
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleGapPortfolioContract(BaseModel):
+    """Frozen merge and later human-review limits."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    deduplicate_by: tuple[str, str]
+    preserve_route_provenance: Literal[True] = True
+    preserve_provider_rank: Literal[True] = True
+    maximum_unique_candidates_per_case: Literal[12] = 12
+    maximum_cover_sources_per_case: Literal[3] = 3
+    semantic_filter_before_human_qualification: Literal[False] = False
+
+    @model_validator(mode="after")
+    def _validate_deduplication_order(self) -> "RoleGapPortfolioContract":
+        if self.deduplicate_by != (
+            "normalized_doi",
+            "canonical_openalex_url",
+        ):
+            raise ValueError("v8 deduplication precedence drifted")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleGapQualificationContract(BaseModel):
+    """Conjunctive human gates; this preflight cannot claim they passed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    minimum_cases_with_relevant_novel_candidate: Literal[6] = 6
+    minimum_candidate_pool_precision: Literal[0.25] = 0.25
+    minimum_human_correct_routing_decisions: Literal[6] = 6
+    minimum_cases_with_selected_role_closure_value: Literal[4] = 4
+    minimum_human_coverable_cases: Literal[6] = 6
+    minimum_coverability_gain_over_anchor: Literal[2] = 2
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleGapRoleSpec(BaseModel):
+    """One semantic role plus the only phrases and query that may route it."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str = Field(pattern=r"^[a-z][a-z0-9_]{2,80}$")
+    description: str = Field(min_length=10, max_length=600)
+    signal_groups: tuple[tuple[str, ...], ...] = Field(min_length=1, max_length=4)
+    closure_query: str = Field(min_length=20, max_length=500)
+
+    @field_validator("signal_groups")
+    @classmethod
+    def _validate_signal_groups(
+        cls,
+        value: tuple[tuple[str, ...], ...],
+    ) -> tuple[tuple[str, ...], ...]:
+        normalized_groups: list[tuple[str, ...]] = []
+        for group in value:
+            if not 1 <= len(group) <= 4:
+                raise ValueError("each role signal group must contain 1-4 phrases")
+            phrases = tuple(" ".join(phrase.split()) for phrase in group)
+            if any(len(phrase) < 2 for phrase in phrases):
+                raise ValueError("role signal phrases cannot be blank or one character")
+            if len({phrase.casefold() for phrase in phrases}) != len(phrases):
+                raise ValueError("phrases must be unique within a signal group")
+            normalized_groups.append(phrases)
+        if len(set(normalized_groups)) != len(normalized_groups):
+            raise ValueError("signal groups must be unique within a role")
+        return tuple(normalized_groups)
+
+    def profile_spec(self) -> EvidenceSetRoleSpec:
+        """Strip routing-only fields before using the shared role profile."""
+
+        return EvidenceSetRoleSpec(
+            role_id=self.role_id,
+            description=self.description,
+        )
+
+
+class RoleGapRoleGroups(BaseModel):
+    """Exactly five roles produce exactly five closure options per case."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required: tuple[RoleGapRoleSpec, RoleGapRoleSpec]
+    scope: tuple[RoleGapRoleSpec]
+    supporting: tuple[RoleGapRoleSpec, RoleGapRoleSpec]
+
+    @model_validator(mode="after")
+    def _validate_unique_role_ids(self) -> "RoleGapRoleGroups":
+        role_ids = tuple(role.role_id for _, role in self.ordered_roles())
+        if len(role_ids) != len(set(role_ids)):
+            raise ValueError("v8 role IDs must be unique within a case")
+        return self
+
+    def ordered_roles(self) -> tuple[tuple[EvidenceRoleKind, RoleGapRoleSpec], ...]:
+        return (
+            *(("required", role) for role in self.required),
+            *(("scope", role) for role in self.scope),
+            *(("supporting", role) for role in self.supporting),
+        )
+
+    def profile(self) -> EvidenceSetRoleProfile:
+        # The shared profile remains the source of truth for semantic role
+        # identity. Signal phrases and closure queries are deliberately absent.
+        return EvidenceSetRoleProfile(
+            required_roles=tuple(role.profile_spec() for role in self.required),
+            scope_roles=tuple(role.profile_spec() for role in self.scope),
+            supporting_roles=tuple(
+                role.profile_spec() for role in self.supporting
+            ),
+        )
+
+
+class RoleGapCaseSpec(BaseModel):
+    """One anchor plus a complete, mutually exclusive closure portfolio."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^A[CD]0[1-8]$")
+    topic: str = Field(min_length=20, max_length=300)
+    anchor_query: str = Field(min_length=20, max_length=500)
+    closure_priority_role_ids: tuple[str, str, str, str, str]
+    roles: RoleGapRoleGroups
+
+    @model_validator(mode="after")
+    def _validate_priority_and_queries(self) -> "RoleGapCaseSpec":
+        role_ids = tuple(role.role_id for _, role in self.roles.ordered_roles())
+        if len(set(self.closure_priority_role_ids)) != 5:
+            raise ValueError("closure-priority role IDs must be unique")
+        if set(self.closure_priority_role_ids) != set(role_ids):
+            raise ValueError("closure priority must name every role exactly once")
+        queries = (
+            self.anchor_query,
+            *(role.closure_query for _, role in self.roles.ordered_roles()),
+        )
+        if len({query.casefold() for query in queries}) != len(queries):
+            raise ValueError("anchor and closure queries must be distinct")
+        return self
+
+    def sha256(self) -> str:
+        return _model_sha256(self)
+
+
+class RoleGapChallengeManifest(BaseModel):
+    """Complete raw-byte-frozen v8 development and unseen challenge."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    method_id: Literal["openalex-adaptive-role-gap-closure-v8"]
+    provider_contract: RoleGapProviderContract
+    routing_contract: RoleGapRoutingContract
+    portfolio_contract: RoleGapPortfolioContract
+    qualification_contract: RoleGapQualificationContract
+    development_cases: tuple[
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+    ]
+    unseen_cases: tuple[
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+        RoleGapCaseSpec,
+    ]
+
+    @model_validator(mode="after")
+    def _validate_cross_contracts(self) -> "RoleGapChallengeManifest":
+        if tuple(case.case_id for case in self.development_cases) != (
+            _DEVELOPMENT_ORDER
+        ):
+            raise ValueError("development cases must remain AC01 through AC08")
+        if tuple(case.case_id for case in self.unseen_cases) != _UNSEEN_ORDER:
+            raise ValueError("unseen cases must remain AD01 through AD08")
+
+        all_cases = (*self.development_cases, *self.unseen_cases)
+        if len({case.topic.casefold() for case in all_cases}) != len(all_cases):
+            raise ValueError("topic strings must be unique across both cohorts")
+        queries = tuple(
+            query
+            for case in all_cases
+            for query in (
+                case.anchor_query,
+                *(
+                    role.closure_query
+                    for _, role in case.roles.ordered_roles()
+                ),
+            )
+        )
+        if len(queries) != 96:
+            raise ValueError("v8 must freeze one anchor and five closures per case")
+        if len({query.casefold() for query in queries}) != len(queries):
+            raise ValueError("all v8 search queries must be globally unique")
+        if (
+            self.provider_contract.maximum_requests_per_case
+            * self.provider_contract.result_limit_per_request
+            != self.portfolio_contract.maximum_unique_candidates_per_case
+        ):
+            raise ValueError("provider row ceiling and portfolio ceiling drifted")
+        return self
+
+
+class RoleGapCandidateText(BaseModel):
+    """Only source text may drive routing; provider metadata is not accepted."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    title: str = Field(min_length=1, max_length=2000)
+    abstract: str = Field(min_length=1, max_length=50_000)
+
+
+class RoleSignalObservation(BaseModel):
+    """First candidate-local match, or an explicit checked absence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str
+    role_kind: EvidenceRoleKind
+    observed: bool
+    checked_candidate_count: int = Field(ge=0)
+    matched_candidate_index: int | None = Field(default=None, ge=0)
+    matched_signal_group_index: int | None = Field(default=None, ge=0)
+    matched_phrases: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_match_shape(self) -> "RoleSignalObservation":
+        details = (
+            self.matched_candidate_index,
+            self.matched_signal_group_index,
+        )
+        if self.observed:
+            if any(value is None for value in details) or not self.matched_phrases:
+                raise ValueError("an observed role requires local match provenance")
+            if self.matched_candidate_index >= self.checked_candidate_count:
+                raise ValueError("matched candidate index exceeds checked candidates")
+        elif any(value is not None for value in details) or self.matched_phrases:
+            raise ValueError("an absent role cannot carry match provenance")
+        return self
+
+
+class RoleGapClosureOption(BaseModel):
+    """One pre-authorized role/query identity; only one option may be selected."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role_id: str
+    role_kind: EvidenceRoleKind
+    query: str
+    call: ValidatedGapCall
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    closure_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def _validate_query_binding(self) -> "RoleGapClosureOption":
+        if self.query != self.call.query:
+            raise ValueError("closure option query must equal its validated call")
+        return self
+
+
+class RoleGapRouteDecision(BaseModel):
+    """Serializable decision that distinguishes abstention from unchecked state."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    checked: Literal[True] = True
+    action: Literal["search", "abstain"]
+    reason: Literal[
+        "highest_priority_missing_role",
+        "abstain_no_mechanical_role_gap",
+    ]
+    observations: tuple[RoleSignalObservation, ...]
+    missing_role_ids: tuple[str, ...]
+    selected_closure: RoleGapClosureOption | None = None
+
+    @model_validator(mode="after")
+    def _validate_decision_shape(self) -> "RoleGapRouteDecision":
+        if self.action == "search":
+            if self.reason != "highest_priority_missing_role":
+                raise ValueError("search must report the frozen priority reason")
+            if self.selected_closure is None or not self.missing_role_ids:
+                raise ValueError("search requires a selected missing-role closure")
+            if self.selected_closure.role_id != self.missing_role_ids[0]:
+                raise ValueError("selected closure must be the first missing role")
+        elif (
+            self.reason != "abstain_no_mechanical_role_gap"
+            or self.selected_closure is not None
+            or self.missing_role_ids
+        ):
+            raise ValueError("no-gap abstention cannot carry a closure or missing role")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedRoleGapCase:
+    """All deterministic identities needed before a future provider exists."""
+
+    spec: RoleGapCaseSpec
+    collection: SourceCollection
+    context: GapContext
+    anchor_call: ValidatedGapCall
+    anchor_plan_sha256: str
+    anchor_contract_sha256: str
+    closure_options: tuple[RoleGapClosureOption, ...]
+    collection_sha256: str
+    profile_sha256: str
+    case_contract_sha256: str
+
+
+def _plan_sha256(plan: ValidatedGapPlan) -> str:
+    return _sha256_bytes(plan.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _normalized_text(value: str) -> str:
+    return " ".join(token for token in _TOKEN_BOUNDARY.split(value.casefold()) if token)
+
+
+def _contains_phrase(normalized_text: str, phrase: str) -> bool:
+    normalized_phrase = _normalized_text(phrase)
+    return f" {normalized_phrase} " in f" {normalized_text} "
+
+
+def _observe_role(
+    role_kind: EvidenceRoleKind,
+    role: RoleGapRoleSpec,
+    candidates: tuple[RoleGapCandidateText, ...],
+) -> RoleSignalObservation:
+    """Match every phrase in one group inside one candidate, never a pool."""
+
+    for candidate_index, candidate in enumerate(candidates):
+        # Joining title and abstract is allowed by the frozen wording, but the
+        # loop remains candidate-local. Moving this normalization outside the
+        # loop would recreate the cross-source evidence-pooling defect.
+        candidate_text = _normalized_text(f"{candidate.title} {candidate.abstract}")
+        for group_index, phrases in enumerate(role.signal_groups):
+            if all(_contains_phrase(candidate_text, phrase) for phrase in phrases):
+                return RoleSignalObservation(
+                    role_id=role.role_id,
+                    role_kind=role_kind,
+                    observed=True,
+                    checked_candidate_count=len(candidates),
+                    matched_candidate_index=candidate_index,
+                    matched_signal_group_index=group_index,
+                    matched_phrases=phrases,
+                )
+    return RoleSignalObservation(
+        role_id=role.role_id,
+        role_kind=role_kind,
+        observed=False,
+        checked_candidate_count=len(candidates),
+    )
+
+
+def route_anchor_candidates(
+    prepared: PreparedRoleGapCase,
+    candidates: tuple[RoleGapCandidateText, ...],
+) -> RoleGapRouteDecision:
+    """Choose one frozen closure by priority, or explicitly spend no request."""
+
+    role_by_id = {
+        role.role_id: (role_kind, role)
+        for role_kind, role in prepared.spec.roles.ordered_roles()
+    }
+    option_by_role = {option.role_id: option for option in prepared.closure_options}
+    if set(option_by_role) != set(role_by_id):
+        raise OpenAlexRoleGapPreflightError(
+            f"{prepared.spec.case_id}: closure options do not cover every role"
+        )
+
+    # Evaluation follows serialized role order so the audit is stable. The
+    # missing list is rebuilt from frozen priority, which prevents JSON role
+    # order from silently becoming the routing policy.
+    observations = tuple(
+        _observe_role(role_kind, role, candidates)
+        for role_kind, role in prepared.spec.roles.ordered_roles()
+    )
+    observed_role_ids = {
+        observation.role_id for observation in observations if observation.observed
+    }
+    missing_role_ids = tuple(
+        role_id
+        for role_id in prepared.spec.closure_priority_role_ids
+        if role_id not in observed_role_ids
+    )
+    if not missing_role_ids:
+        return RoleGapRouteDecision(
+            action="abstain",
+            reason="abstain_no_mechanical_role_gap",
+            observations=observations,
+            missing_role_ids=(),
+        )
+    return RoleGapRouteDecision(
+        action="search",
+        reason="highest_priority_missing_role",
+        observations=observations,
+        missing_role_ids=missing_role_ids,
+        selected_closure=option_by_role[missing_role_ids[0]],
+    )
+
+
+def _seed_source(spec: RoleGapCaseSpec) -> EvidenceSource:
+    """Create a valid gap context without claiming provider evidence exists."""
+
+    return EvidenceSource(
+        source_id="A1",
+        title=f"{spec.topic}: frozen adaptive role-gap v8 baseline context",
+        url=(
+            "https://doi.org/10.5555/openalex-role-gap-v8."
+            f"{spec.case_id.casefold()}"
+        ),
+        publisher="Frozen Adaptive Role-gap v8 Fixture",
+        accessed_date=_ACCESSED_DATE,
+        source_type="academic_paper",
+        evidence_summary=(
+            f"This synthetic baseline records the question {spec.topic}. "
+            "It contains no provider candidate and preserves an explicit "
+            "academic retrieval gap for this disconnected preflight."
+        ),
+        summary_source="abstract",
+    )
+
+
+def _single_call_plan(
+    context: GapContext,
+    *,
+    query: str,
+    trigger_id: str,
+    result_limit: int,
+    rationale: str,
+) -> ValidatedGapPlan:
+    return validate_gap_plan(
+        context,
+        GapPlanProposal(
+            decision="search",
+            rationale=rationale,
+            calls=(
+                GapSearchIntent(
+                    tool="academic_search",
+                    query=query,
+                    trigger_ids=(trigger_id,),
+                    result_limit=result_limit,
+                ),
+            ),
+        ),
+    )
+
+
+def _case_contract_sha256(
+    spec: RoleGapCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    routing_contract_sha256: str,
+    portfolio_contract_sha256: str,
+    qualification_contract_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "method_id": method_id,
+            "spec": spec.model_dump(mode="json"),
+            "provider_contract_sha256": provider_contract_sha256,
+            "routing_contract_sha256": routing_contract_sha256,
+            "portfolio_contract_sha256": portfolio_contract_sha256,
+            "qualification_contract_sha256": qualification_contract_sha256,
+        }
+    )
+
+
+def _route_contract_sha256(
+    spec: RoleGapCaseSpec,
+    *,
+    lane_id: str,
+    role_kind: EvidenceRoleKind | None,
+    role: RoleGapRoleSpec | None,
+    call: ValidatedGapCall,
+    method_id: str,
+    provider_contract_sha256: str,
+    routing_contract_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "method_id": method_id,
+            "case_id": spec.case_id,
+            "topic": spec.topic,
+            "lane_id": lane_id,
+            "role_kind": role_kind,
+            "role": role.model_dump(mode="json") if role else None,
+            "validated_call": call.model_dump(mode="json"),
+            "provider_contract_sha256": provider_contract_sha256,
+            "routing_contract_sha256": routing_contract_sha256,
+        }
+    )
+
+
+def build_case(
+    spec: RoleGapCaseSpec,
+    *,
+    method_id: str,
+    provider_contract_sha256: str,
+    routing_contract_sha256: str,
+    portfolio_contract_sha256: str,
+    qualification_contract_sha256: str,
+    result_limit: int,
+) -> PreparedRoleGapCase:
+    """Expand six possible identities while authorizing no provider request."""
+
+    collection = SourceCollection(
+        topic=spec.topic,
+        display_topic=spec.topic,
+        output_language="English",
+        weight_profile="industrial",
+        collected_at=_COLLECTED_AT,
+        academic_sources=[_seed_source(spec)],
+        academic_queries=[spec.topic],
+        patent_queries=[spec.topic],
+        market_queries=[spec.topic],
+        failed_domains={"academic": "frozen adaptive role-gap v8 challenge"},
+    )
+    context = build_gap_context(collection)
+    trigger = next(
+        (
+            signal
+            for signal in context.signals
+            if signal.code == "retrieval_domain_failed"
+            and signal.subject == "academic"
+        ),
+        None,
+    )
+    if trigger is None:
+        raise OpenAlexRoleGapPreflightError(
+            f"{spec.case_id}: frozen academic gap signal was not produced"
+        )
+
+    anchor_plan = _single_call_plan(
+        context,
+        query=spec.anchor_query,
+        trigger_id=trigger.signal_id,
+        result_limit=result_limit,
+        rationale=(
+            "The frozen v8 case authorizes its one code-owned anchor request "
+            "before any candidate-local role observation exists."
+        ),
+    )
+    anchor_call = anchor_plan.calls[0]
+    options: list[RoleGapClosureOption] = []
+    for role_kind, role in spec.roles.ordered_roles():
+        option_plan = _single_call_plan(
+            context,
+            query=role.closure_query,
+            trigger_id=trigger.signal_id,
+            result_limit=result_limit,
+            rationale=(
+                "The frozen v8 role portfolio pre-authorizes this one query "
+                "only if candidate-local routing later selects its missing role."
+            ),
+        )
+        option_call = option_plan.calls[0]
+        options.append(
+            RoleGapClosureOption(
+                role_id=role.role_id,
+                role_kind=role_kind,
+                query=role.closure_query,
+                call=option_call,
+                plan_sha256=_plan_sha256(option_plan),
+                closure_contract_sha256=_route_contract_sha256(
+                    spec,
+                    lane_id="role_closure",
+                    role_kind=role_kind,
+                    role=role,
+                    call=option_call,
+                    method_id=method_id,
+                    provider_contract_sha256=provider_contract_sha256,
+                    routing_contract_sha256=routing_contract_sha256,
+                ),
+            )
+        )
+
+    profile_sha256 = spec.roles.profile().sha256()
+    return PreparedRoleGapCase(
+        spec=spec,
+        collection=collection,
+        context=context,
+        anchor_call=anchor_call,
+        anchor_plan_sha256=_plan_sha256(anchor_plan),
+        anchor_contract_sha256=_route_contract_sha256(
+            spec,
+            lane_id="anchor_search",
+            role_kind=None,
+            role=None,
+            call=anchor_call,
+            method_id=method_id,
+            provider_contract_sha256=provider_contract_sha256,
+            routing_contract_sha256=routing_contract_sha256,
+        ),
+        closure_options=tuple(options),
+        collection_sha256=source_collection_sha256(collection),
+        profile_sha256=profile_sha256,
+        case_contract_sha256=_case_contract_sha256(
+            spec,
+            method_id=method_id,
+            provider_contract_sha256=provider_contract_sha256,
+            routing_contract_sha256=routing_contract_sha256,
+            portfolio_contract_sha256=portfolio_contract_sha256,
+            qualification_contract_sha256=qualification_contract_sha256,
+        ),
+    )
+
+
+def load_frozen_cases(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> tuple[
+    str,
+    RoleGapChallengeManifest,
+    tuple[PreparedRoleGapCase, ...],
+]:
+    """Validate raw bytes before parsing or expanding either cohort."""
+
+    raw = fixture_path.read_bytes()
+    fixture_sha256 = _sha256_bytes(raw)
+    if fixture_sha256 != expected_fixture_sha256:
+        raise OpenAlexRoleGapPreflightError(
+            "adaptive role-gap v8 fixture byte identity drifted: "
+            f"expected {expected_fixture_sha256}, got {fixture_sha256}"
+        )
+    manifest = RoleGapChallengeManifest.model_validate_json(raw)
+    specs = (
+        manifest.development_cases
+        if cohort == "development"
+        else manifest.unseen_cases
+    )
+    provider_sha256 = manifest.provider_contract.sha256()
+    routing_sha256 = manifest.routing_contract.sha256()
+    portfolio_sha256 = manifest.portfolio_contract.sha256()
+    qualification_sha256 = manifest.qualification_contract.sha256()
+    return (
+        fixture_sha256,
+        manifest,
+        tuple(
+            build_case(
+                spec,
+                method_id=manifest.method_id,
+                provider_contract_sha256=provider_sha256,
+                routing_contract_sha256=routing_sha256,
+                portfolio_contract_sha256=portfolio_sha256,
+                qualification_contract_sha256=qualification_sha256,
+                result_limit=manifest.provider_contract.result_limit_per_request,
+            )
+            for spec in specs
+        ),
+    )
+
+
+def _serialize_case(case: PreparedRoleGapCase) -> dict[str, Any]:
+    # An empty-anchor probe is not a provider observation. It exists so tests
+    # can assert that every negative observation and selected identity survives
+    # the same serialized seam a future runner would expose.
+    route_probe = route_anchor_candidates(case, ())
+    return {
+        "case_id": case.spec.case_id,
+        "case_spec_sha256": case.spec.sha256(),
+        "collection_sha256": case.collection_sha256,
+        "profile_sha256": case.profile_sha256,
+        "case_contract_sha256": case.case_contract_sha256,
+        "closure_priority_role_ids": list(
+            case.spec.closure_priority_role_ids
+        ),
+        "anchor": {
+            "lane_id": "anchor_search",
+            "query": case.spec.anchor_query,
+            "idempotency_key": case.anchor_call.idempotency_key,
+            "plan_sha256": case.anchor_plan_sha256,
+            "anchor_contract_sha256": case.anchor_contract_sha256,
+            "result_limit": case.anchor_call.result_limit,
+        },
+        "closure_options": [
+            {
+                "role_id": option.role_id,
+                "role_kind": option.role_kind,
+                "query": option.query,
+                "idempotency_key": option.call.idempotency_key,
+                "plan_sha256": option.plan_sha256,
+                "closure_contract_sha256": option.closure_contract_sha256,
+                "result_limit": option.call.result_limit,
+            }
+            for option in case.closure_options
+        ],
+        "empty_anchor_route_probe": route_probe.model_dump(mode="json"),
+        "route_probe_uses_provider_observations": False,
+    }
+
+
+def dry_run(
+    cohort: Literal["development", "unseen"] = "development",
+    fixture_path: Path = DEFAULT_FIXTURE_PATH,
+    *,
+    expected_fixture_sha256: str = EXPECTED_FIXTURE_SHA256,
+) -> dict[str, Any]:
+    """Expose every frozen identity while constructing no live client."""
+
+    fixture_sha256, manifest, cases = load_frozen_cases(
+        cohort,
+        fixture_path,
+        expected_fixture_sha256=expected_fixture_sha256,
+    )
+    potential_calls = len(cases) * (1 + len(cases[0].closure_options))
+    maximum_executed_calls = (
+        len(cases) * manifest.provider_contract.maximum_requests_per_case
+    )
+    return {
+        "mode": "openalex_adaptive_role_gap_v8_dry_run",
+        "cohort": cohort,
+        "method_id": manifest.method_id,
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "shadow_planner_connected": False,
+        "checkpoint_connected": False,
+        "recovery_connected": False,
+        "real_network_calls_performed": False,
+        "real_model_calls_performed": False,
+        "private_labels_opened": False,
+        "human_qualification_performed": False,
+        "live_provider_requests_authorized": False,
+        "live_model_calls_authorized": False,
+        "fixture_sha256": fixture_sha256,
+        "case_count": len(cases),
+        "potential_call_identity_count": potential_calls,
+        "maximum_executed_search_request_count": maximum_executed_calls,
+        "maximum_provider_row_count": (
+            maximum_executed_calls
+            * manifest.provider_contract.result_limit_per_request
+        ),
+        "maximum_model_call_count": 0,
+        "provider_contract": manifest.provider_contract.model_dump(mode="json"),
+        "routing_contract": manifest.routing_contract.model_dump(mode="json"),
+        "portfolio_contract": manifest.portfolio_contract.model_dump(mode="json"),
+        "qualification_contract": manifest.qualification_contract.model_dump(
+            mode="json"
+        ),
+        "provider_contract_sha256": manifest.provider_contract.sha256(),
+        "routing_contract_sha256": manifest.routing_contract.sha256(),
+        "portfolio_contract_sha256": manifest.portfolio_contract.sha256(),
+        "qualification_contract_sha256": (
+            manifest.qualification_contract.sha256()
+        ),
+        "cases": [_serialize_case(case) for case in cases],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cohort",
+        choices=("development", "unseen"),
+        default="development",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    print(json.dumps(dry_run(args.cohort), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/openalex_role_gap_v8_challenge.json
+++ b/tests/fixtures/openalex_role_gap_v8_challenge.json
@@ -1,0 +1,608 @@
+{
+  "schema_version": 1,
+  "method_id": "openalex-adaptive-role-gap-closure-v8",
+  "provider_contract": {
+    "provider": "anonymous_openalex",
+    "maximum_requests_per_case": 2,
+    "result_limit_per_request": 6,
+    "require_abstract": true,
+    "allow_redirects": false,
+    "allow_retries": false
+  },
+  "routing_contract": {
+    "anchor_lane_id": "anchor_search",
+    "closure_lane_id": "role_closure",
+    "candidate_local_signals": true,
+    "group_match_requires_all_phrases": true,
+    "provider_metadata_may_establish_role": false,
+    "missing_role_tiebreak": "frozen_case_priority",
+    "closure_query_must_be_frozen": true,
+    "maximum_closure_calls": 1,
+    "stop_when_no_gap": true
+  },
+  "portfolio_contract": {
+    "deduplicate_by": [
+      "normalized_doi",
+      "canonical_openalex_url"
+    ],
+    "preserve_route_provenance": true,
+    "preserve_provider_rank": true,
+    "maximum_unique_candidates_per_case": 12,
+    "maximum_cover_sources_per_case": 3,
+    "semantic_filter_before_human_qualification": false
+  },
+  "qualification_contract": {
+    "minimum_cases_with_relevant_novel_candidate": 6,
+    "minimum_candidate_pool_precision": 0.25,
+    "minimum_human_correct_routing_decisions": 6,
+    "minimum_cases_with_selected_role_closure_value": 4,
+    "minimum_human_coverable_cases": 6,
+    "minimum_coverability_gain_over_anchor": 2
+  },
+  "development_cases": [
+    {
+      "case_id": "AC01",
+      "topic": "Engineered PET hydrolases for closed-loop recycling of polyester textile waste",
+      "anchor_query": "engineered PET hydrolase enzymatic depolymerization polyester textile waste",
+      "closure_priority_role_ids": [
+        "engineered_pet_hydrolase",
+        "polyester_textile_waste",
+        "enzyme_thermal_stability",
+        "enzymatic_pet_depolymerization",
+        "monomer_yield"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "enzymatic_pet_depolymerization",
+            "description": "Evidence that PET is depolymerized or hydrolyzed through an enzymatic process.",
+            "signal_groups": [["PET", "depolymerization"], ["polyethylene terephthalate", "hydrolysis"]],
+            "closure_query": "enzymatic PET depolymerization hydrolysis terephthalate monomer recovery"
+          },
+          {
+            "role_id": "engineered_pet_hydrolase",
+            "description": "Evidence that an engineered PETase, cutinase, or related PET hydrolase performs the reaction.",
+            "signal_groups": [["engineered", "PETase"], ["engineered", "cutinase"], ["PET hydrolase", "mutant"]],
+            "closure_query": "engineered PETase cutinase PET hydrolase mutant polyester degradation"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "polyester_textile_waste",
+            "description": "Evidence that polyester textiles, fabric, fibres, or textile waste are treated.",
+            "signal_groups": [["polyester", "textile"], ["PET", "fabric"], ["polyester", "fiber"]],
+            "closure_query": "enzymatic recycling polyester textile waste PET fabric hydrolase"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "monomer_yield",
+            "description": "Evidence reporting recovered monomer yield, conversion, or product purity.",
+            "signal_groups": [["monomer", "yield"], ["terephthalic acid", "recovery"], ["conversion", "purity"]],
+            "closure_query": "PET hydrolase monomer yield terephthalic acid recovery conversion"
+          },
+          {
+            "role_id": "enzyme_thermal_stability",
+            "description": "Evidence reporting hydrolase thermostability or activity at industrially relevant temperature.",
+            "signal_groups": [["enzyme", "thermostability"], ["thermal stability", "hydrolase"], ["temperature", "PETase"]],
+            "closure_query": "thermostable PET hydrolase PETase cutinase industrial temperature stability"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC02",
+      "topic": "Cell-free enzyme cascades for biosynthesis of rare plant alkaloids",
+      "anchor_query": "cell free enzyme cascade biosynthesis rare plant alkaloid",
+      "closure_priority_role_ids": [
+        "rare_plant_alkaloid",
+        "cell_free_biosynthesis",
+        "enzyme_cascade",
+        "product_titer",
+        "pathway_scalability"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "cell_free_biosynthesis",
+            "description": "Evidence that the target molecule is produced in a cell-free biosynthetic system.",
+            "signal_groups": [["cell free", "biosynthesis"], ["in vitro", "biocatalysis"]],
+            "closure_query": "cell free biosynthesis in vitro biocatalysis plant natural product"
+          },
+          {
+            "role_id": "enzyme_cascade",
+            "description": "Evidence that two or more enzymes form a reaction cascade or reconstructed pathway.",
+            "signal_groups": [["enzyme cascade"], ["multi enzyme", "pathway"], ["enzymatic cascade"]],
+            "closure_query": "multi enzyme cascade reconstructed pathway cell free alkaloid synthesis"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "rare_plant_alkaloid",
+            "description": "Evidence that a scarce or high-value plant alkaloid is the target product.",
+            "signal_groups": [["plant", "alkaloid"], ["benzylisoquinoline", "alkaloid"], ["tropane", "alkaloid"]],
+            "closure_query": "cell free synthesis rare plant alkaloid benzylisoquinoline tropane"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "product_titer",
+            "description": "Evidence reporting product titre, yield, conversion, or productivity.",
+            "signal_groups": [["titer"], ["titre"], ["productivity"], ["yield"]],
+            "closure_query": "cell free alkaloid synthesis titer yield productivity enzyme cascade"
+          },
+          {
+            "role_id": "pathway_scalability",
+            "description": "Evidence addressing scale-up, enzyme reuse, cofactor regeneration, or continuous operation.",
+            "signal_groups": [["scale up"], ["cofactor regeneration"], ["enzyme reuse"], ["continuous", "operation"]],
+            "closure_query": "cell free enzyme cascade scale up cofactor regeneration continuous production"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC03",
+      "topic": "Gas-diffusion flow cells for electrochemical carbon dioxide conversion to ethylene",
+      "anchor_query": "gas diffusion electrode flow cell electrochemical carbon dioxide ethylene",
+      "closure_priority_role_ids": [
+        "gas_diffusion_electrode",
+        "flow_cell_operation",
+        "long_term_stability",
+        "co2_to_ethylene",
+        "faradaic_efficiency"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "co2_to_ethylene",
+            "description": "Evidence that electrochemical carbon dioxide reduction produces ethylene.",
+            "signal_groups": [["carbon dioxide", "ethylene"], ["CO2 reduction", "C2H4"]],
+            "closure_query": "electrochemical CO2 reduction ethylene C2H4 copper catalyst"
+          },
+          {
+            "role_id": "gas_diffusion_electrode",
+            "description": "Evidence that a gas-diffusion electrode or gas-fed cathode is used.",
+            "signal_groups": [["gas diffusion electrode"], ["gas fed", "cathode"]],
+            "closure_query": "gas diffusion electrode gas fed cathode CO2 ethylene electrolysis"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "flow_cell_operation",
+            "description": "Evidence that conversion operates in a flow cell, membrane-electrode assembly, or continuous reactor.",
+            "signal_groups": [["flow cell"], ["membrane electrode assembly"], ["continuous", "electrolyzer"]],
+            "closure_query": "CO2 ethylene flow cell membrane electrode assembly continuous electrolyzer"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "faradaic_efficiency",
+            "description": "Evidence reporting ethylene Faradaic efficiency, current density, or selectivity.",
+            "signal_groups": [["faradaic efficiency"], ["current density", "ethylene"], ["ethylene", "selectivity"]],
+            "closure_query": "CO2 ethylene Faradaic efficiency current density selectivity flow cell"
+          },
+          {
+            "role_id": "long_term_stability",
+            "description": "Evidence reporting multi-hour stability, durability, flooding, or carbonate management.",
+            "signal_groups": [["long term", "stability"], ["hours", "stable"], ["electrode flooding"], ["carbonate", "durability"]],
+            "closure_query": "CO2 ethylene flow cell long term stability flooding carbonate durability"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC04",
+      "topic": "Microneedle patches for continuous glucose monitoring in interstitial fluid",
+      "anchor_query": "microneedle patch glucose sensor continuous interstitial fluid monitoring",
+      "closure_priority_role_ids": [
+        "interstitial_fluid_monitoring",
+        "microneedle_sensor",
+        "wear_duration",
+        "glucose_detection",
+        "analytical_accuracy"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "microneedle_sensor",
+            "description": "Evidence that a microneedle array or patch performs sensing or sampling.",
+            "signal_groups": [["microneedle", "sensor"], ["microneedle", "patch"]],
+            "closure_query": "microneedle array patch biosensor glucose minimally invasive"
+          },
+          {
+            "role_id": "glucose_detection",
+            "description": "Evidence that glucose concentration is measured.",
+            "signal_groups": [["glucose", "detection"], ["glucose", "sensor"], ["glucose", "monitoring"]],
+            "closure_query": "microneedle glucose detection biosensor continuous monitoring"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "interstitial_fluid_monitoring",
+            "description": "Evidence that measurements use interstitial fluid in vivo or through skin.",
+            "signal_groups": [["interstitial fluid"], ["dermal", "fluid"], ["in vivo", "microneedle"]],
+            "closure_query": "microneedle glucose interstitial fluid in vivo transdermal monitoring"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "analytical_accuracy",
+            "description": "Evidence reporting accuracy, sensitivity, detection range, or correlation with blood glucose.",
+            "signal_groups": [["accuracy"], ["sensitivity"], ["detection range"], ["blood glucose", "correlation"]],
+            "closure_query": "microneedle glucose sensor accuracy sensitivity blood correlation"
+          },
+          {
+            "role_id": "wear_duration",
+            "description": "Evidence of continuous, repeated, or multi-hour wearable operation.",
+            "signal_groups": [["continuous", "hours"], ["wearable", "monitoring"], ["long term", "microneedle"]],
+            "closure_query": "wearable microneedle glucose continuous hours long term operation"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC05",
+      "topic": "Fungal mycelium composite insulation panels for humid building envelopes",
+      "anchor_query": "mycelium composite thermal insulation panel humid building envelope",
+      "closure_priority_role_ids": [
+        "humid_building_envelope",
+        "moisture_resistance",
+        "mycelium_composite",
+        "thermal_insulation",
+        "fire_or_mechanical_performance"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "mycelium_composite",
+            "description": "Evidence that fungal mycelium binds or forms a bio-based composite material.",
+            "signal_groups": [["mycelium", "composite"], ["fungal", "composite"]],
+            "closure_query": "fungal mycelium bio composite panel material"
+          },
+          {
+            "role_id": "thermal_insulation",
+            "description": "Evidence that the material provides thermal insulation or low thermal conductivity.",
+            "signal_groups": [["thermal insulation"], ["thermal conductivity"], ["insulation", "panel"]],
+            "closure_query": "mycelium composite thermal insulation conductivity building panel"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "humid_building_envelope",
+            "description": "Evidence of wall, roof, facade, or building-envelope use under humid or wet conditions.",
+            "signal_groups": [["building envelope", "humidity"], ["wall", "moisture"], ["facade", "humid"]],
+            "closure_query": "mycelium insulation building envelope wall humidity moisture"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "moisture_resistance",
+            "description": "Evidence reporting water absorption, humidity response, dimensional stability, or fungal durability.",
+            "signal_groups": [["water absorption"], ["moisture resistance"], ["relative humidity", "stability"]],
+            "closure_query": "mycelium composite water absorption moisture resistance humidity durability"
+          },
+          {
+            "role_id": "fire_or_mechanical_performance",
+            "description": "Evidence reporting fire reaction, compressive strength, flexural strength, or structural integrity.",
+            "signal_groups": [["fire resistance"], ["compressive strength"], ["flexural strength"], ["mechanical", "performance"]],
+            "closure_query": "mycelium insulation panel fire resistance compressive mechanical performance"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC06",
+      "topic": "Manganese-oxide ion sieves for direct lithium extraction from geothermal brines",
+      "anchor_query": "manganese oxide ion sieve direct lithium extraction geothermal brine",
+      "closure_priority_role_ids": [
+        "manganese_oxide_ion_sieve",
+        "geothermal_brine",
+        "sorbent_regeneration",
+        "lithium_extraction",
+        "lithium_selectivity"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "manganese_oxide_ion_sieve",
+            "description": "Evidence that a manganese-oxide lithium ion sieve or related spinel sorbent is used.",
+            "signal_groups": [["manganese oxide", "ion sieve"], ["lithium manganese oxide", "sorbent"]],
+            "closure_query": "manganese oxide lithium ion sieve spinel sorbent extraction"
+          },
+          {
+            "role_id": "lithium_extraction",
+            "description": "Evidence that lithium is adsorbed, extracted, recovered, or concentrated.",
+            "signal_groups": [["lithium", "extraction"], ["lithium", "recovery"], ["lithium", "adsorption"]],
+            "closure_query": "ion sieve lithium extraction adsorption recovery brine"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "geothermal_brine",
+            "description": "Evidence that geothermal water or a comparable high-salinity natural brine is treated.",
+            "signal_groups": [["geothermal", "brine"], ["geothermal water", "lithium"], ["natural brine", "lithium"]],
+            "closure_query": "manganese ion sieve lithium geothermal brine geothermal water"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "lithium_selectivity",
+            "description": "Evidence reporting lithium selectivity over magnesium, sodium, calcium, or potassium.",
+            "signal_groups": [["lithium selectivity"], ["selective", "magnesium"], ["separation factor", "lithium"]],
+            "closure_query": "manganese ion sieve lithium selectivity magnesium separation factor"
+          },
+          {
+            "role_id": "sorbent_regeneration",
+            "description": "Evidence reporting desorption, regeneration cycles, acid elution, or retained capacity.",
+            "signal_groups": [["sorbent regeneration"], ["desorption", "cycles"], ["acid elution"], ["capacity retention"]],
+            "closure_query": "lithium ion sieve regeneration desorption cycles acid elution capacity"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC07",
+      "topic": "CRISPR diagnostics for rapid detection of antimicrobial-resistance genes in wastewater",
+      "anchor_query": "CRISPR diagnostic antimicrobial resistance gene wastewater rapid detection",
+      "closure_priority_role_ids": [
+        "wastewater",
+        "crispr_diagnostic",
+        "amr_gene_detection",
+        "rapid_field_operation",
+        "limit_of_detection"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "crispr_diagnostic",
+            "description": "Evidence that CRISPR-Cas collateral cleavage or sequence recognition is used for detection.",
+            "signal_groups": [["CRISPR", "detection"], ["Cas12", "diagnostic"], ["Cas13", "diagnostic"]],
+            "closure_query": "CRISPR Cas12 Cas13 diagnostic nucleic acid detection"
+          },
+          {
+            "role_id": "amr_gene_detection",
+            "description": "Evidence that antimicrobial-resistance genes or determinants are detected.",
+            "signal_groups": [["antimicrobial resistance", "gene"], ["antibiotic resistance", "gene"], ["AMR", "detection"]],
+            "closure_query": "CRISPR antimicrobial resistance gene antibiotic resistance detection"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "wastewater",
+            "description": "Evidence that municipal, hospital, agricultural, or environmental wastewater is sampled.",
+            "signal_groups": [["wastewater"], ["sewage"], ["waste water"]],
+            "closure_query": "CRISPR AMR gene detection wastewater sewage environmental sample"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "limit_of_detection",
+            "description": "Evidence reporting detection limit, sensitivity, specificity, or analytical recovery.",
+            "signal_groups": [["limit of detection"], ["sensitivity", "specificity"], ["detection limit"]],
+            "closure_query": "CRISPR AMR diagnostic limit of detection sensitivity specificity"
+          },
+          {
+            "role_id": "rapid_field_operation",
+            "description": "Evidence of rapid, portable, point-of-use, or field-compatible operation.",
+            "signal_groups": [["rapid", "detection"], ["point of care"], ["portable", "assay"], ["field", "detection"]],
+            "closure_query": "portable rapid CRISPR AMR assay field wastewater detection"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AC08",
+      "topic": "Prussian-blue-analogue sodium-ion cathodes for stationary energy storage",
+      "anchor_query": "Prussian blue analogue cathode sodium ion battery stationary storage",
+      "closure_priority_role_ids": [
+        "stationary_energy_storage",
+        "prussian_blue_cathode",
+        "cycle_life",
+        "sodium_ion_battery",
+        "energy_density"
+      ],
+      "roles": {
+        "required": [
+          {
+            "role_id": "prussian_blue_cathode",
+            "description": "Evidence that a Prussian blue or Prussian blue analogue is used as the cathode.",
+            "signal_groups": [["Prussian blue", "cathode"], ["Prussian blue analogue", "positive electrode"]],
+            "closure_query": "Prussian blue analogue cathode positive electrode sodium battery"
+          },
+          {
+            "role_id": "sodium_ion_battery",
+            "description": "Evidence that the electrochemical cell is a sodium-ion battery.",
+            "signal_groups": [["sodium ion battery"], ["sodium ion", "cell"]],
+            "closure_query": "Prussian blue sodium ion battery cell cathode"
+          }
+        ],
+        "scope": [
+          {
+            "role_id": "stationary_energy_storage",
+            "description": "Evidence of grid, stationary, renewable-integration, or long-duration storage use.",
+            "signal_groups": [["stationary", "storage"], ["grid", "storage"], ["renewable", "storage"]],
+            "closure_query": "sodium ion Prussian blue stationary grid energy storage application"
+          }
+        ],
+        "supporting": [
+          {
+            "role_id": "cycle_life",
+            "description": "Evidence reporting cycling stability, capacity retention, or cycle count.",
+            "signal_groups": [["cycle life"], ["capacity retention"], ["cycling stability"]],
+            "closure_query": "Prussian blue sodium cathode cycle life capacity retention stability"
+          },
+          {
+            "role_id": "energy_density",
+            "description": "Evidence reporting capacity, voltage, energy density, or rate capability.",
+            "signal_groups": [["energy density"], ["specific capacity"], ["rate capability"]],
+            "closure_query": "Prussian blue sodium cathode energy density specific capacity voltage"
+          }
+        ]
+      }
+    }
+  ],
+  "unseen_cases": [
+    {
+      "case_id": "AD01",
+      "topic": "Enzymatic polyurethane depolymerization for recovery of reusable polyols",
+      "anchor_query": "enzymatic polyurethane depolymerization recycling reusable polyol recovery",
+      "closure_priority_role_ids": ["polyol_reuse", "polyurethane_hydrolase", "polyurethane_depolymerization", "depolymerization_yield", "enzyme_durability"],
+      "roles": {
+        "required": [
+          {"role_id": "polyurethane_depolymerization", "description": "Evidence that polyurethane bonds or networks are depolymerized.", "signal_groups": [["polyurethane", "depolymerization"], ["polyurethane", "hydrolysis"]], "closure_query": "polyurethane enzymatic depolymerization hydrolysis recycling"},
+          {"role_id": "polyurethane_hydrolase", "description": "Evidence that an enzyme, esterase, urethanase, or hydrolase performs degradation.", "signal_groups": [["enzyme", "polyurethane"], ["esterase", "polyurethane"], ["urethanase"]], "closure_query": "polyurethane degrading enzyme esterase urethanase hydrolase"}
+        ],
+        "scope": [
+          {"role_id": "polyol_reuse", "description": "Evidence that recovered polyols or oligomers are reused in new polymer production.", "signal_groups": [["polyol", "reuse"], ["recovered polyol"], ["polyol", "repolymerization"]], "closure_query": "enzymatic polyurethane recycling recovered polyol reuse repolymerization"}
+        ],
+        "supporting": [
+          {"role_id": "depolymerization_yield", "description": "Evidence reporting mass loss, conversion, product yield, or recovered fraction.", "signal_groups": [["conversion", "yield"], ["mass loss"], ["recovered", "fraction"]], "closure_query": "polyurethane enzyme depolymerization conversion yield recovered products"},
+          {"role_id": "enzyme_durability", "description": "Evidence reporting enzyme stability, reuse, immobilization, or operating temperature.", "signal_groups": [["enzyme stability"], ["enzyme reuse"], ["immobilized", "enzyme"], ["operating temperature"]], "closure_query": "polyurethane hydrolase enzyme stability reuse immobilization temperature"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD02",
+      "topic": "Microbial electrolysis cells for ammonia recovery from source-separated urine",
+      "anchor_query": "microbial electrolysis cell ammonia recovery source separated urine",
+      "closure_priority_role_ids": ["source_separated_urine", "microbial_electrolysis_cell", "ammonia_recovery", "nitrogen_recovery_efficiency", "energy_balance"],
+      "roles": {
+        "required": [
+          {"role_id": "microbial_electrolysis_cell", "description": "Evidence that a microbial electrolysis cell or bioelectrochemical reactor is used.", "signal_groups": [["microbial electrolysis cell"], ["bioelectrochemical", "reactor"]], "closure_query": "microbial electrolysis cell bioelectrochemical ammonia recovery"},
+          {"role_id": "ammonia_recovery", "description": "Evidence that ammonia or ammonium is recovered rather than only removed.", "signal_groups": [["ammonia", "recovery"], ["ammonium", "recovery"]], "closure_query": "bioelectrochemical ammonia ammonium recovery capture"
+          }
+        ],
+        "scope": [
+          {"role_id": "source_separated_urine", "description": "Evidence that human urine or source-separated sanitation liquid is treated.", "signal_groups": [["source separated", "urine"], ["human urine"], ["urine", "sanitation"]], "closure_query": "microbial electrolysis ammonia recovery source separated human urine"}
+        ],
+        "supporting": [
+          {"role_id": "nitrogen_recovery_efficiency", "description": "Evidence reporting nitrogen recovery, flux, concentration, or product purity.", "signal_groups": [["nitrogen recovery", "efficiency"], ["ammonia flux"], ["product purity"]], "closure_query": "microbial electrolysis urine nitrogen recovery efficiency ammonia flux purity"},
+          {"role_id": "energy_balance", "description": "Evidence reporting voltage, energy consumption, energy recovery, or net energy.", "signal_groups": [["energy consumption"], ["applied voltage"], ["energy recovery"]], "closure_query": "microbial electrolysis ammonia recovery energy consumption applied voltage"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD03",
+      "topic": "Perovskite photodetectors for low-dose X-ray medical imaging",
+      "anchor_query": "perovskite photodetector low dose X ray medical imaging",
+      "closure_priority_role_ids": ["medical_xray_imaging", "perovskite_photodetector", "low_dose_detection", "detection_sensitivity", "operational_stability"],
+      "roles": {
+        "required": [
+          {"role_id": "perovskite_photodetector", "description": "Evidence that a metal-halide perovskite directly or indirectly detects X-rays.", "signal_groups": [["perovskite", "X ray detector"], ["perovskite", "photodetector"]], "closure_query": "metal halide perovskite X ray detector photodetector"},
+          {"role_id": "low_dose_detection", "description": "Evidence of X-ray detection at low dose or low dose rate.", "signal_groups": [["low dose", "X ray"], ["low dose rate"], ["detection limit", "X ray"]], "closure_query": "perovskite X ray detector low dose low dose rate detection limit"}
+        ],
+        "scope": [
+          {"role_id": "medical_xray_imaging", "description": "Evidence of radiography, computed tomography, dental, or other medical imaging use.", "signal_groups": [["medical imaging"], ["radiography"], ["computed tomography"], ["dental", "imaging"]], "closure_query": "perovskite X ray detector medical imaging radiography computed tomography"}
+        ],
+        "supporting": [
+          {"role_id": "detection_sensitivity", "description": "Evidence reporting sensitivity, spatial resolution, signal-to-noise, or detection limit.", "signal_groups": [["sensitivity"], ["spatial resolution"], ["signal to noise"]], "closure_query": "perovskite X ray imaging sensitivity spatial resolution signal noise"},
+          {"role_id": "operational_stability", "description": "Evidence reporting radiation, bias, air, or storage stability.", "signal_groups": [["operational stability"], ["radiation stability"], ["bias stability"], ["storage stability"]], "closure_query": "perovskite X ray detector radiation operational stability durability"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD04",
+      "topic": "Hydrogel dressings with on-demand antimicrobial release for diabetic foot ulcers",
+      "anchor_query": "hydrogel dressing on demand antimicrobial release diabetic foot ulcer",
+      "closure_priority_role_ids": ["diabetic_foot_ulcer", "triggered_antimicrobial_release", "hydrogel_dressing", "infection_reduction", "wound_healing"],
+      "roles": {
+        "required": [
+          {"role_id": "hydrogel_dressing", "description": "Evidence that a hydrogel is used as a wound dressing or wound-contact material.", "signal_groups": [["hydrogel", "wound dressing"], ["hydrogel", "wound"]], "closure_query": "hydrogel wound dressing diabetic ulcer biomaterial"},
+          {"role_id": "triggered_antimicrobial_release", "description": "Evidence that antimicrobial release responds to pH, enzymes, light, temperature, or another trigger.", "signal_groups": [["triggered release", "antimicrobial"], ["responsive", "drug release"], ["on demand", "antibacterial"]], "closure_query": "stimuli responsive hydrogel triggered antimicrobial release wound"
+          }
+        ],
+        "scope": [
+          {"role_id": "diabetic_foot_ulcer", "description": "Evidence that diabetic wounds or diabetic foot ulcers are treated.", "signal_groups": [["diabetic foot ulcer"], ["diabetic wound"]], "closure_query": "responsive antimicrobial hydrogel diabetic foot ulcer wound dressing"}
+        ],
+        "supporting": [
+          {"role_id": "infection_reduction", "description": "Evidence reporting bacterial reduction, biofilm disruption, or infection control.", "signal_groups": [["bacterial reduction"], ["biofilm", "inhibition"], ["antibacterial activity"]], "closure_query": "hydrogel diabetic wound antibacterial activity biofilm infection reduction"},
+          {"role_id": "wound_healing", "description": "Evidence reporting closure, epithelialization, angiogenesis, or healing time.", "signal_groups": [["wound closure"], ["epithelialization"], ["angiogenesis"], ["healing time"]], "closure_query": "hydrogel diabetic ulcer wound closure epithelialization healing"
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "AD05",
+      "topic": "Lignin-derived porous carbon electrodes from pulp-mill waste for supercapacitors",
+      "anchor_query": "lignin derived porous carbon electrode pulp mill waste supercapacitor",
+      "closure_priority_role_ids": ["pulp_mill_lignin_waste", "lignin_derived_carbon", "supercapacitor_electrode", "specific_capacitance", "cycling_stability"],
+      "roles": {
+        "required": [
+          {"role_id": "lignin_derived_carbon", "description": "Evidence that lignin is converted into porous, activated, or graphitic carbon.", "signal_groups": [["lignin derived", "carbon"], ["lignin", "porous carbon"]], "closure_query": "lignin derived porous activated carbon electrode"
+          },
+          {"role_id": "supercapacitor_electrode", "description": "Evidence that the carbon is used as a supercapacitor or electrochemical-capacitor electrode.", "signal_groups": [["supercapacitor", "electrode"], ["electrochemical capacitor", "electrode"]], "closure_query": "lignin carbon supercapacitor electrode electrochemical capacitor"}
+        ],
+        "scope": [
+          {"role_id": "pulp_mill_lignin_waste", "description": "Evidence that kraft, black-liquor, or pulp-mill lignin is the feedstock.", "signal_groups": [["kraft lignin"], ["black liquor", "lignin"], ["pulp mill", "lignin"]], "closure_query": "kraft black liquor pulp mill lignin carbon supercapacitor"}
+        ],
+        "supporting": [
+          {"role_id": "specific_capacitance", "description": "Evidence reporting capacitance, energy density, power density, or rate performance.", "signal_groups": [["specific capacitance"], ["energy density", "power density"], ["rate performance"]], "closure_query": "lignin carbon supercapacitor specific capacitance energy power density"},
+          {"role_id": "cycling_stability", "description": "Evidence reporting capacitance retention or long-cycle durability.", "signal_groups": [["cycling stability"], ["capacitance retention"], ["cycles", "retention"]], "closure_query": "lignin supercapacitor cycling stability capacitance retention cycles"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD06",
+      "topic": "Selective capacitive deionization for nitrate removal from agricultural groundwater",
+      "anchor_query": "selective capacitive deionization nitrate agricultural groundwater removal",
+      "closure_priority_role_ids": ["agricultural_groundwater", "nitrate_selective_electrode", "capacitive_deionization", "nitrate_selectivity", "energy_or_regeneration"],
+      "roles": {
+        "required": [
+          {"role_id": "capacitive_deionization", "description": "Evidence that capacitive deionization or electrosorption removes ions.", "signal_groups": [["capacitive deionization"], ["electrosorption", "nitrate"]], "closure_query": "capacitive deionization electrosorption nitrate removal"},
+          {"role_id": "nitrate_selective_electrode", "description": "Evidence that electrode chemistry, ion exchange, or functionalization selectively captures nitrate.", "signal_groups": [["nitrate selective", "electrode"], ["selective nitrate", "adsorption"], ["nitrate", "ion exchange electrode"]], "closure_query": "nitrate selective electrode functionalized capacitive deionization"
+          }
+        ],
+        "scope": [
+          {"role_id": "agricultural_groundwater", "description": "Evidence that agricultural groundwater, drainage, or nitrate-contaminated natural water is treated.", "signal_groups": [["agricultural", "groundwater"], ["nitrate contaminated", "groundwater"], ["agricultural drainage"]], "closure_query": "capacitive deionization nitrate agricultural groundwater drainage"
+          }
+        ],
+        "supporting": [
+          {"role_id": "nitrate_selectivity", "description": "Evidence reporting nitrate preference over chloride, sulfate, bicarbonate, or other ions.", "signal_groups": [["nitrate selectivity"], ["selective", "chloride"], ["selectivity coefficient", "nitrate"]], "closure_query": "capacitive deionization nitrate selectivity chloride sulfate bicarbonate"},
+          {"role_id": "energy_or_regeneration", "description": "Evidence reporting energy use, electrode regeneration, desorption, or cycle stability.", "signal_groups": [["energy consumption"], ["electrode regeneration"], ["desorption", "cycles"], ["cycle stability"]], "closure_query": "nitrate capacitive deionization energy regeneration desorption cycles"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD07",
+      "topic": "Magnetically guided stem-cell delivery for myocardial repair after infarction",
+      "anchor_query": "magnetic guided stem cell delivery myocardial infarction repair",
+      "closure_priority_role_ids": ["myocardial_infarction_repair", "magnetic_guidance", "stem_cell_delivery", "cell_retention", "cardiac_function"],
+      "roles": {
+        "required": [
+          {"role_id": "magnetic_guidance", "description": "Evidence that magnetic particles or an external magnetic field guide or retain cells.", "signal_groups": [["magnetic", "cell targeting"], ["magnetic field", "stem cell"], ["magnetic guidance"]], "closure_query": "magnetic guidance targeting stem cell delivery magnetic field"},
+          {"role_id": "stem_cell_delivery", "description": "Evidence that therapeutic stem or progenitor cells are delivered to tissue.", "signal_groups": [["stem cell", "delivery"], ["progenitor cell", "delivery"], ["cell transplantation"]], "closure_query": "magnetically targeted stem cell delivery transplantation"
+          }
+        ],
+        "scope": [
+          {"role_id": "myocardial_infarction_repair", "description": "Evidence of myocardial infarction, ischemic heart injury, or cardiac repair.", "signal_groups": [["myocardial infarction"], ["ischemic heart", "repair"], ["cardiac", "infarction"]], "closure_query": "magnetic stem cell myocardial infarction cardiac repair"
+          }
+        ],
+        "supporting": [
+          {"role_id": "cell_retention", "description": "Evidence reporting homing, retention, engraftment, or biodistribution.", "signal_groups": [["cell retention"], ["cell homing"], ["engraftment"], ["biodistribution"]], "closure_query": "magnetic stem cell myocardial retention homing engraftment"},
+          {"role_id": "cardiac_function", "description": "Evidence reporting ejection fraction, infarct size, perfusion, or functional recovery.", "signal_groups": [["ejection fraction"], ["infarct size"], ["cardiac function"], ["functional recovery"]], "closure_query": "magnetic stem cell myocardial ejection fraction infarct size function"}
+        ]
+      }
+    },
+    {
+      "case_id": "AD08",
+      "topic": "Self-healing anti-corrosion coatings for offshore wind-turbine steel",
+      "anchor_query": "self healing anticorrosion coating offshore wind turbine steel",
+      "closure_priority_role_ids": ["offshore_wind_steel", "self_healing_coating", "corrosion_protection", "healing_efficiency", "marine_durability"],
+      "roles": {
+        "required": [
+          {"role_id": "self_healing_coating", "description": "Evidence that a coating autonomously repairs scratches, cracks, or barrier damage.", "signal_groups": [["self healing", "coating"], ["autonomous healing", "coating"]], "closure_query": "self healing coating autonomous repair scratch corrosion"},
+          {"role_id": "corrosion_protection", "description": "Evidence that the coating protects steel or metal against corrosion.", "signal_groups": [["corrosion protection"], ["anticorrosion", "steel"], ["corrosion resistance"]], "closure_query": "self healing anticorrosion coating steel corrosion resistance"
+          }
+        ],
+        "scope": [
+          {"role_id": "offshore_wind_steel", "description": "Evidence of offshore wind, marine structural steel, or comparable seawater infrastructure.", "signal_groups": [["offshore wind", "steel"], ["marine", "structural steel"], ["wind turbine", "corrosion"]], "closure_query": "self healing coating offshore wind turbine marine steel"
+          }
+        ],
+        "supporting": [
+          {"role_id": "healing_efficiency", "description": "Evidence reporting scratch closure, impedance recovery, inhibitor release, or healing efficiency.", "signal_groups": [["healing efficiency"], ["impedance recovery"], ["scratch", "recovery"], ["inhibitor release"]], "closure_query": "self healing corrosion coating healing efficiency impedance scratch recovery"},
+          {"role_id": "marine_durability", "description": "Evidence reporting salt-spray, seawater, UV, fatigue, adhesion, or long-term durability.", "signal_groups": [["salt spray"], ["seawater", "durability"], ["UV", "adhesion"], ["marine", "aging"]], "closure_query": "offshore anticorrosion self healing coating salt spray seawater durability"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/openalex_role_gap_v8_challenge.json
+++ b/tests/fixtures/openalex_role_gap_v8_challenge.json
@@ -57,7 +57,7 @@
             "role_id": "enzymatic_pet_depolymerization",
             "description": "Evidence that PET is depolymerized or hydrolyzed through an enzymatic process.",
             "signal_groups": [["PET", "depolymerization"], ["polyethylene terephthalate", "hydrolysis"]],
-            "closure_query": "enzymatic PET depolymerization hydrolysis terephthalate monomer recovery"
+            "closure_query": "enzymatic PET depolymerization hydrolysis terephthalate monomer recovery polyester"
           },
           {
             "role_id": "engineered_pet_hydrolase",
@@ -79,13 +79,13 @@
             "role_id": "monomer_yield",
             "description": "Evidence reporting recovered monomer yield, conversion, or product purity.",
             "signal_groups": [["monomer", "yield"], ["terephthalic acid", "recovery"], ["conversion", "purity"]],
-            "closure_query": "PET hydrolase monomer yield terephthalic acid recovery conversion"
+            "closure_query": "PET hydrolase monomer yield terephthalic acid recovery conversion polyester"
           },
           {
             "role_id": "enzyme_thermal_stability",
             "description": "Evidence reporting hydrolase thermostability or activity at industrially relevant temperature.",
             "signal_groups": [["enzyme", "thermostability"], ["thermal stability", "hydrolase"], ["temperature", "PETase"]],
-            "closure_query": "thermostable PET hydrolase PETase cutinase industrial temperature stability"
+            "closure_query": "thermostable PET hydrolase PETase cutinase industrial temperature stability polyester"
           }
         ]
       }
@@ -450,14 +450,14 @@
       "roles": {
         "required": [
           {"role_id": "polyurethane_depolymerization", "description": "Evidence that polyurethane bonds or networks are depolymerized.", "signal_groups": [["polyurethane", "depolymerization"], ["polyurethane", "hydrolysis"]], "closure_query": "polyurethane enzymatic depolymerization hydrolysis recycling"},
-          {"role_id": "polyurethane_hydrolase", "description": "Evidence that an enzyme, esterase, urethanase, or hydrolase performs degradation.", "signal_groups": [["enzyme", "polyurethane"], ["esterase", "polyurethane"], ["urethanase"]], "closure_query": "polyurethane degrading enzyme esterase urethanase hydrolase"}
+          {"role_id": "polyurethane_hydrolase", "description": "Evidence that an enzyme, esterase, urethanase, or hydrolase performs degradation.", "signal_groups": [["enzyme", "polyurethane"], ["esterase", "polyurethane"], ["urethanase"]], "closure_query": "polyurethane degrading enzyme esterase urethanase hydrolase depolymerization"}
         ],
         "scope": [
           {"role_id": "polyol_reuse", "description": "Evidence that recovered polyols or oligomers are reused in new polymer production.", "signal_groups": [["polyol", "reuse"], ["recovered polyol"], ["polyol", "repolymerization"]], "closure_query": "enzymatic polyurethane recycling recovered polyol reuse repolymerization"}
         ],
         "supporting": [
           {"role_id": "depolymerization_yield", "description": "Evidence reporting mass loss, conversion, product yield, or recovered fraction.", "signal_groups": [["conversion", "yield"], ["mass loss"], ["recovered", "fraction"]], "closure_query": "polyurethane enzyme depolymerization conversion yield recovered products"},
-          {"role_id": "enzyme_durability", "description": "Evidence reporting enzyme stability, reuse, immobilization, or operating temperature.", "signal_groups": [["enzyme stability"], ["enzyme reuse"], ["immobilized", "enzyme"], ["operating temperature"]], "closure_query": "polyurethane hydrolase enzyme stability reuse immobilization temperature"}
+          {"role_id": "enzyme_durability", "description": "Evidence reporting enzyme stability, reuse, immobilization, or operating temperature.", "signal_groups": [["enzyme stability"], ["enzyme reuse"], ["immobilized", "enzyme"], ["operating temperature"]], "closure_query": "polyurethane hydrolase enzyme stability reuse immobilization temperature depolymerization"}
         ]
       }
     },
@@ -537,7 +537,7 @@
         ],
         "supporting": [
           {"role_id": "specific_capacitance", "description": "Evidence reporting capacitance, energy density, power density, or rate performance.", "signal_groups": [["specific capacitance"], ["energy density", "power density"], ["rate performance"]], "closure_query": "lignin carbon supercapacitor specific capacitance energy power density"},
-          {"role_id": "cycling_stability", "description": "Evidence reporting capacitance retention or long-cycle durability.", "signal_groups": [["cycling stability"], ["capacitance retention"], ["cycles", "retention"]], "closure_query": "lignin supercapacitor cycling stability capacitance retention cycles"}
+          {"role_id": "cycling_stability", "description": "Evidence reporting capacitance retention or long-cycle durability.", "signal_groups": [["cycling stability"], ["capacitance retention"], ["cycles", "retention"]], "closure_query": "lignin supercapacitor cycling stability capacitance retention cycles carbon"}
         ]
       }
     },

--- a/tests/test_openalex_role_gap_unseen.py
+++ b/tests/test_openalex_role_gap_unseen.py
@@ -1,0 +1,462 @@
+"""Zero-network seams for adaptive role-gap closure v8."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import socket
+
+import pytest
+
+import openalex_role_gap_unseen as unseen
+
+
+def _write_fixture(tmp_path: Path, payload: dict[str, object]) -> tuple[Path, str]:
+    fixture = tmp_path / "challenge.json"
+    fixture.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return fixture, unseen._sha256_bytes(fixture.read_bytes())  # noqa: SLF001
+
+
+def _development_case(index: int = 0) -> unseen.PreparedRoleGapCase:
+    return unseen.load_frozen_cases("development")[2][index]
+
+
+def _candidate_for_role(role: unseen.RoleGapRoleSpec) -> unseen.RoleGapCandidateText:
+    # One candidate per role keeps the test honest about candidate locality.
+    # The filler abstract also exercises title+abstract normalization without
+    # introducing phrases from another role.
+    return unseen.RoleGapCandidateText(
+        title=" | ".join(role.signal_groups[0]),
+        abstract="Frozen synthetic candidate used only by a zero-network test.",
+    )
+
+
+def _candidates_covering(
+    case: unseen.PreparedRoleGapCase,
+    role_ids: set[str],
+) -> tuple[unseen.RoleGapCandidateText, ...]:
+    return tuple(
+        _candidate_for_role(role)
+        for _, role in case.spec.roles.ordered_roles()
+        if role.role_id in role_ids
+    )
+
+
+def test_development_dry_run_exposes_six_identities_but_caps_two_calls_per_case():
+    result = unseen.dry_run("development")
+
+    assert result["fixture_sha256"] == unseen.EXPECTED_FIXTURE_SHA256
+    assert result["case_count"] == 8
+    assert [item["case_id"] for item in result["cases"]] == [
+        f"AC{index:02d}" for index in range(1, 9)
+    ]
+    assert result["potential_call_identity_count"] == 48
+    assert result["maximum_executed_search_request_count"] == 16
+    assert result["maximum_provider_row_count"] == 96
+    assert result["maximum_model_call_count"] == 0
+
+    anchors = [case["anchor"] for case in result["cases"]]
+    closures = [
+        option for case in result["cases"] for option in case["closure_options"]
+    ]
+    assert len(anchors) == 8
+    assert len(closures) == 40
+    assert len(
+        {item["idempotency_key"] for item in (*anchors, *closures)}
+    ) == 48
+    assert len(
+        {item["anchor_contract_sha256"] for item in anchors}
+    ) == 8
+    assert len(
+        {item["closure_contract_sha256"] for item in closures}
+    ) == 40
+    assert {item["result_limit"] for item in (*anchors, *closures)} == {6}
+
+    for key in (
+        "case_spec_sha256",
+        "collection_sha256",
+        "profile_sha256",
+        "case_contract_sha256",
+    ):
+        assert len({item[key] for item in result["cases"]}) == 8
+
+    assert result["provider_contract"] == {
+        "provider": "anonymous_openalex",
+        "maximum_requests_per_case": 2,
+        "result_limit_per_request": 6,
+        "require_abstract": True,
+        "allow_redirects": False,
+        "allow_retries": False,
+    }
+    assert result["routing_contract"] == {
+        "anchor_lane_id": "anchor_search",
+        "closure_lane_id": "role_closure",
+        "candidate_local_signals": True,
+        "group_match_requires_all_phrases": True,
+        "provider_metadata_may_establish_role": False,
+        "missing_role_tiebreak": "frozen_case_priority",
+        "closure_query_must_be_frozen": True,
+        "maximum_closure_calls": 1,
+        "stop_when_no_gap": True,
+    }
+    assert result["qualification_contract"] == {
+        "minimum_cases_with_relevant_novel_candidate": 6,
+        "minimum_candidate_pool_precision": 0.25,
+        "minimum_human_correct_routing_decisions": 6,
+        "minimum_cases_with_selected_role_closure_value": 4,
+        "minimum_human_coverable_cases": 6,
+        "minimum_coverability_gain_over_anchor": 2,
+    }
+    for flag in (
+        "production_connected",
+        "report_workflow_connected",
+        "shadow_planner_connected",
+        "checkpoint_connected",
+        "recovery_connected",
+        "real_network_calls_performed",
+        "real_model_calls_performed",
+        "private_labels_opened",
+        "human_qualification_performed",
+        "live_provider_requests_authorized",
+        "live_model_calls_authorized",
+    ):
+        assert result[flag] is False
+
+
+def test_every_frozen_closure_option_reaches_the_serialized_boundary():
+    """A valid option is useless if it disappears before the client seam."""
+
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    result = unseen.dry_run("development")
+    role_kinds = ("required", "scope", "supporting")
+    expected = [
+        {
+            "case_id": case["case_id"],
+            "role_id": role["role_id"],
+            "role_kind": role_kind,
+            "query": role["closure_query"],
+        }
+        for case in payload["development_cases"]
+        for role_kind in role_kinds
+        for role in case["roles"][role_kind]
+    ]
+    observed = [
+        {
+            "case_id": case["case_id"],
+            "role_id": option["role_id"],
+            "role_kind": option["role_kind"],
+            "query": option["query"],
+        }
+        for case in result["cases"]
+        for option in case["closure_options"]
+    ]
+
+    assert observed == expected
+    assert all(
+        len(option["idempotency_key"]) == 64
+        and len(option["plan_sha256"]) == 64
+        and len(option["closure_contract_sha256"]) == 64
+        for case in result["cases"]
+        for option in case["closure_options"]
+    )
+
+
+def test_empty_anchor_probe_exposes_every_negative_observation_and_route_identity():
+    result = unseen.dry_run("development")
+
+    for case in result["cases"]:
+        probe = case["empty_anchor_route_probe"]
+        assert case["route_probe_uses_provider_observations"] is False
+        assert probe["checked"] is True
+        assert probe["action"] == "search"
+        assert probe["reason"] == "highest_priority_missing_role"
+        assert len(probe["observations"]) == 5
+        assert all(not observation["observed"] for observation in probe["observations"])
+        assert all(
+            observation["checked_candidate_count"] == 0
+            for observation in probe["observations"]
+        )
+        assert probe["missing_role_ids"] == case["closure_priority_role_ids"]
+        selected = probe["selected_closure"]
+        assert selected["role_id"] == case["closure_priority_role_ids"][0]
+        matching_option = next(
+            option
+            for option in case["closure_options"]
+            if option["role_id"] == selected["role_id"]
+        )
+        assert selected["query"] == matching_option["query"]
+        assert (
+            selected["closure_contract_sha256"]
+            == matching_option["closure_contract_sha256"]
+        )
+
+
+def test_role_phrases_split_across_candidates_cannot_complete_one_signal_group():
+    """This is the required regression seam for cross-candidate pooling."""
+
+    case = _development_case()
+    target_role_id = "engineered_pet_hydrolase"
+    other_role_ids = {
+        role.role_id
+        for _, role in case.spec.roles.ordered_roles()
+        if role.role_id != target_role_id
+    }
+    split_candidates = (
+        unseen.RoleGapCandidateText(
+            title="An engineered catalyst for polymer recycling",
+            abstract="No named hydrolase appears in this candidate.",
+        ),
+        unseen.RoleGapCandidateText(
+            title="PETase activity in a polyester assay",
+            abstract="No engineering claim appears in this candidate.",
+        ),
+    )
+    candidates = (*split_candidates, *_candidates_covering(case, other_role_ids))
+
+    decision = unseen.route_anchor_candidates(case, candidates)
+    observation = next(
+        item for item in decision.observations if item.role_id == target_role_id
+    )
+
+    assert observation.observed is False
+    assert target_role_id in decision.missing_role_ids
+    assert decision.action == "search"
+    assert decision.selected_closure is not None
+    assert decision.selected_closure.role_id == target_role_id
+
+
+def test_frozen_priority_wins_when_serialized_role_order_points_elsewhere():
+    case = _development_case()
+    # AC01 serializes enzymatic_pet_depolymerization before
+    # polyester_textile_waste, but its frozen priority orders them oppositely
+    # once engineered_pet_hydrolase has been observed.
+    missing = {"enzymatic_pet_depolymerization", "polyester_textile_waste"}
+    covered = {
+        role.role_id
+        for _, role in case.spec.roles.ordered_roles()
+        if role.role_id not in missing
+    }
+
+    decision = unseen.route_anchor_candidates(
+        case,
+        _candidates_covering(case, covered),
+    )
+
+    assert decision.missing_role_ids[:2] == (
+        "polyester_textile_waste",
+        "enzymatic_pet_depolymerization",
+    )
+    assert decision.selected_closure is not None
+    assert decision.selected_closure.role_id == "polyester_textile_waste"
+
+
+def test_fully_observed_anchor_abstains_without_a_closure_call():
+    case = _development_case()
+    all_role_ids = {
+        role.role_id for _, role in case.spec.roles.ordered_roles()
+    }
+
+    decision = unseen.route_anchor_candidates(
+        case,
+        _candidates_covering(case, all_role_ids),
+    )
+
+    assert all(observation.observed for observation in decision.observations)
+    assert decision.action == "abstain"
+    assert decision.reason == "abstain_no_mechanical_role_gap"
+    assert decision.missing_role_ids == ()
+    assert decision.selected_closure is None
+
+
+def test_selected_query_is_exactly_one_pre_frozen_closure_option():
+    case = _development_case(1)
+    covered = {
+        role.role_id
+        for _, role in case.spec.roles.ordered_roles()
+        if role.role_id != case.spec.closure_priority_role_ids[0]
+    }
+
+    decision = unseen.route_anchor_candidates(
+        case,
+        _candidates_covering(case, covered),
+    )
+
+    assert decision.selected_closure is not None
+    expected_role = case.spec.closure_priority_role_ids[0]
+    expected_option = next(
+        option for option in case.closure_options if option.role_id == expected_role
+    )
+    assert decision.selected_closure == expected_option
+    assert decision.selected_closure.query == expected_option.call.query
+
+
+def test_unseen_cohort_has_distinct_identities_and_zero_live_authority():
+    development = unseen.dry_run("development")
+    challenge = unseen.dry_run("unseen")
+
+    assert [item["case_id"] for item in challenge["cases"]] == [
+        f"AD{index:02d}" for index in range(1, 9)
+    ]
+    assert {
+        item["case_contract_sha256"] for item in development["cases"]
+    }.isdisjoint(item["case_contract_sha256"] for item in challenge["cases"])
+    development_calls = {
+        item["idempotency_key"]
+        for case in development["cases"]
+        for item in (case["anchor"], *case["closure_options"])
+    }
+    challenge_calls = {
+        item["idempotency_key"]
+        for case in challenge["cases"]
+        for item in (case["anchor"], *case["closure_options"])
+    }
+    assert development_calls.isdisjoint(challenge_calls)
+    assert challenge["real_network_calls_performed"] is False
+    assert challenge["real_model_calls_performed"] is False
+    assert challenge["live_provider_requests_authorized"] is False
+
+
+def test_fixture_byte_drift_fails_before_case_expansion(tmp_path, monkeypatch):
+    fixture = tmp_path / "drifted.json"
+    fixture.write_bytes(unseen.DEFAULT_FIXTURE_PATH.read_bytes() + b" ")
+
+    def must_not_expand(*args, **kwargs):
+        raise AssertionError("case expansion ran before the raw hash check")
+
+    monkeypatch.setattr(unseen, "build_case", must_not_expand)
+    with pytest.raises(
+        unseen.OpenAlexRoleGapPreflightError,
+        match="fixture byte identity drifted",
+    ):
+        unseen.load_frozen_cases("development", fixture)
+
+
+def test_case_order_drift_is_rejected_with_a_matching_test_hash(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0], payload["development_cases"][1] = (
+        payload["development_cases"][1],
+        payload["development_cases"][0],
+    )
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="AC01 through AC08"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_priority_must_name_every_role_exactly_once(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["closure_priority_role_ids"][-1] = (
+        payload["development_cases"][0]["closure_priority_role_ids"][0]
+    )
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="closure-priority role IDs must be unique"):
+        unseen.load_frozen_cases(
+            "development",
+            fixture,
+            expected_fixture_sha256=fixture_hash,
+        )
+
+
+def test_priority_drift_changes_route_identity_but_not_frozen_call_identities(
+    tmp_path,
+):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    priority = payload["development_cases"][0]["closure_priority_role_ids"]
+    priority[0], priority[1] = priority[1], priority[0]
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    original = unseen.dry_run("development")
+    drifted = unseen.dry_run(
+        "development",
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )
+    original_case = original["cases"][0]
+    drifted_case = drifted["cases"][0]
+
+    assert drifted_case["case_spec_sha256"] != original_case["case_spec_sha256"]
+    assert (
+        drifted_case["case_contract_sha256"]
+        != original_case["case_contract_sha256"]
+    )
+    assert (
+        drifted_case["anchor"]["idempotency_key"]
+        == original_case["anchor"]["idempotency_key"]
+    )
+    assert [
+        option["idempotency_key"] for option in drifted_case["closure_options"]
+    ] == [
+        option["idempotency_key"] for option in original_case["closure_options"]
+    ]
+    assert (
+        drifted_case["empty_anchor_route_probe"]["selected_closure"]["role_id"]
+        == priority[0]
+    )
+
+
+def test_closure_query_drift_changes_only_its_query_bound_call(tmp_path):
+    payload = json.loads(unseen.DEFAULT_FIXTURE_PATH.read_text(encoding="utf-8"))
+    payload["development_cases"][0]["roles"]["required"][0][
+        "closure_query"
+    ] += " validation"
+    fixture, fixture_hash = _write_fixture(tmp_path, payload)
+
+    original = unseen.dry_run("development")["cases"][0]
+    drifted = unseen.dry_run(
+        "development",
+        fixture,
+        expected_fixture_sha256=fixture_hash,
+    )["cases"][0]
+
+    assert drifted["collection_sha256"] == original["collection_sha256"]
+    assert drifted["profile_sha256"] == original["profile_sha256"]
+    assert drifted["anchor"]["idempotency_key"] == original["anchor"][
+        "idempotency_key"
+    ]
+    assert drifted["case_contract_sha256"] != original["case_contract_sha256"]
+    assert (
+        drifted["closure_options"][0]["idempotency_key"]
+        != original["closure_options"][0]["idempotency_key"]
+    )
+    assert [
+        option["idempotency_key"] for option in drifted["closure_options"][1:]
+    ] == [
+        option["idempotency_key"] for option in original["closure_options"][1:]
+    ]
+
+
+def test_dry_run_opens_no_socket_even_when_socket_creation_is_blocked(monkeypatch):
+    def block_socket(*args, **kwargs):
+        raise AssertionError("preflight attempted to create a socket")
+
+    monkeypatch.setattr(socket, "socket", block_socket)
+
+    result = unseen.dry_run("development")
+
+    assert result["case_count"] == 8
+    assert result["real_network_calls_performed"] is False
+
+
+def test_preflight_imports_no_provider_model_execution_or_private_review_code():
+    source = Path("openalex_role_gap_unseen.py").read_text(encoding="utf-8")
+
+    for forbidden in (
+        "anonymous_openalex_search",
+        "OpenAlexEvidenceSearchAdapter",
+        "execute_gap_plan",
+        "qwen",
+        "litellm",
+        "crewai",
+        "urllib",
+        "role_directed_review",
+        "outputs/private-notes",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## Why
The v7 fixed second lane recovered relevant evidence but produced zero complete-role-coverability gain. This PR tests a narrower offline hypothesis: route one bounded closure query only when an anchor result has a mechanically observable role gap.

## What changed
- Add frozen AC development and AD unseen cohorts with content-addressed identities.
- Add candidate-local role observation, frozen-priority routing, one exact closure query, and explicit no-gap abstention.
- Serialize every role observation, route, closure option, plan identity, and request identity at the audit boundary.
- Preserve the first preflight failure and corrected fixture hashes in an erratum instead of weakening the existing scope validator.
- Document the implementation and update public project status.

## Verification
- 1909 tests passed plus 657 subtests.
- Latest Ruff passed.
- CI-aligned narrow Pylint passed.
- Defect reinjection caught cross-candidate phrase pooling and dropped closure-option serialization.

## Boundary
This is zero-network offline infrastructure only. AC01-AC08 and AD01-AD08 have not been sent to OpenAlex or any model. The module is not connected to production, reports, checkpoints, recovery, or human labels.