### PR TITLE
Record the adaptive role-gap v8 AC live-provider result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  107 test modules plus conftest, organised by subject
+tests/                  111 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -740,7 +740,7 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   re-injected and made their seam tests fail before restoration.
 
   The separately pre-registered, production-disconnected AC write-once runner
-  is now implemented. Its default CLI path remains zero-network. It locks the
+  is implemented. Its default CLI path remains zero-network. It locks the
   fixture and six behavior dependencies before output reservation, persists
   the complete manifest before adapter construction, the anchor journal before
   routing, the full five-observation route before an optional closure, and the
@@ -753,17 +753,32 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   adapter construction and dropping one route only at serialization were
   separately re-injected and made their tests fail before restoration.
 
-  AC and AD remain unopened; provider compatibility, routing correctness,
-  source value, role coverability and report value are `not_evaluated`. Do not
-  execute AC without separate owner authorization naming the exact merged
-  revision, fixture hash, at most sixteen sequential anonymous OpenAlex
-  requests and a soft stop no greater than USD 0.02. Do not open AD before AC
-  passes every frozen gate, and do not connect v8 to production. See
+  The owner then separately authorized AC execution on exact merged revision
+  `59b5870614d23c0d9c61e7e398fa363026b6a528` and fixture
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`.
+  The default dry-run passed before the live flag was supplied. The live run
+  completed 15/15 single-attempt anonymous OpenAlex requests: eight anchors,
+  seven role closures and one AC08 no-gap abstention. All 8/8 portfolios were
+  committed. Ninety accounted provider rows became 72 abstract-bearing
+  candidates plus 18 no-abstract schema rejections and 64 unique candidates
+  after deduplication. Provider-reported anonymous-budget usage was USD 0.015.
+  Independent SHA-256 recomputation found 0/38 indexed source-file mismatches.
+  The mechanical state is `eligible_for_source_lock`.
+
+  This is not a source-value pass. All 64 candidate labels and eight case
+  labels remain blank; `human_review_state=not_prepared`,
+  `source_lock_state=not_created` and `source_value_state=not_evaluated`.
+  Routing correctness, source relevance, closure value, role coverability and
+  gain over anchor remain unknown. Next implement a separate source lock and
+  Schema v2 review boundary tied to the exact artifact index. Do not tune on or
+  rerun AC as validation, open AD before every frozen AC gate passes, or
+  connect v8 to the planner or production. See
   `docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`,
   `docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md`,
   `docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md`,
   `docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`, and
-  `docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`.
+  `docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md`,
+  `docs/results-2026-09-02-openalex-adaptive-role-gap-v8-ac-live.md`.
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus

--- a/README.md
+++ b/README.md
@@ -974,20 +974,22 @@ connection has occurred, so routing accuracy and source value remain
 [query-scope erratum](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md),
 and [offline result](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md).
 
-The separately pre-registered **v8 AC write-once live runner is now
-implemented but has not been executed against OpenAlex**. Its 19/19 focused
-zero-network tests cover both a complete eight-anchor abstention path and a
-complete sixteen-request closure path. The manifest precedes adapter
-construction; each anchor journal precedes routing; each complete route
-precedes an optional closure; and each portfolio precedes the next case.
-Provider rows, all five role observations, the selected closure identity,
-deduplication lineage, cost, latency, and blank candidate/case review seams are
-content-addressed. Moving the manifest after client construction and dropping
-one route only at the aggregate boundary were separately re-injected and made
-the relevant tests fail. AC remains unopened, AD remains unseen, and provider
-compatibility, routing accuracy, and source value remain `not_evaluated`. See
+The separately pre-registered **v8 AC write-once live runner has now completed
+its first authorized provider execution** on merged revision `59b5870`.
+Fifteen single-attempt anonymous OpenAlex requests completed: eight anchors,
+seven role-specific closures, and one correct no-gap abstention. All eight case
+portfolios were committed, ninety provider rows became seventy-two
+abstract-bearing candidates plus eighteen no-abstract schema rejections, and
+deduplication retained sixty-four unique candidates. Provider-reported
+anonymous-budget usage was USD 0.015. Independent recomputation matched all
+38 indexed source-artifact hashes. The mechanical result is
+`eligible_for_source_lock`, but the sixty-four candidate and eight case labels
+remain blank: routing accuracy, source value, closure gain, and coverability
+are still `not_evaluated`. AD remains unseen and production remains
+disconnected. See
 the [live-runner amendment](docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)
-and [implementation result](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md).
+the [implementation result](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md),
+and the [AC live-provider result](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-ac-live.md).
 
 Local verification now passes **1,928 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
@@ -2325,16 +2327,17 @@ AC01–AC08 开发集和 AD01–AD08 未见集为每个案例冻结一条 anchor
 [查询范围勘误](docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md)与
 [离线结果](docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md)。
 
-另行预注册的 **v8 AC 写一次 live runner 已完成实现，但尚未对 OpenAlex 执行**。
-19/19 个定向零网络测试同时覆盖了仅用八次 anchor 并全部弃权的完整路径，以及八个
-案例均触发 closure、共十六次请求的完整路径。manifest 必须先于 adapter 构造，
-anchor journal 必须先于路由，完整 route 必须先于可选 closure，每个 portfolio
-必须先于下一案例。provider 行、五项角色观察、所选 closure 身份、去重谱系、成本、
-时延以及候选和案例两类空白人工评审接缝均被内容寻址。将 manifest 移到 client
-构造之后、以及仅在聚合边界丢失一项 route 两个缺陷均被重新注入，并使对应测试
-失败。AC 仍未打开、AD 仍保持未见，供应商兼容性、路由正确率和来源价值均为
-`not_evaluated`。详见 [live runner 补充预注册](docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)
-与[实现结果](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)。
+另行预注册的 **v8 AC 写一次 live runner 已在合并版本 `59b5870` 上完成首次授权
+Provider 实验**。15 次匿名 OpenAlex 单尝试请求全部完成，其中包含 8 条 anchor、
+7 条按角色触发的 closure 和 1 次正确的无缺口弃权；8/8 个案例 portfolio 全部提交。
+90 条供应商行包含 72 条带摘要候选和 18 条无可重建摘要的 schema 拒绝，去重后为
+64 条唯一候选，供应商报告匿名预算使用量为 0.015 美元。独立重算的 38 个源工件
+哈希全部匹配。机械状态达到 `eligible_for_source_lock`，但 64 条候选标签和 8 条
+案例标签仍为空，因此路由正确率、来源价值、closure 增益和 coverability 仍为
+`not_evaluated`。AD 保持未见，生产继续断开。详见
+[live runner 补充预注册](docs/prereg-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)、
+[实现结果](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-live-runner.md)与
+[AC 真实 Provider 结果](docs/results-2026-09-02-openalex-adaptive-role-gap-v8-ac-live.md)。
 
 本地验证现通过 **1,928 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
 窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。

--- a/docs/results-2026-09-02-openalex-adaptive-role-gap-v8-ac-live.md
+++ b/docs/results-2026-09-02-openalex-adaptive-role-gap-v8-ac-live.md
@@ -1,0 +1,137 @@
+# Adaptive role-gap v8 AC live-provider result
+
+**Executed:** 2026-09-02
+
+**Authorized merged revision:**
+`59b5870614d23c0d9c61e7e398fa363026b6a528`
+
+**Fixture SHA-256:**
+`0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+
+**Cohort opened:** AC01-AC08 development only
+
+**AD01-AD08 opened:** no
+
+**Production connection:** false
+
+**Model calls:** 0
+
+**Provider-reported anonymous-budget usage:** USD 0.015
+
+## Authorization and preflight
+
+The owner separately authorized at most sixteen sequential anonymous OpenAlex
+requests, a total soft stop of USD 0.02, and a single in-flight overrun. Retry,
+redirect, model calls, recovery, supplementary search, AD access, and
+production connection were forbidden.
+
+Execution used a detached worktree at the exact merged revision. Before the
+live flag was supplied, the default zero-network preflight verified:
+
+- the exact fixture bytes;
+- AC01-AC08 and all eight anchor plus forty possible closure identities;
+- all six frozen implementation hashes;
+- a maximum of sixteen requests and ninety-six provider rows;
+- zero authorized model calls;
+- the anonymous no-key mode and absent `OPENALEX_API_KEY`; and
+- false production, report-workflow, recovery, and planner connections.
+
+The preflight made zero provider requests. The live run then wrote to a fresh
+write-once output directory.
+
+## Execution outcome
+
+The execution completed its mechanical boundary:
+
+- 15/15 requests completed;
+- every request had exactly one outbound attempt;
+- all provider request IDs and idempotency keys were unique;
+- 8/8 anchor requests completed;
+- 7/7 selected closure requests completed;
+- AC08 observed every frozen role and correctly emitted
+  `abstain_no_mechanical_role_gap` instead of spending a closure request;
+- 8/8 case portfolios were committed before the next case;
+- known provider-reported cost was USD 0.015, below the USD 0.02 soft stop;
+- request latency ranged from 645.631 ms to 2,424.569 ms, with 19,057.293 ms
+  summed request latency; and
+- final execution state was `completed` with
+  `eligible_for_source_lock`.
+
+The latency range is a description of these fifteen requests. It is not a p95,
+SLO, throughput, or reliability claim.
+
+OpenAlex returned ninety accounted rows. Seventy-two rows retained a
+reconstructable abstract and eighteen were mechanically rejected because no
+abstract could be reconstructed. This is provider-schema accounting, not a
+source-relevance judgment. DOI-first and canonical-URL deduplication produced
+sixty-four unique candidates and eight cross-lane duplicate occurrences.
+
+## Per-case mechanical observations
+
+| Case | Anchor roles observed | Missing roles | Route | Selected closure role | Anchor valid | Closure valid | Provider rejected | Unique |
+|---|---:|---:|---|---|---:|---:|---:|---:|
+| AC01 | 3/5 | 2 | search | `engineered_pet_hydrolase` | 6 | 6 | 0 | 12 |
+| AC02 | 2/5 | 3 | search | `cell_free_biosynthesis` | 6 | 4 | 2 | 10 |
+| AC03 | 3/5 | 2 | search | `flow_cell_operation` | 4 | 3 | 5 | 7 |
+| AC04 | 4/5 | 1 | search | `wear_duration` | 4 | 5 | 3 | 8 |
+| AC05 | 4/5 | 1 | search | `humid_building_envelope` | 6 | 5 | 1 | 9 |
+| AC06 | 2/5 | 3 | search | `manganese_oxide_ion_sieve` | 4 | 4 | 4 | 6 |
+| AC07 | 1/5 | 4 | search | `wastewater` | 5 | 5 | 2 | 7 |
+| AC08 | 5/5 | 0 | abstain | — | 5 | 0 | 1 | 5 |
+
+These are deterministic lexical observations over the returned title and
+abstract fields. They do not establish that a missing role was truly absent,
+that a selected route was correct, or that its closure added useful evidence.
+
+## Artifact integrity
+
+The run produced thirty-nine files: thirty-eight source artifacts named by
+`artifact-index.json` plus the index itself. Independent SHA-256 recomputation
+found 0/38 mismatches.
+
+The indexed boundary contains:
+
+- the manifest and final execution artifact;
+- fifteen lane journals;
+- eight route journals;
+- eight case portfolios;
+- complete provider-row, route, and unique-candidate CSV files;
+- sixty-four blank candidate-review rows;
+- eight blank case-review rows; and
+- hashes for every preceding source artifact.
+
+All sixty-four candidate rows and eight case rows have empty human labels.
+`human_review_state` remains `not_prepared`, `source_lock_state` remains
+`not_created`, and `source_value_state` remains `not_evaluated`.
+
+## Mechanical interpretation
+
+The live-provider stage passes only the frozen execution and accounting
+boundary. It establishes that the adaptive 8-to-16-request sequence can run
+against anonymous OpenAlex with a durable route between the anchor and optional
+closure request.
+
+It does not yet pass or fail the six source-value gates:
+
+- candidate-pool precision at least 25%;
+- relevant novel evidence in at least 6/8 cases;
+- selected closure value in at least 4/8 cases;
+- human-correct routing in at least 6/8 cases;
+- human coverability in at least 6/8 cases; and
+- coverability gain over anchor-only retrieval in at least two cases.
+
+None of those metrics may be inferred from the router's lexical observations.
+
+## Next boundary
+
+The next step is a separately implemented, zero-network source lock and Schema
+v2 human-review boundary tied to this exact artifact index. It must expose the
+frozen baseline, role definitions, route, and source title/abstract while
+keeping aggregate answers unavailable to the reviewer. Intake must preserve
+the reviewer's raw declaration, distinguish incomplete or ineligible review
+from a pass, and calculate all six gates only after every required label is
+present.
+
+AD01-AD08 remain unopened. This completed provider run does not authorize
+tuning on AC, rerunning AC as validation, opening AD, connecting v8 to the
+planner, or connecting Tool Calling to production.


### PR DESCRIPTION
Records the separately authorized AC01-AC08 anonymous OpenAlex execution on merge revision 59b5870 and the frozen fixture. The result reached only the mechanical source-lock boundary: 15 single-attempt requests, USD 0.015 provider-reported usage, 8/8 committed portfolios, complete row accounting, and 0/38 artifact hash mismatches. Candidate and case labels remain blank, so the PR explicitly keeps source relevance, routing correctness, closure value, coverability, AD access, planner integration, and production Tool Calling unevaluated. README and AGENTS are synchronized, including the measured 111-test-module index. Validation: 1928 tests plus 657 subtests, latest Ruff, and narrow Pylint all pass with zero provider calls.