### PR TITLE
Implement the adaptive role-gap v8 write-once runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1909 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1928 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -231,6 +231,10 @@ openalex_role_directed_live.py
                         write-once AA v7 runner; CLI defaults to zero-network
 openalex_role_directed_review.py
                         exact AA source lock, lane-blind packet + five-gate review
+openalex_role_gap_unseen.py
+                        frozen AC/AD adaptive role-gap identities and router
+openalex_role_gap_live.py
+                        write-once AC adaptive runner; defaults to zero-network
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -733,15 +737,33 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   retained; a narrow pre-provider erratum appended one existing topic token to
   each query and preserves both fixture hashes. Cross-candidate phrase pooling
   and dropping one valid closure only at serialization were separately
-  re-injected and made their seam tests fail before restoration. AC and AD
-  remain unopened; provider compatibility, routing correctness, source value,
-  role coverability and report value are `not_evaluated`. Do not build or run a
-  live AC harness without a separate identity-locked runner and explicit owner
-  authorization, do not open AD before AC passes every frozen gate, and do not
-  connect v8 to production. See
+  re-injected and made their seam tests fail before restoration.
+
+  The separately pre-registered, production-disconnected AC write-once runner
+  is now implemented. Its default CLI path remains zero-network. It locks the
+  fixture and six behavior dependencies before output reservation, persists
+  the complete manifest before adapter construction, the anchor journal before
+  routing, the full five-observation route before an optional closure, and the
+  case portfolio before the next case. Both eight-anchor no-gap completion and
+  sixteen-request closure completion pass in injected tests. Every provider
+  row, rejection, route decision, selected closure, occurrence, deduplication
+  owner, cost and latency reaches content-addressed aggregate and blank-review
+  boundaries. The runner/review seams pass 19/19 focused tests, and the full
+  suite passes 1928 tests plus 657 subtests. Moving manifest persistence after
+  adapter construction and dropping one route only at serialization were
+  separately re-injected and made their tests fail before restoration.
+
+  AC and AD remain unopened; provider compatibility, routing correctness,
+  source value, role coverability and report value are `not_evaluated`. Do not
+  execute AC without separate owner authorization naming the exact merged
+  revision, fixture hash, at most sixteen sequential anonymous OpenAlex
+  requests and a soft stop no greater than USD 0.02. Do not open AD before AC
+  passes every frozen gate, and do not connect v8 to production. See
   `docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`,
-  `docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md`, and
-  `docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md`.
+  `docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md`,
+  `docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md`,
+  `docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`, and
+  `docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`.
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus

--- a/README.md
+++ b/README.md
@@ -974,7 +974,22 @@ connection has occurred, so routing accuracy and source value remain
 [query-scope erratum](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md),
 and [offline result](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md).
 
-Local verification now passes **1,909 tests plus 657 subtests**, latest Ruff,
+The separately pre-registered **v8 AC write-once live runner is now
+implemented but has not been executed against OpenAlex**. Its 19/19 focused
+zero-network tests cover both a complete eight-anchor abstention path and a
+complete sixteen-request closure path. The manifest precedes adapter
+construction; each anchor journal precedes routing; each complete route
+precedes an optional closure; and each portfolio precedes the next case.
+Provider rows, all five role observations, the selected closure identity,
+deduplication lineage, cost, latency, and blank candidate/case review seams are
+content-addressed. Moving the manifest after client construction and dropping
+one route only at the aggregate boundary were separately re-injected and made
+the relevant tests fail. AC remains unopened, AD remains unseen, and provider
+compatibility, routing accuracy, and source value remain `not_evaluated`. See
+the [live-runner amendment](docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)
+and [implementation result](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md).
+
+Local verification now passes **1,928 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2310,7 +2325,18 @@ AC01–AC08 开发集和 AD01–AD08 未见集为每个案例冻结一条 anchor
 [查询范围勘误](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md)与
 [离线结果](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md)。
 
-本地验证现通过 **1,909 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
+另行预注册的 **v8 AC 写一次 live runner 已完成实现，但尚未对 OpenAlex 执行**。
+19/19 个定向零网络测试同时覆盖了仅用八次 anchor 并全部弃权的完整路径，以及八个
+案例均触发 closure、共十六次请求的完整路径。manifest 必须先于 adapter 构造，
+anchor journal 必须先于路由，完整 route 必须先于可选 closure，每个 portfolio
+必须先于下一案例。provider 行、五项角色观察、所选 closure 身份、去重谱系、成本、
+时延以及候选和案例两类空白人工评审接缝均被内容寻址。将 manifest 移到 client
+构造之后、以及仅在聚合边界丢失一项 route 两个缺陷均被重新注入，并使对应测试
+失败。AC 仍未打开、AD 仍保持未见，供应商兼容性、路由正确率和来源价值均为
+`not_evaluated`。详见 [live runner 补充预注册](docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)
+与[实现结果](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)。
+
+本地验证现通过 **1,928 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md
+++ b/docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md
@@ -1,0 +1,201 @@
+# Pre-registration amendment: adaptive role-gap closure v8 live runner
+
+**Frozen:** 2026-09-02, on top of merged zero-network v8 revision
+`aa9bd79920f6b5cf7d718374d0286bd22fd87913`, before implementing a
+network-capable AC01-AC08 runner, constructing an OpenAlex adapter for those
+cases, or making any provider request for AC01-AC08 or AD01-AD08.
+
+**Parent protocol:**
+[`prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`](prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md)
+
+**Challenge fixture:**
+`tests/fixtures/openalex_role_gap_v8_challenge.json`
+
+**Raw fixture SHA-256:**
+`0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+
+**Production connection authorized:** no
+
+**Live provider execution authorized:** no. This amendment authorizes only
+implementation and zero-network verification of the disconnected AC runner.
+A real AC execution requires separate owner authorization naming the merged
+revision, the exact fixture hash, no more than sixteen sequential anonymous
+OpenAlex requests, and a provider-reported cost soft stop no greater than USD
+0.02. AD01-AD08 remain unopened unless AC passes every frozen mechanical and
+human gate without tuning.
+
+## Question
+
+Can the frozen v8 adaptive sequence be executed through a durable boundary
+that first observes one anchor result set, persists the resulting role-gap
+decision, and then spends at most one role-specific closure request without
+allowing an unrecorded route, missing provider row, or interrupted run to look
+complete?
+
+This implementation phase does not ask whether a source is relevant, novel,
+or sufficient for a commercial decision. Those remain independent human-review
+questions and must stay `not_evaluated` after implementation or a provider run.
+
+## Frozen execution scope
+
+Only development cases AC01-AC08 may enter this runner. The existing preflight
+may continue to validate AD01-AD08 offline, but the live runner must not accept
+the unseen cohort.
+
+For each ordered AC case:
+
+1. issue exactly one frozen `anchor_search`, capped at six provider rows;
+2. derive all five role observations from candidate-local title and abstract
+   text using the frozen router;
+3. persist either `abstain_no_mechanical_role_gap` or the highest-priority
+   missing role and its already-frozen closure identity;
+4. issue exactly one `role_closure` request only when that persisted decision
+   selects it, capped at six provider rows; and
+5. join the completed anchor and optional closure into one case portfolio.
+
+The complete study may make between eight and sixteen requests and observe at
+most 96 provider rows. Redirects, retries, fallback queries, supplementary
+search, result-page fetches, model calls, repair, recovery, parallel requests,
+and a second closure are forbidden. A failed request, invalid response,
+identity mismatch, uninspectable cost, or reached soft stop prevents a later
+provider request.
+
+## Identity and authorization boundary
+
+Before output reservation or construction of any network-capable object, the
+runner must verify:
+
+- the raw challenge fixture bytes;
+- all eight ordered AC case identities, eight anchor identities, and forty
+  pre-authorized but mutually exclusive closure identities;
+- the committed bytes of `openalex_role_gap_unseen.py`;
+- the committed bytes of `evidence.py`, `evidence_gap.py`, and
+  `evidence_search.py`;
+- the committed bytes of `domain_evidence_search.py` and
+  `anonymous_openalex_search.py`; and
+- the exact provider, routing, portfolio, and qualification contracts expanded
+  by the preflight.
+
+The runner records its observed self SHA-256 rather than embedding a recursive
+expected hash of itself. A later execution authorization must therefore name
+the exact merged revision that owns that observed runner.
+
+The live path must require an explicit `--execute-live` flag, a fresh
+write-once output directory, acknowledgement of the anonymous OpenAlex daily
+budget, and a positive soft stop no greater than USD 0.02. It must refuse to
+start when `OPENALEX_API_KEY` is configured. Supplying an output path alone
+cannot convert the default zero-network CLI mode into live authority.
+
+## Write-once ordering
+
+After identities and arguments pass, ordering is fixed:
+
+1. reserve the fresh output directory;
+2. persist `manifest.json` with every expanded collection, role profile,
+   anchor identity, closure option, idempotency key, budget, contract, and
+   implementation identity;
+3. only then construct the adapter;
+4. issue one anchor request and persist its complete request journal before
+   routing or any later request;
+5. derive and persist the complete route decision before a selected closure
+   request may begin;
+6. if selected and still within budget, issue one closure request and persist
+   its journal before portfolio construction;
+7. persist the completed case portfolio before the next case may begin; and
+8. finish with write-once execution, provider-row, route-decision,
+   unique-candidate, blank-review, and artifact-index files.
+
+An interrupted prefix is durable history, not resumable authority. A persisted
+route without its selected closure is explicitly partial. No portfolio may be
+fabricated from a failed anchor or an unspent selected closure.
+
+## Frozen portfolio and provenance contract
+
+Every provider-valid candidate remains reviewable; v8 adds no semantic source
+filter. Within a case, candidates are visited in anchor-then-closure order and
+provider-rank order. A later occurrence merges with the first owner only by:
+
+1. the same non-empty normalized DOI, compared case-insensitively; otherwise
+2. the same canonical OpenAlex work URL.
+
+Different non-empty DOIs do not merge merely because they share a malformed
+URL. Every occurrence retains its lane, provider rank, request identity,
+candidate hash, deduplication basis, and owner. Unique rows retain all
+occurrences and lane memberships. Every provider rejection remains attached to
+its request and reaches raw-row accounting.
+
+Route provenance is a separate first-class boundary. It must retain all five
+checked observations, candidate counts, local signal matches, missing-role
+order, action, reason, and the selected closure contract when present. A route
+that was not checked cannot be represented as abstention.
+
+## Final states and later qualification
+
+`completed` means every AC case has a persisted anchor journal, route decision,
+and valid portfolio, plus a closure journal exactly when its route selected
+one. It does not mean source value passed. Final output must distinguish:
+
+- provider cost as `not_observed`, `known`, or `uninspectable`;
+- execution as `completed` or `partial`;
+- source-lock eligibility as `eligible_for_source_lock` only after every
+  mechanical boundary, otherwise `incomplete`;
+- human review as `not_prepared`; and
+- source value as `not_evaluated`.
+
+The parent protocol's six conjunctive human gates remain unchanged. Blank
+review material must expose frozen baseline context, route context, and source
+title/abstract text without hidden answers or model labels. This runner must
+not calculate or claim relevance, novelty, routing correctness, closure value,
+candidate precision, role coverability, or gain over anchor-only retrieval.
+
+## Required zero-network verification
+
+Before a real AC authorization, tests must prove that:
+
+1. dry-run locks eight AC cases, eight anchors, forty possible closures,
+   dependency hashes, and request ceilings while opening no socket;
+2. fixture, implementation, order, budget, or authorization drift fails before
+   output reservation and adapter construction;
+3. `manifest.json` exists before an injected adapter factory can run;
+4. an anchor journal exists before its router runs and the persisted route
+   exists before a selected closure request;
+5. the complete case portfolio exists before the next case request;
+6. a no-gap route spends no closure request while still producing a complete
+   case;
+7. every provider candidate and rejection reaches the raw-row boundary;
+8. every route observation, selected identity, duplicate occurrence, and lane
+   membership reaches its aggregate and blank-review boundary;
+9. provider failure, invalid accounting, identity mismatch, unknown cost, and
+   soft stop remain distinct partial states with no retry;
+10. no environment secret reaches any artifact;
+11. production code imports no v8 preflight, runner, or experimental adapter;
+    and
+12. the full zero-network suite, latest Ruff, and narrow Pylint pass.
+
+Two defects must be re-injected and observed red before restoration: moving
+manifest persistence after adapter construction, and dropping one correctly
+computed route decision from the final serialized boundary. Existing
+assertions may not be weakened or skipped.
+
+## Stop and falsification rules
+
+Runner implementation fails if a network-capable object can exist before the
+manifest, if a closure can begin before its anchor journal and route decision,
+if a later case can begin before its predecessor portfolio, if any provider
+row or route/deduplication lineage disappears before the client artifact, or if
+production imports a v8 component.
+
+A later AC run fails mechanically if any ordered case lacks its required
+durable boundaries or inspectable accounting. A mechanically complete run
+still requires a separately pre-registered source lock and eligible human
+review. Failure seals v8; it does not authorize tuning on AC, rerunning AC as
+validation, opening AD, lowering a gate, or connecting v8 to production.
+
+## Explicit non-claims
+
+Passing this stage would establish only a bounded, adaptive, inspectable, and
+production-disconnected execution contract. It would not establish live
+OpenAlex compatibility on AC, source relevance, novelty, precision, recall,
+routing correctness, closure value, role coverability, report improvement,
+planner-trigger precision, user utility, autonomous tool choice, an SLO, or
+completed production Tool Calling.

--- a/docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md
+++ b/docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md
@@ -1,0 +1,159 @@
+# Adaptive role-gap closure v8 live-runner implementation result
+
+**Implemented:** 2026-09-02
+
+**Parent protocol:**
+[`prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`](prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md)
+
+**Live-runner amendment:**
+[`prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`](prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)
+
+**Fixture SHA-256:**
+`0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+
+**Provider requests made:** 0
+
+**Model calls made:** 0
+
+**Production connection:** false
+
+**AC source value:** `not_evaluated`
+
+## Outcome
+
+The production-disconnected AC01-AC08 write-once runner is implemented. It can
+execute the frozen adaptive method, but its default CLI path remains a
+zero-network protocol check. No OpenAlex request was authorized or made during
+this implementation stage.
+
+The runner preserves the distinction that motivated v8:
+
+- every case spends one frozen anchor request;
+- the anchor journal reaches durable storage before routing;
+- all five candidate-local role observations are computed by the already
+  frozen deterministic router;
+- the complete route is persisted before a selected closure may run;
+- a no-gap decision explicitly abstains and spends no closure request;
+- a search decision can spend exactly one already-frozen role closure;
+- the completed adaptive portfolio is persisted before the next case can
+  begin; and
+- a selected but unspent closure remains partial rather than becoming an
+  abstention or a fabricated portfolio.
+
+The same implementation therefore supports a mechanically complete eight-call
+run when all anchors contain every role and a mechanically complete sixteen-
+call run when every case requires a closure. This variability is planned
+behavior, not hidden retry or fallback.
+
+## Identity and authorization boundary
+
+Before output reservation or adapter construction, the runner verifies:
+
+- the frozen challenge bytes;
+- ordered AC01-AC08 case, anchor, and forty possible closure identities;
+- provider, routing, portfolio, and qualification contracts;
+- six behavior-bearing implementation file hashes; and
+- the positive soft stop at or below USD 0.02, daily-budget acknowledgement,
+  fresh output path, and absence of `OPENALEX_API_KEY`.
+
+The complete manifest is then written before the injected or real adapter is
+constructed. The runner records its observed self hash without trying to
+create a recursive self lock. A future real run still requires separate owner
+authorization naming the exact merged revision and fixture.
+
+The concrete anonymous transport follows no redirects and has no retry loop.
+The imported adapter remains the existing one-request OpenAlex boundary. The
+runner adds no model, recovery, supplementary search, result-page fetch, or
+parallel request path.
+
+## Durable artifacts
+
+A complete synthetic execution produced and validated:
+
+- `manifest.json`;
+- one `lane-executions/ACxx--anchor_search.json` per case;
+- one `route-executions/ACxx.json` per checked route;
+- zero or one `lane-executions/ACxx--role_closure.json` per case;
+- one `case-portfolios/ACxx.json` per completed case;
+- `execution.json`;
+- `provider-rows.csv`;
+- `route-decisions.csv`;
+- `unique-candidates.csv`;
+- `candidate-review.csv`;
+- `case-review.csv`; and
+- `artifact-index.json` with hashes for every preceding source artifact.
+
+Provider-valid candidates are not semantically filtered. Deduplication uses a
+non-empty normalized DOI first and an unambiguous canonical OpenAlex work URL
+second. Every occurrence retains its request lane, selected closure role,
+provider rank, candidate identity, owner, and deduplication basis. Provider
+rejections remain in raw-row accounting.
+
+The route boundary separately retains all observations, checked candidate
+counts, matched candidate and signal-group provenance, frozen missing-role
+order, action, reason, and selected closure identity. Blank candidate and case
+review files expose source, baseline, profile, and route context while leaving
+all human labels empty.
+
+## Failure semantics
+
+Focused tests verify distinct behavior for:
+
+- invalid live arguments before output or adapter construction;
+- configured-key refusal;
+- existing output refusal;
+- implementation drift before output or adapter construction;
+- provider failure with no retry;
+- a schema-valid response that lacks the frozen OpenAlex accounting;
+- response idempotency mismatch;
+- uninspectable cost;
+- soft stop after an anchor, with the checked route retained but no fabricated
+  closure or portfolio; and
+- strict-GBK CLI output without changing authoritative UTF-8 artifacts.
+
+A response without auditable OpenAlex usage is recorded as
+`accounting_invalid` with uninspectable cost. It is not converted to zero cost
+and its unaccounted candidates cannot enter the provider-row or source-review
+boundary.
+
+## Verification
+
+The new focused suite passes:
+
+```text
+19 passed
+```
+
+The complete zero-network suite passes:
+
+```text
+1928 passed, 657 subtests passed
+```
+
+Latest Ruff passes for the runner and tests. The project narrow Pylint gate is
+also run before delivery.
+
+Both protocol-mandated defects were re-injected:
+
+1. manifest persistence was moved after adapter construction; the injected
+   factory failed because `manifest.json` did not exist;
+2. one correctly computed route was dropped from the final route CSV; the
+   aggregate boundary failed because seven serialized routes could not satisfy
+   the eight persisted decisions.
+
+Both defects were restored, and the focused suite returned to 19/19.
+
+## Interpretation
+
+This stage establishes a bounded, sequential, adaptive, write-once and
+inspectable execution contract. It does not establish OpenAlex compatibility
+on AC, source relevance, novelty, candidate precision, routing correctness,
+closure value, role coverability, gain over anchor-only retrieval, planner
+trigger precision, report improvement, user utility, an SLO, autonomous tool
+choice, or production Tool Calling.
+
+AC01-AC08 have not been opened. AD01-AD08 remain unseen. A live AC study may
+begin only after this implementation is merged and the owner separately
+authorizes the exact merged revision, fixture hash, maximum sixteen sequential
+anonymous OpenAlex requests, and a provider-reported soft stop no greater than
+USD 0.02.

