### PR TITLE
Bind the AD unseen run to a blind human-review boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -839,8 +839,25 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   route decision into the blind projection were each re-injected and made the
   intended seam test fail before restoration. The full suite passes 1980 tests
   plus 657 subtests; Ruff, narrow Pylint and Chromium smoke are green locally.
-  Human review remains pending, so AD source value, route accuracy and role
-  coverability are not evaluated.
+
+  One human reviewer then completed 67/67 rows. The first declaration recorded
+  `MOST_OR_ALL`, so the strict first intake correctly preserved
+  `excluded_substantive_ai / not_evaluated` without joining hidden provenance.
+  The owner confirmed the judgments were human-completed and that no generative
+  AI was used; only that field was corrected to `NONE`. The unchanged labels
+  still contained one explicit `UNVERIFIABLE` row, so the second intake
+  correctly remained `not_inspectable / not_evaluated`. The reviewer then
+  inspected the publisher full text for that single row, revised its label,
+  visible roles and note, and updated the declaration to
+  `external_sources_checked=SOME`. The other 66 judgments were unchanged.
+
+  The final eligible result is `complete / fail`. Relevant novel evidence
+  covered 8/8 cases, candidate precision was 33/67 (49.25%), and union role
+  coverability reached 6/8. Human-correct routing was only 5/8, selected-role
+  closure value only 2/7, and union coverability gained only +1 case over the
+  anchor (6 versus 5). Three of six conjunctive gates therefore failed. AD is
+  consumed, adaptive role-gap v8 is sealed, and planner-trigger, report and
+  production Tool Calling connections remain false.
 
   Do not tune on or rerun AC or AD as validation, infer source value from the
   blank packet, or connect v8 to the planner or production. See
@@ -856,8 +873,10 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md`,
   `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-runner-implementation.md`,
   `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md`,
-  `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md`, and
-  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md`.
+  `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md`,
+  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md`,
+  and
+  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md`.
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 1964 tests (657 subtests), CI green on Linux + Windows × Python
+Current state: 1980 tests (657 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -239,6 +239,8 @@ openalex_role_gap_evaluation.py
                         write-once AD unseen runner; defaults to zero-network
 openalex_role_gap_review.py
                         exact AC source lock, route/lane-blind Schema v2 review
+openalex_role_gap_evaluation_review.py
+                        exact AD source lock, route/lane-blind Schema v2 review
 ops_report.py           what real runs actually did, vs what the benchmark covers
 user_utility_audit.py   zero-network 3–5 reviewer packet + strict unblinding
 checkpoint_fault_audit.py
@@ -815,12 +817,33 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   serialization were each re-injected; both made their seam tests fail before
   restoration. Existing AC code and artifacts were not changed.
 
-  This implementation still authorizes no AD provider request. A real request
-  requires separate owner authorization naming the exact merged implementation
-  revision and unchanged fixture hash. AD remains outcome-unseen and production
-  remains disconnected.
-  Do not tune on or rerun AC as validation, execute AD without that later
-  authorization, or connect v8 to the planner or production. See
+  A separately authorized run on merged revision `b54fa22` then completed all
+  eight AD cases. It made fifteen single-attempt anonymous OpenAlex requests:
+  eight anchors and seven selected closures, with AD03 the only explicit
+  abstention. Provider-reported usage was USD 0.015. Ninety provider rows
+  became 73 abstract-bearing candidates, 17 schema rejections and 67
+  DOI/OpenAlex-deduplicated review rows. All 38 indexed files recomputed to the
+  recorded hashes. There were zero model calls, retries, redirects, recovery
+  attempts or production/report/planner connections. This is a mechanical
+  provider-execution pass, not evidence that v8 generalized.
+
+  The AD human-review protocol was separately frozen after that run and before
+  its review implementation or any human label. A dedicated AD-only review
+  module now binds the exact artifact-index digest, rebuilds every journal,
+  portfolio and aggregate row, and emits all 67 candidates plus eight frozen
+  contexts through a route- and lane-blind Schema v2 packet. Its private source
+  lock is `ac4aa302...`; the packet manifest is `f017b1d9...`. The blank result
+  is `incomplete / not_evaluated`, with zero completed labels, no route join and
+  no gate metrics. Sixteen focused tests pass. Replacing the explicit AD
+  closure set with the AC positional `CASE_IDS[:-1]` assumption and leaking a
+  route decision into the blind projection were each re-injected and made the
+  intended seam test fail before restoration. The full suite passes 1980 tests
+  plus 657 subtests; Ruff, narrow Pylint and Chromium smoke are green locally.
+  Human review remains pending, so AD source value, route accuracy and role
+  coverability are not evaluated.
+
+  Do not tune on or rerun AC or AD as validation, infer source value from the
+  blank packet, or connect v8 to the planner or production. See
   `docs/prereg-2026-09-02-openalex-adaptive-role-gap-closure-v8.md`,
   `docs/errata-2026-09-02-openalex-role-gap-v8-query-scope.md`,
   `docs/results-2026-09-02-openalex-adaptive-role-gap-closure-v8-offline.md`,
@@ -830,8 +853,11 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-human-review.md`,
   `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-human-review-boundary.md`,
   `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-human-review.md`,
-  `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md`, and
-  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-runner-implementation.md`.
+  `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md`,
+  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-runner-implementation.md`,
+  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md`,
+  `docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md`, and
+  `docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md`.
   docs/results-2026-08-29-openalex-evidence-set-v5-implementation.md, and
   docs/results-2026-08-29-openalex-evidence-set-v5-development-runner-implementation.md,
   plus

--- a/README.md
+++ b/README.md
@@ -1033,14 +1033,29 @@ lineage through the final artifact index and blank-review boundaries. Its
 pre-registered defects were re-injected: allowing `development` made the cohort
 authority test fail, and dropping one route only at serialization made the
 client-boundary test fail. Both were restored before the suite returned green.
-
-No AD provider request, model call, human review or production connection has
-occurred. AD remains outcome-unseen. A real run still requires a separate owner
-authorization naming the exact merged implementation revision and unchanged
-fixture hash. See the [AD evaluation pre-registration](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md)
+See the [AD evaluation pre-registration](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md)
 and [runner implementation result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-runner-implementation.md).
 
-Local verification now passes **1,964 tests plus 657 subtests**, latest Ruff,
+A separately authorized run on merged revision `b54fa22` then completed the
+frozen AD cohort: 15/15 single-attempt anonymous OpenAlex requests, eight
+portfolios, one explicit AD03 abstention, seven closure requests and USD 0.015
+of provider-reported usage. Ninety provider rows produced 73 abstract-bearing
+candidates, 17 provider-schema rejections and 67 deduplicated review rows. All
+38 indexed artifacts recomputed correctly. No model, retry, redirect, recovery
+or production connection occurred. See the
+[AD live result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md).
+
+An AD-specific source lock and route/lane-blind Schema v2 review boundary are
+now implemented under the separately frozen protocol. The private packet
+contains all 67 candidates and eight baseline/role contexts while hiding the
+mechanical route and retrieval provenance. Its blank summary is correctly
+`incomplete / not_evaluated`: 0/67 labels, no unblinded route assessment and no
+gate metrics. Human review is still pending, so AD generalization and source
+value remain unmeasured. See the
+[review pre-registration](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md)
+and [boundary result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md).
+
+Local verification now passes **1,980 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2417,14 +2432,24 @@ cohort，在保留输出目录或构造网络适配器前锁定原始 fixture、
 测试、657 个 subtests 均通过。项目还按预注册分别回注了两项缺陷：放行 `development`
 会使 cohort 权限测试失败；仅在序列化时丢失一条 route 会使客户端接缝测试失败。
 恢复正确实现后测试重新全绿。
-
-本阶段没有发生 AD Provider 请求、模型调用、人工评审或生产连接，AD 仍保持结果未见。
-真实执行仍需另行授权，并点名精确的合并实现 revision 与未变化的 fixture 哈希。详见
-[AD 评估预注册](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md)与
+详见 [AD 评估预注册](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-evaluation.md)与
 [执行器实现结果](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-runner-implementation.md)。
 
-本地验证现通过 **1,964 项测试与 657 个 subtests**、最新版 Ruff、CI 同款
-窄范围 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
+随后经单独授权，冻结 AD cohort 在合并版本 `b54fa22` 上完成 15/15 次匿名 OpenAlex
+单尝试请求、8 个 portfolio、AD03 一次显式弃权、7 次 closure 与供应商报告的
+`$0.015` 用量。90 条供应商行形成 73 条带摘要候选、17 条 schema 拒绝和 67 条去重
+评审行；38 个索引工件全部重新计算一致。全过程没有模型、重试、重定向、恢复或生产
+连接。详见 [AD 真实运行结果](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md)。
+
+项目又按另行冻结的协议实现了 AD 专用 source lock 与 route/lane-blind Schema v2 人评
+边界。私有包包含全部 67 条候选和 8 份基线/角色上下文，同时隐藏机械路由与检索谱系。
+空白汇总严格为 `incomplete / not_evaluated`：0/67 标签、无解盲路由判断、无门槛指标。
+人工评审尚未完成，因此 AD 泛化与来源价值仍未测得。详见
+[人评预注册](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md)与
+[边界实现结果](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md)。
+
+本地验证现通过 **1,980 项测试与 657 个 subtests**、最新版 Ruff、CI 同款窄范围
+Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始
 

--- a/README.md
+++ b/README.md
@@ -1050,10 +1050,28 @@ now implemented under the separately frozen protocol. The private packet
 contains all 67 candidates and eight baseline/role contexts while hiding the
 mechanical route and retrieval provenance. Its blank summary is correctly
 `incomplete / not_evaluated`: 0/67 labels, no unblinded route assessment and no
-gate metrics. Human review is still pending, so AD generalization and source
-value remain unmeasured. See the
-[review pre-registration](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md)
-and [boundary result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md).
+gate metrics.
+
+One eligible human review later completed all 67 rows. The first declaration
+mistakenly recorded substantive AI use, so the strict intake preserved the
+return as `excluded_substantive_ai / not_evaluated`. After the owner confirmed
+the judgments were human-completed, correcting only that field exposed one
+explicitly unverifiable row and correctly remained
+`not_inspectable / not_evaluated`. The reviewer then inspected that row's
+publisher full text, revised only its label, roles and note, and declared
+`external_sources_checked=SOME`; hidden route provenance remained unavailable
+until this clarification validated.
+
+The final strict result is `complete / fail`. Relevant novel evidence covered
+8/8 cases, candidate precision was 33/67 (49.25%), and union role coverability
+reached 6/8, so three gates passed. Human-correct routing was only 5/8,
+selected-role closure value only 2/7, and union coverability improved on the
+anchor by only +1 case (6 versus 5), so the other three gates failed. Adaptive
+role-gap v8 is sealed, AD is consumed, and production Tool Calling remains
+disconnected. See the
+[review pre-registration](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md),
+the [boundary result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md),
+and the [final human-review result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md).
 
 Local verification now passes **1,980 tests plus 657 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.

--- a/docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md
+++ b/docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md
@@ -1,0 +1,151 @@
+# Pre-analysis plan: adaptive role-gap v8 AD human review
+
+**Date:** 2026-09-03 (Australia/Sydney)
+
+**Status:** frozen after the completed AD01-AD08 provider run and before an
+AD-specific review-boundary implementation, source-lock creation, packet
+delivery, human labels, or source-value aggregate
+
+**Production connection authorized:** no
+
+## Question
+
+The outcome-unseen AD01-AD08 run completed fifteen bounded anonymous OpenAlex
+requests and preserved every provider, route, cost, and deduplication seam.
+This review asks whether the resulting sixty-seven unique title-and-abstract
+candidates satisfy the same six human routing-and-value gates that the AC
+development cohort passed.
+
+The review does not reopen retrieval, rerun AD, invoke a model, inspect a
+different provider, estimate recall or full-text truth, evaluate a report, or
+connect the planner or production workflow.
+
+## Exact source identity
+
+- authorized and executed revision:
+  `b54fa22666805f8d0de0ff7e26c42af88b641615`
+- challenge fixture SHA-256:
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+- live-runner SHA-256:
+  `1f188fbdef225e0f6407b24a2ddbf40b66f5425ff9013021b5e94e0f176ccffa`
+- artifact-index SHA-256:
+  `01b3193d60d7405388b6d624da543131e18e67d13910bdb42f74e42e21af6e8f`
+- source boundary: thirty-eight indexed artifacts plus the index itself
+- exact closure cases: `AD01`, `AD02`, `AD04`, `AD05`, `AD06`, `AD07`, and
+  `AD08`; `AD03` is the only no-gap abstention
+- unique candidates by case: AD01=10, AD02=4, AD03=5, AD04=11, AD05=10,
+  AD06=9, AD07=10, AD08=8
+- fixed totals: eight cases, fifteen requests, seven closure requests, ninety
+  provider rows, seventy-three abstract-bearing provider candidates,
+  seventeen provider-schema rejections, and sixty-seven deduplicated
+  candidates
+- provider-reported cost: USD 0.015
+
+The source lock must verify the exact artifact-index bytes before parsing it,
+recompute every indexed file hash, parse every Pydantic artifact, rebuild the
+lane journals, route journals, case portfolios, and aggregate CSV rows, and
+confirm that the two provider-created review CSVs remain blank. A different
+valid AD execution is not an acceptable substitute.
+
+The source lock is controller-only evidence. It must be stored separately from
+the reviewer packet and must never be delivered to the reviewer.
+
+## Blind reviewer projection
+
+The Schema v2 packet exposes, for every candidate:
+
+- case and candidate identity;
+- topic;
+- title, canonical OpenAlex URL, DOI, publisher, publication date, abstract,
+  and citation count;
+- the exact frozen baseline; and
+- the five role IDs and descriptions.
+
+It hides anchor/closure lane membership, provider rank, duplicate occurrence
+count, mechanical signal observations, missing roles, selected closure role,
+route action, computed coverability, aggregate results, and answer keys. Rows
+may be reordered, but every read-only field must remain unchanged.
+
+The reviewer labels only:
+
+- `directly_relevant`;
+- `baseline_novel` relative to the visible frozen baseline;
+- `supported_role_ids`; and
+- a source-grounded note.
+
+Allowed relevance/novelty pairs are `YES/YES`, `YES/NO`, `NO/N/A`, and
+`UNVERIFIABLE/UNVERIFIABLE`. Relevant rows require at least one visible role;
+other rows require an empty role array. Every completed note must contain at
+least twelve non-whitespace characters. External pages are optional because
+this is a title-and-abstract study, but their use must be declared. Only
+`NONE` or `LANGUAGE_ONLY` substantive generative-AI use is eligible.
+
+The raw declaration strings and file hash must be retained alongside the
+normalized declaration. Incomplete, substantively AI-generated, unconfirmed,
+or unverifiable reviews are distinct states and cannot produce gate metrics.
+
+## Post-label deterministic join
+
+Hidden route and lane provenance may be joined only after all sixty-seven
+labels and the reviewer declaration pass strict validation.
+
+- A human source portfolio contains only `YES/YES` rows.
+- A portfolio is coverable when no more than three rows jointly support every
+  required role, at least one scope role, and at least one supporting role.
+- A closure route is human-correct when its selected role is absent from every
+  directly relevant anchor candidate. Novelty is not required for this
+  absence check because routing asks whether the role was retrieved, not
+  whether it was new to the baseline.
+- The AD03 abstention is human-correct only when the anchor's `YES/YES` rows
+  are already coverable.
+- A closure earns selected-role value only when a closure-only `YES/YES` row
+  supports the selected role. A cross-lane duplicate cannot earn incremental
+  credit.
+
+The strict result may reveal per-case route assessments only after this join.
+The reviewer-visible packet must continue to report route and lane exposure as
+false.
+
+## Frozen conjunctive gates
+
+1. At least 6/8 cases contain a `YES/YES` candidate.
+2. Directly relevant candidates are at least 25% of all sixty-seven rows.
+3. At least 6/8 routing decisions are human-correct.
+4. At least four of the seven closure cases contain selected-role closure
+   value.
+5. At least 6/8 union portfolios are human-coverable.
+6. The union makes at least two more cases coverable than the anchor alone.
+
+All six must pass. A missing or unavailable denominator is `not_evaluated`,
+never pass. Failure seals adaptive role-gap v8. Passing all six permits only
+separately pre-registered disabled-path, planner-trigger, and report-value
+studies; it does not authorize production.
+
+## Required implementation evidence
+
+Before packet delivery:
+
+1. a synthetic fifteen-request AD source must be reconstructed at every seam;
+2. the implementation must bind the exact non-positional closure-case set, so
+   the AC assumption that the final case abstains cannot be reused;
+3. every candidate must reach the packet while all hidden fields remain absent;
+4. a blank packet must remain `incomplete / not_evaluated` with no route
+   assessment;
+5. a complete synthetic review must exercise all six gate calculations;
+6. each frozen gate must independently veto the conjunctive decision;
+7. source, packet, label, role, declaration, and production-import drift must
+   fail closed;
+8. the `CASE_IDS[:-1]` positional closure defect and a route-decision leak at
+   the reviewer boundary must each be re-injected and make a seam test fail
+   before restoration; and
+9. the full zero-network suite, latest Ruff, narrow Pylint, browser smoke, and
+   Docker checks must pass.
+
+## Non-claims
+
+This review can establish candidate value, human-grounded route accuracy,
+incremental closure value, and bounded role coverability for one consumed AD
+unseen run. One reviewer cannot establish inter-rater agreement. A title-and-
+abstract review cannot establish full-text truth or recall. Neither a complete
+packet nor a six-gate pass establishes report improvement, planner-trigger
+precision, autonomous Tool Calling, user utility, or production readiness.

--- a/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md
+++ b/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md
@@ -1,0 +1,92 @@
+# Adaptive role-gap v8: AD unseen human-review boundary
+
+**Date:** 2026-09-03 (Australia/Sydney)
+
+**Status:** implemented; exact private packet prepared; human labels pending
+
+**Production connection authorized:** no
+
+## Outcome
+
+The completed AD01-AD08 provider run is now bound to an AD-specific source
+lock and a route- and lane-blind Schema v2 human-review packet. The boundary
+rebuilds the exact write-once run rather than trusting its aggregate counts:
+it verifies the artifact-index bytes, recomputes all thirty-eight indexed file
+hashes, validates every Pydantic artifact, rebuilds the lane journals, route
+journals, case portfolios and aggregate CSV rows, and confirms that the
+provider-created review fields remain blank.
+
+The packet contains all 67 DOI/OpenAlex-deduplicated candidates and all eight
+frozen baseline/role contexts. It exposes no anchor/closure membership,
+provider rank, duplicate occurrence, mechanical route, selected closure role,
+computed coverability, aggregate result or answer key. Hidden provenance can
+be joined only after every label and the reviewer declaration validate.
+
+Preparing and summarizing the packet made zero network requests and zero model
+calls. The blank packet correctly reports `incomplete / not_evaluated`, with
+0/67 completed rows, no route assessment and no gate metric.
+
+## Frozen identities
+
+- executed revision:
+  `b54fa22666805f8d0de0ff7e26c42af88b641615`
+- challenge fixture SHA-256:
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+- AD runner SHA-256:
+  `1f188fbdef225e0f6407b24a2ddbf40b66f5425ff9013021b5e94e0f176ccffa`
+- artifact-index SHA-256:
+  `01b3193d60d7405388b6d624da543131e18e67d13910bdb42f74e42e21af6e8f`
+- private source-lock SHA-256:
+  `ac4aa3027e0675e7c24528b999a2d0113654703fbb2ad763913f3ecd814b0be8`
+- private packet-manifest SHA-256:
+  `f017b1d993f6c47acf974959b8de4214856aac3589c3856dddc081859489248f`
+- private blank-label CSV SHA-256:
+  `18f5454c2accad3aed01168ec592025bd604647011d2e663538a028680747e21`
+- private blank declaration SHA-256:
+  `eb17b0ae23599575afcd9a68ad6a6d64644d4c0001fd10cdabb853a3f3ee1a31`
+
+Raw titles, abstracts, source lock and working labels remain in the private
+notes repository. They are not committed to this public repository.
+
+## Implementation evidence
+
+The AD review module is a separate audit snapshot. It does not generalize or
+modify the consumed AC review implementation. In particular, it freezes the
+seven closure cases explicitly: AD01, AD02 and AD04-AD08. AD03 is the only
+abstention and is deliberately in the middle of the ordered cohort, so the AC
+shortcut `CASE_IDS[:-1]` is invalid.
+
+Sixteen focused zero-network tests cover exact source reconstruction, the
+non-positional route set, all-candidate delivery, reviewer blinding, blank and
+ineligible states, all six conjunctive gates, source/packet/label/declaration
+drift, and production-import isolation. Two required defects were re-injected:
+
+1. replacing the explicit closure set with `CASE_IDS[:-1]` made the AD03/AD08
+   seam fail with both a missing AD08 closure and an invented AD03 closure;
+2. inserting `frozen_route_decision` into the blind row projection made the
+   packet-boundary test fail.
+
+After restoration, the focused suite passed 16/16. The complete suite passed
+1,980 tests plus 657 subtests, latest Ruff and the narrow Pylint check passed,
+and the Chromium smoke journey reported zero external and paid-provider
+requests. The local Docker daemon was unavailable; the pull request's Linux
+Docker job is therefore the authoritative container-build check.
+
+## Next decision
+
+An independent reviewer must complete all 67 rows and the declaration without
+seeing the source lock or hidden route/lane provenance. The unchanged strict
+summarizer will then compute the same six conjunctive gates used for AC.
+
+Until that return is complete and eligible, AD source value, route accuracy,
+closure value and role coverability remain `not_evaluated`. Even a six-gate AD
+pass would authorize only separately pre-registered planner-trigger,
+disabled-path and report-value studies. It would not authorize production
+Tool Calling.
+
+## Non-claims
+
+This boundary establishes immutable lineage, reviewer blinding and a strict
+zero-label state for one consumed AD run. It does not establish candidate
+relevance, novelty, full-text truth, recall, inter-rater agreement, report
+improvement, user utility, planner-trigger precision or production readiness.

--- a/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md
+++ b/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md
@@ -1,0 +1,98 @@
+# Adaptive role-gap v8: AD unseen human-review result
+
+**Date:** 2026-09-03 (Australia/Sydney)
+
+**Status:** `complete / fail`; AD consumed; adaptive role-gap v8 sealed;
+production Tool Calling remains disconnected
+
+## Outcome
+
+One eligible human review completed all 67 source rows from the exact AD01-AD08
+run on revision `b54fa22666805f8d0de0ff7e26c42af88b641615`. The final strict
+intake validated the source lock, packet manifest, every read-only candidate
+field, all labels and visible role IDs before joining hidden route and lane
+provenance. It then evaluated the same six conjunctive gates frozen before the
+AD review implementation.
+
+Three gates passed and three failed:
+
+| Frozen gate | Observed | Required | Result |
+|---|---:|---:|---|
+| cases with relevant, baseline-novel evidence | 8/8 | at least 6/8 | pass |
+| directly relevant candidate share | 33/67 (49.25%) | at least 25% | pass |
+| human-correct routing decisions | 5/8 | at least 6/8 | **fail** |
+| closure cases with selected-role value | 2/7 | at least 4/7 | **fail** |
+| union role-coverable cases | 6/8 | at least 6/8 | pass |
+| union gain over anchor coverability | +1 (6 versus 5) | at least +2 | **fail** |
+
+Because all six gates were conjunctive, the strict decision is `fail`.
+Adaptive role-gap v8 did not generalize from its AC development pass to the AD
+unseen cohort. AD is consumed and must not be tuned or rerun as validation.
+
+## Route findings
+
+The deterministic route was human-correct for AD03, AD04, AD06, AD07 and AD08.
+It was incorrect for AD01, AD02 and AD05 because directly relevant anchor
+evidence already contained the mechanically selected role. Only AD04 and AD08
+obtained closure-only evidence supporting the selected role.
+
+Anchor evidence alone was human-coverable within three sources for AD01-AD05.
+The bounded closure added only AD08, taking union coverability to 6/8. AD06 and
+AD07 remained incomplete. This is the measured reason v8 failed: the adaptive
+search often spent its second request on a role that the anchor already
+covered, and the closure improved a complete role set in only one new case.
+
+## Review audit history
+
+The first returned packet contained 67/67 structurally valid labels: 32
+`YES/YES`, 34 `NO/N/A`, and one `UNVERIFIABLE/UNVERIFIABLE`. Its declaration
+mistakenly recorded `generative_ai_use=MOST_OR_ALL`. The strict first intake
+therefore returned `excluded_substantive_ai / not_evaluated` before joining
+hidden provenance or scoring any gate. The original declaration, labels and
+excluded result are retained privately by hash.
+
+The study owner then confirmed that the judgments were human-completed and no
+generative AI had been used. Only the declaration's AI-use field was corrected
+to `NONE`; the 67 labels were unchanged. That second strict intake returned
+`not_inspectable / not_evaluated` because row `AD01/d871d82909fa` remained
+explicitly unverifiable. It still did not join route provenance or expose gate
+metrics.
+
+The human reviewer subsequently inspected the publisher full text for that
+single row while the packet remained route- and lane-blind. The row was revised
+to `YES/YES`, its visible supported roles and source-grounded note were
+completed, and the declaration was updated to `external_sources_checked=SOME`.
+The other 66 judgments were unchanged. Only then did the strict intake join
+hidden provenance and compute the final result above.
+
+## Frozen identities
+
+- executed revision:
+  `b54fa22666805f8d0de0ff7e26c42af88b641615`;
+- fixture SHA-256:
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`;
+- source-lock SHA-256:
+  `ac4aa3027e0675e7c24528b999a2d0113654703fbb2ad763913f3ecd814b0be8`;
+- packet-manifest SHA-256:
+  `f017b1d993f6c47acf974959b8de4214856aac3589c3856dddc081859489248f`;
+- final labels SHA-256:
+  `8b1b97782a6762351c8e66b67f054742fc5896d16674b27576205461dcf98c74`;
+- final declaration SHA-256:
+  `557867391b0f86aaa518bf73c055166c9a1aa5b0f41269d40201cac5f3c38fb2`;
+- final strict-result SHA-256:
+  `babfff8f7ffd1a73a20e6e385f272280b57a924ac0c5753d8676c97dd0f45933`.
+
+## Limits and next decision
+
+This is one human reviewer judging 66 rows from frozen titles and abstracts and
+one row with publisher full-text assistance. It does not establish full-text
+truth for the remaining sources, retrieval recall, inter-rater agreement,
+planner-trigger precision, report improvement, user utility, latency or an
+SLO. The AI-use correction was relayed by the study owner rather than supplied
+as a separately signed reviewer amendment.
+
+The failed unseen result retires adaptive role-gap v8. It does not authorize a
+Planner trigger, source insertion, report-path integration or production Tool
+Calling. Any later method must start with a new pre-registration and fresh
+development/evaluation cohorts; it may use this result only as disclosed
+development evidence.

--- a/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md
+++ b/docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-live.md
@@ -1,0 +1,115 @@
+# Adaptive role-gap v8: AD unseen live-provider result
+
+**Date:** 2026-09-03 (Australia/Sydney)
+
+**Executed revision:**
+`b54fa22666805f8d0de0ff7e26c42af88b641615`
+
+**Production connection authorized:** no
+
+## Outcome
+
+The separately authorized AD01-AD08 unseen run completed under the frozen
+adaptive role-gap v8 contract. The runner made fifteen sequential anonymous
+OpenAlex requests: eight anchor requests and seven selected role-closure
+requests. AD03 found no mechanical role gap and explicitly abstained from a
+second request. Every request completed on its first and only attempt.
+
+This is a mechanical provider-execution pass and is eligible for an exact
+source lock. It is not a source-value result and does not establish that v8
+generalizes.
+
+| Observation | Result |
+|---|---:|
+| Cases completed | 8 / 8 |
+| Requests completed | 15 / 15 |
+| Anchor requests | 8 |
+| Closure requests | 7 |
+| Explicit no-gap abstentions | 1 (`AD03`) |
+| Provider rows | 90 |
+| Abstract-bearing candidates | 73 |
+| Provider-schema rejections | 17 |
+| DOI/OpenAlex-deduplicated candidates | 67 |
+| Provider-reported cost | USD 0.015 |
+| Frozen soft stop | USD 0.02 |
+| Recorded provider latency | 17,011.77 ms |
+| Model calls | 0 |
+| API key used | no |
+| Retry, redirect, fallback, or recovery | none |
+
+The request count stayed below the sixteen-request ceiling and the recorded
+cost stayed below the separately authorized soft stop. The anonymous adapter's
+daily-budget contract remained USD 0.10; the narrower run-level stop was USD
+0.02 and governed whether a later request could start.
+
+## Frozen identity
+
+- challenge fixture SHA-256:
+  `0be98f249bfd1eaf891cd3c20903b9d6ae4cd2d6431282ee32e82298a2d8ecc7`
+- AD runner SHA-256:
+  `1f188fbdef225e0f6407b24a2ddbf40b66f5425ff9013021b5e94e0f176ccffa`
+- artifact-index SHA-256:
+  `01b3193d60d7405388b6d624da543131e18e67d13910bdb42f74e42e21af6e8f`
+- execution artifact SHA-256:
+  `4197bace48cc305b4db71bd8943d68ef7b5691a9950a49ebb78b8724badf7f26`
+- manifest SHA-256:
+  `f16ba2eef97a46d3f10b04e6381ca1244b39a6876f7c01966c8231ddda0ab5d6`
+- indexed source files: 38; all 38 recomputed hashes matched the index
+
+The write-once source remains in the local, gitignored output directory
+`outputs/20260903-openalex-role-gap-v8-ad-live-b54fa22/`. Raw titles and
+abstracts are not added to the public repository by this result note.
+
+## Route observations
+
+| Case | Action | Selected missing role |
+|---|---|---|
+| AD01 | search | `polyol_reuse` |
+| AD02 | search | `source_separated_urine` |
+| AD03 | abstain | none |
+| AD04 | search | `infection_reduction` |
+| AD05 | search | `pulp_mill_lignin_waste` |
+| AD06 | search | `agricultural_groundwater` |
+| AD07 | search | `magnetic_guidance` |
+| AD08 | search | `offshore_wind_steel` |
+
+These are deterministic lexical route observations, not human judgments that
+the route was correct. The exact unique-candidate denominators by case are 10,
+4, 5, 11, 10, 9, 10, and 8 respectively.
+
+## Boundary result
+
+The aggregate reports:
+
+- `overall_state=completed`;
+- `review_packet_eligibility=eligible_for_source_lock`;
+- `serialized_boundary_complete=true`;
+- `source_lock_state=not_created`;
+- `human_review_state=not_prepared`; and
+- `source_value_state=not_evaluated`.
+
+The manifest and artifact index both keep production, report-workflow,
+planner-trigger, checkpoint-recovery, and model-call connections false. A
+successful process exit therefore does not masquerade as a successful human
+value evaluation.
+
+## Next decision
+
+Before seeing any AD human label, freeze an AD-specific source-lock and blind
+review protocol. That boundary must bind the exact bytes above, expose all 67
+candidate rows and eight frozen case contexts, hide route and lane provenance,
+and join adaptive provenance only after every label and reviewer declaration
+validate. The inherited six conjunctive gates must not change.
+
+Even if all six AD gates pass, v8 remains production-disconnected. A pass would
+permit only separately pre-registered disabled-path, planner-trigger, and
+report-value studies.
+
+## Non-claims
+
+This run establishes one frozen cohort's anonymous OpenAlex compatibility,
+bounded request accounting, durable route execution, and serialized lineage.
+It does not establish candidate relevance, novelty, route correctness,
+closure value, role coverability, recall, full-text truth, inter-rater
+agreement, report improvement, user utility, latency reliability, autonomous
+query generation, or production Tool Calling.

--- a/openalex_role_gap_evaluation_review.py
+++ b/openalex_role_gap_evaluation_review.py
@@ -1,0 +1,1568 @@
+"""Source-lock and review the frozen adaptive role-gap v8 AD unseen run.
+
+The provider runner deliberately stopped after one mechanically complete,
+production-disconnected AD01-AD08 retrieval run.  This module binds those
+exact write-once bytes, prepares a route- and lane-blind Schema v2 packet, and
+joins hidden adaptive provenance only after every human source label has been
+validated.  It opens no socket, invokes no model, does not reopen either the
+AC development cohort or AD retrieval, and never authorizes production Tool
+Calling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from evidence_gap_phase4_review import (
+    DECLARATION_FIELDS,
+    ELIGIBLE_AI_USE,
+    VALID_LABEL_PAIRS,
+    Phase4ReviewError as RoleGapReviewError,
+    _file_sha256,
+    _read_csv,
+    _read_json_object,
+    _validated_declaration,
+    _write_csv_new,
+    _write_text_new,
+)
+from openalex_role_gap_evaluation import (
+    EXPECTED_IMPLEMENTATION_SHA256,
+    RoleGapCasePortfolio,
+    RoleGapExecutionArtifact,
+    RoleGapLaneExecution,
+    RoleGapManifestArtifact,
+    RoleGapRouteExecution,
+    _AGGREGATE_SOURCE_FILES,
+    _CANDIDATE_REVIEW_COLUMNS,
+    _CASE_REVIEW_COLUMNS,
+    _LANE_ORDER,
+    _PROVIDER_ROW_COLUMNS,
+    _ROUTE_COLUMNS,
+    _UNIQUE_CANDIDATE_COLUMNS,
+    _provider_rows,
+    _route_execution,
+    _route_rows,
+    _unique_and_review_rows,
+    build_case_portfolio,
+)
+from openalex_role_gap_unseen import EXPECTED_FIXTURE_SHA256
+
+
+EXPECTED_EXECUTED_REVISION = "b54fa22666805f8d0de0ff7e26c42af88b641615"
+EXPECTED_RUNNER_SHA256 = (
+    "1f188fbdef225e0f6407b24a2ddbf40b66f5425ff9013021b5e94e0f176ccffa"
+)
+EXPECTED_ARTIFACT_INDEX_SHA256 = (
+    "01b3193d60d7405388b6d624da543131e18e67d13910bdb42f74e42e21af6e8f"
+)
+
+CASE_IDS = tuple(f"AD{index:02d}" for index in range(1, 9))
+# Unlike the AC development run, the AD abstention is in the middle of the
+# cohort. Spell out the seven closures so a convenient CASE_IDS[:-1]
+# assumption cannot drop AD08 or invent an AD03 closure while still producing
+# plausible totals.
+EXPECTED_CLOSURE_CASE_IDS = (
+    "AD01",
+    "AD02",
+    "AD04",
+    "AD05",
+    "AD06",
+    "AD07",
+    "AD08",
+)
+INDEXED_SOURCE_FILES = (
+    *_AGGREGATE_SOURCE_FILES,
+    *(
+        f"lane-executions/{case_id}--{lane_id}.json"
+        for case_id in CASE_IDS
+        for lane_id in (
+            _LANE_ORDER if case_id in EXPECTED_CLOSURE_CASE_IDS else ("anchor_search",)
+        )
+    ),
+    *(f"route-executions/{case_id}.json" for case_id in CASE_IDS),
+    *(f"case-portfolios/{case_id}.json" for case_id in CASE_IDS),
+)
+SOURCE_FILES = (*INDEXED_SOURCE_FILES, "artifact-index.json")
+
+EXPECTED_UNIQUE_PER_CASE = {
+    "AD01": 10,
+    "AD02": 4,
+    "AD03": 5,
+    "AD04": 11,
+    "AD05": 10,
+    "AD06": 9,
+    "AD07": 10,
+    "AD08": 8,
+}
+EXPECTED_REQUEST_COUNT = 15
+EXPECTED_CLOSURE_REQUEST_COUNT = 7
+EXPECTED_PROVIDER_ROW_COUNT = 90
+EXPECTED_PROVIDER_CANDIDATE_COUNT = 73
+EXPECTED_PROVIDER_REJECTION_COUNT = 17
+EXPECTED_REVIEW_ROW_COUNT = 67
+EXPECTED_PROVIDER_COST_USD = 0.015
+
+LABEL_FIELDS = (
+    "case_id",
+    "row_id",
+    "unique_candidate_sha256",
+    "topic",
+    "title",
+    "url",
+    "normalized_doi",
+    "publisher",
+    "published_date",
+    "evidence_summary",
+    "summary_source",
+    "citation_count",
+    "frozen_baseline_sources",
+    "frozen_role_profile",
+    "directly_relevant",
+    "baseline_novel",
+    "supported_role_ids",
+    "review_note",
+)
+READ_ONLY_LABEL_FIELDS = LABEL_FIELDS[:-4]
+HIDDEN_REVIEW_FIELDS = (
+    "lane_memberships",
+    "selected_closure_role_id",
+    "occurrence_count",
+    "provider_ranks",
+    "frozen_route_decision",
+    "closure_contributed_selected_role",
+    "owner_occurrence_sha256",
+    "occurrence_sha256s",
+    "candidate_sha256",
+    "route_action",
+    "route_reason",
+    "missing_role_ids",
+    "selected_role_id",
+    "selected_role_kind",
+)
+MEASUREMENT_LIMIT = (
+    "This source-locked unseen review measures title-and-abstract relevance, "
+    "novelty relative to the visible frozen baseline, human-grounded routing, "
+    "selected-role closure contribution, and role coverability for one exact "
+    "AD01-AD08 run. It does not verify full-text source truth, estimate recall, "
+    "establish inter-rater agreement, measure report value or planner-trigger "
+    "precision, or authorize production Tool Calling."
+)
+
+
+class RoleGapSourceLock(BaseModel):
+    """Study-owner attestation over the exact AD01-AD08 provider bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    mode: Literal["openalex_adaptive_role_gap_v8_ad_source_artifact_lock"] = (
+        "openalex_adaptive_role_gap_v8_ad_source_artifact_lock"
+    )
+    cohort: Literal["unseen"] = "unseen"
+    production_connected: Literal[False] = False
+    report_workflow_connected: Literal[False] = False
+    planner_trigger_connected: Literal[False] = False
+    recovery_connected: Literal[False] = False
+    model_call_count: Literal[0] = 0
+    api_key_used: Literal[False] = False
+    authorized_output: Literal[True] = True
+    executed_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    implementation_sha256: dict[str, str]
+    runner_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_file_sha256: dict[str, str]
+    review_row_count: int = Field(gt=0, le=96)
+    study_owner_id: str = Field(min_length=2, max_length=200)
+    authorized_at: datetime
+    note: str | None = Field(default=None, max_length=1000)
+
+    @model_validator(mode="after")
+    def _validate_frozen_identity(self) -> "RoleGapSourceLock":
+        if self.executed_revision != EXPECTED_EXECUTED_REVISION:
+            raise ValueError("source lock executed revision does not match")
+        if self.fixture_sha256 != EXPECTED_FIXTURE_SHA256:
+            raise ValueError("source lock fixture identity does not match")
+        if self.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256:
+            raise ValueError("source lock implementation identities do not match")
+        if self.runner_sha256 != EXPECTED_RUNNER_SHA256:
+            raise ValueError("source lock runner identity does not match")
+        if set(self.source_file_sha256) != set(SOURCE_FILES):
+            raise ValueError("source lock must identify every v8 AD source file")
+        if self.source_file_sha256.get("artifact-index.json") != (
+            EXPECTED_ARTIFACT_INDEX_SHA256
+        ):
+            raise ValueError("source lock does not identify the frozen v8 AD run")
+        if any(
+            len(value) != 64
+            or any(character not in "0123456789abcdef" for character in value)
+            for value in self.source_file_sha256.values()
+        ):
+            raise ValueError("source lock hashes must be lowercase SHA-256 values")
+        if self.review_row_count != EXPECTED_REVIEW_ROW_COUNT:
+            raise ValueError("source lock review denominator does not match")
+        if self.authorized_at.tzinfo is None:
+            raise ValueError("source lock timestamp must be timezone-aware")
+        return self
+
+
+@dataclass(frozen=True)
+class RoleGapReviewCandidate:
+    """One source with reviewer-visible context and hidden adaptive lineage."""
+
+    case_id: str
+    unique_candidate_sha256: str
+    topic: str
+    title: str
+    url: str
+    normalized_doi: str
+    publisher: str
+    published_date: str
+    evidence_summary: str
+    summary_source: str
+    citation_count: str
+    frozen_baseline_sources: str
+    frozen_role_profile: str
+    lane_memberships: tuple[str, ...]
+
+    @property
+    def row_id(self) -> str:
+        return f"{self.case_id}/{self.unique_candidate_sha256[:12]}"
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return self.case_id, self.unique_candidate_sha256
+
+    @property
+    def identity_sha256(self) -> str:
+        rendered = json.dumps(
+            self.visible_values(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(rendered).hexdigest()
+
+    def visible_values(self) -> dict[str, str]:
+        """Return the exact blind projection; route and lanes stay excluded."""
+
+        return {
+            "case_id": self.case_id,
+            "row_id": self.row_id,
+            "unique_candidate_sha256": self.unique_candidate_sha256,
+            "topic": self.topic,
+            "title": self.title,
+            "url": self.url,
+            "normalized_doi": self.normalized_doi,
+            "publisher": self.publisher,
+            "published_date": self.published_date,
+            "evidence_summary": self.evidence_summary,
+            "summary_source": self.summary_source,
+            "citation_count": self.citation_count,
+            "frozen_baseline_sources": self.frozen_baseline_sources,
+            "frozen_role_profile": self.frozen_role_profile,
+        }
+
+
+@dataclass(frozen=True)
+class RoleGapSourceSnapshot:
+    """Validated source reused unchanged at lock, packet, and result seams."""
+
+    file_hashes: dict[str, str]
+    manifest: RoleGapManifestArtifact
+    execution: RoleGapExecutionArtifact
+    candidates: tuple[RoleGapReviewCandidate, ...]
+    case_contexts: tuple[dict[str, Any], ...]
+
+
+def _validate_artifact_index(source_dir: Path) -> dict[str, str]:
+    """Trust the index only after its exact real-run digest is confirmed."""
+
+    index_path = source_dir / "artifact-index.json"
+    if _file_sha256(index_path) != EXPECTED_ARTIFACT_INDEX_SHA256:
+        raise RoleGapReviewError("artifact-index identity does not match the v8 AD run")
+    index = _read_json_object(index_path)
+    expected_envelope = {
+        "schema_version": 1,
+        "mode": "openalex_adaptive_role_gap_v8_ad_artifact_index",
+        "cohort": "unseen",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "recovery_connected": False,
+        "model_call_count": 0,
+    }
+    if any(index.get(key) != value for key, value in expected_envelope.items()):
+        raise RoleGapReviewError("artifact index connection or schema envelope drifted")
+    indexed = index.get("source_file_sha256")
+    if not isinstance(indexed, dict) or set(indexed) != set(INDEXED_SOURCE_FILES):
+        raise RoleGapReviewError("artifact index does not cover the exact v8 AD files")
+    if any(
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+        for value in indexed.values()
+    ):
+        raise RoleGapReviewError("artifact index contains a malformed source hash")
+    return dict(indexed)
+
+
+def _validate_complete_execution(
+    manifest: RoleGapManifestArtifact,
+    execution: RoleGapExecutionArtifact,
+) -> None:
+    if execution.overall_state != "completed":
+        raise RoleGapReviewError("only the completed AD01-AD08 run may be locked")
+    if (
+        execution.request_count != EXPECTED_REQUEST_COUNT
+        or execution.successful_request_count != EXPECTED_REQUEST_COUNT
+        or execution.route_decision_count != len(CASE_IDS)
+        or execution.closure_request_count != EXPECTED_CLOSURE_REQUEST_COUNT
+        or execution.completed_portfolio_count != len(CASE_IDS)
+    ):
+        raise RoleGapReviewError("adaptive request, route, or portfolio totals drifted")
+    observed_closure_case_ids = tuple(
+        route.case_id
+        for route in execution.route_executions
+        if route.decision.action == "search"
+    )
+    if observed_closure_case_ids != EXPECTED_CLOSURE_CASE_IDS:
+        raise RoleGapReviewError("adaptive closure case identities drifted")
+    if (
+        execution.provider_row_count != EXPECTED_PROVIDER_ROW_COUNT
+        or execution.provider_candidate_count != EXPECTED_PROVIDER_CANDIDATE_COUNT
+        or execution.provider_rejection_count != EXPECTED_PROVIDER_REJECTION_COUNT
+        or execution.unique_candidate_count != EXPECTED_REVIEW_ROW_COUNT
+    ):
+        raise RoleGapReviewError("adaptive provider or review denominator drifted")
+    if (
+        execution.review_packet_eligibility != "eligible_for_source_lock"
+        or execution.provider_summary.stopped_reason != "completed"
+        or execution.provider_summary.cost_state != "known"
+    ):
+        raise RoleGapReviewError("the mechanical gate did not authorize source locking")
+    if any(
+        (
+            execution.production_connected,
+            execution.report_workflow_connected,
+            execution.planner_trigger_connected,
+            execution.recovery_connected,
+            execution.api_key_used,
+        )
+    ) or execution.model_call_count != 0:
+        raise RoleGapReviewError("the source execution crossed a forbidden boundary")
+    if (
+        manifest.fixture_sha256 != execution.fixture_sha256
+        or manifest.implementation_sha256 != execution.implementation_sha256
+        or manifest.runner_sha256 != execution.runner_sha256
+        or manifest.soft_stop_usd != execution.soft_stop_usd
+    ):
+        raise RoleGapReviewError("execution identity does not join manifest")
+
+
+def _validate_frozen_totals(
+    manifest: RoleGapManifestArtifact,
+    execution: RoleGapExecutionArtifact,
+) -> None:
+    """Check the exact observed run rather than its permissive schema alone."""
+
+    if (
+        manifest.runner_sha256 != EXPECTED_RUNNER_SHA256
+        or execution.runner_sha256 != EXPECTED_RUNNER_SHA256
+    ):
+        raise RoleGapReviewError("adaptive role-gap runner identity drifted")
+    if (
+        manifest.fixture_sha256 != EXPECTED_FIXTURE_SHA256
+        or execution.fixture_sha256 != EXPECTED_FIXTURE_SHA256
+    ):
+        raise RoleGapReviewError("adaptive role-gap fixture identity drifted")
+    if (
+        manifest.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256
+        or execution.implementation_sha256 != EXPECTED_IMPLEMENTATION_SHA256
+    ):
+        raise RoleGapReviewError("adaptive role-gap implementation identity drifted")
+    if not math.isclose(
+        execution.provider_summary.reported_cost_usd or -1.0,
+        EXPECTED_PROVIDER_COST_USD,
+        rel_tol=1e-9,
+        abs_tol=1e-9,
+    ):
+        raise RoleGapReviewError("adaptive role-gap provider cost drifted")
+    observed_per_case = {
+        portfolio.case_id: len(portfolio.unique_candidates)
+        for portfolio in execution.portfolios
+    }
+    if observed_per_case != EXPECTED_UNIQUE_PER_CASE:
+        raise RoleGapReviewError("adaptive candidate distribution drifted")
+    if tuple(case.spec.case_id for case in manifest.cases) != CASE_IDS:
+        raise RoleGapReviewError("manifest does not contain AD01-AD08 exactly")
+    if tuple(portfolio.case_id for portfolio in execution.portfolios) != CASE_IDS:
+        raise RoleGapReviewError("execution portfolios are not AD01-AD08")
+
+
+def _validate_lane_journals(
+    source_dir: Path,
+    manifest: RoleGapManifestArtifact,
+    execution: RoleGapExecutionArtifact,
+) -> dict[tuple[str, str], RoleGapLaneExecution]:
+    journal_dir = source_dir / "lane-executions"
+    if not journal_dir.is_dir():
+        raise RoleGapReviewError("lane-executions journal directory is missing")
+    expected_names = {
+        Path(name).name
+        for name in INDEXED_SOURCE_FILES
+        if name.startswith("lane-executions/")
+    }
+    observed_names = {path.name for path in journal_dir.glob("*.json")}
+    if observed_names != expected_names:
+        raise RoleGapReviewError("lane journals do not cover the frozen path exactly")
+
+    aggregate = {
+        (item.case_id, item.lane_id): item for item in execution.lane_executions
+    }
+    frozen_cases = {case.spec.case_id: case for case in manifest.cases}
+    routes = {item.case_id: item for item in execution.route_executions}
+    validated: dict[tuple[str, str], RoleGapLaneExecution] = {}
+    known_cost = 0.0
+    for case_id in CASE_IDS:
+        frozen = frozen_cases[case_id]
+        route = routes[case_id]
+        lane_ids = (
+            _LANE_ORDER if route.decision.action == "search" else ("anchor_search",)
+        )
+        for lane_id in lane_ids:
+            journal = RoleGapLaneExecution.model_validate(
+                _read_json_object(journal_dir / f"{case_id}--{lane_id}.json")
+            )
+            key = (case_id, lane_id)
+            if journal != aggregate.get(key):
+                raise RoleGapReviewError(
+                    f"{case_id}/{lane_id}: journal differs from execution"
+                )
+            if lane_id == "anchor_search":
+                expected_call = frozen.anchor_call
+                expected_plan = frozen.anchor_plan_sha256
+                expected_contract = frozen.anchor_contract_sha256
+                expected_role_id = None
+                expected_role_kind = None
+            else:
+                selected = route.decision.selected_closure
+                if selected is None:  # pragma: no cover - Pydantic guards this
+                    raise RoleGapReviewError(f"{case_id}: closure route lost its role")
+                expected_call = selected.call
+                expected_plan = selected.plan_sha256
+                expected_contract = selected.closure_contract_sha256
+                expected_role_id = selected.role_id
+                expected_role_kind = selected.role_kind
+            if (
+                journal.state != "completed"
+                or journal.outbound_attempt_count != 1
+                or journal.response is None
+                or journal.collection_sha256 != frozen.collection_sha256
+                or journal.profile_sha256 != frozen.profile_sha256
+                or journal.case_contract_sha256 != frozen.case_contract_sha256
+                or journal.plan_sha256 != expected_plan
+                or journal.lane_contract_sha256 != expected_contract
+                or journal.idempotency_key != expected_call.idempotency_key
+                or journal.selected_role_id != expected_role_id
+                or journal.selected_role_kind != expected_role_kind
+            ):
+                raise RoleGapReviewError(
+                    f"{case_id}/{lane_id}: completed request contract drifted"
+                )
+            if journal.search_cost_usd is None:
+                raise RoleGapReviewError(
+                    f"{case_id}/{lane_id}: provider cost is not inspectable"
+                )
+            known_cost += journal.search_cost_usd
+            validated[key] = journal
+    if not math.isclose(
+        known_cost,
+        EXPECTED_PROVIDER_COST_USD,
+        rel_tol=1e-9,
+        abs_tol=1e-9,
+    ):
+        raise RoleGapReviewError("lane costs do not join the frozen provider total")
+    return validated
+
+
+def _validate_route_journals(
+    source_dir: Path,
+    manifest: RoleGapManifestArtifact,
+    execution: RoleGapExecutionArtifact,
+    lanes: Mapping[tuple[str, str], RoleGapLaneExecution],
+) -> tuple[RoleGapRouteExecution, ...]:
+    route_dir = source_dir / "route-executions"
+    if not route_dir.is_dir():
+        raise RoleGapReviewError("route-executions journal directory is missing")
+    expected_names = {f"{case_id}.json" for case_id in CASE_IDS}
+    observed_names = {path.name for path in route_dir.glob("*.json")}
+    if observed_names != expected_names:
+        raise RoleGapReviewError("route journals do not cover AD01-AD08 exactly")
+
+    aggregate = {item.case_id: item for item in execution.route_executions}
+    frozen_cases = {case.spec.case_id: case for case in manifest.cases}
+    validated: list[RoleGapRouteExecution] = []
+    for case_id in CASE_IDS:
+        route = RoleGapRouteExecution.model_validate(
+            _read_json_object(route_dir / f"{case_id}.json")
+        )
+        if route != aggregate.get(case_id):
+            raise RoleGapReviewError(f"{case_id}: route journal differs from execution")
+        rebuilt = _route_execution(frozen_cases[case_id], lanes[(case_id, "anchor_search")])  # type: ignore[arg-type]
+        if route != rebuilt:
+            raise RoleGapReviewError(
+                f"{case_id}: route cannot be rebuilt from its anchor journal"
+            )
+        validated.append(route)
+    return tuple(validated)
+
+
+def _validate_case_portfolios(
+    source_dir: Path,
+    manifest: RoleGapManifestArtifact,
+    execution: RoleGapExecutionArtifact,
+    lanes: Mapping[tuple[str, str], RoleGapLaneExecution],
+    routes: tuple[RoleGapRouteExecution, ...],
+) -> tuple[RoleGapCasePortfolio, ...]:
+    portfolio_dir = source_dir / "case-portfolios"
+    if not portfolio_dir.is_dir():
+        raise RoleGapReviewError("case-portfolios directory is missing")
+    expected_names = {f"{case_id}.json" for case_id in CASE_IDS}
+    observed_names = {path.name for path in portfolio_dir.glob("*.json")}
+    if observed_names != expected_names:
+        raise RoleGapReviewError("case portfolios do not cover AD01-AD08 exactly")
+
+    aggregate = {item.case_id: item for item in execution.portfolios}
+    frozen_cases = {case.spec.case_id: case for case in manifest.cases}
+    route_by_case = {item.case_id: item for item in routes}
+    validated: list[RoleGapCasePortfolio] = []
+    for case_id in CASE_IDS:
+        portfolio = RoleGapCasePortfolio.model_validate(
+            _read_json_object(portfolio_dir / f"{case_id}.json")
+        )
+        if portfolio != aggregate.get(case_id):
+            raise RoleGapReviewError(
+                f"{case_id}: portfolio differs from aggregate execution"
+            )
+        route = route_by_case[case_id]
+        lane_ids = (
+            _LANE_ORDER if route.decision.action == "search" else ("anchor_search",)
+        )
+        ordered_lanes = tuple(lanes[(case_id, lane_id)] for lane_id in lane_ids)
+        rebuilt = build_case_portfolio(  # type: ignore[arg-type]
+            frozen_cases[case_id],
+            route,
+            ordered_lanes,
+        )
+        if portfolio != rebuilt:
+            raise RoleGapReviewError(
+                f"{case_id}: portfolio cannot be rebuilt from route and lanes"
+            )
+        validated.append(portfolio)
+    return tuple(validated)
+
+
+def _case_contexts(
+    manifest: RoleGapManifestArtifact,
+) -> tuple[dict[str, Any], ...]:
+    """Project baseline and role context without exposing adaptive answers."""
+
+    contexts: list[dict[str, Any]] = []
+    for frozen in manifest.cases:
+        baseline_sources = [
+            source.model_dump(mode="json")
+            for source in frozen.source_collection.academic_sources
+        ]
+        gap_state = frozen.source_collection.failed_domains.get("academic", "")
+        if not baseline_sources or not gap_state:
+            raise RoleGapReviewError(
+                f"{frozen.spec.case_id}: frozen academic context is incomplete"
+            )
+        contexts.append(
+            {
+                "case_id": frozen.spec.case_id,
+                "topic": frozen.spec.topic,
+                "collection_sha256": frozen.collection_sha256,
+                "profile_sha256": frozen.profile_sha256,
+                "gap_subject": "academic",
+                "gap_state": gap_state,
+                "frozen_baseline_sources": baseline_sources,
+                "frozen_role_profile": frozen.spec.roles.profile().model_dump(
+                    mode="json"
+                ),
+            }
+        )
+    return tuple(contexts)
+
+
+def _candidate_from_review_row(
+    row: Mapping[str, str],
+    lanes_by_candidate: Mapping[tuple[str, str], tuple[str, ...]],
+) -> RoleGapReviewCandidate:
+    key = (row["case_id"], row["unique_candidate_sha256"])
+    lane_memberships = lanes_by_candidate.get(key)
+    if lane_memberships is None:
+        raise RoleGapReviewError(f"review candidate has no portfolio lineage: {key}")
+    return RoleGapReviewCandidate(
+        case_id=row["case_id"],
+        unique_candidate_sha256=row["unique_candidate_sha256"],
+        topic=row["topic"],
+        title=row["title"],
+        url=row["url"],
+        normalized_doi=row["normalized_doi"],
+        publisher=row["publisher"],
+        published_date=row["published_date"],
+        evidence_summary=row["evidence_summary"],
+        summary_source=row["summary_source"],
+        citation_count=row["citation_count"],
+        frozen_baseline_sources=row["frozen_baseline_sources"],
+        frozen_role_profile=row["frozen_role_profile"],
+        lane_memberships=lane_memberships,
+    )
+
+
+def validate_finalized_source(
+    source_dir: Path,
+    *,
+    expected_hashes: Mapping[str, str] | None = None,
+) -> RoleGapSourceSnapshot:
+    """Reconstruct every AC source seam without network, labels, or mutation."""
+
+    if not source_dir.is_dir():
+        raise RoleGapReviewError(f"source directory does not exist: {source_dir}")
+    indexed_hashes = _validate_artifact_index(source_dir)
+    file_hashes = {
+        name: _file_sha256(source_dir / name) for name in INDEXED_SOURCE_FILES
+    }
+    if file_hashes != indexed_hashes:
+        drift = {
+            name: {"expected": indexed_hashes[name], "observed": file_hashes[name]}
+            for name in INDEXED_SOURCE_FILES
+            if file_hashes[name] != indexed_hashes[name]
+        }
+        raise RoleGapReviewError(f"source files drifted from artifact index: {drift}")
+    file_hashes["artifact-index.json"] = EXPECTED_ARTIFACT_INDEX_SHA256
+    if expected_hashes is not None and file_hashes != dict(expected_hashes):
+        raise RoleGapReviewError("source artifact identity drifted after owner locking")
+
+    manifest = RoleGapManifestArtifact.model_validate(
+        _read_json_object(source_dir / "manifest.json")
+    )
+    execution = RoleGapExecutionArtifact.model_validate(
+        _read_json_object(source_dir / "execution.json")
+    )
+    _validate_complete_execution(manifest, execution)
+    _validate_frozen_totals(manifest, execution)
+    lanes = _validate_lane_journals(source_dir, manifest, execution)
+    routes = _validate_route_journals(source_dir, manifest, execution, lanes)
+    portfolios = _validate_case_portfolios(
+        source_dir,
+        manifest,
+        execution,
+        lanes,
+        routes,
+    )
+
+    provider_rows = _read_csv(
+        source_dir / "provider-rows.csv", _PROVIDER_ROW_COLUMNS
+    )
+    if provider_rows != _provider_rows(execution.lane_executions, portfolios):
+        raise RoleGapReviewError("provider rows cannot be rebuilt from lane journals")
+    route_rows = _read_csv(source_dir / "route-decisions.csv", _ROUTE_COLUMNS)
+    if route_rows != _route_rows(routes):
+        raise RoleGapReviewError("route CSV cannot be rebuilt from route journals")
+    unique_rows = _read_csv(
+        source_dir / "unique-candidates.csv", _UNIQUE_CANDIDATE_COLUMNS
+    )
+    candidate_review_rows = _read_csv(
+        source_dir / "candidate-review.csv", _CANDIDATE_REVIEW_COLUMNS
+    )
+    case_review_rows = _read_csv(
+        source_dir / "case-review.csv", _CASE_REVIEW_COLUMNS
+    )
+    expected_unique, expected_candidate_review, expected_case_review = (
+        _unique_and_review_rows(manifest, routes, portfolios)
+    )
+    if unique_rows != expected_unique:
+        raise RoleGapReviewError("unique-candidate CSV does not match portfolios")
+    if candidate_review_rows != expected_candidate_review:
+        raise RoleGapReviewError("candidate-review CSV cannot be reconstructed")
+    if case_review_rows != expected_case_review:
+        raise RoleGapReviewError("case-review CSV cannot be reconstructed")
+    if any(
+        row[field].strip()
+        for row in candidate_review_rows
+        for field in (
+            "directly_relevant",
+            "baseline_novel",
+            "supported_role_ids",
+            "closure_contributed_selected_role",
+            "review_note",
+        )
+    ):
+        raise RoleGapReviewError("source candidate-review.csv is no longer blank")
+    if any(
+        row[field].strip()
+        for row in case_review_rows
+        for field in (
+            "routing_decision_correct",
+            "anchor_human_coverable_within_three",
+            "union_human_coverable_within_three",
+            "review_note",
+        )
+    ):
+        raise RoleGapReviewError("source case-review.csv is no longer blank")
+
+    lanes_by_candidate = {
+        (candidate.case_id, candidate.unique_candidate_sha256): tuple(
+            candidate.lane_memberships
+        )
+        for portfolio in portfolios
+        for candidate in portfolio.unique_candidates
+    }
+    candidates = tuple(
+        _candidate_from_review_row(row, lanes_by_candidate)
+        for row in candidate_review_rows
+    )
+    if len(candidates) != EXPECTED_REVIEW_ROW_COUNT:
+        raise RoleGapReviewError("review denominator does not match the frozen run")
+    if len({candidate.key for candidate in candidates}) != len(candidates):
+        raise RoleGapReviewError("review candidates contain duplicate identities")
+    observed_per_case = dict(
+        sorted(Counter(candidate.case_id for candidate in candidates).items())
+    )
+    if observed_per_case != EXPECTED_UNIQUE_PER_CASE:
+        raise RoleGapReviewError("review rows lost the frozen case denominator")
+    return RoleGapSourceSnapshot(
+        file_hashes=file_hashes,
+        manifest=manifest,
+        execution=execution,
+        candidates=candidates,
+        case_contexts=_case_contexts(manifest),
+    )
+
+
+def create_source_lock(
+    source_dir: Path,
+    output_path: Path,
+    *,
+    study_owner_id: str,
+    confirm_authorized_output: bool,
+    note: str | None = None,
+    authorized_at: datetime | None = None,
+) -> RoleGapSourceLock:
+    """Write a separate owner attestation over the exact inspected bytes."""
+
+    if not confirm_authorized_output:
+        raise RoleGapReviewError(
+            "source locking requires explicit authorized-output confirmation"
+        )
+    if output_path.exists():
+        raise RoleGapReviewError(f"refusing to overwrite source lock: {output_path}")
+    snapshot = validate_finalized_source(source_dir)
+    source_lock = RoleGapSourceLock(
+        executed_revision=EXPECTED_EXECUTED_REVISION,
+        fixture_sha256=EXPECTED_FIXTURE_SHA256,
+        implementation_sha256=EXPECTED_IMPLEMENTATION_SHA256,
+        runner_sha256=EXPECTED_RUNNER_SHA256,
+        source_file_sha256=snapshot.file_hashes,
+        review_row_count=len(snapshot.candidates),
+        study_owner_id=study_owner_id.strip(),
+        authorized_at=authorized_at or datetime.now(UTC),
+        note=note.strip() if note and note.strip() else None,
+    )
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RoleGapReviewError(
+            f"could not create source-lock parent {output_path.parent}: {exc}"
+        ) from exc
+    _write_text_new(
+        output_path,
+        source_lock.model_dump_json(indent=2) + "\n",
+    )
+    return source_lock
+
+
+def _load_source_lock(path: Path) -> RoleGapSourceLock:
+    try:
+        return RoleGapSourceLock.model_validate(_read_json_object(path))
+    except ValueError as exc:
+        if isinstance(exc, RoleGapReviewError):
+            raise
+        raise RoleGapReviewError(f"source lock is invalid: {exc}") from exc
+
+
+def _packet_rows(snapshot: RoleGapSourceSnapshot) -> list[dict[str, str]]:
+    """Return all source rows without any route or retrieval-lane clue."""
+
+    return [
+        {
+            **candidate.visible_values(),
+            "identity_sha256": candidate.identity_sha256,
+        }
+        for candidate in snapshot.candidates
+    ]
+
+
+def _packet_readme(snapshot: RoleGapSourceSnapshot) -> str:
+    case_rows = "\n".join(
+        (
+            f"| {context['case_id']} | {context['topic']} | "
+            f"{len(context['frozen_baseline_sources'])} | "
+            f"{len(context['frozen_role_profile']['required_roles'])} / "
+            f"{len(context['frozen_role_profile']['scope_roles'])} / "
+            f"{len(context['frozen_role_profile']['supporting_roles'])} |"
+        )
+        for context in snapshot.case_contexts
+    )
+    return f"""# OpenAlex adaptive role-gap v8 human source review
+
+This packet contains all {len(snapshot.candidates)} DOI/OpenAlex-deduplicated
+candidates from one exact, completed and production-disconnected AD01-AD08
+run. Preparing or summarizing it makes zero API or model calls.
+
+Do not edit `packet_manifest.json`. Complete only `labels.csv` and
+`reviewer_declaration.csv`. Rows may be reordered, but every read-only field
+must remain byte-for-byte unchanged. Do not send the separate source-lock file
+to the reviewer.
+
+## Blinding
+
+The packet deliberately hides anchor/closure membership, provider rank,
+duplicate occurrences, the mechanical route, selected closure role, computed
+coverability, aggregate answers and answer keys. Judge only the visible topic,
+frozen baseline, role catalogue, title and abstract. Hidden provenance is
+joined only after all labels and the declaration pass validation.
+
+## Cases
+
+| Case | Topic | Baseline sources | Required / scope / supporting roles |
+|---|---|---:|---:|
+{case_rows}
+
+For every row, read the `frozen_baseline_sources` and `frozen_role_profile`
+JSON. `supported_role_ids` must be a JSON array containing only visible role
+IDs, for example `["required_role", "scope_role"]`.
+
+## Labels
+
+- `YES/YES`: directly relevant and materially absent from the visible baseline.
+- `YES/NO`: directly relevant but already represented by the baseline.
+- `NO/N/A`: adjacent, generic, or not directly relevant.
+- `UNVERIFIABLE/UNVERIFIABLE`: the frozen title and abstract are insufficient
+  for a defensible judgment.
+
+Relevant rows require at least one supported role. `NO/N/A` and
+`UNVERIFIABLE/UNVERIFIABLE` require `[]`. Every completed row requires a
+source-grounded `review_note` of at least twelve non-whitespace characters.
+
+This protocol is intentionally title-and-abstract based. Opening external
+pages is optional; declare `ALL_ATTEMPTED`, `SOME`, or `NONE`. External access
+is not an eligibility gate. Complete `reviewer_declaration.csv` after all rows.
+Only `NONE` and `LANGUAGE_ONLY` generative-AI use are eligible. Substantive
+generated judgments remain inspectable but are excluded from gate evaluation.
+
+After every label is locked, the summarizer reveals the frozen route and joins
+it to the human labels. A search route is correct only when its selected role
+is absent from directly relevant anchor rows. An abstention is correct only
+when directly relevant, baseline-novel anchor rows already cover all required
+roles plus at least one scope and one supporting role in no more than three
+sources. Closure value requires a closure-only `YES/YES` row supporting the
+selected role; a duplicate already returned by the anchor cannot earn credit.
+
+All six frozen gates are conjunctive. Passing AD permits only separately
+pre-registered planner-trigger, disabled-path and report-value studies. It never
+authorizes production Tool Calling.
+"""
+
+
+def _packet_manifest(
+    snapshot: RoleGapSourceSnapshot,
+    source_lock_path: Path,
+    *,
+    prepared_at: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "mode": "openalex_adaptive_role_gap_v8_ad_source_review_packet",
+        "prepared_at": prepared_at or datetime.now(UTC).isoformat(timespec="seconds"),
+        "cohort": "unseen",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "recovery_connected": False,
+        "model_call_count": 0,
+        "ad_cohort_opened": True,
+        "retrieval_lane_provenance_exposed": False,
+        "mechanical_route_exposed": False,
+        "external_source_access_required": False,
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "fixture_sha256": EXPECTED_FIXTURE_SHA256,
+        "artifact_index_sha256": EXPECTED_ARTIFACT_INDEX_SHA256,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "row_count": len(snapshot.candidates),
+        "mechanical_result": {
+            "request_count": snapshot.execution.request_count,
+            "provider_row_count": snapshot.execution.provider_row_count,
+            "unique_candidate_count": snapshot.execution.unique_candidate_count,
+            "review_packet_eligibility": (
+                snapshot.execution.review_packet_eligibility
+            ),
+            "provider_cost_state": snapshot.execution.provider_summary.cost_state,
+            "provider_reported_cost_usd": (
+                snapshot.execution.provider_summary.reported_cost_usd
+            ),
+        },
+        "case_contexts": list(snapshot.case_contexts),
+        "rows": _packet_rows(snapshot),
+        "valid_label_pairs": [list(pair) for pair in sorted(VALID_LABEL_PAIRS)],
+        "supported_role_ids_format": "JSON array of visible role IDs",
+        "qualification_thresholds": (
+            snapshot.manifest.qualification_contract.model_dump(mode="json")
+        ),
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def prepare_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Create a route- and lane-blind Schema v2 packet from locked bytes."""
+
+    if packet_dir.exists():
+        raise RoleGapReviewError(f"refusing to overwrite packet: {packet_dir}")
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    if source_lock.review_row_count != len(snapshot.candidates):
+        raise RoleGapReviewError("source-lock review denominator drifted")
+    try:
+        packet_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        raise RoleGapReviewError(f"could not create packet {packet_dir}: {exc}") from exc
+
+    manifest = _packet_manifest(snapshot, source_lock_path)
+    label_rows = [
+        {
+            **candidate.visible_values(),
+            "directly_relevant": "",
+            "baseline_novel": "",
+            "supported_role_ids": "",
+            "review_note": "",
+        }
+        for candidate in snapshot.candidates
+    ]
+    _write_csv_new(packet_dir / "labels.csv", LABEL_FIELDS, label_rows)
+    _write_csv_new(
+        packet_dir / "reviewer_declaration.csv",
+        DECLARATION_FIELDS,
+        [{}],
+    )
+    _write_text_new(packet_dir / "README.md", _packet_readme(snapshot))
+    _write_text_new(
+        packet_dir / "packet_manifest.json",
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    return manifest
+
+
+def _manifest_candidates(
+    manifest: dict[str, Any],
+    snapshot: RoleGapSourceSnapshot,
+    source_lock_path: Path,
+) -> dict[tuple[str, str], RoleGapReviewCandidate]:
+    try:
+        prepared_at = datetime.fromisoformat(str(manifest["prepared_at"]))
+    except (KeyError, ValueError) as exc:
+        raise RoleGapReviewError("packet prepared_at is not an ISO timestamp") from exc
+    if prepared_at.tzinfo is None:
+        raise RoleGapReviewError("packet prepared_at must be timezone-aware")
+    expected_manifest = _packet_manifest(
+        snapshot,
+        source_lock_path,
+        prepared_at=str(manifest["prepared_at"]),
+    )
+    if manifest != expected_manifest:
+        raise RoleGapReviewError(
+            "packet manifest does not match the source-locked blind projection"
+        )
+    expected_rows = _packet_rows(snapshot)
+    if any(
+        hidden in row
+        for row in expected_rows
+        for hidden in HIDDEN_REVIEW_FIELDS
+    ):
+        raise RoleGapReviewError("reviewer packet leaks adaptive provenance")
+    return {candidate.key: candidate for candidate in snapshot.candidates}
+
+
+def _profile_role_groups(
+    candidate: RoleGapReviewCandidate,
+) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+    try:
+        profile = json.loads(candidate.frozen_role_profile)
+        required = frozenset(
+            item["role_id"] for item in profile["required_roles"]
+        )
+        scope = frozenset(item["role_id"] for item in profile["scope_roles"])
+        supporting = frozenset(
+            item["role_id"] for item in profile["supporting_roles"]
+        )
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise RoleGapReviewError(
+            f"{candidate.row_id}: frozen role profile is malformed"
+        ) from exc
+    if (
+        not required
+        or not scope
+        or not supporting
+        or (required & scope)
+        or (required & supporting)
+        or (scope & supporting)
+    ):
+        raise RoleGapReviewError(
+            f"{candidate.row_id}: frozen role groups are incomplete or overlap"
+        )
+    return required, scope, supporting
+
+
+def _validated_role_ids(
+    value: str,
+    candidate: RoleGapReviewCandidate,
+) -> tuple[str, ...]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise RoleGapReviewError(
+            f"{candidate.row_id}: supported_role_ids must be JSON"
+        ) from exc
+    if (
+        not isinstance(parsed, list)
+        or any(not isinstance(item, str) or not item for item in parsed)
+        or len(parsed) != len(set(parsed))
+    ):
+        raise RoleGapReviewError(
+            f"{candidate.row_id}: supported_role_ids must be a unique string array"
+        )
+    required, scope, supporting = _profile_role_groups(candidate)
+    unknown = sorted(set(parsed) - (required | scope | supporting))
+    if unknown:
+        raise RoleGapReviewError(
+            f"{candidate.row_id}: unknown supported role IDs {unknown}"
+        )
+    return tuple(sorted(parsed))
+
+
+def _validated_label(
+    row: dict[str, str],
+    expected: RoleGapReviewCandidate,
+) -> dict[str, Any] | None:
+    observed_visible = {field: row[field] for field in READ_ONLY_LABEL_FIELDS}
+    if observed_visible != expected.visible_values():
+        raise RoleGapReviewError(
+            f"label identity or read-only context drifted for {expected.row_id}"
+        )
+    values = [
+        row[field].strip()
+        for field in (
+            "directly_relevant",
+            "baseline_novel",
+            "supported_role_ids",
+            "review_note",
+        )
+    ]
+    if not any(values):
+        return None
+    if not all(values):
+        raise RoleGapReviewError(f"{expected.row_id} is partially completed")
+    relevant, novel, role_text, note = values
+    relevant = relevant.upper()
+    novel = novel.upper()
+    if (relevant, novel) not in VALID_LABEL_PAIRS:
+        raise RoleGapReviewError(
+            f"{expected.row_id} has invalid relevance/novelty pair: "
+            f"{relevant}/{novel}"
+        )
+    role_ids = _validated_role_ids(role_text, expected)
+    if relevant == "YES" and not role_ids:
+        raise RoleGapReviewError(
+            f"{expected.row_id}: relevant rows require supported roles"
+        )
+    if relevant != "YES" and role_ids:
+        raise RoleGapReviewError(
+            f"{expected.row_id}: non-relevant rows must use an empty role array"
+        )
+    if len("".join(note.split())) < 12:
+        raise RoleGapReviewError(
+            f"{expected.row_id}: review_note is too short to ground the judgment"
+        )
+    return {
+        "case_id": expected.case_id,
+        "unique_candidate_sha256": expected.unique_candidate_sha256,
+        "row_id": expected.row_id,
+        "directly_relevant": relevant,
+        "baseline_novel": novel,
+        "supported_role_ids": role_ids,
+        "review_note": note,
+    }
+
+
+def _minimal_cover(
+    case_candidates: list[tuple[RoleGapReviewCandidate, dict[str, Any]]],
+    *,
+    anchor_only: bool,
+) -> tuple[str, ...] | None:
+    eligible = [
+        (candidate, label)
+        for candidate, label in case_candidates
+        if label["directly_relevant"] == "YES"
+        and label["baseline_novel"] == "YES"
+        and (not anchor_only or "anchor_search" in candidate.lane_memberships)
+    ]
+    if not eligible:
+        return None
+    eligible.sort(key=lambda item: item[0].row_id)
+    required, scope, supporting = _profile_role_groups(eligible[0][0])
+    for size in range(1, min(3, len(eligible)) + 1):
+        for selected in combinations(eligible, size):
+            covered = set().union(
+                *(set(label["supported_role_ids"]) for _, label in selected)
+            )
+            if (
+                required.issubset(covered)
+                and bool(scope & covered)
+                and bool(supporting & covered)
+            ):
+                return tuple(candidate.row_id for candidate, _ in selected)
+    return None
+
+
+def _role_gap_metrics(
+    snapshot: RoleGapSourceSnapshot,
+    completed: Mapping[tuple[str, str], dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, str], str, list[dict[str, Any]]]:
+    relevant_rows = [
+        label
+        for label in completed.values()
+        if label["directly_relevant"] == "YES"
+    ]
+    denominator = len(snapshot.candidates)
+    precision = len(relevant_rows) / denominator if denominator else None
+    relevant_novel_case_ids = sorted(
+        {
+            label["case_id"]
+            for label in completed.values()
+            if label["directly_relevant"] == "YES"
+            and label["baseline_novel"] == "YES"
+        }
+    )
+
+    candidates_by_case = {
+        case_id: [
+            candidate
+            for candidate in snapshot.candidates
+            if candidate.case_id == case_id
+        ]
+        for case_id in CASE_IDS
+    }
+    route_by_case = {
+        route.case_id: route for route in snapshot.execution.route_executions
+    }
+    anchor_covers: dict[str, tuple[str, ...]] = {}
+    union_covers: dict[str, tuple[str, ...]] = {}
+    correct_route_ids: list[str] = []
+    closure_value_ids: list[str] = []
+    route_assessments: list[dict[str, Any]] = []
+    for case_id in CASE_IDS:
+        case_items = [
+            (candidate, completed[candidate.key])
+            for candidate in candidates_by_case[case_id]
+        ]
+        anchor_cover = _minimal_cover(case_items, anchor_only=True)
+        union_cover = _minimal_cover(case_items, anchor_only=False)
+        if anchor_cover is not None:
+            anchor_covers[case_id] = anchor_cover
+        if union_cover is not None:
+            union_covers[case_id] = union_cover
+
+        human_anchor_role_ids = sorted(
+            set().union(
+                *(
+                    set(label["supported_role_ids"])
+                    for candidate, label in case_items
+                    if "anchor_search" in candidate.lane_memberships
+                    and label["directly_relevant"] == "YES"
+                )
+            )
+        )
+        route = route_by_case[case_id]
+        selected = route.decision.selected_closure
+        if route.decision.action == "search":
+            if selected is None:  # pragma: no cover - Pydantic guards this
+                raise RoleGapReviewError(f"{case_id}: search route lost selected role")
+            route_correct = selected.role_id not in human_anchor_role_ids
+            contribution_rows = sorted(
+                candidate.row_id
+                for candidate, label in case_items
+                if candidate.lane_memberships == ("role_closure",)
+                and label["directly_relevant"] == "YES"
+                and label["baseline_novel"] == "YES"
+                and selected.role_id in label["supported_role_ids"]
+            )
+        else:
+            route_correct = anchor_cover is not None
+            contribution_rows = []
+        if route_correct:
+            correct_route_ids.append(case_id)
+        if contribution_rows:
+            closure_value_ids.append(case_id)
+        route_assessments.append(
+            {
+                "case_id": case_id,
+                "route_action": route.decision.action,
+                "route_reason": route.decision.reason,
+                "mechanical_missing_role_ids": list(
+                    route.decision.missing_role_ids
+                ),
+                "selected_role_id": selected.role_id if selected else None,
+                "human_relevant_anchor_role_ids": human_anchor_role_ids,
+                "routing_decision_correct": route_correct,
+                "anchor_human_coverable_within_three": anchor_cover is not None,
+                "anchor_selected_cover_row_ids": list(anchor_cover or ()),
+                "union_human_coverable_within_three": union_cover is not None,
+                "union_selected_cover_row_ids": list(union_cover or ()),
+                "closure_selected_role_contribution_row_ids": contribution_rows,
+            }
+        )
+
+    anchor_case_ids = sorted(anchor_covers)
+    union_case_ids = sorted(union_covers)
+    coverability_gain = len(union_case_ids) - len(anchor_case_ids)
+    thresholds = snapshot.manifest.qualification_contract
+    threshold_results = {
+        "relevant_novel_cases": (
+            "pass"
+            if len(relevant_novel_case_ids)
+            >= thresholds.minimum_cases_with_relevant_novel_candidate
+            else "fail"
+        ),
+        "candidate_pool_precision": (
+            "pass"
+            if precision is not None
+            and precision >= thresholds.minimum_candidate_pool_precision
+            else "fail"
+        ),
+        "human_correct_routing_decisions": (
+            "pass"
+            if len(correct_route_ids)
+            >= thresholds.minimum_human_correct_routing_decisions
+            else "fail"
+        ),
+        "selected_role_closure_value": (
+            "pass"
+            if len(closure_value_ids)
+            >= thresholds.minimum_cases_with_selected_role_closure_value
+            else "fail"
+        ),
+        "human_coverable_cases": (
+            "pass"
+            if len(union_case_ids) >= thresholds.minimum_human_coverable_cases
+            else "fail"
+        ),
+        "coverability_gain_over_anchor": (
+            "pass"
+            if coverability_gain >= thresholds.minimum_coverability_gain_over_anchor
+            else "fail"
+        ),
+    }
+    metrics = {
+        "case_denominator": len(CASE_IDS),
+        "reviewable_candidate_denominator": denominator,
+        "directly_relevant_candidate_count": len(relevant_rows),
+        "candidate_pool_precision": precision,
+        "relevant_novel_case_ids": relevant_novel_case_ids,
+        "relevant_novel_case_count": len(relevant_novel_case_ids),
+        "human_correct_routing_case_ids": sorted(correct_route_ids),
+        "human_correct_routing_case_count": len(correct_route_ids),
+        "selected_role_closure_value_case_ids": sorted(closure_value_ids),
+        "selected_role_closure_value_case_count": len(closure_value_ids),
+        "anchor_human_coverable_case_ids": anchor_case_ids,
+        "anchor_human_coverable_case_count": len(anchor_case_ids),
+        "union_human_coverable_case_ids": union_case_ids,
+        "union_human_coverable_case_count": len(union_case_ids),
+        "coverability_gain_over_anchor": coverability_gain,
+    }
+    decision = (
+        "pass"
+        if all(result == "pass" for result in threshold_results.values())
+        else "fail"
+    )
+    return metrics, threshold_results, decision, route_assessments
+
+
+def summarize_packet(
+    source_dir: Path,
+    source_lock_path: Path,
+    packet_dir: Path,
+) -> dict[str, Any]:
+    """Validate labels before joining hidden adaptive route provenance."""
+
+    if not packet_dir.is_dir():
+        raise RoleGapReviewError(f"packet directory does not exist: {packet_dir}")
+    source_lock = _load_source_lock(source_lock_path)
+    snapshot = validate_finalized_source(
+        source_dir,
+        expected_hashes=source_lock.source_file_sha256,
+    )
+    manifest = _read_json_object(packet_dir / "packet_manifest.json")
+    expected_candidates = _manifest_candidates(
+        manifest,
+        snapshot,
+        source_lock_path,
+    )
+
+    label_rows = _read_csv(packet_dir / "labels.csv", LABEL_FIELDS)
+    observed_keys = [
+        (row["case_id"], row["unique_candidate_sha256"]) for row in label_rows
+    ]
+    if len(observed_keys) != len(set(observed_keys)):
+        raise RoleGapReviewError("labels contain duplicate candidate identities")
+    if set(observed_keys) != set(expected_candidates):
+        missing = sorted(set(expected_candidates) - set(observed_keys))
+        extra = sorted(set(observed_keys) - set(expected_candidates))
+        raise RoleGapReviewError(
+            f"label identities do not match packet; missing={missing}, extra={extra}"
+        )
+
+    completed: dict[tuple[str, str], dict[str, Any]] = {}
+    incomplete_row_ids: list[str] = []
+    for row in label_rows:
+        key = (row["case_id"], row["unique_candidate_sha256"])
+        validated = _validated_label(row, expected_candidates[key])
+        if validated is None:
+            incomplete_row_ids.append(expected_candidates[key].row_id)
+        else:
+            completed[key] = validated
+
+    declaration_path = packet_dir / "reviewer_declaration.csv"
+    declaration_rows = _read_csv(declaration_path, DECLARATION_FIELDS)
+    if len(declaration_rows) != 1:
+        raise RoleGapReviewError(
+            "reviewer_declaration.csv must contain exactly one row"
+        )
+    raw_declaration = dict(declaration_rows[0])
+    declaration = _validated_declaration(raw_declaration)
+    ordered_completed = [completed[key] for key in sorted(completed)]
+    uninspectable_row_ids = [
+        row["row_id"]
+        for row in ordered_completed
+        if row["directly_relevant"] == "UNVERIFIABLE"
+    ]
+    method_issues: list[str] = []
+    if declaration is not None and declaration["reviewed_all"] != "YES":
+        method_issues.append("reviewer_did_not_confirm_all_rows")
+
+    if incomplete_row_ids or declaration is None:
+        protocol_status = "incomplete"
+    elif declaration["generative_ai_use"] not in ELIGIBLE_AI_USE:
+        protocol_status = "excluded_substantive_ai"
+    elif uninspectable_row_ids or method_issues:
+        protocol_status = "not_inspectable"
+    else:
+        protocol_status = "complete"
+
+    metrics: dict[str, Any] | None = None
+    route_assessments: list[dict[str, Any]] | None = None
+    threshold_results = {
+        "relevant_novel_cases": "not_evaluated",
+        "candidate_pool_precision": "not_evaluated",
+        "human_correct_routing_decisions": "not_evaluated",
+        "selected_role_closure_value": "not_evaluated",
+        "human_coverable_cases": "not_evaluated",
+        "coverability_gain_over_anchor": "not_evaluated",
+    }
+    decision = "not_evaluated"
+    if protocol_status == "complete":
+        metrics, threshold_results, decision, route_assessments = _role_gap_metrics(
+            snapshot,
+            completed,
+        )
+
+    return {
+        "schema_version": 1,
+        "mode": "openalex_adaptive_role_gap_v8_ad_source_review_result",
+        "cohort": "unseen",
+        "production_connected": False,
+        "report_workflow_connected": False,
+        "planner_trigger_connected": False,
+        "recovery_connected": False,
+        "model_call_count": 0,
+        "ad_cohort_opened": True,
+        "source_lock_sha256": _file_sha256(source_lock_path),
+        "source_file_sha256": snapshot.file_hashes,
+        "packet_manifest_sha256": _file_sha256(
+            packet_dir / "packet_manifest.json"
+        ),
+        "labels_file_sha256": _file_sha256(packet_dir / "labels.csv"),
+        "reviewer_declaration_file_sha256": _file_sha256(declaration_path),
+        "executed_revision": EXPECTED_EXECUTED_REVISION,
+        "protocol_status": protocol_status,
+        "decision": decision,
+        "row_count": len(expected_candidates),
+        "completed_row_count": len(completed),
+        "incomplete_row_ids": sorted(incomplete_row_ids),
+        "uninspectable_row_ids": sorted(uninspectable_row_ids),
+        "method_issues": method_issues,
+        # Preserve exact spreadsheet strings as well as the normalized
+        # declaration. This prevents a later correction from rewriting history.
+        "reviewer_declaration_raw": raw_declaration,
+        "reviewer_declaration": declaration,
+        "external_source_access_required": False,
+        "retrieval_lane_provenance_exposed_to_reviewer": False,
+        "mechanical_route_exposed_to_reviewer": False,
+        "adaptive_provenance_joined_after_label_validation": (
+            protocol_status == "complete"
+        ),
+        "observed_label_counts": (
+            {
+                "directly_relevant": dict(
+                    sorted(
+                        Counter(
+                            row["directly_relevant"] for row in ordered_completed
+                        ).items()
+                    )
+                ),
+                "baseline_novel": dict(
+                    sorted(
+                        Counter(
+                            row["baseline_novel"] for row in ordered_completed
+                        ).items()
+                    )
+                ),
+            }
+            if not incomplete_row_ids
+            else None
+        ),
+        "route_assessments_after_unblinding": route_assessments,
+        "role_gap_result": {
+            "metrics": metrics,
+            "threshold_results": threshold_results,
+            "decision": decision,
+        },
+        "qualification_thresholds": manifest["qualification_thresholds"],
+        "post_ad_studies_eligible": decision == "pass",
+        "production_connection_authorized": False,
+        "remaining_production_blockers": (
+            [
+                "planner_trigger_precision",
+                "disabled_path_regression",
+                "report_value",
+            ]
+            if decision == "pass"
+            else [
+                "adaptive_role_gap_v8_unseen_candidate_value",
+                "planner_trigger_precision",
+                "disabled_path_regression",
+                "report_value",
+            ]
+        ),
+        "measurement_limit": MEASUREMENT_LIMIT,
+    }
+
+
+def write_summary(path: Path, result: dict[str, Any]) -> None:
+    """Persist one strict interpretation without replacing human evidence."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RoleGapReviewError(
+            f"could not create summary parent {path.parent}: {exc}"
+        ) from exc
+    _write_text_new(
+        path,
+        json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _stdout_json(value: object) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    # Provider titles may contain characters outside a Windows console code
+    # page. Escaping stdout cannot alter the UTF-8 artifacts already written.
+    return json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    lock = commands.add_parser("lock", help="bind the exact v8 AD unseen output")
+    lock.add_argument("source", type=Path)
+    lock.add_argument("output", type=Path)
+    lock.add_argument("--study-owner-id", required=True)
+    lock.add_argument("--confirm-authorized-output", action="store_true")
+    lock.add_argument("--note")
+
+    prepare = commands.add_parser(
+        "prepare",
+        help="create a blank route- and lane-blind Schema v2 packet",
+    )
+    prepare.add_argument("source", type=Path)
+    prepare.add_argument("source_lock", type=Path)
+    prepare.add_argument("packet", type=Path)
+
+    summarize = commands.add_parser(
+        "summarize",
+        help="validate human labels and write one strict result",
+    )
+    summarize.add_argument("source", type=Path)
+    summarize.add_argument("source_lock", type=Path)
+    summarize.add_argument("packet", type=Path)
+    summarize.add_argument("output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "lock":
+        result = create_source_lock(
+            args.source,
+            args.output,
+            study_owner_id=args.study_owner_id,
+            confirm_authorized_output=args.confirm_authorized_output,
+            note=args.note,
+        )
+    elif args.command == "prepare":
+        result = prepare_packet(args.source, args.source_lock, args.packet)
+    else:
+        result = summarize_packet(
+            args.source,
+            args.source_lock,
+            args.packet,
+        )
+        write_summary(args.output, result)
+    print(_stdout_json(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openalex_role_gap_evaluation_review.py
+++ b/tests/test_openalex_role_gap_evaluation_review.py
@@ -1,0 +1,553 @@
+"""Zero-network source-lock and blind human-review seams for role-gap v8."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import openalex_role_gap_evaluation as live
+import openalex_role_gap_evaluation_review as review
+from academic_agent.evidence_gap import ValidatedGapCall
+from academic_agent.tools.evidence_search import (
+    ToolAdapterResponse,
+    ToolEvidenceCandidate,
+    ToolProviderUsage,
+)
+from openalex_role_gap_unseen import (
+    PreparedRoleGapCase,
+    RoleGapClosureOption,
+    load_frozen_cases,
+)
+
+
+def _work_id(case_id: str, lane_id: live.LaneId, index: int) -> str:
+    lane_digit = 1 if lane_id == "anchor_search" else 2
+    return f"https://openalex.org/W{int(case_id[2:]):02d}{lane_digit}{index:05d}"
+
+
+def _all_role_signal_text(case: PreparedRoleGapCase) -> str:
+    phrases = [
+        phrase
+        for _, role in case.spec.roles.ordered_roles()
+        for phrase in role.signal_groups[0]
+    ]
+    return f"This AD03 anchor contains every frozen role signal: {'; '.join(phrases)}."
+
+
+def _candidate(
+    case: PreparedRoleGapCase,
+    lane_id: live.LaneId,
+    index: int,
+) -> ToolEvidenceCandidate:
+    if index == 0:
+        # Different Works share one DOI so the review denominator must come
+        # from the production deduplicator rather than a test approximation.
+        label = "shared DOI candidate"
+        doi = f"10.5555/{case.spec.case_id.casefold()}.adaptive-review-shared"
+    else:
+        label = f"{lane_id} unique {index} candidate"
+        doi = None
+    summary = (
+        _all_role_signal_text(case)
+        if case.spec.case_id == "AD03" and lane_id == "anchor_search" and index == 0
+        else (
+            f"This synthetic {lane_id} abstract for {case.spec.case_id} is long "
+            "enough to test immutable review context without asserting real "
+            "source relevance or commercial value."
+        )
+    )
+    return ToolEvidenceCandidate(
+        title=f"{case.spec.case_id} {label} for adaptive review",
+        url=_work_id(case.spec.case_id, lane_id, index),
+        doi=doi,
+        publisher="OpenAlex zero-network adaptive review fixture",
+        evidence_summary=summary,
+        summary_source="abstract",
+        citation_count=index + 1,
+        provider_result_index=index,
+    )
+
+
+class ReviewFactory:
+    """Return three deterministic candidates for every selected v8 lane."""
+
+    def __init__(self) -> None:
+        _, _, cases = load_frozen_cases("unseen")
+        self.by_key: dict[
+            str,
+            tuple[PreparedRoleGapCase, live.LaneId, RoleGapClosureOption | None],
+        ] = {}
+        for case in cases:
+            self.by_key[case.anchor_call.idempotency_key] = (
+                case,
+                "anchor_search",
+                None,
+            )
+            for option in case.closure_options:
+                self.by_key[option.call.idempotency_key] = (
+                    case,
+                    "role_closure",
+                    option,
+                )
+
+    def __call__(self):
+        def run(call: ValidatedGapCall) -> ToolAdapterResponse:
+            case, lane_id, _ = self.by_key[call.idempotency_key]
+            candidates = tuple(_candidate(case, lane_id, index) for index in range(3))
+            request_id = f"client-v8-review-{call.idempotency_key[:16]}"
+            usage = ToolProviderUsage(
+                provider="openalex",
+                request_id=request_id,
+                request_id_source="client_generated",
+                result_count=len(candidates),
+                cost_basis="reported_usd",
+                reported_cost_usd=0.001,
+            )
+            return ToolAdapterResponse(
+                tool="academic_search",
+                idempotency_key=call.idempotency_key,
+                candidates=candidates,
+                search_cost_usd=0.001,
+                provider_request_id=request_id,
+                provider_usage=usage,
+            )
+
+        return run
+
+
+def _source(tmp_path: Path, monkeypatch) -> Path:
+    """Materialize one 15-request path and bind only test-local identities."""
+
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+    source = tmp_path / "role-gap-v8-source"
+    artifact = live.execute_unseen_study(
+        output_dir=source,
+        soft_stop_usd=0.02,
+        acknowledge_anonymous_daily_budget=True,
+        adapter_factory=ReviewFactory(),
+    )
+    assert artifact.request_count == 15
+    assert artifact.closure_request_count == 7
+    routes = {
+        item.case_id: item.decision.action for item in artifact.route_executions
+    }
+    assert routes["AD03"] == "abstain"
+    assert {
+        case_id for case_id, action in routes.items() if action == "search"
+    } == set(review.EXPECTED_CLOSURE_CASE_IDS)
+
+    monkeypatch.setattr(
+        review,
+        "EXPECTED_ARTIFACT_INDEX_SHA256",
+        hashlib.sha256((source / "artifact-index.json").read_bytes()).hexdigest(),
+    )
+    monkeypatch.setattr(review, "EXPECTED_RUNNER_SHA256", artifact.runner_sha256)
+    monkeypatch.setattr(review, "EXPECTED_PROVIDER_ROW_COUNT", 45)
+    monkeypatch.setattr(review, "EXPECTED_PROVIDER_CANDIDATE_COUNT", 45)
+    monkeypatch.setattr(review, "EXPECTED_PROVIDER_REJECTION_COUNT", 0)
+    monkeypatch.setattr(review, "EXPECTED_REVIEW_ROW_COUNT", 38)
+    monkeypatch.setattr(
+        review,
+        "EXPECTED_UNIQUE_PER_CASE",
+        {case_id: (3 if case_id == "AD03" else 5) for case_id in review.CASE_IDS},
+    )
+    return source
+
+
+def test_middle_abstention_preserves_exact_closure_case_set(
+    tmp_path,
+    monkeypatch,
+):
+    """AD03 abstains while AD08 closes; positional AC assumptions must fail."""
+
+    source = _source(tmp_path, monkeypatch)
+
+    assert not (source / "lane-executions" / "AD03--role_closure.json").exists()
+    assert (source / "lane-executions" / "AD08--role_closure.json").is_file()
+    snapshot = review.validate_finalized_source(source)
+    assert len(snapshot.candidates) == 38
+
+
+def _lock(source: Path, tmp_path: Path) -> Path:
+    path = tmp_path / "private" / "source-lock.json"
+    review.create_source_lock(
+        source,
+        path,
+        study_owner_id="offline-v8-review-owner",
+        confirm_authorized_output=True,
+        authorized_at=datetime(2026, 9, 3, 12, 0, tzinfo=UTC),
+    )
+    return path
+
+
+def _write_csv(
+    path: Path,
+    fields: tuple[str, ...],
+    rows: list[dict[str, str]],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="raise")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _declaration(
+    packet: Path,
+    *,
+    ai_use: str = "NONE",
+    reviewed_all: str = "YES",
+    external_sources_checked: str = "NONE",
+) -> None:
+    _write_csv(
+        packet / "reviewer_declaration.csv",
+        review.DECLARATION_FIELDS,
+        [
+            {
+                "reviewer_id": "human-v8-reviewer",
+                "reviewed_all": reviewed_all,
+                "generative_ai_use": ai_use,
+                "external_sources_checked": external_sources_checked,
+                "elapsed_minutes": "90",
+                "expertise": "academic evidence synthesis",
+                "completed_date": "2026-09-03",
+                "limitations": (
+                    "Judgments use only the frozen titles, abstracts, and baseline."
+                ),
+            }
+        ],
+    )
+
+
+def _role_ids(row: dict[str, str]) -> list[str]:
+    profile = json.loads(row["frozen_role_profile"])
+    return [
+        item["role_id"]
+        for field in ("required_roles", "scope_roles", "supporting_roles")
+        for item in profile[field]
+    ]
+
+
+def _hidden_source_rows(source: Path) -> dict[tuple[str, str], dict[str, str]]:
+    with (source / "candidate-review.csv").open(
+        encoding="utf-8", newline=""
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+    return {
+        (row["case_id"], row["unique_candidate_sha256"]): row for row in rows
+    }
+
+
+def _selected_roles(source: Path) -> dict[str, str]:
+    with (source / "case-review.csv").open(
+        encoding="utf-8", newline=""
+    ) as handle:
+        return {
+            row["case_id"]: row["selected_role_id"] for row in csv.DictReader(handle)
+        }
+
+
+def _set_label(
+    row: dict[str, str],
+    *,
+    relevant: str,
+    novel: str,
+    roles: list[str],
+) -> None:
+    row["directly_relevant"] = relevant
+    row["baseline_novel"] = novel
+    row["supported_role_ids"] = json.dumps(roles)
+    row["review_note"] = (
+        "The frozen title and abstract were compared with the visible baseline "
+        "and role catalogue for this human judgment."
+    )
+
+
+def _complete_labels(
+    packet: Path,
+    source: Path,
+    *,
+    strategy: str = "pass",
+) -> None:
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    hidden = _hidden_source_rows(source)
+    selected_by_case = _selected_roles(source)
+    for row in rows:
+        case_id = row["case_id"]
+        case_number = int(case_id[2:])
+        roles = _role_ids(row)
+        selected_role = selected_by_case[case_id]
+        lineage = hidden[(case_id, row["unique_candidate_sha256"])]
+        lanes = tuple(json.loads(lineage["lane_memberships"]))
+
+        if case_id == "AD03":
+            supported = roles if "shared DOI" in row["title"] else [roles[0]]
+        elif lanes == ("role_closure",):
+            # One closure-only row can form a compact union cover and proves
+            # incremental selected-role value without counting a duplicate.
+            supported = roles
+        else:
+            supported = [role for role in roles if role != selected_role]
+        relevant, novel = "YES", "YES"
+
+        if strategy == "relevant_novel" and case_number <= 3:
+            novel = "NO"
+        elif strategy == "candidate_precision" and case_number > 1:
+            relevant, novel, supported = "NO", "N/A", []
+        elif (
+            strategy == "routing"
+            and case_id in {"AD01", "AD02", "AD04"}
+            and "anchor_search" in lanes
+        ):
+            supported = roles
+        elif (
+            strategy == "closure_value"
+            and case_id in {"AD01", "AD02", "AD04", "AD05"}
+            and lanes == ("role_closure",)
+        ):
+            relevant, novel, supported = "NO", "N/A", []
+        elif strategy == "human_coverable" and case_number <= 3:
+            supported = [roles[0]]
+        elif strategy == "coverability_gain" and case_number <= 7 and (
+            "anchor_search" in lanes
+        ):
+            supported = roles
+
+        _set_label(
+            row,
+            relevant=relevant,
+            novel=novel,
+            roles=supported,
+        )
+    _write_csv(packet / "labels.csv", review.LABEL_FIELDS, rows)
+
+
+def _packet(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]:
+    source = _source(tmp_path, monkeypatch)
+    source_lock = _lock(source, tmp_path)
+    packet = tmp_path / "packet"
+    review.prepare_packet(source, source_lock, packet)
+    return source, source_lock, packet
+
+
+def test_source_lock_and_packet_preserve_rows_without_adaptive_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    """All candidates reach the packet but route answers never do."""
+
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    manifest = json.loads(
+        (packet / "packet_manifest.json").read_text(encoding="utf-8")
+    )
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        labels = list(csv.DictReader(handle))
+
+    assert len(manifest["rows"]) == len(labels) == 38
+    assert len(manifest["case_contexts"]) == 8
+    assert manifest["retrieval_lane_provenance_exposed"] is False
+    assert manifest["mechanical_route_exposed"] is False
+    assert manifest["ad_cohort_opened"] is True
+    assert source_lock.parent != source
+    assert all(
+        field not in row
+        for row in manifest["rows"]
+        for field in review.HIDDEN_REVIEW_FIELDS
+    )
+    assert all(field not in labels[0] for field in review.HIDDEN_REVIEW_FIELDS)
+
+
+def test_blank_packet_is_incomplete_and_keeps_route_hidden(tmp_path, monkeypatch):
+    """No labels is unmeasured, not a zero-error route-value pass."""
+
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    result = review.summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "incomplete"
+    assert result["decision"] == "not_evaluated"
+    assert result["completed_row_count"] == 0
+    assert result["role_gap_result"]["metrics"] is None
+    assert result["route_assessments_after_unblinding"] is None
+    assert result["adaptive_provenance_joined_after_label_validation"] is False
+    assert result["post_ad_studies_eligible"] is False
+
+
+def test_complete_review_passes_six_gates_then_joins_route(tmp_path, monkeypatch):
+    """The route becomes inspectable only after every human label is valid."""
+
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source)
+    _declaration(packet, external_sources_checked="NONE")
+
+    result = review.summarize_packet(source, source_lock, packet)
+    metrics = result["role_gap_result"]["metrics"]
+
+    assert result["protocol_status"] == "complete"
+    assert result["decision"] == "pass"
+    assert set(result["role_gap_result"]["threshold_results"].values()) == {
+        "pass"
+    }
+    assert metrics["reviewable_candidate_denominator"] == 38
+    assert metrics["human_correct_routing_case_count"] == 8
+    assert metrics["selected_role_closure_value_case_count"] == 7
+    assert metrics["union_human_coverable_case_count"] == 8
+    assert metrics["anchor_human_coverable_case_count"] == 1
+    assert metrics["coverability_gain_over_anchor"] == 7
+    assert len(result["route_assessments_after_unblinding"]) == 8
+    assert result["adaptive_provenance_joined_after_label_validation"] is True
+    assert result["mechanical_route_exposed_to_reviewer"] is False
+    assert result["reviewer_declaration_raw"]["elapsed_minutes"] == "90"
+    assert result["post_ad_studies_eligible"] is True
+    assert result["production_connection_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("strategy", "failed_gate"),
+    [
+        ("relevant_novel", "relevant_novel_cases"),
+        ("candidate_precision", "candidate_pool_precision"),
+        ("routing", "human_correct_routing_decisions"),
+        ("closure_value", "selected_role_closure_value"),
+        ("human_coverable", "human_coverable_cases"),
+        ("coverability_gain", "coverability_gain_over_anchor"),
+    ],
+)
+def test_each_frozen_gate_can_veto_the_conjunctive_decision(
+    tmp_path,
+    monkeypatch,
+    strategy,
+    failed_gate,
+):
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source, strategy=strategy)
+    _declaration(packet)
+
+    result = review.summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "complete"
+    assert result["decision"] == "fail"
+    assert result["role_gap_result"]["threshold_results"][failed_gate] == "fail"
+    assert result["post_ad_studies_eligible"] is False
+
+
+def test_substantive_ai_review_is_preserved_but_not_evaluated(
+    tmp_path,
+    monkeypatch,
+):
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source)
+    _declaration(packet, ai_use="MOST_OR_ALL")
+
+    result = review.summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "excluded_substantive_ai"
+    assert result["decision"] == "not_evaluated"
+    assert result["completed_row_count"] == 38
+    assert result["reviewer_declaration_raw"]["generative_ai_use"] == "MOST_OR_ALL"
+    assert result["route_assessments_after_unblinding"] is None
+
+
+def test_unconfirmed_or_unverifiable_review_is_not_inspectable(
+    tmp_path,
+    monkeypatch,
+):
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source)
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    _set_label(
+        rows[0],
+        relevant="UNVERIFIABLE",
+        novel="UNVERIFIABLE",
+        roles=[],
+    )
+    _write_csv(packet / "labels.csv", review.LABEL_FIELDS, rows)
+    _declaration(packet, reviewed_all="NO")
+
+    result = review.summarize_packet(source, source_lock, packet)
+
+    assert result["protocol_status"] == "not_inspectable"
+    assert result["decision"] == "not_evaluated"
+    assert result["uninspectable_row_ids"] == [rows[0]["row_id"]]
+    assert result["method_issues"] == ["reviewer_did_not_confirm_all_rows"]
+
+
+def test_unknown_role_and_relevance_role_contradiction_fail_closed(
+    tmp_path,
+    monkeypatch,
+):
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source)
+    _declaration(packet)
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    rows[0]["supported_role_ids"] = '["not_a_frozen_role"]'
+    _write_csv(packet / "labels.csv", review.LABEL_FIELDS, rows)
+    with pytest.raises(review.RoleGapReviewError, match="unknown supported"):
+        review.summarize_packet(source, source_lock, packet)
+
+    _complete_labels(packet, source)
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    rows[0]["directly_relevant"] = "NO"
+    rows[0]["baseline_novel"] = "N/A"
+    _write_csv(packet / "labels.csv", review.LABEL_FIELDS, rows)
+    with pytest.raises(review.RoleGapReviewError, match="empty role array"):
+        review.summarize_packet(source, source_lock, packet)
+
+
+def test_packet_and_label_drift_fail_before_adaptive_join(tmp_path, monkeypatch):
+    source, source_lock, packet = _packet(tmp_path, monkeypatch)
+    _complete_labels(packet, source)
+    _declaration(packet)
+
+    manifest_path = packet / "packet_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["rows"][0]["frozen_route_decision"] = {"action": "search"}
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(review.RoleGapReviewError, match="blind projection"):
+        review.summarize_packet(source, source_lock, packet)
+
+    manifest["rows"][0].pop("frozen_route_decision")
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with (packet / "labels.csv").open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    rows[0]["title"] += " changed"
+    _write_csv(packet / "labels.csv", review.LABEL_FIELDS, rows)
+    with pytest.raises(review.RoleGapReviewError, match="read-only context drifted"):
+        review.summarize_packet(source, source_lock, packet)
+
+
+def test_source_byte_drift_fails_against_owner_lock(tmp_path, monkeypatch):
+    source, source_lock, _ = _packet(tmp_path, monkeypatch)
+    execution_path = source / "execution.json"
+    execution_path.write_text(
+        execution_path.read_text(encoding="utf-8") + " ",
+        encoding="utf-8",
+    )
+    with pytest.raises(review.RoleGapReviewError, match="artifact index"):
+        review.prepare_packet(source, source_lock, tmp_path / "drifted-packet")
+
+
+def test_production_worker_and_provider_adapter_do_not_import_review_path():
+    """The human-review path remains disconnected from production imports."""
+
+    production_files = (
+        Path("src/academic_agent/pipeline_worker.py"),
+        Path("src/academic_agent/tools/anonymous_openalex_search.py"),
+        Path("src/academic_agent/evidence_gap_execution.py"),
+    )
+    for path in production_files:
+        assert "openalex_role_gap_evaluation_review" not in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- record the exact AD01-AD08 live-provider result and freeze its human-review protocol before implementation
- add a separate AD-only source lock and route/lane-blind Schema v2 review boundary for all 67 candidates
- preserve explicit AD03 abstention and AD08 closure semantics instead of reusing the AC positional shortcut
- update README and AGENTS without claiming source value or production Tool Calling

## Verification
- 16/16 focused review-boundary tests
- 1980 tests plus 657 subtests
- latest Ruff
- narrow Pylint
- Chromium smoke: zero external and paid-provider requests
- both required defect re-injections failed at the intended seams before restoration

Docker Desktop was not running locally, so the PR Linux Docker job is the authoritative container-build check. Raw titles, abstracts, source lock, and labels remain in the private notes repository.