--- a/openalex_role_gap_live.py
+++ b/openalex_role_gap_live.py
@@ -1,0 +1,2100 @@
+"""Write-once live runner for the frozen AC01-AC08 role-gap v8 study.
+
+The production pipeline never imports this module. Each case spends one
+anonymous OpenAlex anchor request, records a candidate-local role decision,
+and may then spend one already-frozen closure request. The CLI defaults to a
+zero-network protocol check; a provider run requires a separate owner
+authorization naming the merged revision and frozen fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import os
+import re
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from academic_agent.evidence import canonicalize_url, normalize_doi
+from academic_agent.evidence_gap import ValidatedGapCall, source_collection_sha256
+from academic_agent.openalex_evidence_set import EvidenceRoleKind
+from academic_agent.source_pipeline import SourceCollection
+from academic_agent.tools.anonymous_openalex_search import (
+    AnonymousOpenAlexEvidenceSearchAdapter,
+)
+from academic_agent.tools.evidence_search import (
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+)
+from openalex_role_gap_unseen import (
+    EXPECTED_FIXTURE_SHA256,
+    PreparedRoleGapCase,
+    RoleGapCaseSpec,
+    RoleGapClosureOption,
+    RoleGapPortfolioContract,
+    RoleGapProviderContract,
+    RoleGapQualificationContract,
+    RoleGapRouteDecision,
+    RoleGapRoutingContract,
+    RoleGapCandidateText,
+    dry_run,
+    load_frozen_cases,
+    route_anchor_candidates,
+)
+
+
+_ROOT = Path(__file__).resolve().parent
+_RUNNER_PATH = Path(__file__).resolve()
+_IMPLEMENTATION_PATHS = {
+    "anonymous_openalex_search.py": (
+        _ROOT / "src/academic_agent/tools/anonymous_openalex_search.py"
+    ),
+    "domain_evidence_search.py": (
+        _ROOT / "src/academic_agent/tools/domain_evidence_search.py"
+    ),
+    "evidence.py": _ROOT / "src/academic_agent/evidence.py",
+    "evidence_gap.py": _ROOT / "src/academic_agent/evidence_gap.py",
+    "evidence_search.py": _ROOT / "src/academic_agent/tools/evidence_search.py",
+    "openalex_role_gap_unseen.py": _ROOT / "openalex_role_gap_unseen.py",
+}
+# Behavior-bearing dependencies are locked before output reservation or client
+# construction. The runner records its observed self hash because embedding an
+# expected digest of its own complete bytes would be recursive.
+EXPECTED_IMPLEMENTATION_SHA256 = {
+    "anonymous_openalex_search.py": (
+        "bcaa201622fe5241115661cd9d5a6f7616761eddfedb9acf364b3693e7a044c9"
+    ),
+    "domain_evidence_search.py": (
+        "ae79c38378321f6ce4481e682787ee49f930ec4c34b696d404fcf78d97b2eeab"
+    ),
+    "evidence.py": (
+        "8e9eda3126dc1b81ec5a97e23ecfce8ba64c59a0d77c9a3fb3aec259f07b38c5"
+    ),
+    "evidence_gap.py": (
+        "f2b978ce2af6b4e1d759116466d5a79371e6e4a7e414198b728b427cd93eea25"
+    ),
+    "evidence_search.py": (
+        "2721debe3bb193b8971f8a89db0f4c91342944cb232f1829c02dd8d3780422d0"
+    ),
+    "openalex_role_gap_unseen.py": (
+        "51c77c8615cf160b364ac68232c4a366f73a171aca9b011b73f311a5d0072b19"
+    ),
+}
+
+MAXIMUM_REQUESTS = 16
+MAXIMUM_PROVIDER_ROWS = 96
+MAXIMUM_SOFT_STOP_USD = 0.02
+ANONYMOUS_DAILY_BUDGET_USD = 0.10
+_CASE_ORDER = tuple(f"AC{index:02d}" for index in range(1, 9))
+_LANE_ORDER: tuple[Literal["anchor_search"], Literal["role_closure"]] = (
+    "anchor_search",
+    "role_closure",
+)
+_AGGREGATE_SOURCE_FILES = (
+    "manifest.json",
+    "execution.json",
+    "provider-rows.csv",
+    "route-decisions.csv",
+    "unique-candidates.csv",
+    "candidate-review.csv",
+    "case-review.csv",
+)
+_PROVIDER_ROW_COLUMNS = (
+    "case_id",
+    "lane_id",
+    "lane_index",
+    "selected_role_id",
+    "selected_role_kind",
+    "provider",
+    "tool",
+    "provider_request_id",
+    "provider_request_id_source",
+    "provider_cost_basis",
+    "provider_result_index",
+    "adapter_disposition",
+    "candidate_sha256",
+    "occurrence_sha256",
+    "unique_candidate_sha256",
+    "deduplication_basis",
+    "deduplication_value",
+    "owner_occurrence_sha256",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+    "provider_rejection_code",
+    "rejection_detail",
+    "latency_ms",
+    "trace_id",
+)
+_ROUTE_COLUMNS = (
+    "case_id",
+    "route_execution_sha256",
+    "anchor_execution_sha256",
+    "checked",
+    "action",
+    "reason",
+    "missing_role_ids",
+    "selected_role_id",
+    "selected_role_kind",
+    "selected_query",
+    "selected_idempotency_key",
+    "selected_plan_sha256",
+    "selected_closure_contract_sha256",
+    "observations",
+)
+_UNIQUE_CANDIDATE_COLUMNS = (
+    "case_id",
+    "unique_candidate_sha256",
+    "owner_occurrence_sha256",
+    "lane_memberships",
+    "selected_closure_role_id",
+    "occurrence_sha256s",
+    "provider_ranks",
+    "candidate_sha256",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+)
+_CANDIDATE_REVIEW_COLUMNS = (
+    "case_id",
+    "topic",
+    "unique_candidate_sha256",
+    "lane_memberships",
+    "selected_closure_role_id",
+    "occurrence_count",
+    "provider_ranks",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+    "frozen_baseline_sources",
+    "frozen_role_profile",
+    "frozen_route_decision",
+    "directly_relevant",
+    "baseline_novel",
+    "supported_role_ids",
+    "closure_contributed_selected_role",
+    "review_note",
+)
+_CASE_REVIEW_COLUMNS = (
+    "case_id",
+    "topic",
+    "route_execution_sha256",
+    "route_action",
+    "route_reason",
+    "missing_role_ids",
+    "selected_role_id",
+    "selected_role_kind",
+    "anchor_candidate_count",
+    "closure_candidate_count",
+    "frozen_role_profile",
+    "frozen_route_decision",
+    "routing_decision_correct",
+    "anchor_human_coverable_within_three",
+    "union_human_coverable_within_three",
+    "review_note",
+)
+
+
+LaneId = Literal["anchor_search", "role_closure"]
+RoleGapAdapter = Callable[
+    [ValidatedGapCall],
+    ToolAdapterResponse | dict[str, Any],
+]
+AdapterFactory = Callable[[], RoleGapAdapter]
+Clock = Callable[[], float]
+StopReason = Literal[
+    "completed",
+    "soft_stop",
+    "cost_uninspectable",
+    "request_failed",
+    "accounting_invalid",
+]
+CostState = Literal["known", "uninspectable", "not_observed"]
+DeduplicationBasis = Literal[
+    "new_unique",
+    "normalized_doi",
+    "canonical_openalex_url",
+]
+
+
+class OpenAlexRoleGapLiveError(ValueError):
+    """Raised when the frozen adaptive live boundary cannot be represented."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+def _model_sha256(value: BaseModel) -> str:
+    return _sha256_bytes(value.model_dump_json(exclude_none=False).encode("utf-8"))
+
+
+def _candidate_sha256(value: ToolEvidenceCandidate) -> str:
+    return _model_sha256(value)
+
+
+def _normalized_doi(value: str | None) -> str | None:
+    normalized = normalize_doi(value)
+    return normalized.casefold() if normalized else None
+
+
+def _canonical_openalex_url(value: str) -> str:
+    """Return one stable OpenAlex work identity, rejecting non-record URLs."""
+
+    canonical = canonicalize_url(value)
+    parsed = urlsplit(canonical)
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").casefold() != "openalex.org"
+        or parsed.query
+        or re.fullmatch(r"/W[0-9]+", parsed.path, flags=re.IGNORECASE) is None
+    ):
+        raise OpenAlexRoleGapLiveError(
+            "adaptive role-gap candidate URL is not a canonical OpenAlex work"
+        )
+    return f"https://openalex.org/{parsed.path.lstrip('/').upper()}"
+
+
+def _has_frozen_openalex_accounting(response: ToolAdapterResponse) -> bool:
+    """Return whether a response is safe to persist as provider evidence."""
+
+    usage = response.provider_usage
+    return (
+        response.tool == "academic_search"
+        and usage is not None
+        and usage.provider == "openalex"
+        and usage.cost_basis == "reported_usd"
+        and usage.result_count <= 6
+        and all(
+            candidate.summary_source == "abstract"
+            for candidate in response.candidates
+        )
+    )
+
+
+class RoleGapFrozenCaseArtifact(BaseModel):
+    """Complete deterministic AC expansion persisted before provider work."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    spec: RoleGapCaseSpec
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_collection: SourceCollection
+    anchor_call: ValidatedGapCall
+    anchor_plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    anchor_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    closure_options: tuple[RoleGapClosureOption, ...] = Field(
+        min_length=5,
+        max_length=5,
+    )
+
+    @model_validator(mode="after")
+    def _validate_expanded_identities(self) -> "RoleGapFrozenCaseArtifact":
+        if source_collection_sha256(self.source_collection) != self.collection_sha256:
+            raise ValueError("expanded source collection hash does not match")
+        if self.spec.roles.profile().sha256() != self.profile_sha256:
+            raise ValueError("expanded role profile hash does not match")
+        role_ids = tuple(option.role_id for option in self.closure_options)
+        expected_ids = tuple(role.role_id for _, role in self.spec.roles.ordered_roles())
+        if role_ids != expected_ids:
+            raise ValueError("manifest closure option order drifted")
+        if self.anchor_call.query != self.spec.anchor_query:
+            raise ValueError("manifest anchor query drifted")
+        return self
+
+class RoleGapManifestArtifact(BaseModel):
+    """Write-once method, input, routing, budget, and disconnection boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    method_id: Literal["openalex-adaptive-role-gap-closure-v8"] = (
+        "openalex-adaptive-role-gap-closure-v8"
+    )
+    mode: Literal["openalex_adaptive_role_gap_v8_manifest"] = (
+        "openalex_adaptive_role_gap_v8_manifest"
+    )
+    cohort: Literal["development"] = "development"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    recovery_connected: Literal[False] = False
+    model_calls_authorized: Literal[False] = False
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[16] = MAXIMUM_REQUESTS
+    maximum_provider_rows: Literal[96] = MAXIMUM_PROVIDER_ROWS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    provider_contract: RoleGapProviderContract
+    routing_contract: RoleGapRoutingContract
+    portfolio_contract: RoleGapPortfolioContract
+    qualification_contract: RoleGapQualificationContract
+    cases: tuple[RoleGapFrozenCaseArtifact, ...] = Field(
+        min_length=8,
+        max_length=8,
+    )
+
+    @model_validator(mode="after")
+    def _validate_frozen_contract(self) -> "RoleGapManifestArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("manifest fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("manifest implementation identities do not match")
+        if tuple(case.spec.case_id for case in self.cases) != _CASE_ORDER:
+            raise ValueError("manifest cases must remain ordered AC01 through AC08")
+        possible_calls = sum(1 + len(case.closure_options) for case in self.cases)
+        if possible_calls != 48:
+            raise ValueError("manifest must retain eight anchors and forty closures")
+        return self
+
+
+class RoleGapLaneExecution(BaseModel):
+    """One spent request with exact adaptive lane identity and accounting."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AC0[1-8]$")
+    lane_id: LaneId
+    lane_index: int = Field(ge=0, le=1)
+    selected_role_id: str | None = None
+    selected_role_kind: EvidenceRoleKind | None = None
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    plan_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    lane_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    idempotency_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    trace_id: str = Field(
+        pattern=r"^openalex-role-gap-v8-ac0[1-8]-(?:anchor-search|role-closure-[a-z0-9-]+)$"
+    )
+    state: Literal["completed", "failed"]
+    outbound_attempt_count: Literal[1] = 1
+    response: ToolAdapterResponse | None = None
+    failure_type: str | None = Field(default=None, max_length=100)
+    failure_detail: str | None = Field(default=None, max_length=500)
+    failure_retryable: bool | None = None
+    search_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_lane_and_response(self) -> "RoleGapLaneExecution":
+        if self.lane_id != _LANE_ORDER[self.lane_index]:
+            raise ValueError("lane identity and index drifted")
+        if self.lane_id == "anchor_search":
+            if self.selected_role_id is not None or self.selected_role_kind is not None:
+                raise ValueError("anchor lane cannot carry a selected closure role")
+        elif self.selected_role_id is None or self.selected_role_kind is None:
+            raise ValueError("closure lane requires its selected role identity")
+
+        if self.response is not None and not _has_frozen_openalex_accounting(
+            self.response
+        ):
+            raise ValueError(
+                "persisted response lacks the frozen abstract-bearing "
+                "OpenAlex accounting"
+            )
+        if self.state == "completed":
+            if self.response is None:
+                raise ValueError("completed lane requires an adapter response")
+            if any(
+                value is not None
+                for value in (
+                    self.failure_type,
+                    self.failure_detail,
+                    self.failure_retryable,
+                )
+            ):
+                raise ValueError("completed lane cannot carry failure metadata")
+            if self.response.idempotency_key != self.idempotency_key:
+                raise ValueError("response idempotency identity drifted")
+            if self.response.search_cost_usd != self.search_cost_usd:
+                raise ValueError("lane cost drifted from provider response")
+        else:
+            if self.failure_type is None or self.failure_detail is None:
+                raise ValueError("failed lane requires explicit failure metadata")
+            if self.response is not None and (
+                self.response.search_cost_usd != self.search_cost_usd
+            ):
+                raise ValueError("failed lane cost drifted from provider response")
+        return self
+
+
+class RoleGapRouteExecution(BaseModel):
+    """Durable checked route between the anchor journal and optional closure."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AC0[1-8]$")
+    anchor_execution_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    decision_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    decision: RoleGapRouteDecision
+
+    @model_validator(mode="after")
+    def _validate_decision_identity(self) -> "RoleGapRouteExecution":
+        if self.decision_sha256 != _model_sha256(self.decision):
+            raise ValueError("route decision identity drifted")
+        return self
+
+
+class RoleGapCandidateOccurrence(BaseModel):
+    """One provider candidate and its request, route, and owner lineage."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AC0[1-8]$")
+    lane_id: LaneId
+    lane_index: int = Field(ge=0, le=1)
+    selected_role_id: str | None = None
+    selected_role_kind: EvidenceRoleKind | None = None
+    provider_result_index: int = Field(ge=0, le=5)
+    candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    unique_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    owner_occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    deduplication_basis: DeduplicationBasis
+    deduplication_value: str = Field(min_length=1, max_length=2000)
+    normalized_doi: str | None = Field(default=None, max_length=300)
+    canonical_openalex_url: str = Field(min_length=20, max_length=2000)
+    candidate: ToolEvidenceCandidate
+
+    @model_validator(mode="after")
+    def _validate_occurrence_identity(self) -> "RoleGapCandidateOccurrence":
+        if self.lane_id != _LANE_ORDER[self.lane_index]:
+            raise ValueError("occurrence lane identity and index drifted")
+        if self.lane_id == "anchor_search" and (
+            self.selected_role_id is not None or self.selected_role_kind is not None
+        ):
+            raise ValueError("anchor occurrence cannot carry a closure role")
+        if self.lane_id == "role_closure" and (
+            self.selected_role_id is None or self.selected_role_kind is None
+        ):
+            raise ValueError("closure occurrence lost its route role")
+        if _candidate_sha256(self.candidate) != self.candidate_sha256:
+            raise ValueError("occurrence candidate identity drifted")
+        if self.candidate.provider_result_index != self.provider_result_index:
+            raise ValueError("occurrence provider rank drifted")
+        is_owner = self.occurrence_sha256 == self.owner_occurrence_sha256
+        if is_owner != (self.deduplication_basis == "new_unique"):
+            raise ValueError("occurrence owner and deduplication basis disagree")
+        if self.normalized_doi != _normalized_doi(self.candidate.doi):
+            raise ValueError("occurrence DOI normalization drifted")
+        if self.canonical_openalex_url != _canonical_openalex_url(self.candidate.url):
+            raise ValueError("occurrence OpenAlex URL normalization drifted")
+        return self
+
+
+class RoleGapUniqueCandidate(BaseModel):
+    """One first-seen source retaining all adaptive-lane occurrences."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AC0[1-8]$")
+    unique_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    owner_occurrence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    primary_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    primary_candidate: ToolEvidenceCandidate
+    lane_memberships: tuple[LaneId, ...] = Field(min_length=1, max_length=2)
+    selected_closure_role_id: str | None = None
+    occurrence_sha256s: tuple[str, ...] = Field(min_length=1, max_length=12)
+
+    @model_validator(mode="after")
+    def _validate_unique_identity(self) -> "RoleGapUniqueCandidate":
+        expected = _sha256_json(
+            {
+                "case_id": self.case_id,
+                "owner_occurrence_sha256": self.owner_occurrence_sha256,
+            }
+        )
+        if self.unique_candidate_sha256 != expected:
+            raise ValueError("unique candidate identity drifted")
+        if _candidate_sha256(self.primary_candidate) != self.primary_candidate_sha256:
+            raise ValueError("primary candidate identity drifted")
+        expected_lanes = tuple(
+            lane for lane in _LANE_ORDER if lane in self.lane_memberships
+        )
+        if self.lane_memberships != expected_lanes:
+            raise ValueError("unique candidate lane memberships are not canonical")
+        has_closure = "role_closure" in self.lane_memberships
+        if has_closure != (self.selected_closure_role_id is not None):
+            raise ValueError("unique candidate closure membership lost its route role")
+        if len(set(self.occurrence_sha256s)) != len(self.occurrence_sha256s):
+            raise ValueError("unique candidate occurrences must be unique")
+        return self
+
+
+class RoleGapCasePortfolio(BaseModel):
+    """One checked route joined to its completed anchor and optional closure."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^AC0[1-8]$")
+    collection_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    profile_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    case_contract_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    route_execution_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    lane_execution_sha256s: tuple[str, ...] = Field(min_length=1, max_length=2)
+    occurrences: tuple[RoleGapCandidateOccurrence, ...] = Field(max_length=12)
+    unique_candidates: tuple[RoleGapUniqueCandidate, ...] = Field(max_length=12)
+
+    @model_validator(mode="after")
+    def _validate_portfolio_lineage(self) -> "RoleGapCasePortfolio":
+        if any(item.case_id != self.case_id for item in self.occurrences):
+            raise ValueError("portfolio occurrence belongs to another case")
+        occurrence_ids = tuple(item.occurrence_sha256 for item in self.occurrences)
+        if len(set(occurrence_ids)) != len(occurrence_ids):
+            raise ValueError("portfolio occurrence identities must be unique")
+        unique_ids = {item.unique_candidate_sha256 for item in self.unique_candidates}
+        if len(unique_ids) != len(self.unique_candidates):
+            raise ValueError("portfolio unique candidate identities must be unique")
+        if any(
+            item.unique_candidate_sha256 not in unique_ids
+            for item in self.occurrences
+        ):
+            raise ValueError("portfolio occurrence lost its unique-source owner")
+        for candidate in self.unique_candidates:
+            linked = tuple(
+                occurrence
+                for occurrence in self.occurrences
+                if occurrence.unique_candidate_sha256
+                == candidate.unique_candidate_sha256
+            )
+            if tuple(item.occurrence_sha256 for item in linked) != (
+                candidate.occurrence_sha256s
+            ):
+                raise ValueError("unique candidate occurrence lineage drifted")
+            lanes = tuple(
+                lane
+                for lane in _LANE_ORDER
+                if any(item.lane_id == lane for item in linked)
+            )
+            if lanes != candidate.lane_memberships:
+                raise ValueError("unique candidate lane lineage drifted")
+        return self
+
+
+class RoleGapProviderSummary(BaseModel):
+    """Provider accounting where missing observations cannot become zero cost."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: Literal["openalex"] = "openalex"
+    access_mode: Literal["anonymous_no_key"] = "anonymous_no_key"
+    authorized_case_count: Literal[8] = 8
+    maximum_request_count: Literal[16] = MAXIMUM_REQUESTS
+    attempted_request_count: int = Field(ge=0, le=16)
+    successful_request_count: int = Field(ge=0, le=16)
+    completed_case_count: int = Field(ge=0, le=8)
+    cost_state: CostState
+    reported_cost_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+    )
+    total_latency_ms: float = Field(ge=0.0, allow_inf_nan=False)
+    stopped_reason: StopReason
+
+    @model_validator(mode="after")
+    def _validate_accounting(self) -> "RoleGapProviderSummary":
+        if self.successful_request_count > self.attempted_request_count:
+            raise ValueError("successful requests cannot exceed attempted requests")
+        if self.cost_state == "known" and self.reported_cost_usd is None:
+            raise ValueError("known provider cost requires a numeric total")
+        if self.cost_state != "known" and self.reported_cost_usd is not None:
+            raise ValueError("unknown provider cost must keep USD null")
+        completed = self.completed_case_count == len(_CASE_ORDER)
+        if (self.stopped_reason == "completed") != completed:
+            raise ValueError("provider completion does not match completed cases")
+        return self
+
+
+class RoleGapExecutionArtifact(BaseModel):
+    """Final adaptive execution; source value remains a human judgment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    method_id: Literal["openalex-adaptive-role-gap-closure-v8"] = (
+        "openalex-adaptive-role-gap-closure-v8"
+    )
+    mode: Literal["openalex_adaptive_role_gap_v8_execution"] = (
+        "openalex_adaptive_role_gap_v8_execution"
+    )
+    cohort: Literal["development"] = "development"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    recovery_connected: Literal[False] = False
+    model_call_count: Literal[0] = 0
+    api_key_used: Literal[False] = False
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    maximum_requests: Literal[16] = MAXIMUM_REQUESTS
+    maximum_provider_rows: Literal[96] = MAXIMUM_PROVIDER_ROWS
+    anonymous_daily_budget_usd: Literal[0.1] = ANONYMOUS_DAILY_BUDGET_USD
+    soft_stop_usd: float = Field(gt=0.0, le=MAXIMUM_SOFT_STOP_USD)
+    request_count: int = Field(ge=0, le=16)
+    successful_request_count: int = Field(ge=0, le=16)
+    route_decision_count: int = Field(ge=0, le=8)
+    closure_request_count: int = Field(ge=0, le=8)
+    completed_portfolio_count: int = Field(ge=0, le=8)
+    provider_row_count: int = Field(ge=0, le=96)
+    provider_candidate_count: int = Field(ge=0, le=96)
+    provider_rejection_count: int = Field(ge=0, le=96)
+    unique_candidate_count: int = Field(ge=0, le=96)
+    serialized_boundary_complete: Literal[True] = True
+    overall_state: Literal["completed", "partial"]
+    review_packet_eligibility: Literal["eligible_for_source_lock", "incomplete"]
+    source_lock_state: Literal["not_created"] = "not_created"
+    human_review_state: Literal["not_prepared"] = "not_prepared"
+    source_value_state: Literal["not_evaluated"] = "not_evaluated"
+    provider_summary: RoleGapProviderSummary
+    lane_executions: tuple[RoleGapLaneExecution, ...] = Field(max_length=16)
+    route_executions: tuple[RoleGapRouteExecution, ...] = Field(max_length=8)
+    portfolios: tuple[RoleGapCasePortfolio, ...] = Field(max_length=8)
+
+    @model_validator(mode="after")
+    def _validate_totals_and_states(self) -> "RoleGapExecutionArtifact":
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("execution fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("execution implementation identities do not match")
+        if len(self.lane_executions) != self.request_count:
+            raise ValueError("request count must equal persisted journals")
+        if sum(item.outbound_attempt_count for item in self.lane_executions) != (
+            self.request_count
+        ):
+            raise ValueError("each journal must represent exactly one request")
+        successful = sum(item.state == "completed" for item in self.lane_executions)
+        if successful != self.successful_request_count:
+            raise ValueError("successful-request count drifted")
+        closure_count = sum(
+            item.lane_id == "role_closure" for item in self.lane_executions
+        )
+        if closure_count != self.closure_request_count:
+            raise ValueError("closure-request count drifted")
+        if len(self.route_executions) != self.route_decision_count:
+            raise ValueError("route-decision count drifted")
+        route_case_ids = tuple(item.case_id for item in self.route_executions)
+        if route_case_ids != _CASE_ORDER[: len(route_case_ids)]:
+            raise ValueError("route executions must preserve the AC prefix")
+        if tuple(item.case_id for item in self.portfolios) != _CASE_ORDER[
+            : len(self.portfolios)
+        ]:
+            raise ValueError("case portfolios must preserve the AC prefix")
+        if len(self.portfolios) != self.completed_portfolio_count:
+            raise ValueError("completed-portfolio count drifted")
+
+        lane_pairs = [(item.case_id, item.lane_id) for item in self.lane_executions]
+        if len(set(lane_pairs)) != len(lane_pairs):
+            raise ValueError("a case lane was attempted more than once")
+        for case_index, case_id in enumerate(_CASE_ORDER):
+            case_lanes = [item for item in self.lane_executions if item.case_id == case_id]
+            if not case_lanes:
+                if any(item[0] in _CASE_ORDER[case_index + 1 :] for item in lane_pairs):
+                    raise ValueError("lane executions skipped an earlier AC case")
+                continue
+            if case_lanes[0].lane_id != "anchor_search" or len(case_lanes) > 2:
+                raise ValueError("each case must begin with one anchor")
+            route = next(
+                (item for item in self.route_executions if item.case_id == case_id),
+                None,
+            )
+            if len(case_lanes) == 2:
+                if (
+                    case_lanes[1].lane_id != "role_closure"
+                    or route is None
+                    or route.decision.action != "search"
+                ):
+                    raise ValueError("closure request lacks its checked search route")
+                selected = route.decision.selected_closure
+                if selected is None or (
+                    case_lanes[1].idempotency_key != selected.call.idempotency_key
+                ):
+                    raise ValueError("closure request identity drifted from route")
+
+        route_by_case = {item.case_id: item for item in self.route_executions}
+        lane_by_pair = {
+            (item.case_id, item.lane_id): item for item in self.lane_executions
+        }
+        for portfolio in self.portfolios:
+            route = route_by_case.get(portfolio.case_id)
+            anchor = lane_by_pair.get((portfolio.case_id, "anchor_search"))
+            if route is None or anchor is None or anchor.state != "completed":
+                raise ValueError("portfolio lacks a completed anchor and route")
+            expected_lanes = [anchor]
+            if route.decision.action == "search":
+                closure = lane_by_pair.get((portfolio.case_id, "role_closure"))
+                if closure is None or closure.state != "completed":
+                    raise ValueError("search route portfolio lacks completed closure")
+                expected_lanes.append(closure)
+            if tuple(_model_sha256(item) for item in expected_lanes) != (
+                portfolio.lane_execution_sha256s
+            ):
+                raise ValueError("portfolio request-journal identities drifted")
+            if _model_sha256(route) != portfolio.route_execution_sha256:
+                raise ValueError("portfolio route identity drifted")
+
+        responses = tuple(
+            item.response for item in self.lane_executions if item.response is not None
+        )
+        provider_candidates = sum(len(item.candidates) for item in responses)
+        provider_rejections = sum(len(item.provider_rejections) for item in responses)
+        if provider_candidates != self.provider_candidate_count:
+            raise ValueError("provider-candidate count drifted")
+        if provider_rejections != self.provider_rejection_count:
+            raise ValueError("provider-rejection count drifted")
+        if provider_candidates + provider_rejections != self.provider_row_count:
+            raise ValueError("provider-row count drifted")
+        if sum(len(item.unique_candidates) for item in self.portfolios) != (
+            self.unique_candidate_count
+        ):
+            raise ValueError("unique-candidate count drifted")
+        completed_occurrences = sum(len(item.occurrences) for item in self.portfolios)
+        portfolio_case_ids = {item.case_id for item in self.portfolios}
+        expected_occurrences = sum(
+            len(item.response.candidates)
+            for item in self.lane_executions
+            if item.state == "completed"
+            and item.response is not None
+            and item.case_id in portfolio_case_ids
+        )
+        if completed_occurrences != expected_occurrences:
+            raise ValueError("completed provider candidate lost portfolio lineage")
+        if self.provider_summary.attempted_request_count != self.request_count:
+            raise ValueError("provider request count drifted from execution")
+        if self.provider_summary.successful_request_count != successful:
+            raise ValueError("provider success count drifted from execution")
+        if self.provider_summary.completed_case_count != len(self.portfolios):
+            raise ValueError("provider completed-case count drifted")
+        expected_latency = sum(item.latency_ms for item in self.lane_executions)
+        if not math.isclose(
+            self.provider_summary.total_latency_ms,
+            expected_latency,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise ValueError("provider latency total drifted from request journals")
+        completed = len(self.portfolios) == len(_CASE_ORDER)
+        if (self.overall_state == "completed") != completed:
+            raise ValueError("overall state does not match durable completion")
+        expected_eligibility = (
+            "eligible_for_source_lock" if completed else "incomplete"
+        )
+        if self.review_packet_eligibility != expected_eligibility:
+            raise ValueError("review-packet eligibility drifted")
+        return self
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Reject redirects because one lane authorizes one outbound request."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+class _OneRequestTransport:
+    """Concrete transport with neither redirect following nor internal retry."""
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        method: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> bytes:
+        request = Request(endpoint, data=body, headers=dict(headers), method=method)
+        opener = build_opener(_NoRedirectHandler())
+        with opener.open(request, timeout=timeout) as response:
+            return response.read()
+
+
+def _file_sha256(path: Path) -> str:
+    try:
+        return _sha256_bytes(path.read_bytes())
+    except OSError as exc:
+        raise OpenAlexRoleGapLiveError(
+            f"could not read frozen implementation file {path.name}: {exc}"
+        ) from exc
+
+
+def verify_frozen_implementation() -> dict[str, str]:
+    """Reject dependency drift before output or adapter construction."""
+
+    if set(_IMPLEMENTATION_PATHS) != set(EXPECTED_IMPLEMENTATION_SHA256):
+        raise OpenAlexRoleGapLiveError(
+            "adaptive role-gap implementation lock names are inconsistent"
+        )
+    observed = {
+        name: _file_sha256(path) for name, path in _IMPLEMENTATION_PATHS.items()
+    }
+    if observed != EXPECTED_IMPLEMENTATION_SHA256:
+        changed = sorted(
+            name
+            for name, digest in observed.items()
+            if EXPECTED_IMPLEMENTATION_SHA256.get(name) != digest
+        )
+        raise OpenAlexRoleGapLiveError(
+            "adaptive role-gap implementation identity drifted: "
+            + ", ".join(changed)
+        )
+    return observed
+
+
+def protocol_dry_run() -> dict[str, Any]:
+    """Expose frozen AC identities while constructing no provider client."""
+
+    result = dry_run("development")
+    result["implementation_sha256"] = verify_frozen_implementation()
+    result["runner_sha256"] = _file_sha256(_RUNNER_PATH)
+    result["live_runner_maximum_requests"] = MAXIMUM_REQUESTS
+    result["live_runner_maximum_soft_stop_usd"] = MAXIMUM_SOFT_STOP_USD
+    return result
+
+
+def _manifest_artifact(
+    cases: tuple[PreparedRoleGapCase, ...],
+    *,
+    fixture_sha256: str,
+    implementation_sha256: dict[str, str],
+    runner_sha256: str,
+    soft_stop_usd: float,
+    provider_contract: RoleGapProviderContract,
+    routing_contract: RoleGapRoutingContract,
+    portfolio_contract: RoleGapPortfolioContract,
+    qualification_contract: RoleGapQualificationContract,
+) -> RoleGapManifestArtifact:
+    return RoleGapManifestArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        provider_contract=provider_contract,
+        routing_contract=routing_contract,
+        portfolio_contract=portfolio_contract,
+        qualification_contract=qualification_contract,
+        cases=tuple(
+            RoleGapFrozenCaseArtifact(
+                spec=case.spec,
+                collection_sha256=case.collection_sha256,
+                profile_sha256=case.profile_sha256,
+                case_contract_sha256=case.case_contract_sha256,
+                source_collection=case.collection,
+                anchor_call=case.anchor_call,
+                anchor_plan_sha256=case.anchor_plan_sha256,
+                anchor_contract_sha256=case.anchor_contract_sha256,
+                closure_options=case.closure_options,
+            )
+            for case in cases
+        ),
+    )
+
+
+def _write_new(path: Path, value: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8", newline="") as handle:
+            handle.write(value)
+    except OSError as exc:
+        raise OpenAlexRoleGapLiveError(
+            f"could not create write-once artifact {path}: {exc}"
+        ) from exc
+
+
+def _json_text(value: BaseModel | dict[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    return (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def _write_lane_journal(
+    output_dir: Path,
+    execution: RoleGapLaneExecution,
+) -> None:
+    journal_dir = output_dir / "lane-executions"
+    journal_dir.mkdir(exist_ok=True)
+    _write_new(
+        journal_dir / f"{execution.case_id}--{execution.lane_id}.json",
+        _json_text(execution),
+    )
+
+
+def _write_route_journal(
+    output_dir: Path,
+    execution: RoleGapRouteExecution,
+) -> None:
+    route_dir = output_dir / "route-executions"
+    route_dir.mkdir(exist_ok=True)
+    _write_new(route_dir / f"{execution.case_id}.json", _json_text(execution))
+
+
+def _write_case_portfolio(
+    output_dir: Path,
+    portfolio: RoleGapCasePortfolio,
+) -> None:
+    portfolio_dir = output_dir / "case-portfolios"
+    portfolio_dir.mkdir(exist_ok=True)
+    _write_new(
+        portfolio_dir / f"{portfolio.case_id}.json",
+        _json_text(portfolio),
+    )
+
+
+def _validation_detail(exc: ValidationError) -> str:
+    """Describe invalid structure without copying potentially unsafe input."""
+
+    details = []
+    for error in exc.errors(include_input=False)[:4]:
+        location = ".".join(str(part) for part in error["loc"]) or "response"
+        details.append(f"{location}:{error['type']}")
+    return "; ".join(details)[:500] or "adapter response failed validation"
+
+
+def _lane_identity(
+    case: PreparedRoleGapCase,
+    lane_id: LaneId,
+    selected_closure: RoleGapClosureOption | None,
+) -> tuple[ValidatedGapCall, str, str, str | None, EvidenceRoleKind | None]:
+    if lane_id == "anchor_search":
+        if selected_closure is not None:
+            raise OpenAlexRoleGapLiveError("anchor lane cannot select a closure")
+        return (
+            case.anchor_call,
+            case.anchor_plan_sha256,
+            case.anchor_contract_sha256,
+            None,
+            None,
+        )
+    if selected_closure is None:
+        raise OpenAlexRoleGapLiveError("closure lane requires a frozen option")
+    return (
+        selected_closure.call,
+        selected_closure.plan_sha256,
+        selected_closure.closure_contract_sha256,
+        selected_closure.role_id,
+        selected_closure.role_kind,
+    )
+
+
+def _trace_id(
+    case_id: str,
+    lane_id: LaneId,
+    selected_role_id: str | None,
+) -> str:
+    suffix = lane_id.replace("_", "-")
+    if selected_role_id is not None:
+        suffix = f"{suffix}-{selected_role_id.replace('_', '-')}"
+    return f"openalex-role-gap-v8-{case_id.casefold()}-{suffix}"
+
+
+def _failure_execution(
+    case: PreparedRoleGapCase,
+    lane_id: LaneId,
+    selected_closure: RoleGapClosureOption | None,
+    *,
+    failure_type: str,
+    failure_detail: str,
+    failure_retryable: bool | None,
+    latency_ms: float,
+    response: ToolAdapterResponse | None = None,
+    search_cost_usd: float | None = None,
+) -> RoleGapLaneExecution:
+    call, plan_sha256, contract_sha256, role_id, role_kind = _lane_identity(
+        case,
+        lane_id,
+        selected_closure,
+    )
+    return RoleGapLaneExecution(
+        case_id=case.spec.case_id,
+        lane_id=lane_id,
+        lane_index=_LANE_ORDER.index(lane_id),
+        selected_role_id=role_id,
+        selected_role_kind=role_kind,
+        collection_sha256=case.collection_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        plan_sha256=plan_sha256,
+        lane_contract_sha256=contract_sha256,
+        idempotency_key=call.idempotency_key,
+        trace_id=_trace_id(case.spec.case_id, lane_id, role_id),
+        state="failed",
+        response=response,
+        failure_type=failure_type,
+        failure_detail=failure_detail[:500],
+        failure_retryable=failure_retryable,
+        search_cost_usd=search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _completed_execution(
+    case: PreparedRoleGapCase,
+    lane_id: LaneId,
+    selected_closure: RoleGapClosureOption | None,
+    response: ToolAdapterResponse,
+    latency_ms: float,
+) -> RoleGapLaneExecution:
+    call, plan_sha256, contract_sha256, role_id, role_kind = _lane_identity(
+        case,
+        lane_id,
+        selected_closure,
+    )
+    return RoleGapLaneExecution(
+        case_id=case.spec.case_id,
+        lane_id=lane_id,
+        lane_index=_LANE_ORDER.index(lane_id),
+        selected_role_id=role_id,
+        selected_role_kind=role_kind,
+        collection_sha256=case.collection_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        plan_sha256=plan_sha256,
+        lane_contract_sha256=contract_sha256,
+        idempotency_key=call.idempotency_key,
+        trace_id=_trace_id(case.spec.case_id, lane_id, role_id),
+        state="completed",
+        response=response,
+        search_cost_usd=response.search_cost_usd,
+        latency_ms=latency_ms,
+    )
+
+
+def _elapsed_ms(clock: Clock, started_at: float) -> float:
+    elapsed = (clock() - started_at) * 1000.0
+    if not math.isfinite(elapsed) or elapsed < 0.0:
+        raise OpenAlexRoleGapLiveError("monotonic request latency is invalid")
+    return elapsed
+
+
+def _execute_request(
+    adapter: RoleGapAdapter,
+    case: PreparedRoleGapCase,
+    lane_id: LaneId,
+    selected_closure: RoleGapClosureOption | None,
+    clock: Clock,
+) -> tuple[RoleGapLaneExecution, StopReason | None]:
+    call, _, _, _, _ = _lane_identity(case, lane_id, selected_closure)
+    started_at = clock()
+    try:
+        raw_response = adapter(call)
+    except ToolAdapterFailure as exc:
+        return (
+            _failure_execution(
+                case,
+                lane_id,
+                selected_closure,
+                failure_type=exc.failure_type,
+                failure_detail=str(exc),
+                failure_retryable=exc.retryable,
+                latency_ms=_elapsed_ms(clock, started_at),
+                search_cost_usd=exc.search_cost_usd,
+            ),
+            "request_failed",
+        )
+    latency_ms = _elapsed_ms(clock, started_at)
+    try:
+        response = ToolAdapterResponse.model_validate(raw_response)
+    except ValidationError as exc:
+        return (
+            _failure_execution(
+                case,
+                lane_id,
+                selected_closure,
+                failure_type="adapter_response_invalid",
+                failure_detail=_validation_detail(exc),
+                failure_retryable=False,
+                latency_ms=latency_ms,
+            ),
+            "accounting_invalid",
+        )
+    if response.idempotency_key != call.idempotency_key:
+        preserved_response = (
+            response if _has_frozen_openalex_accounting(response) else None
+        )
+        return (
+            _failure_execution(
+                case,
+                lane_id,
+                selected_closure,
+                failure_type="adapter_identity_mismatch",
+                failure_detail=(
+                    "adapter response idempotency key does not match the authorized lane"
+                ),
+                failure_retryable=False,
+                latency_ms=latency_ms,
+                response=preserved_response,
+                search_cost_usd=(
+                    response.search_cost_usd
+                    if preserved_response is not None
+                    else None
+                ),
+            ),
+            "accounting_invalid",
+        )
+    try:
+        execution = _completed_execution(
+            case,
+            lane_id,
+            selected_closure,
+            response,
+            latency_ms,
+        )
+    except ValidationError as exc:
+        # A Pydantic-shaped response can still fail this study's stricter
+        # OpenAlex accounting contract. Without provider usage there is no
+        # auditable request or row identity, so retaining the payload would
+        # either fabricate zero cost or make unaccounted candidates look
+        # eligible for aggregation.
+        preserved_response = (
+            response if _has_frozen_openalex_accounting(response) else None
+        )
+        return (
+            _failure_execution(
+                case,
+                lane_id,
+                selected_closure,
+                failure_type="adapter_response_invalid",
+                failure_detail=_validation_detail(exc),
+                failure_retryable=False,
+                latency_ms=latency_ms,
+                response=preserved_response,
+                search_cost_usd=(
+                    response.search_cost_usd
+                    if preserved_response is not None
+                    else None
+                ),
+            ),
+            "accounting_invalid",
+        )
+    return execution, None
+
+
+def _route_execution(
+    case: PreparedRoleGapCase,
+    anchor: RoleGapLaneExecution,
+) -> RoleGapRouteExecution:
+    if anchor.state != "completed" or anchor.response is None:
+        raise OpenAlexRoleGapLiveError("routing requires a completed anchor response")
+    candidates = tuple(
+        RoleGapCandidateText(
+            title=candidate.title,
+            abstract=candidate.evidence_summary,
+        )
+        for candidate in anchor.response.candidates
+    )
+    decision = route_anchor_candidates(case, candidates)
+    return RoleGapRouteExecution(
+        case_id=case.spec.case_id,
+        anchor_execution_sha256=_model_sha256(anchor),
+        decision_sha256=_model_sha256(decision),
+        decision=decision,
+    )
+
+
+def _occurrence_sha256(
+    case_id: str,
+    lane_id: LaneId,
+    provider_result_index: int,
+    candidate_sha256: str,
+) -> str:
+    return _sha256_json(
+        {
+            "case_id": case_id,
+            "lane_id": lane_id,
+            "provider_result_index": provider_result_index,
+            "candidate_sha256": candidate_sha256,
+        }
+    )
+
+
+def _compatible_url_owner(
+    owners: list[dict[str, Any]],
+    normalized_doi: str | None,
+) -> dict[str, Any] | None:
+    """Return one unambiguous owner without merging conflicting DOIs."""
+
+    compatible = [
+        owner
+        for owner in owners
+        if owner["normalized_doi"] is None
+        or normalized_doi is None
+        or owner["normalized_doi"] == normalized_doi
+    ]
+    return compatible[0] if len(compatible) == 1 else None
+
+
+def build_case_portfolio(
+    case: PreparedRoleGapCase,
+    route: RoleGapRouteExecution,
+    lane_executions: tuple[RoleGapLaneExecution, ...],
+) -> RoleGapCasePortfolio:
+    """Join the checked adaptive path while retaining every occurrence."""
+
+    expected_lane_ids: tuple[LaneId, ...] = (
+        ("anchor_search", "role_closure")
+        if route.decision.action == "search"
+        else ("anchor_search",)
+    )
+    if (
+        route.case_id != case.spec.case_id
+        or tuple(item.lane_id for item in lane_executions) != expected_lane_ids
+        or any(
+            item.state != "completed" or item.response is None
+            for item in lane_executions
+        )
+    ):
+        raise OpenAlexRoleGapLiveError(
+            "case portfolio requires its ordered completed adaptive path"
+        )
+    if route.anchor_execution_sha256 != _model_sha256(lane_executions[0]):
+        raise OpenAlexRoleGapLiveError("route anchor identity drifted")
+    selected = route.decision.selected_closure
+    if route.decision.action == "search":
+        if selected is None or lane_executions[1].idempotency_key != (
+            selected.call.idempotency_key
+        ):
+            raise OpenAlexRoleGapLiveError("portfolio closure identity drifted")
+
+    owner_records: list[dict[str, Any]] = []
+    seen_dois: dict[str, dict[str, Any]] = {}
+    seen_urls: dict[str, list[dict[str, Any]]] = {}
+    occurrences: list[RoleGapCandidateOccurrence] = []
+    for lane_execution in lane_executions:
+        response = lane_execution.response
+        if response is None:  # pragma: no cover - guarded above and by Pydantic
+            raise OpenAlexRoleGapLiveError("completed lane lost its response")
+        for candidate in sorted(
+            response.candidates,
+            key=lambda item: (
+                item.provider_result_index
+                if item.provider_result_index is not None
+                else -1
+            ),
+        ):
+            provider_index = candidate.provider_result_index
+            if provider_index is None:
+                raise OpenAlexRoleGapLiveError(
+                    "provider-accounted candidate lost its result index"
+                )
+            candidate_digest = _candidate_sha256(candidate)
+            occurrence_digest = _occurrence_sha256(
+                case.spec.case_id,
+                lane_execution.lane_id,
+                provider_index,
+                candidate_digest,
+            )
+            normalized_doi = _normalized_doi(candidate.doi)
+            canonical_url = _canonical_openalex_url(candidate.url)
+            owner = seen_dois.get(normalized_doi) if normalized_doi else None
+            basis: DeduplicationBasis = "normalized_doi"
+            deduplication_value = normalized_doi or canonical_url
+            if owner is None:
+                owner = _compatible_url_owner(
+                    seen_urls.get(canonical_url, []),
+                    normalized_doi,
+                )
+                basis = "canonical_openalex_url"
+                deduplication_value = canonical_url
+            if owner is None:
+                unique_digest = _sha256_json(
+                    {
+                        "case_id": case.spec.case_id,
+                        "owner_occurrence_sha256": occurrence_digest,
+                    }
+                )
+                owner = {
+                    "unique_candidate_sha256": unique_digest,
+                    "owner_occurrence_sha256": occurrence_digest,
+                    "primary_candidate_sha256": candidate_digest,
+                    "primary_candidate": candidate,
+                    "normalized_doi": normalized_doi,
+                    "canonical_openalex_url": canonical_url,
+                    "lane_memberships": [],
+                    "occurrence_sha256s": [],
+                    "selected_closure_role_id": None,
+                }
+                owner_records.append(owner)
+                basis = "new_unique"
+                deduplication_value = normalized_doi or canonical_url
+                if normalized_doi:
+                    seen_dois[normalized_doi] = owner
+                seen_urls.setdefault(canonical_url, []).append(owner)
+            # A later occurrence can add a DOI to a first-seen URL-only owner,
+            # or add another canonical URL to a DOI owner. Register both
+            # secondary identities without changing which source was first.
+            if normalized_doi and normalized_doi not in seen_dois:
+                seen_dois[normalized_doi] = owner
+            url_owners = seen_urls.setdefault(canonical_url, [])
+            if not any(existing is owner for existing in url_owners):
+                url_owners.append(owner)
+            if lane_execution.lane_id not in owner["lane_memberships"]:
+                owner["lane_memberships"].append(lane_execution.lane_id)
+            if lane_execution.selected_role_id is not None:
+                owner["selected_closure_role_id"] = lane_execution.selected_role_id
+            owner["occurrence_sha256s"].append(occurrence_digest)
+            occurrences.append(
+                RoleGapCandidateOccurrence(
+                    case_id=case.spec.case_id,
+                    lane_id=lane_execution.lane_id,
+                    lane_index=lane_execution.lane_index,
+                    selected_role_id=lane_execution.selected_role_id,
+                    selected_role_kind=lane_execution.selected_role_kind,
+                    provider_result_index=provider_index,
+                    candidate_sha256=candidate_digest,
+                    occurrence_sha256=occurrence_digest,
+                    unique_candidate_sha256=owner["unique_candidate_sha256"],
+                    owner_occurrence_sha256=owner["owner_occurrence_sha256"],
+                    deduplication_basis=basis,
+                    deduplication_value=deduplication_value,
+                    normalized_doi=normalized_doi,
+                    canonical_openalex_url=canonical_url,
+                    candidate=candidate,
+                )
+            )
+
+    unique_candidates = tuple(
+        RoleGapUniqueCandidate(
+            case_id=case.spec.case_id,
+            unique_candidate_sha256=owner["unique_candidate_sha256"],
+            owner_occurrence_sha256=owner["owner_occurrence_sha256"],
+            primary_candidate_sha256=owner["primary_candidate_sha256"],
+            primary_candidate=owner["primary_candidate"],
+            lane_memberships=tuple(owner["lane_memberships"]),
+            selected_closure_role_id=owner["selected_closure_role_id"],
+            occurrence_sha256s=tuple(owner["occurrence_sha256s"]),
+        )
+        for owner in owner_records
+    )
+    return RoleGapCasePortfolio(
+        case_id=case.spec.case_id,
+        collection_sha256=case.collection_sha256,
+        profile_sha256=case.profile_sha256,
+        case_contract_sha256=case.case_contract_sha256,
+        route_execution_sha256=_model_sha256(route),
+        lane_execution_sha256s=tuple(
+            _model_sha256(item) for item in lane_executions
+        ),
+        occurrences=tuple(occurrences),
+        unique_candidates=unique_candidates,
+    )
+
+
+def _provider_cost(
+    executions: list[RoleGapLaneExecution],
+) -> tuple[CostState, float | None]:
+    if not executions:
+        return "not_observed", None
+    if any(item.search_cost_usd is None for item in executions):
+        return "uninspectable", None
+    return "known", sum(
+        item.search_cost_usd
+        for item in executions
+        if item.search_cost_usd is not None
+    )
+
+
+def _json_compact(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _occurrence_by_provider_row(
+    portfolios: tuple[RoleGapCasePortfolio, ...],
+) -> dict[tuple[str, LaneId, int], RoleGapCandidateOccurrence]:
+    return {
+        (item.case_id, item.lane_id, item.provider_result_index): item
+        for portfolio in portfolios
+        for item in portfolio.occurrences
+    }
+
+
+def _provider_rows(
+    executions: tuple[RoleGapLaneExecution, ...],
+    portfolios: tuple[RoleGapCasePortfolio, ...],
+) -> list[dict[str, str]]:
+    occurrence_by_row = _occurrence_by_provider_row(portfolios)
+    rows: list[dict[str, str]] = []
+    for execution in executions:
+        response = execution.response
+        if response is None:
+            continue
+        usage = response.provider_usage
+        if usage is None:
+            raise OpenAlexRoleGapLiveError(
+                "persisted OpenAlex response lost provider accounting"
+            )
+        for candidate in response.candidates:
+            provider_index = candidate.provider_result_index
+            if provider_index is None:
+                raise OpenAlexRoleGapLiveError(
+                    "persisted provider candidate lost its result index"
+                )
+            occurrence = occurrence_by_row.get(
+                (execution.case_id, execution.lane_id, provider_index)
+            )
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "lane_id": execution.lane_id,
+                    "lane_index": str(execution.lane_index),
+                    "selected_role_id": execution.selected_role_id or "",
+                    "selected_role_kind": execution.selected_role_kind or "",
+                    "provider": usage.provider,
+                    "tool": response.tool,
+                    "provider_request_id": usage.request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(provider_index),
+                    "adapter_disposition": "candidate",
+                    "candidate_sha256": _candidate_sha256(candidate),
+                    "occurrence_sha256": (
+                        occurrence.occurrence_sha256 if occurrence else ""
+                    ),
+                    "unique_candidate_sha256": (
+                        occurrence.unique_candidate_sha256 if occurrence else ""
+                    ),
+                    "deduplication_basis": (
+                        occurrence.deduplication_basis
+                        if occurrence
+                        else "NOT_EVALUATED"
+                    ),
+                    "deduplication_value": (
+                        occurrence.deduplication_value if occurrence else ""
+                    ),
+                    "owner_occurrence_sha256": (
+                        occurrence.owner_occurrence_sha256 if occurrence else ""
+                    ),
+                    "title": candidate.title,
+                    "url": candidate.url,
+                    "normalized_doi": _normalized_doi(candidate.doi) or "",
+                    "publisher": candidate.publisher,
+                    "published_date": (
+                        candidate.published_date.isoformat()
+                        if candidate.published_date
+                        else ""
+                    ),
+                    "evidence_summary": candidate.evidence_summary,
+                    "summary_source": candidate.summary_source,
+                    "citation_count": (
+                        str(candidate.citation_count)
+                        if candidate.citation_count is not None
+                        else ""
+                    ),
+                    "provider_rejection_code": "",
+                    "rejection_detail": "",
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+        for rejection in response.provider_rejections:
+            rows.append(
+                {
+                    "case_id": execution.case_id,
+                    "lane_id": execution.lane_id,
+                    "lane_index": str(execution.lane_index),
+                    "selected_role_id": execution.selected_role_id or "",
+                    "selected_role_kind": execution.selected_role_kind or "",
+                    "provider": usage.provider,
+                    "tool": response.tool,
+                    "provider_request_id": usage.request_id,
+                    "provider_request_id_source": usage.request_id_source,
+                    "provider_cost_basis": usage.cost_basis,
+                    "provider_result_index": str(rejection.provider_result_index),
+                    "adapter_disposition": "provider_rejected",
+                    "candidate_sha256": "",
+                    "occurrence_sha256": "",
+                    "unique_candidate_sha256": "",
+                    "deduplication_basis": "NOT_APPLICABLE",
+                    "deduplication_value": "",
+                    "owner_occurrence_sha256": "",
+                    "title": rejection.title or "",
+                    "url": rejection.url or "",
+                    "normalized_doi": "",
+                    "publisher": "",
+                    "published_date": "",
+                    "evidence_summary": "",
+                    "summary_source": "",
+                    "citation_count": "",
+                    "provider_rejection_code": rejection.code,
+                    "rejection_detail": rejection.detail,
+                    "latency_ms": str(execution.latency_ms),
+                    "trace_id": execution.trace_id,
+                }
+            )
+    rows.sort(
+        key=lambda row: (
+            _CASE_ORDER.index(row["case_id"]),
+            int(row["lane_index"]),
+            int(row["provider_result_index"]),
+        )
+    )
+    return rows
+
+
+def _route_rows(
+    routes: tuple[RoleGapRouteExecution, ...],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for route in routes:
+        decision = route.decision
+        selected = decision.selected_closure
+        rows.append(
+            {
+                "case_id": route.case_id,
+                "route_execution_sha256": _model_sha256(route),
+                "anchor_execution_sha256": route.anchor_execution_sha256,
+                "checked": "true",
+                "action": decision.action,
+                "reason": decision.reason,
+                "missing_role_ids": _json_compact(decision.missing_role_ids),
+                "selected_role_id": selected.role_id if selected else "",
+                "selected_role_kind": selected.role_kind if selected else "",
+                "selected_query": selected.query if selected else "",
+                "selected_idempotency_key": (
+                    selected.call.idempotency_key if selected else ""
+                ),
+                "selected_plan_sha256": selected.plan_sha256 if selected else "",
+                "selected_closure_contract_sha256": (
+                    selected.closure_contract_sha256 if selected else ""
+                ),
+                "observations": _json_compact(
+                    [
+                        observation.model_dump(mode="json")
+                        for observation in decision.observations
+                    ]
+                ),
+            }
+        )
+    return rows
+
+
+def _unique_and_review_rows(
+    manifest: RoleGapManifestArtifact,
+    routes: tuple[RoleGapRouteExecution, ...],
+    portfolios: tuple[RoleGapCasePortfolio, ...],
+) -> tuple[
+    list[dict[str, str]],
+    list[dict[str, str]],
+    list[dict[str, str]],
+]:
+    case_inputs = {item.spec.case_id: item for item in manifest.cases}
+    route_by_case = {item.case_id: item for item in routes}
+    unique_rows: list[dict[str, str]] = []
+    candidate_review_rows: list[dict[str, str]] = []
+    case_review_rows: list[dict[str, str]] = []
+    for portfolio in portfolios:
+        frozen = case_inputs[portfolio.case_id]
+        route = route_by_case[portfolio.case_id]
+        occurrence_by_id = {
+            item.occurrence_sha256: item for item in portfolio.occurrences
+        }
+        anchor_count = sum(
+            item.lane_id == "anchor_search" for item in portfolio.occurrences
+        )
+        closure_count = sum(
+            item.lane_id == "role_closure" for item in portfolio.occurrences
+        )
+        selected = route.decision.selected_closure
+        frozen_profile = _json_compact(
+            frozen.spec.roles.profile().model_dump(mode="json")
+        )
+        frozen_route = _json_compact(route.decision.model_dump(mode="json"))
+        case_review_rows.append(
+            {
+                "case_id": portfolio.case_id,
+                "topic": frozen.spec.topic,
+                "route_execution_sha256": _model_sha256(route),
+                "route_action": route.decision.action,
+                "route_reason": route.decision.reason,
+                "missing_role_ids": _json_compact(
+                    route.decision.missing_role_ids
+                ),
+                "selected_role_id": selected.role_id if selected else "",
+                "selected_role_kind": selected.role_kind if selected else "",
+                "anchor_candidate_count": str(anchor_count),
+                "closure_candidate_count": str(closure_count),
+                "frozen_role_profile": frozen_profile,
+                "frozen_route_decision": frozen_route,
+                "routing_decision_correct": "",
+                "anchor_human_coverable_within_three": "",
+                "union_human_coverable_within_three": "",
+                "review_note": "",
+            }
+        )
+        for item in portfolio.unique_candidates:
+            candidate = item.primary_candidate
+            linked = [
+                occurrence_by_id[occurrence_id]
+                for occurrence_id in item.occurrence_sha256s
+            ]
+            provider_ranks = [
+                {
+                    "lane_id": occurrence.lane_id,
+                    "selected_role_id": occurrence.selected_role_id,
+                    "provider_result_index": occurrence.provider_result_index,
+                }
+                for occurrence in linked
+            ]
+            memberships = _json_compact(item.lane_memberships)
+            common = {
+                "case_id": item.case_id,
+                "unique_candidate_sha256": item.unique_candidate_sha256,
+                "lane_memberships": memberships,
+                "selected_closure_role_id": (
+                    item.selected_closure_role_id or ""
+                ),
+                "provider_ranks": _json_compact(provider_ranks),
+                "title": candidate.title,
+                "url": candidate.url,
+                "normalized_doi": _normalized_doi(candidate.doi) or "",
+                "publisher": candidate.publisher,
+                "published_date": (
+                    candidate.published_date.isoformat()
+                    if candidate.published_date
+                    else ""
+                ),
+                "evidence_summary": candidate.evidence_summary,
+                "summary_source": candidate.summary_source,
+                "citation_count": (
+                    str(candidate.citation_count)
+                    if candidate.citation_count is not None
+                    else ""
+                ),
+            }
+            unique_rows.append(
+                {
+                    **common,
+                    "owner_occurrence_sha256": item.owner_occurrence_sha256,
+                    "occurrence_sha256s": _json_compact(
+                        item.occurrence_sha256s
+                    ),
+                    "candidate_sha256": item.primary_candidate_sha256,
+                }
+            )
+            candidate_review_rows.append(
+                {
+                    **common,
+                    "topic": frozen.spec.topic,
+                    "occurrence_count": str(len(item.occurrence_sha256s)),
+                    "frozen_baseline_sources": _json_compact(
+                        [
+                            source.model_dump(mode="json")
+                            for source in frozen.source_collection.academic_sources
+                        ]
+                    ),
+                    "frozen_role_profile": frozen_profile,
+                    "frozen_route_decision": frozen_route,
+                    "directly_relevant": "",
+                    "baseline_novel": "",
+                    "supported_role_ids": "",
+                    "closure_contributed_selected_role": "",
+                    "review_note": "",
+                }
+            )
+    return unique_rows, candidate_review_rows, case_review_rows
+
+
+def _csv_text(columns: tuple[str, ...], rows: list[dict[str, str]]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="raise")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _validate_route_manifest_binding(
+    manifest: RoleGapManifestArtifact,
+    routes: tuple[RoleGapRouteExecution, ...],
+) -> None:
+    """Reject a valid route object bound to the wrong frozen AC case."""
+
+    cases = {item.spec.case_id: item for item in manifest.cases}
+    for route in routes:
+        frozen = cases[route.case_id]
+        expected_role_ids = tuple(
+            role.role_id for _, role in frozen.spec.roles.ordered_roles()
+        )
+        observed_role_ids = tuple(
+            observation.role_id for observation in route.decision.observations
+        )
+        if observed_role_ids != expected_role_ids:
+            raise OpenAlexRoleGapLiveError(
+                f"{route.case_id}: route observations drifted from frozen roles"
+            )
+        selected = route.decision.selected_closure
+        if selected is None:
+            continue
+        expected = next(
+            (
+                option
+                for option in frozen.closure_options
+                if option.role_id == selected.role_id
+            ),
+            None,
+        )
+        if expected is None or expected != selected:
+            raise OpenAlexRoleGapLiveError(
+                f"{route.case_id}: selected closure drifted from manifest"
+            )
+
+
+def _write_final_artifacts(
+    output_dir: Path,
+    manifest: RoleGapManifestArtifact,
+    artifact: RoleGapExecutionArtifact,
+) -> None:
+    _validate_route_manifest_binding(manifest, artifact.route_executions)
+    provider_rows = _provider_rows(
+        artifact.lane_executions,
+        artifact.portfolios,
+    )
+    route_rows = _route_rows(artifact.route_executions)
+    unique_rows, candidate_review_rows, case_review_rows = (
+        _unique_and_review_rows(
+            manifest,
+            artifact.route_executions,
+            artifact.portfolios,
+        )
+    )
+    if len(provider_rows) != artifact.provider_row_count:
+        raise OpenAlexRoleGapLiveError(
+            "provider row disappeared before the aggregate boundary"
+        )
+    if len(route_rows) != artifact.route_decision_count:
+        raise OpenAlexRoleGapLiveError(
+            "route decision disappeared before the aggregate boundary"
+        )
+    if len(unique_rows) != artifact.unique_candidate_count:
+        raise OpenAlexRoleGapLiveError(
+            "unique candidate disappeared before the aggregate boundary"
+        )
+    if len(candidate_review_rows) != artifact.unique_candidate_count:
+        raise OpenAlexRoleGapLiveError(
+            "candidate disappeared before the blank review boundary"
+        )
+    if len(case_review_rows) != artifact.completed_portfolio_count:
+        raise OpenAlexRoleGapLiveError(
+            "completed case disappeared before the route-review boundary"
+        )
+    _write_new(output_dir / "execution.json", _json_text(artifact))
+    _write_new(
+        output_dir / "provider-rows.csv",
+        _csv_text(_PROVIDER_ROW_COLUMNS, provider_rows),
+    )
+    _write_new(
+        output_dir / "route-decisions.csv",
+        _csv_text(_ROUTE_COLUMNS, route_rows),
+    )
+    _write_new(
+        output_dir / "unique-candidates.csv",
+        _csv_text(_UNIQUE_CANDIDATE_COLUMNS, unique_rows),
+    )
+    _write_new(
+        output_dir / "candidate-review.csv",
+        _csv_text(_CANDIDATE_REVIEW_COLUMNS, candidate_review_rows),
+    )
+    _write_new(
+        output_dir / "case-review.csv",
+        _csv_text(_CASE_REVIEW_COLUMNS, case_review_rows),
+    )
+    source_paths = [output_dir / name for name in _AGGREGATE_SOURCE_FILES]
+    source_paths.extend(sorted((output_dir / "lane-executions").glob("*.json")))
+    source_paths.extend(sorted((output_dir / "route-executions").glob("*.json")))
+    source_paths.extend(sorted((output_dir / "case-portfolios").glob("*.json")))
+    file_hashes = {
+        path.relative_to(output_dir).as_posix(): _sha256_bytes(path.read_bytes())
+        for path in source_paths
+    }
+    _write_new(
+        output_dir / "artifact-index.json",
+        _json_text(
+            {
+                "schema_version": 1,
+                "mode": "openalex_adaptive_role_gap_v8_artifact_index",
+                "production_connected": False,
+                "report_workflow_connected": False,
+                "planner_trigger_connected": False,
+                "recovery_connected": False,
+                "model_call_count": 0,
+                "source_file_sha256": file_hashes,
+            }
+        ),
+    )
+
+
+def execute_live_study(
+    *,
+    output_dir: Path,
+    soft_stop_usd: float,
+    acknowledge_anonymous_daily_budget: bool,
+    adapter_factory: AdapterFactory | None = None,
+    monotonic_clock: Clock | None = None,
+) -> RoleGapExecutionArtifact:
+    """Run AC01-AC08 under the frozen adaptive write-once boundary."""
+
+    if not 0.0 < soft_stop_usd <= MAXIMUM_SOFT_STOP_USD:
+        raise OpenAlexRoleGapLiveError(
+            "adaptive role-gap v8 soft stop must be greater than zero "
+            "and at most USD 0.02"
+        )
+    if not acknowledge_anonymous_daily_budget:
+        raise OpenAlexRoleGapLiveError(
+            "adaptive role-gap v8 execution requires daily-budget acknowledgement"
+        )
+    if (os.getenv("OPENALEX_API_KEY") or "").strip():
+        raise OpenAlexRoleGapLiveError(
+            "anonymous adaptive role-gap v8 study refuses a configured "
+            "OPENALEX_API_KEY"
+        )
+    if output_dir.exists():
+        raise FileExistsError(
+            f"adaptive role-gap v8 output already exists: {output_dir}"
+        )
+
+    fixture_sha256, challenge, cases = load_frozen_cases("development")
+    implementation_sha256 = verify_frozen_implementation()
+    runner_sha256 = _file_sha256(_RUNNER_PATH)
+    output_dir.mkdir(parents=True, exist_ok=False)
+    manifest = _manifest_artifact(
+        cases,
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        provider_contract=challenge.provider_contract,
+        routing_contract=challenge.routing_contract,
+        portfolio_contract=challenge.portfolio_contract,
+        qualification_contract=challenge.qualification_contract,
+    )
+    # The manifest is durable authority for every possible request. Constructing
+    # the adapter earlier would make a crash leave an unaudited spender.
+    _write_new(output_dir / "manifest.json", _json_text(manifest))
+    adapter: RoleGapAdapter
+    if adapter_factory is not None:
+        adapter = adapter_factory()
+    else:
+        adapter = AnonymousOpenAlexEvidenceSearchAdapter(
+            transport=_OneRequestTransport()
+        )
+
+    executions: list[RoleGapLaneExecution] = []
+    routes: list[RoleGapRouteExecution] = []
+    portfolios: list[RoleGapCasePortfolio] = []
+    clock = monotonic_clock or time.perf_counter
+    known_cost = 0.0
+    stopped_reason: StopReason = "completed"
+    for case in cases:
+        if known_cost + 1e-12 >= soft_stop_usd:
+            stopped_reason = "soft_stop"
+            break
+
+        anchor, request_stop = _execute_request(
+            adapter,
+            case,
+            "anchor_search",
+            None,
+            clock,
+        )
+        # A spent anchor reaches storage before routing can inspect it.
+        _write_lane_journal(output_dir, anchor)
+        executions.append(anchor)
+        if anchor.search_cost_usd is None:
+            stopped_reason = request_stop or "cost_uninspectable"
+            break
+        known_cost += anchor.search_cost_usd
+        if request_stop is not None:
+            stopped_reason = request_stop
+            break
+
+        route = _route_execution(case, anchor)
+        # A selected closure is not authority until the complete checked route
+        # is durable. This separates a real abstention from an unchecked case.
+        _write_route_journal(output_dir, route)
+        routes.append(route)
+        case_executions = [anchor]
+        selected = route.decision.selected_closure
+        if selected is not None:
+            if known_cost + 1e-12 >= soft_stop_usd:
+                stopped_reason = "soft_stop"
+                break
+            closure, request_stop = _execute_request(
+                adapter,
+                case,
+                "role_closure",
+                selected,
+                clock,
+            )
+            _write_lane_journal(output_dir, closure)
+            executions.append(closure)
+            if closure.search_cost_usd is None:
+                stopped_reason = request_stop or "cost_uninspectable"
+                break
+            known_cost += closure.search_cost_usd
+            if request_stop is not None:
+                stopped_reason = request_stop
+                break
+            case_executions.append(closure)
+
+        portfolio = build_case_portfolio(
+            case,
+            route,
+            tuple(case_executions),
+        )
+        # The next case cannot spend until its predecessor has a complete
+        # adaptive portfolio at rest.
+        _write_case_portfolio(output_dir, portfolio)
+        portfolios.append(portfolio)
+
+    cost_state, reported_cost = _provider_cost(executions)
+    successful_request_count = sum(
+        item.state == "completed" for item in executions
+    )
+    provider_candidate_count = sum(
+        len(item.response.candidates)
+        for item in executions
+        if item.response is not None
+    )
+    provider_rejection_count = sum(
+        len(item.response.provider_rejections)
+        for item in executions
+        if item.response is not None
+    )
+    completed = len(portfolios) == len(_CASE_ORDER)
+    if completed:
+        stopped_reason = "completed"
+    provider_summary = RoleGapProviderSummary(
+        attempted_request_count=len(executions),
+        successful_request_count=successful_request_count,
+        completed_case_count=len(portfolios),
+        cost_state=cost_state,
+        reported_cost_usd=reported_cost,
+        total_latency_ms=sum(item.latency_ms for item in executions),
+        stopped_reason=stopped_reason,
+    )
+    artifact = RoleGapExecutionArtifact(
+        fixture_sha256=fixture_sha256,
+        implementation_sha256=implementation_sha256,
+        runner_sha256=runner_sha256,
+        soft_stop_usd=soft_stop_usd,
+        request_count=len(executions),
+        successful_request_count=successful_request_count,
+        route_decision_count=len(routes),
+        closure_request_count=sum(
+            item.lane_id == "role_closure" for item in executions
+        ),
+        completed_portfolio_count=len(portfolios),
+        provider_row_count=provider_candidate_count + provider_rejection_count,
+        provider_candidate_count=provider_candidate_count,
+        provider_rejection_count=provider_rejection_count,
+        unique_candidate_count=sum(
+            len(item.unique_candidates) for item in portfolios
+        ),
+        overall_state="completed" if completed else "partial",
+        review_packet_eligibility=(
+            "eligible_for_source_lock" if completed else "incomplete"
+        ),
+        provider_summary=provider_summary,
+        lane_executions=tuple(executions),
+        route_executions=tuple(routes),
+        portfolios=tuple(portfolios),
+    )
+    _write_final_artifacts(output_dir, manifest, artifact)
+    return artifact
+
+
+def _stdout_json(value: object) -> str:
+    """Render reversible CLI JSON independently of the caller's locale."""
+
+    # Authoritative artifacts preserve original UTF-8 provider text. Stdout is
+    # only a projection and can still be strict GBK on Windows.
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Frozen OpenAlex adaptive role-gap v8 live harness."
+    )
+    parser.add_argument("--execute-live", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--soft-stop-usd", type=float)
+    parser.add_argument(
+        "--acknowledge-anonymous-daily-budget",
+        action="store_true",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if not args.execute_live:
+        print(_stdout_json(protocol_dry_run()))
+        return 0
+    if args.output_dir is None or args.soft_stop_usd is None:
+        raise SystemExit("--execute-live requires --output-dir and --soft-stop-usd")
+    artifact = execute_live_study(
+        output_dir=args.output_dir,
+        soft_stop_usd=args.soft_stop_usd,
+        acknowledge_anonymous_daily_budget=(
+            args.acknowledge_anonymous_daily_budget
+        ),
+    )
+    print(_stdout_json(artifact.model_dump(mode="json")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_role_gap_live.py
+++ b/tests/test_openalex_role_gap_live.py
@@ -1,0 +1,695 @@
+"""Zero-network seams for the adaptive role-gap closure v8 live runner."""
+
+from __future__ import annotations
+
+import csv
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+import openalex_role_gap_live as live
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.tools.evidence_search import (
+    ProviderResultRejection,
+    ToolAdapterFailure,
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from openalex_role_gap_unseen import (
+    PreparedRoleGapCase,
+    RoleGapClosureOption,
+    load_frozen_cases,
+)
+
+
+def _work_id(case_id: str, lane_id: live.LaneId, suffix: int) -> str:
+    lane_digit = 1 if lane_id == "anchor_search" else 2
+    return (
+        f"https://openalex.org/W{int(case_id[2:]):02d}"
+        f"{lane_digit}{suffix:05d}"
+    )
+
+
+def _all_role_signal_text(case: PreparedRoleGapCase) -> str:
+    phrases = [
+        phrase
+        for _, role in case.spec.roles.ordered_roles()
+        for phrase in role.signal_groups[0]
+    ]
+    return (
+        "This synthetic anchor contains every frozen role signal in one "
+        f"candidate: {'; '.join(phrases)}."
+    )
+
+
+def _candidate(
+    case: PreparedRoleGapCase,
+    lane_id: live.LaneId,
+    index: int,
+    *,
+    shared: bool,
+    anchor_has_all_roles: bool,
+) -> ToolEvidenceCandidate:
+    if shared:
+        doi = f"10.5555/{case.spec.case_id.casefold()}.shared"
+        label = "shared DOI candidate"
+    else:
+        doi = None
+        label = f"{lane_id} unique candidate"
+    if lane_id == "anchor_search" and anchor_has_all_roles:
+        summary = _all_role_signal_text(case)
+    else:
+        summary = (
+            f"This synthetic {lane_id} abstract for {case.spec.case_id} "
+            "contains generic evidence text for persistence testing but no "
+            "claim about real source relevance or commercial value."
+        )
+    return ToolEvidenceCandidate(
+        title=f"{case.spec.case_id} {label} for adaptive retrieval",
+        url=_work_id(case.spec.case_id, lane_id, index + 1),
+        doi=doi,
+        publisher="OpenAlex zero-network adaptive fixture",
+        evidence_summary=summary,
+        summary_source="abstract",
+        citation_count=index + 1,
+        provider_result_index=index,
+    )
+
+
+def _response(
+    case: PreparedRoleGapCase,
+    lane_id: live.LaneId,
+    call: ValidatedGapCall,
+    *,
+    reported_cost_usd: float,
+    include_rejection: bool,
+    identity_mismatch: bool,
+    anchor_has_all_roles: bool,
+) -> ToolAdapterResponse:
+    candidates = (
+        _candidate(
+            case,
+            lane_id,
+            0,
+            shared=True,
+            anchor_has_all_roles=anchor_has_all_roles,
+        ),
+    )
+    if lane_id == "role_closure":
+        candidates += (
+            _candidate(
+                case,
+                lane_id,
+                1,
+                shared=False,
+                anchor_has_all_roles=anchor_has_all_roles,
+            ),
+        )
+    rejections = (
+        (
+            ProviderResultRejection(
+                provider_result_index=len(candidates),
+                code="provider_result_not_object",
+                detail="zero-network fixture row is not an object",
+            ),
+        )
+        if include_rejection
+        else ()
+    )
+    idempotency_key = "0" * 64 if identity_mismatch else call.idempotency_key
+    usage = ToolProviderUsage(
+        provider="openalex",
+        request_id=f"client-v8-{call.idempotency_key[:16]}",
+        request_id_source="client_generated",
+        result_count=len(candidates) + len(rejections),
+        cost_basis="reported_usd",
+        reported_cost_usd=reported_cost_usd,
+    )
+    return ToolAdapterResponse(
+        tool="academic_search",
+        idempotency_key=idempotency_key,
+        candidates=candidates,
+        provider_rejections=rejections,
+        search_cost_usd=reported_cost_usd,
+        provider_request_id=usage.request_id,
+        provider_usage=usage,
+    )
+
+
+class RecordingFactory:
+    """Injected adapter proving manifest, route, and journal ordering."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        *,
+        reported_cost_usd: float = 0.001,
+        include_rejection: bool = False,
+        anchor_has_all_roles: bool = False,
+        fail_at: int | None = None,
+        invalid_at: int | None = None,
+        identity_mismatch_at: int | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.reported_cost_usd = reported_cost_usd
+        self.include_rejection = include_rejection
+        self.anchor_has_all_roles = anchor_has_all_roles
+        self.fail_at = fail_at
+        self.invalid_at = invalid_at
+        self.identity_mismatch_at = identity_mismatch_at
+        self.constructed = 0
+        self.calls: list[tuple[str, live.LaneId, str | None]] = []
+        _, _, cases = load_frozen_cases("development")
+        self.by_key: dict[
+            str,
+            tuple[PreparedRoleGapCase, live.LaneId, RoleGapClosureOption | None],
+        ] = {}
+        for case in cases:
+            self.by_key[case.anchor_call.idempotency_key] = (
+                case,
+                "anchor_search",
+                None,
+            )
+            for option in case.closure_options:
+                self.by_key[option.call.idempotency_key] = (
+                    case,
+                    "role_closure",
+                    option,
+                )
+
+    def __call__(self):
+        # A socket-capable object cannot predate the complete durable method.
+        assert (self.output_dir / "manifest.json").is_file()
+        self.constructed += 1
+
+        def run(call: ValidatedGapCall):
+            case, lane_id, option = self.by_key[call.idempotency_key]
+            if self.calls:
+                previous_case, previous_lane, _ = self.calls[-1]
+                assert (
+                    self.output_dir
+                    / "lane-executions"
+                    / f"{previous_case}--{previous_lane}.json"
+                ).is_file()
+                if previous_case != case.spec.case_id:
+                    assert (
+                        self.output_dir
+                        / "case-portfolios"
+                        / f"{previous_case}.json"
+                    ).is_file()
+            if lane_id == "role_closure":
+                assert (
+                    self.output_dir
+                    / "lane-executions"
+                    / f"{case.spec.case_id}--anchor_search.json"
+                ).is_file()
+                assert (
+                    self.output_dir
+                    / "route-executions"
+                    / f"{case.spec.case_id}.json"
+                ).is_file()
+            ordinal = len(self.calls)
+            role_id = option.role_id if option else None
+            self.calls.append((case.spec.case_id, lane_id, role_id))
+            if ordinal == self.fail_at:
+                raise ToolAdapterFailure(
+                    "offline injected provider failure",
+                    retryable=False,
+                    failure_type="provider_authentication",
+                    search_cost_usd=None,
+                )
+            if ordinal == self.invalid_at:
+                return {
+                    "tool": "academic_search",
+                    "idempotency_key": call.idempotency_key,
+                    "outbound_request_count": 1,
+                }
+            return _response(
+                case,
+                lane_id,
+                call,
+                reported_cost_usd=self.reported_cost_usd,
+                include_rejection=self.include_rejection,
+                identity_mismatch=ordinal == self.identity_mismatch_at,
+                anchor_has_all_roles=self.anchor_has_all_roles,
+            )
+
+        return run
+
+
+def _run(tmp_path: Path, *, monotonic_clock=None, **factory_options):
+    output = tmp_path / "role-gap-v8"
+    factory = RecordingFactory(output, **factory_options)
+    artifact = live.execute_live_study(
+        output_dir=output,
+        soft_stop_usd=0.02,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=factory,
+        monotonic_clock=monotonic_clock,
+    )
+    return output, factory, artifact
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_protocol_dry_run_locks_adaptive_options_without_live_authority(
+    monkeypatch,
+):
+    def block_socket(*args, **kwargs):
+        raise AssertionError("dry-run attempted to create a socket")
+
+    monkeypatch.setattr(socket, "socket", block_socket)
+    result = live.protocol_dry_run()
+
+    assert result["case_count"] == 8
+    assert result["potential_call_identity_count"] == 48
+    assert result["maximum_executed_search_request_count"] == 16
+    assert result["implementation_sha256"] == live.EXPECTED_IMPLEMENTATION_SHA256
+    assert len(result["runner_sha256"]) == 64
+    assert result["live_runner_maximum_requests"] == 16
+    assert result["live_runner_maximum_soft_stop_usd"] == 0.02
+    assert result["live_provider_requests_authorized"] is False
+    assert result["real_network_calls_performed"] is False
+    assert result["real_model_calls_performed"] is False
+    assert result["production_connected"] is False
+
+
+def test_complete_search_routes_reach_all_write_once_boundaries(tmp_path):
+    output, factory, artifact = _run(tmp_path)
+
+    assert factory.constructed == 1
+    assert len(factory.calls) == 16
+    assert [lane for _, lane, _ in factory.calls] == [
+        lane for _ in range(8) for lane in live._LANE_ORDER  # noqa: SLF001
+    ]
+    assert all(role_id for _, lane, role_id in factory.calls if lane == "role_closure")
+    assert artifact.overall_state == "completed"
+    assert artifact.request_count == 16
+    assert artifact.successful_request_count == 16
+    assert artifact.route_decision_count == 8
+    assert artifact.closure_request_count == 8
+    assert artifact.completed_portfolio_count == 8
+    assert artifact.provider_candidate_count == 24
+    assert artifact.unique_candidate_count == 16
+    assert artifact.model_call_count == 0
+    assert artifact.review_packet_eligibility == "eligible_for_source_lock"
+    assert artifact.provider_summary.reported_cost_usd == pytest.approx(0.016)
+    assert all(route.decision.action == "search" for route in artifact.route_executions)
+    assert len(list((output / "lane-executions").glob("*.json"))) == 16
+    assert len(list((output / "route-executions").glob("*.json"))) == 8
+    assert len(list((output / "case-portfolios").glob("*.json"))) == 8
+    assert (output / "artifact-index.json").is_file()
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    execution = json.loads((output / "execution.json").read_text(encoding="utf-8"))
+    assert manifest["runner_sha256"] == artifact.runner_sha256
+    assert execution["runner_sha256"] == artifact.runner_sha256
+
+
+def test_no_gap_routes_complete_with_only_eight_anchor_requests(tmp_path):
+    output, factory, artifact = _run(tmp_path, anchor_has_all_roles=True)
+
+    assert len(factory.calls) == 8
+    assert {lane for _, lane, _ in factory.calls} == {"anchor_search"}
+    assert artifact.overall_state == "completed"
+    assert artifact.request_count == 8
+    assert artifact.closure_request_count == 0
+    assert artifact.completed_portfolio_count == 8
+    assert all(
+        route.decision.action == "abstain"
+        and route.decision.reason == "abstain_no_mechanical_role_gap"
+        and route.decision.selected_closure is None
+        for route in artifact.route_executions
+    )
+    assert len(list((output / "lane-executions").glob("*.json"))) == 8
+    assert len(list((output / "route-executions").glob("*.json"))) == 8
+    assert len(list((output / "case-portfolios").glob("*.json"))) == 8
+
+
+def test_provider_route_and_review_lineage_reaches_every_csv(tmp_path):
+    output, _, artifact = _run(tmp_path, include_rejection=True)
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    route_rows = _read_csv(output / "route-decisions.csv")
+    unique_rows = _read_csv(output / "unique-candidates.csv")
+    candidate_review = _read_csv(output / "candidate-review.csv")
+    case_review = _read_csv(output / "case-review.csv")
+
+    assert artifact.provider_row_count == 40
+    assert len(provider_rows) == 40
+    assert len(route_rows) == artifact.route_decision_count == 8
+    assert len(unique_rows) == len(candidate_review) == 16
+    assert len(case_review) == artifact.completed_portfolio_count == 8
+    candidates = [
+        row for row in provider_rows if row["adapter_disposition"] == "candidate"
+    ]
+    rejections = [
+        row
+        for row in provider_rows
+        if row["adapter_disposition"] == "provider_rejected"
+    ]
+    assert len(candidates) == 24
+    assert len(rejections) == 16
+    assert all(row["occurrence_sha256"] for row in candidates)
+    assert all(row["unique_candidate_sha256"] for row in candidates)
+    assert all(not row["occurrence_sha256"] for row in rejections)
+    assert all(len(json.loads(row["observations"])) == 5 for row in route_rows)
+    assert all(row["selected_role_id"] for row in route_rows)
+    shared = [
+        row
+        for row in unique_rows
+        if len(json.loads(row["occurrence_sha256s"])) == 2
+    ]
+    assert len(shared) == 8
+    assert all(
+        json.loads(row["lane_memberships"])
+        == ["anchor_search", "role_closure"]
+        for row in shared
+    )
+    assert all(
+        not row["directly_relevant"]
+        and not row["baseline_novel"]
+        and not row["supported_role_ids"]
+        and not row["closure_contributed_selected_role"]
+        and not row["review_note"]
+        for row in candidate_review
+    )
+    assert all(row["frozen_route_decision"] for row in candidate_review)
+    assert all(row["frozen_baseline_sources"] for row in candidate_review)
+    assert all(
+        not row["routing_decision_correct"]
+        and not row["anchor_human_coverable_within_three"]
+        and not row["union_human_coverable_within_three"]
+        for row in case_review
+    )
+
+
+def test_doi_precedence_registers_secondary_identity_without_false_merge():
+    _, _, cases = load_frozen_cases("development")
+    case = cases[0]
+
+    def candidate(
+        title: str,
+        url: str,
+        index: int,
+        *,
+        doi: str | None = None,
+    ) -> ToolEvidenceCandidate:
+        return ToolEvidenceCandidate(
+            title=title,
+            url=url,
+            doi=doi,
+            publisher="OpenAlex adaptive deduplication fixture",
+            evidence_summary=(
+                "A sufficiently long synthetic abstract for deterministic "
+                "DOI and canonical OpenAlex URL identity testing."
+            ),
+            summary_source="abstract",
+            provider_result_index=index,
+        )
+
+    anchor_candidates = (
+        candidate("URL-only first owner", "https://openalex.org/W100000001", 0),
+        candidate(
+            "DOI first owner",
+            "https://openalex.org/W100000002",
+            1,
+            doi="10.5555/doi-owner",
+        ),
+    )
+
+    def response(
+        call: ValidatedGapCall,
+        candidates: tuple[ToolEvidenceCandidate, ...],
+    ) -> ToolAdapterResponse:
+        usage = ToolProviderUsage(
+            provider="openalex",
+            request_id=f"request-{call.idempotency_key[:12]}",
+            request_id_source="client_generated",
+            result_count=len(candidates),
+            cost_basis="reported_usd",
+            reported_cost_usd=0.001,
+        )
+        return ToolAdapterResponse(
+            tool="academic_search",
+            idempotency_key=call.idempotency_key,
+            candidates=candidates,
+            search_cost_usd=0.001,
+            provider_request_id=usage.request_id,
+            provider_usage=usage,
+        )
+
+    anchor = live._completed_execution(  # noqa: SLF001
+        case,
+        "anchor_search",
+        None,
+        response(case.anchor_call, anchor_candidates),
+        1.0,
+    )
+    route = live._route_execution(case, anchor)  # noqa: SLF001
+    selected = route.decision.selected_closure
+    assert selected is not None
+    closure_candidates = (
+        candidate(
+            "URL duplicate adds DOI",
+            "https://openalex.org/W100000001",
+            0,
+            doi="10.5555/url-owner-later-doi",
+        ),
+        candidate(
+            "DOI duplicate has another URL",
+            "https://openalex.org/W100000003",
+            1,
+            doi="10.5555/doi-owner",
+        ),
+        candidate(
+            "Conflicting DOI on owner URL",
+            "https://openalex.org/W100000002",
+            2,
+            doi="10.5555/conflicting-doi",
+        ),
+        candidate(
+            "Secondary DOI joins original URL owner",
+            "https://openalex.org/W100000004",
+            3,
+            doi="10.5555/url-owner-later-doi",
+        ),
+    )
+    closure = live._completed_execution(  # noqa: SLF001
+        case,
+        "role_closure",
+        selected,
+        response(selected.call, closure_candidates),
+        1.0,
+    )
+
+    portfolio = live.build_case_portfolio(case, route, (anchor, closure))
+
+    assert len(portfolio.occurrences) == 6
+    assert len(portfolio.unique_candidates) == 3
+    assert [item.deduplication_basis for item in portfolio.occurrences] == [
+        "new_unique",
+        "new_unique",
+        "canonical_openalex_url",
+        "normalized_doi",
+        "new_unique",
+        "normalized_doi",
+    ]
+
+
+def test_request_latency_reaches_journal_csv_and_provider_summary(tmp_path):
+    ticks = iter(float(value) for value in range(32))
+    output, _, artifact = _run(
+        tmp_path,
+        monotonic_clock=lambda: next(ticks),
+    )
+
+    assert artifact.provider_summary.total_latency_ms == pytest.approx(16000.0)
+    assert {item.latency_ms for item in artifact.lane_executions} == {1000.0}
+    first_journal = (
+        output / "lane-executions" / "AC01--anchor_search.json"
+    ).read_text(encoding="utf-8")
+    assert '"latency_ms": 1000.0' in first_journal
+    assert {
+        row["latency_ms"] for row in _read_csv(output / "provider-rows.csv")
+    } == {"1000.0"}
+
+
+@pytest.mark.parametrize(
+    ("soft_stop", "acknowledge"),
+    [(0.0, True), (0.0201, True), (0.02, False)],
+)
+def test_invalid_authorization_fails_before_adapter_and_output(
+    tmp_path,
+    soft_stop,
+    acknowledge,
+):
+    output = tmp_path / "forbidden"
+    factory = RecordingFactory(output)
+
+    with pytest.raises(live.OpenAlexRoleGapLiveError):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=soft_stop,
+            acknowledge_anonymous_daily_budget=acknowledge,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_configured_key_fails_before_adapter_and_output(tmp_path, monkeypatch):
+    output = tmp_path / "configured-key"
+    factory = RecordingFactory(output)
+    monkeypatch.setenv("OPENALEX_API_KEY", "configured-secret")
+
+    with pytest.raises(live.OpenAlexRoleGapLiveError, match="refuses"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_existing_output_fails_before_adapter_construction(tmp_path):
+    output = tmp_path / "existing"
+    output.mkdir()
+    factory = RecordingFactory(output)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+
+
+def test_implementation_hash_drift_fails_before_factory_and_output(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "hash-drift"
+    factory = RecordingFactory(output)
+    monkeypatch.setitem(
+        live.EXPECTED_IMPLEMENTATION_SHA256,
+        "openalex_role_gap_unseen.py",
+        "0" * 64,
+    )
+
+    with pytest.raises(live.OpenAlexRoleGapLiveError, match="identity drifted"):
+        live.execute_live_study(
+            output_dir=output,
+            soft_stop_usd=0.02,
+            acknowledge_anonymous_daily_budget=True,
+            adapter_factory=factory,
+        )
+
+    assert factory.constructed == 0
+    assert not output.exists()
+
+
+def test_soft_stop_preserves_anchor_and_route_without_fabricating_portfolio(
+    tmp_path,
+):
+    output, factory, artifact = _run(tmp_path, reported_cost_usd=0.02)
+
+    assert factory.calls == [("AC01", "anchor_search", None)]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "soft_stop"
+    assert artifact.route_decision_count == 1
+    assert artifact.route_executions[0].decision.action == "search"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert len(artifact.lane_executions) == 1
+    assert not artifact.portfolios
+    assert (output / "lane-executions" / "AC01--anchor_search.json").is_file()
+    assert (output / "route-executions" / "AC01.json").is_file()
+    assert not (output / "case-portfolios" / "AC01.json").exists()
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    assert len(provider_rows) == 1
+    assert {row["deduplication_basis"] for row in provider_rows} == {
+        "NOT_EVALUATED"
+    }
+
+
+def test_provider_failure_remains_inspectable_without_route_or_retry(tmp_path):
+    output, factory, artifact = _run(tmp_path, fail_at=0)
+
+    assert factory.calls == [("AC01", "anchor_search", None)]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "request_failed"
+    assert artifact.provider_summary.cost_state == "uninspectable"
+    assert artifact.lane_executions[0].failure_type == "provider_authentication"
+    assert not artifact.route_executions
+    assert not artifact.portfolios
+    assert (output / "lane-executions" / "AC01--anchor_search.json").is_file()
+
+
+def test_invalid_response_is_not_reported_as_provider_pass(tmp_path):
+    output, factory, artifact = _run(tmp_path, invalid_at=0)
+
+    assert factory.calls == [("AC01", "anchor_search", None)]
+    assert artifact.overall_state == "partial"
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.lane_executions[0].failure_type == "adapter_response_invalid"
+    assert artifact.review_packet_eligibility == "incomplete"
+    assert (output / "execution.json").is_file()
+
+
+def test_identity_mismatch_preserves_response_but_blocks_routing(tmp_path):
+    output, factory, artifact = _run(tmp_path, identity_mismatch_at=0)
+
+    assert factory.calls == [("AC01", "anchor_search", None)]
+    assert artifact.provider_summary.stopped_reason == "accounting_invalid"
+    assert artifact.lane_executions[0].response is not None
+    assert artifact.lane_executions[0].failure_type == "adapter_identity_mismatch"
+    assert not artifact.route_executions
+    assert not artifact.portfolios
+    provider_rows = _read_csv(output / "provider-rows.csv")
+    assert len(provider_rows) == 1
+    assert {row["deduplication_basis"] for row in provider_rows} == {
+        "NOT_EVALUATED"
+    }
+
+
+def test_artifacts_expose_no_key_or_unrelated_process_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNRELATED_PROCESS_SECRET", "must-not-reach-artifacts")
+    output, _, _ = _run(tmp_path)
+
+    rendered = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in output.rglob("*")
+        if path.is_file()
+    )
+    assert "must-not-reach-artifacts" not in rendered
+    assert "configured-secret" not in rendered
+    assert '"api_key_used": false' in rendered
+
+
+def test_cli_json_projection_survives_strict_gbk_stdout():
+    payload = {"title": "Adaptive role-gap evidence • completed"}
+
+    rendered = live._stdout_json(payload)  # noqa: SLF001
+    encoded = rendered.encode("gbk", errors="strict")
+
+    assert "\\u2022" in rendered
+    assert json.loads(encoded.decode("gbk")) == payload
+
+
+def test_production_worker_does_not_import_role_gap_components():
+    worker = Path("src/academic_agent/pipeline_worker.py").read_text(encoding="utf-8")
+
+    assert "openalex_role_gap_live" not in worker
+    assert "openalex_role_gap_unseen" not in worker
+    assert "AnonymousOpenAlexEvidenceSearchAdapter" not in worker


### PR DESCRIPTION
## Why

The v7 evidence lane added relevant candidates without improving role coverability. The preregistered v8 hypothesis therefore permits a second retrieval only when an anchor portfolio exposes a specific mechanical role gap.

## What changed

- add a production-disconnected, write-once AC runner with an 8-to-16-request bound
- persist manifest, anchor, route, optional closure, and portfolio seams before later effects
- retain complete provider, rejection, routing, deduplication, latency, and accounting evidence
- fail closed when provider accounting is missing or uninspectable
- keep AC and AD unopened and keep production imports disconnected

## Verification

- `19 passed` focused runner tests
- `1,928 passed, 657 subtests passed` full zero-network suite
- latest Ruff clean
- narrow Pylint clean
- moving manifest persistence after adapter construction made the ordering test fail
- dropping a computed route at serialization made the boundary test fail

This PR performs no OpenAlex or model request. A live AC study requires a separate authorization after merge.