### PR TITLE
Preserve terminal facts before watchdog exits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 2014 tests (660 subtests), CI green on Linux + Windows × Python
+Current state: 2043 tests (674 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -66,6 +66,7 @@ is, in this order:
 | Why was this change made? | `git log` — bodies run to ~25 lines and explain the alternative that was rejected |
 | Was this hypothesis tested? | `docs/prereg-*.md` — predictions and falsification criteria registered *before* paid runs |
 | How does crash recovery work? | `docs/checkpoint-recovery.md` — identity, persistence, authorization, observable states, the 30/30 offline process audit, and the at-least-once boundary |
+| How are timeout and partial usage facts preserved? | `docs/runtime-terminal-integrity.md` — deadline ownership, immutable terminal records, monotonic usage snapshots, and complete/lower-bound/unavailable semantics |
 | Full decision history, first person | `notes/简历项目说明.md` — **a separate private repo** (`shuxiachai/academic-agent-notes`), gitignored here. 4,000+ lines with 61 numbered postmortems and supporting decision records. Ask the user for access if you need it |
 
 Before writing or modifying CrewAI code specifically — the crew, the agents,
@@ -172,10 +173,12 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
   run_spec.py           immutable, non-secret input and decision-applicability
                         contract for child recovery
   checkpoints.py        atomic content-addressed storage and inspection states
+  runtime_budget.py     API-worker provider deadlines and reserved closeout windows
+  run_terminal.py       write-once terminal truth and usage-accounting state
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  113 test modules plus conftest, organised by subject
+tests/                  120 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -249,6 +252,13 @@ checkpoint_fault_audit.py
 
 Runs are subprocesses writing to `outputs/<run_id>/`; the API, the browser and
 the CLI all observe the same run through those files rather than shared memory.
+A completed, failed, cancelled or timed-out API run also has a write-once
+`terminal.json`. Worker-owned exits commit it directly; the API commits it only
+after an external stop. Monotonic per-node snapshots mean usage is reported as
+`complete`, `lower_bound`, or `unavailable` rather than conflating an interrupted
+request with zero cost. See `docs/runtime-terminal-integrity.md` before changing
+this boundary.
+
 A run URL is a read capability. Mutating a code-owned run additionally requires
 its owner/admin code; an ownerless BYOK run has no second server-side identity.
 Failed, cancelled, or timed-out runs with a retrieval checkpoint can start an
@@ -1106,6 +1116,20 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   resume this consumed canary, call the P1 production seam validated, infer
   zero cost, or raise the timeout alone. Fix terminal timing/accounting and
   stage-budget behavior under a separate measured change first.
+  That P0 change is now implemented and zero-network validated: API workers
+  receive one hard-deadline identity, provider requests are bounded at 150
+  seconds with hidden SDK retries disabled, Reviewer reserves 240 seconds for
+  the existing validated-Writer fallback, and other paid work reserves 60
+  seconds for finalization. Every completed-node callback persists monotonic
+  usage; externally stopped runs commit an immutable terminal record whose
+  accounting state is explicitly `lower_bound` or `unavailable`. Both public
+  endpoints and the browser expose the distinction. Three defect reinjections
+  proved the provider-call, callback-to-disk and disk-to-client seams. This does
+  not establish production success or exact interrupted-request billing; a new
+  separately authorized canary is still required. See
+  `docs/runtime-terminal-integrity.md` and
+  `docs/results-2026-09-04-runtime-terminal-integrity-implementation.md`.
+
   See
   `docs/prereg-2026-08-26-decision-context-report-contract.md`,
   `docs/results-2026-08-26-decision-context-report-contract.md`,

--- a/README.md
+++ b/README.md
@@ -793,6 +793,17 @@ result is a production timeout/accounting observation, not a report-quality verd
 or evidence that the post-fix delivery seam works. See the
 [failed canary record](docs/results-2026-09-04-report-decision-seams-paid-canary.md).
 
+The resulting P0 runtime fix is now implemented and zero-network validated.
+API workers persist monotonic usage after every completed node, reserve a
+bounded Reviewer fallback/finalization window, disable hidden SDK retries, and
+commit an immutable `terminal.json` even when the API watchdog must stop the
+process. Both status endpoints and the browser distinguish complete usage from
+a lower bound or an unavailable measurement; terminal elapsed time no longer
+falls back to a stale status-file timestamp. This is not yet a production
+validation result: one separately authorized post-deployment canary is still
+required. See the [runtime contract](docs/runtime-terminal-integrity.md) and
+[implementation result](docs/results-2026-09-04-runtime-terminal-integrity-implementation.md).
+
 The canary observed live transport and accounting for one run, not general
 report quality or benchmark equivalence. It exposed two internal-x10 score
 phrases that reached report prose; the deterministic score payload remained
@@ -1167,6 +1178,10 @@ the API — no build step and no framework, so what is in `web/` is what runs.
 - **Reliability**: a separate panel distinguishes a failed retrieval domain,
   incomplete clinical-authority coverage, a check that could not run, and a
   check that ran without finding a problem — silence is never rendered as pass
+- **Terminal integrity**: completed-node usage is persisted monotonically, and
+  an immutable terminal record distinguishes complete, lower-bound and
+  unavailable accounting after normal or externally stopped exits
+
 - **Crash recovery**: terminal failures with a durable retrieval checkpoint can
   start an immutable child run. The header reports reused stages or degraded
   checkpointing; fresh BYOK credentials are sent again and never recovered
@@ -1213,10 +1228,19 @@ curl -X POST http://localhost:8000/api/runs/20260729T031500Z-a1b2c3d4e5/resume \
 | `GET` | `/api/runs/{id}/report` | Final report as Markdown |
 | `GET` | `/api/runs/{id}/{artifact}` | Run artifacts, including `scores`, `sources`, checks, and failed-run `retrieval` diagnostics |
 
+Terminal state, reason, elapsed time and usage-accounting completeness are
+returned by both the status and progress payloads.
+
 Concurrency is capped at 2 paid operations (`API_MAX_CONCURRENT` to change),
 shared by worker runs and inline PDF extraction — the binding constraint is
 upstream provider capacity, not local CPU. Runs exceeding 30 minutes are
 terminated automatically; extraction releases its slot on every exit path.
+
+API-launched workers bound each provider request, disable transport-hidden
+retries, and reserve time before the hard watchdog edge for the validated
+Writer fallback and independently guarded Scorer. Direct CLI runs remain
+intentionally operator-controlled and do not inherit the API watchdog.
+
 
 The web client and the JSON API share the same `outputs/` directory and launch the
 same worker, so a run started from one is visible to the other.
@@ -1561,6 +1585,8 @@ academic_agent/
 │   ├── pipeline_worker.py   # Subprocess worker: runs pipeline, writes status.json + steps.jsonl
 │   ├── checkpoint_runtime.py # CrewAI adapter: validates and restores a contiguous task prefix
 │   ├── checkpoints.py       # Atomic, content-addressed node checkpoint contracts
+│   ├── runtime_budget.py    # API-worker request deadlines and fallback/finalization reserves
+│   ├── run_terminal.py      # Immutable terminal facts and usage-accounting state
 │   ├── run_spec.py          # Frozen non-secret run inputs used by recovery
 │   ├── main.py              # CLI entry point (--topic "your topic" flag)
 │   ├── evidence.py          # Evidence models, guardrail validators, CommercializationScore
@@ -1618,6 +1644,7 @@ academic_agent/
 - **Decision applicability**: immutable context completeness and success-criteria provenance cross checkpoint identity, report Markdown, both status endpoints, and the browser without exposing the private criteria text in public status
 - **Agent observability**: OpenTelemetry + OpenInference instrumentors with redacted content and optional Arize Phoenix OTLP export
 - **Durable recovery**: content-addressed node checkpoints keyed by input, evidence, configuration, and pipeline hashes; immutable child runs reuse only a validated contiguous prefix and require fresh BYOK credentials
+- **Terminal integrity**: write-once terminal records plus monotonic per-node usage snapshots distinguish complete, lower-bound and unavailable accounting across worker, API and browser seams
 - **Web client**: static HTML, CSS and ES modules served by FastAPI — no build step, no framework
 - **Browser E2E**: Playwright Chromium on the real FastAPI/DOM seam; loopback-only route policy blocks external and mutating requests so CI cannot start paid work
 - **HTTP API**: FastAPI + Uvicorn, serving both the client and the JSON API (OpenAPI docs at `/docs`)

--- a/api/main.py
+++ b/api/main.py
@@ -820,6 +820,9 @@ def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgres
         # get_state() reaches one endpoint and silently not the other.
         # test_api_contract.py now fails when they diverge.
         usage=state.get("usage"),
+        usage_accounting=state.get("usage_accounting"),
+        runtime_budget=state.get("runtime_budget"),
+        terminal=state.get("terminal"),
         claim_grounding=state.get("claim_grounding"),
         authority_coverage=state.get("authority_coverage"),
         component_coverage=state.get("component_coverage"),

--- a/api/models.py
+++ b/api/models.py
@@ -193,6 +193,24 @@ class RunProgress(BaseModel):
                     "total. Absent for runs that predate cost accounting and "
                     "for runs that failed before the crew started.",
     )
+    usage_accounting: dict | None = Field(
+        default=None,
+        description="Temporal completeness of usage: complete, a durable "
+                    "lower bound, or unavailable. This is independent of "
+                    "whether every model had a known price.",
+    )
+    runtime_budget: dict | None = Field(
+        default=None,
+        description="Code-owned request timeout and finalization reserves "
+                    "applied by this worker. None means the run predates "
+                    "deadline persistence.",
+    )
+    terminal: dict | None = Field(
+        default=None,
+        description="Immutable process outcome metadata. record_state is "
+                    "committed or unreadable; None means a live or historical "
+                    "run without the terminal contract.",
+    )
     claim_grounding: dict | None = Field(
         default=None,
         description="How many of the run's quantitative claims could be "
@@ -310,6 +328,24 @@ class RunStatus(BaseModel):
         description="Tokens and estimated cost for the run, per agent and in "
                     "total. Absent for runs that predate cost accounting and "
                     "for runs that failed before the crew started.",
+    )
+    usage_accounting: dict | None = Field(
+        default=None,
+        description="Temporal completeness of usage: complete, a durable "
+                    "lower bound, or unavailable. This is independent of "
+                    "whether every model had a known price.",
+    )
+    runtime_budget: dict | None = Field(
+        default=None,
+        description="Code-owned request timeout and finalization reserves "
+                    "applied by this worker. None means the run predates "
+                    "deadline persistence.",
+    )
+    terminal: dict | None = Field(
+        default=None,
+        description="Immutable process outcome metadata. record_state is "
+                    "committed or unreadable; None means a live or historical "
+                    "run without the terminal contract.",
     )
     claim_grounding: dict | None = Field(
         default=None,

--- a/api/runs.py
+++ b/api/runs.py
@@ -3,13 +3,14 @@
 Owns the registry of live worker processes, enforces the concurrency cap,
 and derives run state from the artifacts on disk.
 
-State lives in two places by design:
-  • status.json — written by the worker, the source of truth for stage/progress
-  • terminal markers (error.log, cancelled.marker) — written by this module for
-    events the worker cannot know about (cancellation, timeout)
+State is projected through durable files by design:
+  • status.json — mutable worker progress and the latest completed-node usage
+  • terminal.json — immutable worker/API join for the actual process outcome
+  • legacy error/cancellation markers — compatibility for historical readers
 
-Keeping the worker's contract unchanged means the HTTP API and CLI can observe
-the same run through files without sharing process memory.
+The HTTP API, browser and CLI therefore observe the same run without sharing
+process memory. The API writes terminal truth only after an externally stopped
+worker can no longer write it itself.
 """
 
 from __future__ import annotations
@@ -34,6 +35,13 @@ from academic_agent.run_spec import (
     RESUME_SNAPSHOT_DIRECTORY,
     DecisionContext,
     RunSpec,
+)
+from academic_agent.run_terminal import (
+    TerminalRecord,
+    TerminalRecordUnreadable,
+    UsageAccounting,
+    commit_terminal_record,
+    load_terminal_record,
 )
 
 # A run is killed after this long. The bound belongs to the worker contract,
@@ -126,6 +134,7 @@ _ARTIFACTS = {
     "retrieval": "retrieval_diagnostics.json",
     "gap-shadow": "evidence_gap_shadow.json",
     "report-audit": "report_audit.json",
+    "terminal": "terminal.json",
 }
 
 
@@ -258,6 +267,7 @@ class _Handle:
     topic: str
     proc: subprocess.Popen
     started: float = field(default_factory=time.monotonic)
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     log_file: object = None
     #: Billed to the visitor rather than the operator, and therefore capped
     #: separately -- see BYOK_MAX_CONCURRENT.
@@ -270,19 +280,24 @@ class _Handle:
     def alive(self) -> bool:
         return self.proc.poll() is None
 
-    def terminate(self) -> None:
-        """Terminate, then kill if it ignores SIGTERM."""
+    def terminate(self) -> str:
+        """Terminate, then kill if needed, returning the observed method."""
+        method = "already_exited"
         if self.proc.poll() is None:
+            method = "terminate"
             self.proc.terminate()
             try:
                 self.proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
+                method = "kill"
                 self.proc.kill()
+                self.proc.wait(timeout=5)
         if self.log_file is not None:
             try:
                 self.log_file.close()
             except OSError:
                 pass
+        return method
 
 
 class ConcurrencyLimitReached(Exception):
@@ -689,9 +704,17 @@ def _start_run_from_spec(
             shutil.copytree(source_checkpoints, snapshot_root / "checkpoints")
 
 
+        # One deadline travels to both the worker and the parent reaper. The
+        # monotonic handle remains authoritative here; the wall value is
+        # converted once by the child so clock changes cannot extend it.
+        worker_started = time.monotonic()
+        worker_started_at = datetime.now(UTC)
+        hard_deadline_epoch = time.time() + TIMEOUT_SECONDS
         cmd = [
             sys.executable, "-m", "academic_agent.pipeline_worker",
             run_id, spec.topic, "--run-spec", str(spec_path),
+            "--hard-deadline-epoch", repr(hard_deadline_epoch),
+            "--hard-timeout-seconds", str(TIMEOUT_SECONDS),
         ]
         # Keep the explicit flags for CLI/process introspection and backwards
         # compatibility, while RunSpec remains the worker's authoritative
@@ -738,6 +761,8 @@ def _start_run_from_spec(
         # that had not launched yet, which is to say none of them.
         _registry[run_id] = _Handle(
             run_id=run_id, topic=spec.topic, proc=proc, log_file=log_file,
+            started=worker_started,
+            started_at=worker_started_at,
             byok=byok is not None,
         )
     return run_id, run_dir
@@ -868,7 +893,7 @@ def cancel_run(run_id: str) -> None:
         if handle is None or not handle.alive():
             raise RunNotFound(f"No live run with id {run_id}")
         _registry.pop(run_id, None)
-    handle.terminate()
+    method = handle.terminate()
     try:
         (run_dir_for(run_id) / _CANCEL_MARKER).write_text(
             datetime.now(UTC).isoformat(), encoding="utf-8"
@@ -879,6 +904,19 @@ def cancel_run(run_id: str) -> None:
         # the race to remove it — see delete_run's docstring. Nothing left to
         # mark at that point is a fine outcome, not a failure to report.
         pass
+    try:
+        _commit_external_terminal(
+            handle,
+            state="cancelled",
+            reason_code="user_cancelled",
+            termination_method=method,
+            timeout_seconds=TIMEOUT_SECONDS,
+        )
+    except (OSError, ValueError) as exc:
+        # The legacy marker still preserves cancellation if the stronger
+        # audit record cannot be committed; never turn cancel into HTTP 500.
+        print(f"[api] terminal record failed for {run_id}: {exc}", file=sys.stderr)
+
 
 
 def delete_run(run_id: str) -> None:
@@ -920,11 +958,33 @@ def reap_timeouts() -> list[str]:
             _registry.pop(run_id, None)
 
     for run_id, handle in expired:
-        handle.terminate()
-        (run_dir_for(run_id) / "error.log").write_text(
-            f"Analysis timed out after {TIMEOUT_SECONDS // 60} minutes.",
-            encoding="utf-8",
-        )
+        method = handle.terminate()
+        if method == "already_exited":
+            # It won the race with the watchdog; do not relabel it timeout.
+            continue
+        try:
+            (run_dir_for(run_id) / "error.log").write_text(
+                f"Analysis timed out after {TIMEOUT_SECONDS // 60} minutes.",
+                encoding="utf-8",
+            )
+        except OSError:
+            # The immutable record below is authoritative; this text file is
+            # retained only for compatibility with historical readers.
+            pass
+        try:
+            _commit_external_terminal(
+                handle,
+                state="timeout",
+                reason_code="hard_timeout",
+                termination_method=method,
+                timeout_seconds=TIMEOUT_SECONDS,
+            )
+        except (OSError, ValueError) as exc:
+            # One damaged run directory must not stop the global reaper.
+            print(
+                f"[api] terminal record failed for {run_id}: {exc}",
+                file=sys.stderr,
+            )
         killed.append(run_id)
     return killed
 
@@ -966,6 +1026,80 @@ def _read_status(run_dir: Path) -> dict:
         return json.loads(raw)
     except json.JSONDecodeError as exc:
         raise StatusUnreadable(f"{path}: {exc}") from exc
+
+
+def _external_usage_accounting(
+    status: dict,
+    *,
+    ended_at: datetime,
+) -> UsageAccounting:
+    """Classify the last worker snapshot after an external process stop.
+
+    Even a durable snapshot is only a lower bound: the killed request may
+    have reached the provider before its usage counters returned. No snapshot
+    is reported as unavailable, never as zero.
+    """
+
+    usage = status.get("usage")
+    has_trustworthy_snapshot = (
+        isinstance(usage, dict) and not usage.get("collection_error")
+    )
+    return UsageAccounting(
+        state="lower_bound" if has_trustworthy_snapshot else "unavailable",
+        snapshot_at=ended_at,
+        through_stage=str(status.get("stage") or ""),
+        run_complete=False,
+        in_flight_request_may_have_spent=True,
+    )
+
+
+def _commit_external_terminal(
+    handle: _Handle,
+    *,
+    state: str,
+    reason_code: str,
+    termination_method: str,
+    timeout_seconds: int | None,
+) -> None:
+    """Persist facts the stopped worker can no longer record itself."""
+
+    run_dir = run_dir_for(handle.run_id)
+    try:
+        status = _read_status(run_dir)
+    except StatusUnreadable:
+        # Terminal state remains knowable even when the last live projection
+        # is damaged. Its missing stage/usage must stay unavailable rather
+        # than preventing the stronger process outcome from being committed.
+        status = {}
+    ended_at = datetime.now(UTC)
+    accounting = _external_usage_accounting(status, ended_at=ended_at)
+    record = TerminalRecord(
+        state=state,
+        reason_code=reason_code,
+        termination_method=termination_method,
+        started_at=handle.started_at,
+        ended_at=ended_at,
+        elapsed_seconds=handle.elapsed,
+        last_stage=str(status.get("stage") or ""),
+        timeout_seconds=timeout_seconds,
+        usage=status.get("usage"),
+        usage_accounting=accounting,
+        checkpointing=status.get("checkpointing"),
+        recovery=status.get("recovery"),
+    )
+    commit_terminal_record(run_dir, record)
+
+
+def _read_terminal(run_dir: Path) -> tuple[TerminalRecord | None, dict | None]:
+    """Return a valid record and its projection, or an explicit unreadable state."""
+
+    try:
+        record = load_terminal_record(run_dir)
+    except TerminalRecordUnreadable:
+        return None, {"record_state": "unreadable"}
+    if record is None:
+        return None, None
+    return record, record.public_projection()
 
 
 def read_steps(run_id: str, since: int = 0) -> list[dict]:
@@ -1157,6 +1291,7 @@ def get_state(run_id: str) -> dict:
         # Report what is known rather than guessing. "unknown" is a state a
         # client can retry; "failed" is one it reports to the user.
         status, status_readable = {}, False
+    terminal_record, terminal_projection = _read_terminal(run_dir)
     handle = _registry.get(run_id)
 
     if handle is not None and handle.alive():
@@ -1164,30 +1299,55 @@ def get_state(run_id: str) -> dict:
         error = None
         elapsed = handle.elapsed
     else:
-        # A finished run has no handle, and returning None here meant a client
-        # showed 0:00 for a run that plainly took minutes. The elapsed time is
-        # still on disk: the directory name carries the start and status.json's
-        # mtime the last write.
-        elapsed = _elapsed_seconds(run_dir)
-        if (run_dir / _CANCEL_MARKER).exists():
-            state, error = "cancelled", "Cancelled by request."
-        elif status.get("error"):
-            state, error = "failed", _public_failure_reason(status["error"])
-        elif status.get("done"):
-            state, error = "completed", None
-        elif not status_readable:
-            state = "unknown"
-            error = ("Run status is temporarily unreadable; the run itself may "
-                     "have completed. Retry in a moment.")
+        if terminal_record is not None:
+            elapsed = terminal_record.elapsed_seconds
+            state = terminal_record.state
+            if state == "cancelled":
+                error = "Cancelled by request."
+            elif state == "timeout":
+                error = (
+                    "The analysis exceeded its time limit. Resume from the "
+                    "last validated checkpoint or start a new run."
+                )
+            elif state == "failed":
+                error = _public_failure_reason(status.get("error") or _failure_reason(run_dir))
+            else:
+                error = None
         else:
-            reason = _failure_reason(run_dir)
-            state = "timeout" if _is_timeout_failure(reason) else "failed"
-            error = _public_failure_reason(reason)
+            # Historical runs have no terminal record. Preserve their legacy
+            # derivation without mistaking status mtime for new-run truth.
+            elapsed = _elapsed_seconds(run_dir)
+            if (run_dir / _CANCEL_MARKER).exists():
+                state, error = "cancelled", "Cancelled by request."
+            elif status.get("error"):
+                state, error = "failed", _public_failure_reason(status["error"])
+            elif status.get("done"):
+                state, error = "completed", None
+            elif not status_readable:
+                state = "unknown"
+                error = ("Run status is temporarily unreadable; the run itself may "
+                         "have completed. Retry in a moment.")
+            else:
+                reason = _failure_reason(run_dir)
+                state = "timeout" if _is_timeout_failure(reason) else "failed"
+                error = _public_failure_reason(reason)
+
+    usage = status.get("usage")
+    usage_accounting = status.get("usage_accounting")
+    checkpointing = status.get("checkpointing")
+    recovery = status.get("recovery")
+    if terminal_record is not None:
+        if terminal_record.usage is not None:
+            usage = terminal_record.usage
+        usage_accounting = terminal_record.usage_accounting.model_dump(mode="json")
+        checkpointing = terminal_record.checkpointing or checkpointing
+        recovery = terminal_record.recovery or recovery
+
 
     return {
         "run_id": run_id,
         "state": state,
-        "stage": status.get("stage", ""),
+        "stage": status.get("stage") or (terminal_record.last_stage if terminal_record else ""),
         "topic": status.get("topic") or (handle.topic if handle else ""),
         "output_language": status.get("output_language") or "English",
         # This is the immutable identity persisted by the executing worker.
@@ -1215,7 +1375,12 @@ def get_state(run_id: str) -> dict:
         # crew has run, including on failed runs — a run that died halfway
         # still spent whatever it spent, and that is the case where the number
         # is least guessable and most worth showing.
-        "usage": status.get("usage"),
+        "usage": usage,
+        # Temporal completeness is independent of price completeness. A
+        # lower-bound token total can still have a complete price table.
+        "usage_accounting": usage_accounting,
+        "runtime_budget": status.get("runtime_budget"),
+        "terminal": terminal_projection,
         # Counts from the claim-grounding screen: how many quantitative claims
         # could be checked against the text of the sources they cite, how many
         # cited a figure absent from it, and how many could not be checked at
@@ -1261,8 +1426,8 @@ def get_state(run_id: str) -> dict:
         # explicit so a failed auxiliary write cannot look like successful
         # recovery, and a cold start cannot look like a cache hit simply
         # because checkpointing itself was healthy.
-        "checkpointing": status.get("checkpointing"),
-        "recovery": status.get("recovery"),
+        "checkpointing": checkpointing,
+        "recovery": recovery,
         "artifacts": available_artifacts(run_dir),
     }
 
@@ -1283,6 +1448,11 @@ def _elapsed_seconds(run_dir: Path) -> int | None:
     worker wrote. Used for runs whose handle is gone, where the in-memory
     timer is no longer available.
     """
+    terminal_record, _projection = _read_terminal(run_dir)
+    if terminal_record is not None:
+        return terminal_record.elapsed_seconds
+
+    # Historical runs fall back to the last live-status write timestamp.
     try:
         stamp = run_dir.name.split("-")[0]
         start = datetime.strptime(stamp, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)

--- a/docs/results-2026-09-04-runtime-terminal-integrity-implementation.md
+++ b/docs/results-2026-09-04-runtime-terminal-integrity-implementation.md
@@ -1,0 +1,74 @@
+# Runtime terminal integrity P0 — implementation result
+
+Date: 2026-09-04
+Scope: zero-network implementation and regression validation
+Production provider calls: none
+
+## Trigger
+
+The separately pre-registered Decision Context canary reached a validated
+Writer checkpoint and then the 30-minute API watchdog stopped Reviewer. Its
+public record reported 1,404 seconds because elapsed time came from the stale
+`status.json` mtime, while final usage was `null` because the kill bypassed the
+worker's exception path. Raising the watchdog would not repair either seam.
+
+## Implemented
+
+1. Added an immutable `terminal.json` owned by the worker for normal exits and
+   by the API after externally stopping a process. It records actual monotonic
+   duration, terminal reason/method, last stage, timeout policy, usage state,
+   and checkpoint/recovery snapshots.
+2. Added cumulative usage snapshots at every completed-node callback. Per-role
+   counters and cost merge monotonically under locks; collection failure is
+   `unavailable`, not a zero or a pass.
+3. Added one API-to-worker deadline identity. API workers use a 150-second
+   provider timeout, disable SDK-hidden retries, reserve 240 seconds before the
+   hard edge for Reviewer fallback, and reserve 60 seconds for finalization on
+   the other nodes.
+4. Threaded `usage_accounting`, `runtime_budget`, and `terminal` through both
+   public run endpoints. Browser copy distinguishes complete, partial, and
+   unavailable accounting.
+
+The implementation deliberately reuses the existing validated-Writer Reviewer
+fallback and independent guarded Scorer. It does not weaken a guardrail, change
+the score formula, alter retrieval, add a tool call, or increase the hard
+timeout.
+
+## Validation
+
+The post-change suite passed **2,043 tests and 674 subtests** with zero network
+access. Latest Ruff and the CI-matching narrow Pylint checks also passed.
+The loopback Chromium smoke also passed with zero console/page errors, zero
+external requests, zero mutation attempts and zero paid-provider requests.
+Additional endpoint/client seams confirm that a usage-collector diagnostic
+remains `unavailable` after an API-owned stop, and that a durable zero-token
+snapshot still displays its lower-bound state rather than disappearing.
+
+
+Three original defects were then re-injected independently:
+
+| Re-injected defect | Required failure |
+|---|---|
+| Removed the pre-call full-window check | Deadline test failed because the provider stub was called instead of raising `RunDeadlineExceeded` |
+| Removed usage/accounting from the task-completion write | Worker seam test failed with missing intermediate `usage`, although final collection still computed 100 tokens |
+| Removed terminal elapsed precedence | Timeout test observed the old mtime-derived `0` seconds instead of the terminal record's `1,801` seconds |
+
+Each temporary defect was reversed, and all three focused tests returned to
+green. The tests therefore exercise the call, callback-to-disk, and
+disk-to-client seams rather than merely checking that new fields exist.
+
+## Interpretation and limits
+
+This closes the deterministic P0 implementation gap exposed by the failed
+canary. It does **not** establish production success, a timeout rate, stable
+Qwen latency, exact billing, or that Reviewer fallback will occur in the next
+live run. Provider acceptance of an in-flight request remains unknowable when
+no response returns, so externally stopped runs intentionally report a lower
+bound or unavailable accounting state.
+
+The next evidence step is one new post-deployment canary under a separately
+frozen identity and explicit owner budget. Until that happens, documentation
+must say “implemented and zero-network validated,” not “production validated.”
+
+See [the runtime contract](runtime-terminal-integrity.md) and the
+[triggering canary result](results-2026-09-04-report-decision-seams-paid-canary.md).

--- a/docs/runtime-terminal-integrity.md
+++ b/docs/runtime-terminal-integrity.md
@@ -1,0 +1,114 @@
+# Runtime terminal integrity and deadline budget
+
+The API's 30-minute watchdog is the final availability boundary for a paid
+assessment. It is not a useful timeout for each model request: if Reviewer is
+allowed to consume that whole window, the parent can kill the worker after a
+validated Writer checkpoint exists but before Reviewer fallback, independent
+Scorer execution, usage accounting, and final artifacts are persisted.
+
+This contract adds an earlier provider-call budget and an immutable process
+outcome without changing retrieval, prompts, guardrails, scoring, checkpoints,
+or the six-node topology.
+
+## Time budget
+
+The API calculates one wall-clock deadline when it launches the subprocess and
+passes that deadline plus the public watchdog duration to the worker. The
+worker converts the remaining interval to `time.monotonic()` exactly once, so a
+later system-clock correction cannot extend paid execution.
+
+Current code-owned policy:
+
+| Boundary | Value | Purpose |
+|---|---:|---|
+| API hard watchdog | 1,800 seconds | Last-resort process termination; unchanged |
+| One provider attempt | 150 seconds | Bounds the OpenAI-compatible transport |
+| Reviewer reserve | 240 seconds | Leaves room for validated-draft fallback and Scorer |
+| Other paid-node reserve | 60 seconds | Leaves room for usage, audits, status and terminal writes |
+
+Reviewer therefore may not begin an attempt unless its full 150-second window
+fits before `hard deadline - 240 seconds`. Other nodes use `hard deadline - 60
+seconds`. The existing project retry wrapper is the only retry owner: SDK
+retries are set to zero inside API workers, and another visible retry is refused
+unless its backoff plus a complete request window still fit. A code-owned
+`RunDeadlineExceeded` is not classified as a transport failure and is never
+retried.
+
+The 240-second reserve is operational policy, not an SLO. It was selected from
+an observed 102-second Writer/Reviewer/Scorer recovery suffix and must be
+re-measured before it is changed. A direct CLI invocation has no parent
+watchdog, so its runtime budget is explicitly reported as `unbounded_cli`; the
+private worker transport setting is removed rather than inherited from a stale
+environment.
+
+## Immutable terminal record
+
+`status.json` remains the mutable live projection. Every normal stage update
+rewrites it atomically, but it cannot authoritatively report a parent kill: the
+worker that owns it has already been stopped.
+
+`outputs/<run_id>/terminal.json` is a smaller write-once record containing:
+
+- terminal state and reason code;
+- whether the worker exited itself or the API used terminate/kill;
+- timezone-aware start/end timestamps and monotonic elapsed seconds;
+- last observed stage and configured hard timeout;
+- the last durable usage snapshot plus its accounting state;
+- checkpoint and recovery snapshots needed to explain resumability.
+
+The worker writes the record after its final status update for `completed` and
+`failed`. The API writes it only after it has stopped a worker for cancellation
+or timeout. A byte-equivalent repeat is idempotent; a conflicting second
+outcome raises instead of rewriting history. Historical runs without this file
+retain their existing derivation rules. An invalid file is exposed as
+`terminal.record_state=unreadable`, not silently treated as absent.
+
+Both `/api/runs/{id}` and `/api/runs/{id}/progress` expose the same terminal
+projection and use its elapsed time. The downloadable `terminal` artifact
+contains the full non-secret record.
+
+## Usage states
+
+Price coverage and temporal accounting are different questions. Existing
+`usage.cost_complete` still means every observed model had a known price.
+Adjacent `usage_accounting.state` means:
+
+- `complete`: the run completed and its final usage collector succeeded;
+- `lower_bound`: a durable snapshot exists, but the run did not complete and a
+  provider request may have spent without returning counters;
+- `unavailable`: no trustworthy counters are available, including when the
+  collector itself failed. This never means zero spend.
+
+Each completed Crew node takes a cumulative usage snapshot. Parallel callbacks
+are serialized, and per-agent counters merge monotonically so a late provider
+counter update cannot erase a larger value already on disk. A timeout or
+cancellation copies the last snapshot into `terminal.json` as a lower bound;
+the browser labels it as partial. If no snapshot exists, the browser says
+`usage unavailable` rather than showing an empty or zero bill.
+
+This is still at-least-once cost observability. No local process can prove
+whether a provider accepted a request whose response never returned. The
+in-flight flag preserves that uncertainty instead of fabricating an exact
+total.
+
+## Reviewer deadline behavior
+
+Deadline exhaustion enters the existing narrow Reviewer recovery path. It is
+eligible only when Writer has a validated output and neither Reviewer nor
+Scorer has completed. The unchanged Writer draft is delivered with an explicit
+`quality_review.status=fallback`, while Scorer executes independently under its
+own guardrail and earlier deadline. A Writer failure or Scorer failure still
+fails the run.
+
+## Remaining boundary
+
+This implementation has zero-network test evidence only. A fresh, separately
+pre-registered paid canary is required after deployment to observe whether a
+slow production Reviewer exits early enough for fallback and Scorer, and
+whether partial usage survives a real external timeout. The consumed
+2026-09-04 canary must not be rerun or reclassified.
+
+An operating-system or host loss that bypasses both worker cleanup and the API
+watchdog can still leave no terminal record. Checkpoints remain the recovery
+source in that case; distributed process supervision and exactly-once provider
+accounting are outside this single-process Railway design.

--- a/src/academic_agent/llm_config.py
+++ b/src/academic_agent/llm_config.py
@@ -13,8 +13,11 @@ import functools
 import os
 import random
 import time
+from dataclasses import dataclass
 
 from crewai import LLM
+
+from academic_agent.runtime_budget import WORKER_LLM_TIMEOUT_ENV
 
 _SUPPORTED_PROVIDERS = ("deepseek", "qwen", "openai", "anthropic")
 
@@ -96,7 +99,35 @@ _MAX_ATTEMPTS = 3
 _BASE_DELAY_SECONDS = 2.0
 
 
+class RunDeadlineExceeded(TimeoutError):
+    """The run lacks a full bounded window for another provider attempt."""
+
+
+@dataclass
+class _CallBudget:
+    """Mutable because the worker assigns a stage deadline after Crew creation."""
+
+    deadline_monotonic: float | None = None
+    stage: str = "unbounded call"
+    request_timeout_seconds: float = 0.0
+
+    def require_window(self, *, delay_seconds: float = 0.0) -> None:
+        if self.deadline_monotonic is None:
+            return
+        remaining = self.deadline_monotonic - time.monotonic()
+        required = delay_seconds + self.request_timeout_seconds
+        if remaining < required:
+            raise RunDeadlineExceeded(
+                f"{self.stage} has {max(0.0, remaining):.1f}s remaining; "
+                f"a bounded provider attempt requires {required:.1f}s"
+            )
+
+
 def _is_retryable(exc: BaseException) -> bool:
+    # This TimeoutError comes from our run budget, not the transport. Retrying
+    # it can only consume the time reserved for fallback and final persistence.
+    if isinstance(exc, RunDeadlineExceeded):
+        return False
     if isinstance(exc, _RETRYABLE):
         return True
     # CrewAI wraps provider errors in its own types, so the class is often
@@ -121,10 +152,12 @@ def _wrap_with_retry(llm):
     Wrapping the instance the factory built leaves that behaviour intact.
     """
     inner = llm.call
+    budget = _CallBudget()
 
     @functools.wraps(inner)
     def call_with_retry(*args, **kwargs):
         for attempt in range(1, _MAX_ATTEMPTS + 1):
+            budget.require_window()
             try:
                 return inner(*args, **kwargs)
             except BaseException as exc:      # noqa: BLE001 - re-raised below
@@ -134,6 +167,12 @@ def _wrap_with_retry(llm):
                 # return at the same instant.
                 delay = _BASE_DELAY_SECONDS * (2 ** (attempt - 1))
                 delay += random.uniform(0, delay * 0.25)
+                try:
+                    budget.require_window(delay_seconds=delay)
+                except RunDeadlineExceeded as deadline_error:
+                    # Keep the transport error as causal context while making
+                    # the actionable failure type visible to Reviewer fallback.
+                    raise deadline_error from exc
                 print(
                     f"[llm] {type(exc).__name__} on attempt {attempt}/{_MAX_ATTEMPTS}; "
                     f"retrying in {delay:.1f}s",
@@ -142,7 +181,54 @@ def _wrap_with_retry(llm):
                 time.sleep(delay)
 
     llm.call = call_with_retry
+    # A private attribute is the seam between factory-time wrapping and the
+    # worker, which cannot know the concrete provider subclass CrewAI returns.
+    llm._academic_agent_call_budget = budget
     return llm
+
+
+def configure_llm_deadline(
+    llm,
+    *,
+    deadline_monotonic: float | None,
+    stage: str,
+    request_timeout_seconds: float,
+):
+    """Attach one code-owned stage deadline to a wrapped CrewAI provider."""
+
+    budget = getattr(llm, "_academic_agent_call_budget", None)
+    if not isinstance(budget, _CallBudget):
+        raise RuntimeError("LLM was not created through the retry/deadline adapter")
+    if request_timeout_seconds <= 0:
+        raise ValueError("request timeout must be positive")
+    budget.deadline_monotonic = deadline_monotonic
+    budget.stage = stage
+    budget.request_timeout_seconds = request_timeout_seconds
+    return llm
+
+
+def _apply_worker_transport_budget(kwargs: dict) -> None:
+    """Bound SDK calls only inside an API worker, never inline PDF extraction.
+
+    The project's wrapper remains the sole retry owner. CrewAI's compatible
+    clients otherwise perform their own hidden retries inside each of our
+    three visible attempts, which makes neither the time nor request count
+    bounded at the orchestration layer.
+    """
+
+    raw = os.getenv(WORKER_LLM_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return
+    try:
+        timeout = float(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{WORKER_LLM_TIMEOUT_ENV} must be a positive number"
+        ) from exc
+    if timeout <= 0:
+        raise RuntimeError(f"{WORKER_LLM_TIMEOUT_ENV} must be a positive number")
+    kwargs["timeout"] = timeout
+    kwargs["max_retries"] = 0
 
 
 def create_llm(
@@ -197,6 +283,7 @@ def create_llm(
             kwargs["response_format"] = {"type": "json_object"}
         if temperature is not None:
             kwargs["temperature"] = temperature
+        _apply_worker_transport_budget(kwargs)
         return _wrap_with_retry(LLM(**kwargs))
 
     logical_provider = _detect_provider()
@@ -260,6 +347,7 @@ def create_llm(
     if temperature is not None:
         kwargs["temperature"] = temperature
 
+    _apply_worker_transport_budget(kwargs)
     return _wrap_with_retry(LLM(**kwargs))
 
 

--- a/src/academic_agent/pipeline_worker.py
+++ b/src/academic_agent/pipeline_worker.py
@@ -4,7 +4,7 @@ Invoked as:
     python -m academic_agent.pipeline_worker <run_id> <topic>
 
 Writes status.json for stage progress and steps.jsonl for the live agent
-log, both polled by the parent process (app.py) without shared memory.
+log; API and CLI readers observe both files without shared memory.
 """
 import argparse
 import copy
@@ -13,11 +13,19 @@ import os
 import re
 import sys
 import threading
+import time
 import traceback
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from academic_agent.run_terminal import (
+    TerminalRecord,
+    UsageAccounting,
+    commit_terminal_record,
+)
+from academic_agent.runtime_budget import RuntimeBudget, WORKER_LLM_TIMEOUT_ENV
 
 for stream in (sys.stdout, sys.stderr):
     if hasattr(stream, "reconfigure"):
@@ -272,6 +280,129 @@ class ProgressTracker:
             return finished, stage, (nxt if nxt < self._total else None)
 
 
+
+
+_USAGE_COUNTER_FIELDS = (
+    "prompt_tokens",
+    "cached_prompt_tokens",
+    "cache_creation_tokens",
+    "completion_tokens",
+    "reasoning_tokens",
+    "total_tokens",
+    "requests",
+)
+
+
+def _merge_usage_snapshots(
+    previous: dict[str, Any] | None,
+    current: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge provider counters monotonically at every completed-node seam.
+
+    CrewAI's counters are cumulative, but the first three callbacks originate
+    from parallel threads. Serializing status writes prevents torn JSON; this
+    per-agent maximum additionally prevents a later observation from erasing
+    an already persisted counter if a provider updates its summary slightly
+    after invoking the task callback.
+    """
+
+    if previous is None:
+        return dict(current) if current is not None else None
+    if current is None:
+        return dict(previous)
+
+    merged_agents: dict[tuple[str, str], dict[str, Any]] = {}
+    order: list[tuple[str, str]] = []
+    for snapshot in (previous, current):
+        for candidate in snapshot.get("agents") or []:
+            if not isinstance(candidate, dict):
+                continue
+            key = (str(candidate.get("role") or ""), str(candidate.get("model") or ""))
+            if key not in merged_agents:
+                merged_agents[key] = dict(candidate)
+                order.append(key)
+                continue
+            target = merged_agents[key]
+            for field in _USAGE_COUNTER_FIELDS:
+                target[field] = max(
+                    int(target.get(field) or 0), int(candidate.get(field) or 0)
+                )
+            costs = [
+                value
+                for value in (target.get("cost_usd"), candidate.get("cost_usd"))
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+            ]
+            target["cost_usd"] = max(costs) if costs else None
+
+    agents = [merged_agents[key] for key in order]
+    merged = dict(previous)
+    merged.update(current)
+    merged["agents"] = agents
+    if agents:
+        merged["total_tokens"] = sum(int(a.get("total_tokens") or 0) for a in agents)
+        merged["total_requests"] = sum(int(a.get("requests") or 0) for a in agents)
+        known_costs = [a.get("cost_usd") for a in agents if a.get("cost_usd") is not None]
+        merged["cost_usd"] = round(sum(known_costs), 6) if known_costs else None
+    else:
+        merged["total_tokens"] = max(
+            int(previous.get("total_tokens") or 0), int(current.get("total_tokens") or 0)
+        )
+        merged["total_requests"] = max(
+            int(previous.get("total_requests") or 0), int(current.get("total_requests") or 0)
+        )
+        costs = [
+            value
+            for value in (previous.get("cost_usd"), current.get("cost_usd"))
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        ]
+        merged["cost_usd"] = max(costs) if costs else None
+
+    merged["cost_complete"] = bool(previous.get("cost_complete", True)) and bool(
+        current.get("cost_complete", True)
+    )
+    merged["unpriced_models"] = sorted(
+        set(previous.get("unpriced_models") or ())
+        | set(current.get("unpriced_models") or ())
+    )
+    bases = [
+        str(value)
+        for value in (previous.get("price_basis"), current.get("price_basis"))
+        if value
+    ]
+    merged["price_basis"] = " + ".join(dict.fromkeys(bases))
+    if current.get("collection_error") or previous.get("collection_error"):
+        merged["collection_error"] = (
+            current.get("collection_error") or previous.get("collection_error")
+        )
+    return merged
+
+
+def _usage_accounting_snapshot(
+    usage: dict[str, Any] | None,
+    *,
+    stage: str,
+    run_complete: bool,
+    in_flight_request_may_have_spent: bool,
+) -> dict[str, Any]:
+    """Serialize temporal completeness separately from price completeness."""
+
+    # A collector error is not an observed zero. Preserve its diagnostic in
+    # ``usage`` while making the accounting state explicitly unavailable.
+    if usage is None or usage.get("collection_error"):
+        state = "unavailable"
+    elif run_complete:
+        state = "complete"
+    else:
+        state = "lower_bound"
+    return UsageAccounting(
+        state=state,
+        snapshot_at=datetime.now(UTC),
+        through_stage=stage,
+        run_complete=run_complete,
+        in_flight_request_may_have_spent=in_flight_request_may_have_spent,
+    ).model_dump(mode="json")
+
+
 def _merge_status_fields(
     existing: dict,
     *,
@@ -307,6 +438,7 @@ def _merge_status_fields(
     # later status write would otherwise erase the warning it carries.
     for sticky in (
         "topic", "source_counts", "evidence_incomplete", "failed_domains", "usage",
+        "usage_accounting", "runtime_budget",
         "claim_grounding", "consistency", "observability", "authority_coverage",
         "component_coverage", "evidence_gap_shadow", "decision_gate", "report_audit",
         "quality_review",
@@ -325,6 +457,8 @@ def _merge_status_fields(
 
 
 def main() -> None:
+    worker_started_at = datetime.now(UTC)
+    worker_started_monotonic = time.monotonic()
     parser = argparse.ArgumentParser()
     parser.add_argument("run_id")
     parser.add_argument("topic")
@@ -339,7 +473,29 @@ def main() -> None:
         "--resume-from", default="",
         help="Prior run id whose validated checkpoint prefix may be reused",
     )
+    parser.add_argument(
+        "--hard-deadline-epoch",
+        type=float,
+        default=None,
+        help="API-owned wall deadline converted once to a monotonic worker budget",
+    )
+    parser.add_argument(
+        "--hard-timeout-seconds",
+        type=int,
+        default=None,
+        help="Public watchdog duration recorded in the immutable terminal outcome",
+    )
     args = parser.parse_args()
+    runtime_budget = RuntimeBudget.from_wall_deadline(
+        args.hard_deadline_epoch,
+        args.hard_timeout_seconds,
+    )
+    if runtime_budget.active:
+        os.environ[WORKER_LLM_TIMEOUT_ENV] = str(runtime_budget.request_timeout_seconds)
+    else:
+        # This is a private parent-to-worker contract, not an operator setting.
+        # Removing an inherited stale value keeps direct CLI runs unbounded.
+        os.environ.pop(WORKER_LLM_TIMEOUT_ENV, None)
 
     _max_rpm_env = os.getenv("MAX_RPM", "6")
     try:
@@ -361,6 +517,7 @@ def main() -> None:
         task_node,
     )
     from academic_agent.checkpoints import CheckpointStore, hash_text
+    from academic_agent.llm_config import configure_llm_deadline
     from academic_agent.evidence_gap import (
         persist_shadow_audit,
         run_shadow_assessment,
@@ -395,6 +552,9 @@ def main() -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     status_path = run_dir / "status.json"
     steps_path  = run_dir / "steps.jsonl"
+    status_lock = threading.RLock()
+    usage_lock = threading.Lock()
+    usage_snapshot: dict[str, Any] | None = None
 
     def write_status(
         stage: str,
@@ -408,6 +568,8 @@ def main() -> None:
         evidence_incomplete: bool | None = None,
         failed_domains: list[str] | None = None,
         usage: dict | None = None,
+        usage_accounting: dict | None = None,
+        runtime_budget: dict | None = None,
         claim_grounding: dict | None = None,
         observability: dict | None = None,
         consistency: dict | None = None,
@@ -420,6 +582,7 @@ def main() -> None:
         recovery: dict | None = None,
         quality_review: dict | None = None,
     ) -> None:
+        status_lock.acquire()
         try:
             try:
                 existing = json.loads(status_path.read_text(encoding="utf-8"))
@@ -439,6 +602,10 @@ def main() -> None:
                 data["failed_domains"] = failed_domains
             if usage is not None:
                 data["usage"] = usage
+            if usage_accounting is not None:
+                data["usage_accounting"] = usage_accounting
+            if runtime_budget is not None:
+                data["runtime_budget"] = runtime_budget
             if claim_grounding is not None:
                 data["claim_grounding"] = claim_grounding
             if consistency is not None:
@@ -474,6 +641,48 @@ def main() -> None:
             os.replace(tmp_path, status_path)
         except Exception as _e:
             print(f"[worker] write_status failed (stage={stage!r}): {_e}", file=sys.stderr)
+        finally:
+            status_lock.release()
+
+    def commit_worker_terminal(
+        *,
+        state: str,
+        reason_code: str,
+        stage: str,
+        usage: dict[str, Any] | None,
+        usage_accounting: dict[str, Any],
+        checkpoint_state: dict[str, Any],
+    ) -> None:
+        """Publish one worker-owned outcome after the final live status write."""
+
+        ended_at = datetime.now(UTC)
+        record = TerminalRecord(
+            state=state,
+            reason_code=reason_code,
+            termination_method="worker_exit",
+            started_at=worker_started_at,
+            ended_at=ended_at,
+            elapsed_seconds=max(
+                0, int(time.monotonic() - worker_started_monotonic)
+            ),
+            last_stage=stage,
+            timeout_seconds=args.hard_timeout_seconds,
+            usage=usage,
+            usage_accounting=UsageAccounting.model_validate(usage_accounting),
+            checkpointing=checkpoint_state.get("checkpointing"),
+            recovery=checkpoint_state.get("recovery"),
+        )
+        try:
+            commit_terminal_record(run_dir, record)
+        except (OSError, ValueError) as terminal_error:
+            # status.json remains a usable compatibility path. Do not rewrite
+            # a completed report as failed merely because its stronger audit
+            # record could not be published; surface the persistence fault.
+            print(
+                f"[worker] terminal record failed: {terminal_error}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     # Execution identity belongs to the worker that actually runs the paid
     # workflow, not to whichever API deployment later serves its files. Capture
@@ -488,6 +697,7 @@ def main() -> None:
     write_status(
         _STAGE_INITIAL, topic=args.topic, pipeline_revision=revision,
         observability=telemetry.snapshot(),
+        runtime_budget=runtime_budget.public_snapshot(),
     )
 
     # Bound before the try so the failure path can still account for a run
@@ -498,18 +708,29 @@ def main() -> None:
     checkpoint_runtime = None
     checkpoint_snapshot: dict[str, Any] = {}
 
-    def snapshot_usage() -> dict | None:
-        if crew_obj is None:
-            return None
-        usage = collect_usage(crew_obj)
-        if not usage.agents and usage.collection_error is None:
-            return None
-        cost = "unknown" if usage.cost_usd is None else f"${usage.cost_usd:.4f}"
-        if not usage.cost_complete:
-            cost += f" (at least; unpriced: {', '.join(usage.unpriced_models)})"
-        print(f"[usage] {usage.total_tokens} tokens over {usage.total_requests} "
-              f"requests, {cost}", flush=True)
-        return usage.as_dict()
+    def snapshot_usage(*, emit: bool = False) -> dict[str, Any] | None:
+        nonlocal usage_snapshot
+        with usage_lock:
+            if crew_obj is not None:
+                observed = collect_usage(crew_obj)
+                candidate = None
+                if observed.agents or observed.collection_error is not None:
+                    candidate = observed.as_dict()
+                usage_snapshot = _merge_usage_snapshots(usage_snapshot, candidate)
+            if usage_snapshot is None:
+                return None
+            if emit:
+                cost = usage_snapshot.get("cost_usd")
+                cost_text = "unknown" if cost is None else f"${float(cost):.4f}"
+                if not usage_snapshot.get("cost_complete", True):
+                    unpriced = ", ".join(usage_snapshot.get("unpriced_models") or ())
+                    cost_text += f" (at least; unpriced: {unpriced})"
+                print(
+                    f"[usage] {usage_snapshot.get('total_tokens', 0)} tokens over "
+                    f"{usage_snapshot.get('total_requests', 0)} requests, {cost_text}",
+                    flush=True,
+                )
+            return copy.deepcopy(usage_snapshot)
 
     try:
         if args.run_spec:
@@ -794,9 +1015,20 @@ def main() -> None:
                 checkpoint_runtime.snapshot()
                 if checkpoint_runtime is not None else checkpoint_snapshot
             )
+            current_usage = snapshot_usage()
+            current_accounting = _usage_accounting_snapshot(
+                current_usage,
+                stage=stage,
+                run_complete=False,
+                # Parallel nodes or the next sequential node may already have
+                # entered a provider call when this callback takes its view.
+                in_flight_request_may_have_spent=True,
+            )
             write_status(
                 stage,
                 output_language=source_collection.output_language,
+                usage=current_usage,
+                usage_accounting=current_accounting,
                 **current_checkpoint_snapshot,
             )
 
@@ -804,6 +1036,18 @@ def main() -> None:
             source_collection,
             task_callback=on_task_complete,
         ).crew()
+        if runtime_budget.active:
+            for index, agent in enumerate(crew_obj.agents):
+                # Agent instances are constructed before the API deadline is
+                # available to their wrapped call methods. Configure that
+                # mutable seam once, before either checkpoint hydration or
+                # paid execution can invoke a provider.
+                configure_llm_deadline(
+                    agent.llm,
+                    deadline_monotonic=runtime_budget.deadline_for_agent(index),
+                    stage=str(agent.role or f"Agent {index + 1}"),
+                    request_timeout_seconds=runtime_budget.request_timeout_seconds,
+                )
         crew_inputs = source_collection.crew_inputs()
         # Decision context does not alter retrieval or scoring. It enters only
         # the Writer/Reviewer placeholders, while remaining part of the exact
@@ -1014,7 +1258,13 @@ def main() -> None:
                   f"report's recommendation disagrees with its own scorecard",
                   flush=True)
 
-        final_usage = snapshot_usage()
+        final_usage = snapshot_usage(emit=True)
+        final_accounting = _usage_accounting_snapshot(
+            final_usage,
+            stage="Done",
+            run_complete=True,
+            in_flight_request_may_have_spent=False,
+        )
         telemetry.set_attributes({
             "academic_agent.usage.total_tokens": (
                 final_usage.get("total_tokens") if final_usage else None
@@ -1037,11 +1287,20 @@ def main() -> None:
             evidence_incomplete=not evidence_saved,
             report_audit=report_audit,
             usage=final_usage,
+            usage_accounting=final_accounting,
             claim_grounding=grounding,
             consistency=consistency,
             observability=telemetry.snapshot(),
             quality_review=quality_review,
             **checkpoint_snapshot,
+        )
+        commit_worker_terminal(
+            state="completed",
+            reason_code="worker_completed",
+            stage="Done",
+            usage=final_usage,
+            usage_accounting=final_accounting,
+            checkpoint_state=checkpoint_snapshot,
         )
 
     except Exception as exc:
@@ -1065,7 +1324,16 @@ def main() -> None:
         except Exception as _save_err:
             print(f"[worker] save_error failed: {_save_err}", file=sys.stderr)
         print(error_details, file=sys.stderr, flush=True)
-        error_usage = snapshot_usage()
+        error_usage = snapshot_usage(emit=True)
+        error_accounting = _usage_accounting_snapshot(
+            error_usage,
+            stage="Error",
+            run_complete=False,
+            # Before Crew construction no LLM request can have started. Once
+            # it exists, fail conservatively because a transport error may
+            # have reached the provider without returning usage counters.
+            in_flight_request_may_have_spent=crew_obj is not None,
+        )
         telemetry.finish(exc)
         checkpoint_snapshot = (
             checkpoint_runtime.snapshot()
@@ -1074,8 +1342,17 @@ def main() -> None:
         write_status(
             "Error", done=True, error=str(exc)[:400],
             usage=error_usage,
+            usage_accounting=error_accounting,
             observability=telemetry.snapshot(),
             **checkpoint_snapshot,
+        )
+        commit_worker_terminal(
+            state="failed",
+            reason_code="worker_exception",
+            stage="Error",
+            usage=error_usage,
+            usage_accounting=error_accounting,
+            checkpoint_state=checkpoint_snapshot,
         )
         sys.exit(1)
 

--- a/src/academic_agent/run_terminal.py
+++ b/src/academic_agent/run_terminal.py
@@ -1,0 +1,194 @@
+"""Durable terminal facts for one assessment process.
+
+``status.json`` is a live projection and is intentionally rewritten at every
+stage.  It cannot be the authoritative end record for a process killed by the
+API: the worker that owns the file is exactly the process that no longer gets
+to write it.  ``terminal.json`` is the smaller immutable contract shared by
+both writers.  A worker commits it after its final status write; the API
+commits it only after a timeout or cancellation has stopped the worker.
+
+The record does not claim exactly-once provider accounting.  A process can be
+terminated after a provider accepted a request but before the SDK exposed its
+usage.  ``usage_accounting`` therefore distinguishes a complete total, a
+durable lower bound, and an unavailable measurement instead of presenting a
+partial number as the bill.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+TERMINAL_FILENAME = "terminal.json"
+
+TerminalState = Literal["completed", "failed", "cancelled", "timeout"]
+TerminationMethod = Literal["worker_exit", "terminate", "kill", "already_exited"]
+UsageAccountingState = Literal["complete", "lower_bound", "unavailable"]
+
+
+class TerminalRecordUnreadable(OSError):
+    """The terminal file exists but cannot be parsed as the frozen contract."""
+
+
+class UsageAccounting(BaseModel):
+    """How much confidence a reader may place in the adjacent usage snapshot."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    state: UsageAccountingState
+    snapshot_at: datetime
+    through_stage: str = Field(default="", max_length=300)
+    run_complete: bool
+    in_flight_request_may_have_spent: bool
+
+    @field_validator("snapshot_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("snapshot_at must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _state_matches_completion(self) -> "UsageAccounting":
+        if self.state == "complete" and not self.run_complete:
+            raise ValueError("complete accounting requires a completed run")
+        if self.state == "lower_bound" and self.run_complete:
+            raise ValueError("a completed run cannot have lower-bound accounting")
+        if self.state == "complete" and self.in_flight_request_may_have_spent:
+            raise ValueError("complete accounting cannot have an in-flight request")
+        return self
+
+
+class TerminalRecord(BaseModel):
+    """Immutable process outcome written once after execution has stopped."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal[1] = 1
+    state: TerminalState
+    reason_code: str = Field(min_length=1, max_length=100)
+    termination_method: TerminationMethod
+    started_at: datetime
+    ended_at: datetime
+    elapsed_seconds: int = Field(ge=0)
+    last_stage: str = Field(default="", max_length=300)
+    timeout_seconds: int | None = Field(default=None, gt=0)
+    usage: dict[str, Any] | None = None
+    usage_accounting: UsageAccounting
+    checkpointing: dict[str, Any] | None = None
+    recovery: dict[str, Any] | None = None
+
+    @field_validator("started_at", "ended_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("terminal timestamps must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _end_cannot_precede_start(self) -> "TerminalRecord":
+        if self.ended_at < self.started_at:
+            raise ValueError("ended_at cannot precede started_at")
+        if self.usage_accounting.state == "complete" and self.usage is None:
+            # A completed zero-call workflow still needs an explicit zero
+            # snapshot.  None means accounting could not run, not zero spend.
+            raise ValueError("complete accounting requires a usage snapshot")
+        return self
+
+    def public_projection(self) -> dict[str, Any]:
+        """Process metadata safe for both capability-based read endpoints.
+
+        Usage, checkpoint and recovery data already have top-level response
+        fields.  Repeating them here creates two client paths that can drift,
+        so the nested projection contains only terminal-process facts.
+        """
+
+        return {
+            "record_state": "committed",
+            "schema_version": self.schema_version,
+            "state": self.state,
+            "reason_code": self.reason_code,
+            "termination_method": self.termination_method,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat(),
+            "elapsed_seconds": self.elapsed_seconds,
+            "last_stage": self.last_stage,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+def load_terminal_record(run_directory: Path | str) -> TerminalRecord | None:
+    """Load the terminal record, returning None only when it was never written."""
+
+    path = Path(run_directory) / TERMINAL_FILENAME
+    try:
+        payload = path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise TerminalRecordUnreadable(str(path)) from exc
+    try:
+        return TerminalRecord.model_validate_json(payload)
+    except ValueError as exc:
+        raise TerminalRecordUnreadable(f"{path}: invalid terminal record") from exc
+
+
+def commit_terminal_record(
+    run_directory: Path | str,
+    record: TerminalRecord,
+) -> Path:
+    """Atomically publish one immutable terminal record.
+
+    The lifecycle serializes the two possible writers: the worker writes only
+    while it owns execution; the API waits for that process to stop before it
+    writes.  A pre-existing byte-identical record is idempotent.  A conflicting
+    record is never replaced, because doing so would turn a race into a false
+    history rather than making the race visible.
+    """
+
+    directory = Path(run_directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / TERMINAL_FILENAME
+    payload = (record.model_dump_json(indent=2) + "\n").encode("utf-8")
+
+    try:
+        existing = path.read_bytes()
+    except FileNotFoundError:
+        existing = None
+    if existing is not None:
+        try:
+            current = TerminalRecord.model_validate_json(existing)
+        except ValueError as exc:
+            raise TerminalRecordUnreadable(
+                f"{path}: existing terminal record is invalid"
+            ) from exc
+        if current == record:
+            return path
+        raise FileExistsError(f"conflicting terminal record already exists: {path}")
+
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # os.replace gives readers an all-or-nothing JSON document.  The
+        # lifecycle ordering above, rather than this replace alone, prevents a
+        # second writer from intentionally overwriting an existing outcome.
+        if path.exists():
+            return commit_terminal_record(directory, record)
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            # Preserve the publication error; this file is unreferenced and a
+            # cleanup failure says nothing about the committed outcome.
+            pass
+    return path

--- a/src/academic_agent/runtime_budget.py
+++ b/src/academic_agent/runtime_budget.py
@@ -1,0 +1,105 @@
+"""Code-owned time budget shared by the API worker and LLM adapter.
+
+The API's 30-minute watchdog is an availability boundary, not a useful model
+timeout.  If every provider call is allowed to consume that whole window, a
+Reviewer request can be killed after the validated Writer draft exists but
+before the existing Reviewer fallback, independent Scorer, usage snapshot and
+terminal files run.  This module derives earlier monotonic deadlines while
+leaving the public watchdog unchanged.
+
+The constants are deliberately conservative operational policy, not an SLO.
+A measured successful Writer/Reviewer/Scorer recovery suffix took 102 seconds;
+240 seconds is reserved before the hard stop so the Reviewer can fail closed,
+the independent Scorer can run, and final artifacts still have 60 seconds to
+commit.  Provider traces should be used before changing these numbers.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+WORKER_LLM_TIMEOUT_ENV = "ACADEMIC_AGENT_WORKER_LLM_TIMEOUT_SECONDS"
+REQUEST_TIMEOUT_SECONDS = 150
+REVIEWER_RESERVE_SECONDS = 240
+FINALIZATION_RESERVE_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class RuntimeBudget:
+    """Monotonic worker deadlines derived once from the API's wall deadline."""
+
+    hard_deadline_monotonic: float | None
+    hard_deadline_epoch: float | None
+    hard_timeout_seconds: int | None
+    request_timeout_seconds: int = REQUEST_TIMEOUT_SECONDS
+    reviewer_reserve_seconds: int = REVIEWER_RESERVE_SECONDS
+    finalization_reserve_seconds: int = FINALIZATION_RESERVE_SECONDS
+
+    @classmethod
+    def from_wall_deadline(
+        cls,
+        deadline_epoch: float | None,
+        timeout_seconds: int | None,
+        *,
+        wall_now: float | None = None,
+        monotonic_now: float | None = None,
+    ) -> "RuntimeBudget":
+        """Convert once so later system-clock changes cannot extend a run."""
+
+        if deadline_epoch is None:
+            return cls(None, None, timeout_seconds)
+        if deadline_epoch <= 0:
+            raise ValueError("hard deadline epoch must be positive")
+        if timeout_seconds is not None and timeout_seconds <= 0:
+            raise ValueError("hard timeout seconds must be positive")
+        observed_wall = time.time() if wall_now is None else wall_now
+        observed_monotonic = (
+            time.monotonic() if monotonic_now is None else monotonic_now
+        )
+        remaining = max(0.0, deadline_epoch - observed_wall)
+        return cls(
+            observed_monotonic + remaining,
+            deadline_epoch,
+            timeout_seconds,
+        )
+
+    @property
+    def active(self) -> bool:
+        return self.hard_deadline_monotonic is not None
+
+    @property
+    def reviewer_deadline(self) -> float | None:
+        if self.hard_deadline_monotonic is None:
+            return None
+        return self.hard_deadline_monotonic - self.reviewer_reserve_seconds
+
+    @property
+    def paid_work_deadline(self) -> float | None:
+        if self.hard_deadline_monotonic is None:
+            return None
+        return self.hard_deadline_monotonic - self.finalization_reserve_seconds
+
+    def deadline_for_agent(self, index: int) -> float | None:
+        """Reviewer stops early; every other node shares the finalization edge."""
+
+        return self.reviewer_deadline if index == 4 else self.paid_work_deadline
+
+    def public_snapshot(self) -> dict[str, object]:
+        """Serializable policy metadata; monotonic process-local values stay private."""
+
+        deadline_at = None
+        if self.hard_deadline_epoch is not None:
+            deadline_at = datetime.fromtimestamp(
+                self.hard_deadline_epoch, tz=UTC
+            ).isoformat()
+        return {
+            "state": "active" if self.active else "unbounded_cli",
+            "hard_timeout_seconds": self.hard_timeout_seconds,
+            "hard_deadline_at": deadline_at,
+            "request_timeout_seconds": self.request_timeout_seconds,
+            "reviewer_reserve_seconds": self.reviewer_reserve_seconds,
+            "finalization_reserve_seconds": self.finalization_reserve_seconds,
+        }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -207,6 +207,10 @@ class SubmitRunTests(_ApiTestCase):
         cmd = mock_popen.call_args[0][0]
         self.assertIn("academic_agent.pipeline_worker", cmd)
         self.assertIn("perovskite solar cells", cmd)
+        self.assertIn("--hard-deadline-epoch", cmd)
+        self.assertIn("--hard-timeout-seconds", cmd)
+        timeout_index = cmd.index("--hard-timeout-seconds")
+        self.assertEqual(cmd[timeout_index + 1], str(runs.TIMEOUT_SECONDS))
 
     @patch("api.runs.subprocess.Popen")
     def test_chinese_topic_is_normalized_across_the_paid_boundary(self, mock_popen):
@@ -639,6 +643,24 @@ class TimeoutReaperTests(_ApiTestCase):
         proc = self._live_proc()
         mock_popen.return_value = proc
         rid = self.client.post("/api/runs", json={"topic": "slow topic"}).json()["run_id"]
+        run_dir = runs.run_dir_for(rid)
+        usage = {
+            "total_tokens": 12_345,
+            "total_requests": 4,
+            "cost_usd": 0.02,
+            "cost_complete": True,
+            "agents": [],
+        }
+        (run_dir / "status.json").write_text(json.dumps({
+            "stage": "Agent 5 — Quality Review & Citation Check",
+            "done": False,
+            "usage": usage,
+            "checkpointing": {
+                "state": "partial",
+                "committed_nodes": ["retrieval", "academic", "patent", "market", "writer"],
+            },
+            "recovery": {"state": "not_requested"},
+        }), encoding="utf-8")
 
         # Backdate the start so the handle looks overdue.
         runs._registry[rid].started -= runs.TIMEOUT_SECONDS + 1
@@ -646,7 +668,50 @@ class TimeoutReaperTests(_ApiTestCase):
         killed = runs.reap_timeouts()
         self.assertIn(rid, killed)
         proc.terminate.assert_called_once()
-        self.assertEqual(self.client.get(f"/api/runs/{rid}").json()["state"], "timeout")
+        status = self.client.get(f"/api/runs/{rid}").json()
+        progress = self.client.get(f"/api/runs/{rid}/progress").json()
+        self.assertEqual(status["state"], "timeout")
+        self.assertGreaterEqual(status["elapsed_seconds"], runs.TIMEOUT_SECONDS)
+        self.assertEqual(status["usage"], usage)
+        self.assertEqual(status["usage_accounting"]["state"], "lower_bound")
+        self.assertTrue(
+            status["usage_accounting"]["in_flight_request_may_have_spent"]
+        )
+        self.assertEqual(status["terminal"]["reason_code"], "hard_timeout")
+        self.assertEqual(status["terminal"]["last_stage"],
+                         "Agent 5 — Quality Review & Citation Check")
+        self.assertEqual(runs._elapsed_seconds(run_dir), status["elapsed_seconds"])
+        self.assertEqual(status["checkpointing"]["committed_nodes"][-1], "writer")
+        for field in ("state", "elapsed_seconds", "usage", "usage_accounting", "terminal"):
+            with self.subTest(field=field):
+                self.assertEqual(progress[field], status[field])
+        self.assertIn("terminal", status["artifacts"])
+
+    @patch("api.runs.subprocess.Popen")
+    def test_reaped_collection_failure_is_unavailable_not_a_lower_bound(
+        self, mock_popen
+    ):
+        """A diagnostic object is not evidence that any counters were observed."""
+        proc = self._live_proc()
+        mock_popen.return_value = proc
+        rid = self.client.post(
+            "/api/runs", json={"topic": "usage collector failure"}
+        ).json()["run_id"]
+        run_dir = runs.run_dir_for(rid)
+        failed_usage = {
+            "collection_error": "RuntimeError: metrics unavailable",
+        }
+        (run_dir / "status.json").write_text(
+            json.dumps({"stage": "Reviewer", "usage": failed_usage}),
+            encoding="utf-8",
+        )
+        runs._registry[rid].started -= runs.TIMEOUT_SECONDS + 1
+
+        self.assertEqual(runs.reap_timeouts(), [rid])
+        status = self.client.get(f"/api/runs/{rid}").json()
+        self.assertEqual(status["usage"], failed_usage)
+        self.assertEqual(status["usage_accounting"]["state"], "unavailable")
+        self.assertEqual(status["terminal"]["state"], "timeout")
 
     @patch("api.runs.subprocess.Popen")
     def test_healthy_run_not_reaped(self, mock_popen):

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -11,6 +11,7 @@ The load test below fails against the unlocked version.
 
 from __future__ import annotations
 
+import json
 import threading
 import unittest
 from pathlib import Path
@@ -145,6 +146,14 @@ class ConcurrencyCapTests(_ConcurrencyTestBase):
             self.assertEqual(runs.active_count(), 1)
             runs.cancel_run(run_id)
             self.assertEqual(runs.active_count(), 0)
+
+        terminal = json.loads(
+            (runs.run_dir_for(run_id) / "terminal.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(terminal["state"], "cancelled")
+        self.assertEqual(terminal["reason_code"], "user_cancelled")
+        self.assertEqual(terminal["usage_accounting"]["state"], "unavailable")
+        self.assertTrue(terminal["usage_accounting"]["in_flight_request_may_have_spent"])
 
     def test_concurrent_cancels_do_not_both_succeed(self):
         """Exactly one caller owns a given run."""

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -48,6 +48,16 @@ _STATUS = {
     "failed_domains": [],
     "usage": {"total_tokens": 77819, "total_requests": 6, "cost_usd": 0.0333,
               "cost_complete": True, "agents": []},
+    "usage_accounting": {
+        "state": "complete", "snapshot_at": "2026-08-14T00:28:30+00:00",
+        "through_stage": "Done", "run_complete": True,
+        "in_flight_request_may_have_spent": False,
+    },
+    "runtime_budget": {
+        "state": "active", "hard_timeout_seconds": 1800,
+        "request_timeout_seconds": 150, "reviewer_reserve_seconds": 240,
+        "finalization_reserve_seconds": 60,
+    },
     "claim_grounding": {"checked": 2, "ungrounded": 0, "unverifiable": 2,
                         "by_domain": {}},
     "authority_coverage": {
@@ -151,6 +161,8 @@ class StateReachesTheClientTests(unittest.TestCase):
             body["evidence_gap_shadow"]["gate_state"], "eligible"
         )
         self.assertEqual(body["decision_gate"]["mode"], "decision_support")
+        self.assertEqual(body["usage_accounting"]["state"], "complete")
+        self.assertEqual(body["runtime_budget"]["request_timeout_seconds"], 150)
 
     def test_the_progress_endpoint_returns_them_with_their_values(self):
         """This endpoint names each field in its constructor, so it is the one
@@ -168,6 +180,8 @@ class StateReachesTheClientTests(unittest.TestCase):
             body["evidence_gap_shadow"]["gate_state"], "eligible"
         )
         self.assertEqual(body["decision_gate"]["mode"], "decision_support")
+        self.assertEqual(body["usage_accounting"]["state"], "complete")
+        self.assertEqual(body["runtime_budget"]["request_timeout_seconds"], 150)
 
     def test_shadow_state_matches_the_downloadable_artifact(self):
         """A persisted audit must reach the client through its advertised name."""

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from academic_agent.llm_config import _detect_provider, create_deepseek_llm, create_llm
+from academic_agent.runtime_budget import WORKER_LLM_TIMEOUT_ENV
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +200,34 @@ def test_temperature_omitted_when_none():
     env = {"DEEPSEEK_API_KEY": "sk-ds"}
     kw = _make_llm(env, temperature=None)
     assert "temperature" not in kw
+
+
+def test_worker_transport_disables_sdk_retries_and_sets_timeout():
+    """The project wrapper, not a hidden SDK loop, owns retry accounting."""
+
+    env = {
+        "DEEPSEEK_API_KEY": "sk-ds",
+        WORKER_LLM_TIMEOUT_ENV: "150",
+    }
+    kw = _make_llm(env)
+    assert kw["timeout"] == 150.0
+    assert kw["max_retries"] == 0
+
+
+def test_non_worker_llm_does_not_inherit_runtime_transport_policy():
+    env = {
+        "DEEPSEEK_API_KEY": "sk-ds",
+        WORKER_LLM_TIMEOUT_ENV: "",
+    }
+    kw = _make_llm(env)
+    assert "timeout" not in kw
+    assert "max_retries" not in kw
+
+
+def test_invalid_worker_timeout_fails_before_provider_construction():
+    env = {"DEEPSEEK_API_KEY": "sk-ds", WORKER_LLM_TIMEOUT_ENV: "zero"}
+    with pytest.raises(RuntimeError, match=WORKER_LLM_TIMEOUT_ENV):
+        _make_llm(env)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from academic_agent.llm_config import _MAX_ATTEMPTS, _is_retryable, _wrap_with_retry
+from academic_agent.llm_config import (
+    _MAX_ATTEMPTS,
+    RunDeadlineExceeded,
+    _is_retryable,
+    _wrap_with_retry,
+    configure_llm_deadline,
+)
 
 
 class RetryClassificationTests(unittest.TestCase):
@@ -59,6 +65,11 @@ class RetryClassificationTests(unittest.TestCase):
         """Unknown failures are treated as permanent — a wrong retry costs
         money and time, a wrong give-up costs one run."""
         self.assertFalse(_is_retryable(ValueError("something unexpected")))
+
+    def test_run_budget_exhaustion_is_not_a_transport_retry(self):
+        """No retry can add time back to the parent watchdog."""
+
+        self.assertFalse(_is_retryable(RunDeadlineExceeded("deadline")))
 
 
 class RetryBehaviourTests(unittest.TestCase):
@@ -130,6 +141,47 @@ class RetryBehaviourTests(unittest.TestCase):
         llm, call = self._llm(return_value="answer")
         llm.call("prompt", tools=["t"])
         call.assert_called_once_with("prompt", tools=["t"])
+
+    @patch("academic_agent.llm_config.time.monotonic", return_value=90.0)
+    def test_provider_is_not_called_without_one_full_bounded_window(self, _clock):
+        """Starting a request that cannot finish before fallback is itself a bug."""
+
+        llm, call = self._llm(return_value="too late")
+        configure_llm_deadline(
+            llm,
+            deadline_monotonic=100.0,
+            stage="Reviewer",
+            request_timeout_seconds=11.0,
+        )
+
+        with self.assertRaisesRegex(RunDeadlineExceeded, "Reviewer"):
+            llm.call("prompt")
+
+        call.assert_not_called()
+
+    @patch("academic_agent.llm_config.random.uniform", return_value=0.0)
+    @patch("academic_agent.llm_config.time.monotonic", return_value=90.0)
+    def test_retry_is_refused_when_backoff_and_attempt_no_longer_fit(
+        self,
+        _clock,
+        _jitter,
+    ):
+        """The wrapper owns retries and must reserve both sleep and call time."""
+
+        llm, call = self._llm(side_effect=ConnectionError("down"))
+        configure_llm_deadline(
+            llm,
+            deadline_monotonic=100.0,
+            stage="Scorer",
+            request_timeout_seconds=9.0,
+        )
+
+        with self.assertRaises(RunDeadlineExceeded) as caught:
+            llm.call("prompt")
+
+        self.assertIsInstance(caught.exception.__cause__, ConnectionError)
+        self.assertEqual(call.call_count, 1)
+        self.sleep.assert_not_called()
 
     def test_the_factory_product_is_preserved(self):
         """Subclassing crewai.LLM would bypass its factory and lose the

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -23,6 +23,8 @@ from academic_agent.pipeline_worker import (
     _IDX_REVIEW,
     _IDX_SCORING,
     _merge_status_fields,
+    _merge_usage_snapshots,
+    _usage_accounting_snapshot,
     _recover_from_reviewer_failure,
     _review_quality_from_outputs,
     _select_report_and_scores,
@@ -315,6 +317,78 @@ class MergeStatusFieldsTests(unittest.TestCase):
         self.assertTrue(data["done"])
         self.assertIsNone(data["error"])   # not stuck from a previous failed run
 
+    def test_usage_accounting_and_runtime_budget_remain_sticky(self):
+        existing = {
+            "usage_accounting": {"state": "lower_bound"},
+            "runtime_budget": {"state": "active"},
+        }
+        data = self._merge(existing, stage="Agent 5")
+        self.assertEqual(data["usage_accounting"]["state"], "lower_bound")
+        self.assertEqual(data["runtime_budget"]["state"], "active")
+
+
+class UsageSnapshotMergeTests(unittest.TestCase):
+    """A later callback cannot make already observed provider usage shrink."""
+
+    def test_same_agent_counters_and_cost_are_monotonic(self):
+        previous = {
+            "agents": [{
+                "role": "Academic", "model": "qwen3.5-plus",
+                "total_tokens": 100, "requests": 1, "cost_usd": 0.01,
+            }],
+            "total_tokens": 100,
+            "total_requests": 1,
+            "cost_usd": 0.01,
+            "cost_complete": True,
+        }
+        stale = {
+            "agents": [{
+                "role": "Academic", "model": "qwen3.5-plus",
+                "total_tokens": 80, "requests": 0, "cost_usd": 0.008,
+            }],
+            "total_tokens": 80,
+            "total_requests": 0,
+            "cost_usd": 0.008,
+            "cost_complete": True,
+        }
+
+        merged = _merge_usage_snapshots(previous, stale)
+
+        self.assertEqual(merged["total_tokens"], 100)
+        self.assertEqual(merged["total_requests"], 1)
+        self.assertEqual(merged["cost_usd"], 0.01)
+
+    def test_new_agent_is_added_without_erasing_existing_agent(self):
+        first = {
+            "agents": [{"role": "Academic", "model": "m", "total_tokens": 3}],
+            "cost_complete": True,
+        }
+        second = {
+            "agents": [{"role": "Patent", "model": "m", "total_tokens": 7}],
+            "cost_complete": False,
+            "unpriced_models": ["m"],
+        }
+
+        merged = _merge_usage_snapshots(first, second)
+
+        self.assertEqual(merged["total_tokens"], 10)
+        self.assertEqual(
+            [agent["role"] for agent in merged["agents"]],
+            ["Academic", "Patent"],
+        )
+        self.assertFalse(merged["cost_complete"])
+
+    def test_collection_error_is_unavailable_not_complete(self):
+        accounting = _usage_accounting_snapshot(
+            {"collection_error": "RuntimeError: metrics unavailable"},
+            stage="Done",
+            run_complete=True,
+            in_flight_request_may_have_spent=False,
+        )
+
+        self.assertEqual(accounting["state"], "unavailable")
+        self.assertTrue(accounting["run_complete"])
+
 
 class MainEndToEndTests(unittest.TestCase):
     """main() is an orchestrator: these check that it calls the right things
@@ -355,8 +429,11 @@ class MainEndToEndTests(unittest.TestCase):
         self._source_collection.model_dump.return_value = {}
         self._source_collection.crew_inputs.return_value = {}
 
-    def _run(self, run_id="20260101T000000Z-abcdef01", *, spec=None):
+    def _run(
+        self, run_id="20260101T000000Z-abcdef01", *, spec=None, extra_args=None
+    ):
         argv = ["pipeline_worker.py", run_id, "a topic"]
+        argv.extend(extra_args or ())
         if spec is not None:
             run_dir = self.output_root / run_id
             run_dir.mkdir(parents=True, exist_ok=True)
@@ -414,6 +491,45 @@ class MainEndToEndTests(unittest.TestCase):
         )
         self.assertEqual(status["evidence_gap_shadow"]["executed_call_count"], 0)
         self.assertTrue((run_dir / "evidence_gap_shadow.json").exists())
+        terminal = json.loads((run_dir / "terminal.json").read_text(encoding="utf-8"))
+        self.assertEqual(terminal["state"], "completed")
+        self.assertEqual(terminal["termination_method"], "worker_exit")
+        self.assertEqual(terminal["usage_accounting"]["state"], "unavailable")
+        self.assertEqual(status["usage_accounting"]["state"], "unavailable")
+        self.assertEqual(status["runtime_budget"]["state"], "unbounded_cli")
+
+    def test_api_deadline_is_attached_to_all_six_agent_calls(self):
+        """The parent flag is useful only if it reaches every provider wrapper."""
+
+        crew = MagicMock()
+        crew.agents = [
+            SimpleNamespace(role=f"Agent {index + 1}", llm=SimpleNamespace())
+            for index in range(6)
+        ]
+        crew.kickoff.return_value = self._crew_result()
+        extra_args = [
+            "--hard-deadline-epoch",
+            "4102444800",
+            "--hard-timeout-seconds",
+            "1800",
+        ]
+
+        with patch(
+            "academic_agent.llm_config.configure_llm_deadline"
+        ) as configure, patch("academic_agent.crew.AcademicAgent") as agent_cls:
+            agent_cls.return_value.crew.return_value = crew
+            run_dir = self._run(extra_args=extra_args)
+
+        self.assertEqual(configure.call_count, 6)
+        reviewer = configure.call_args_list[4].kwargs
+        scorer = configure.call_args_list[5].kwargs
+        self.assertLess(reviewer["deadline_monotonic"], scorer["deadline_monotonic"])
+        self.assertEqual(reviewer["request_timeout_seconds"], 150)
+        status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+        self.assertEqual(status["runtime_budget"]["state"], "active")
+        self.assertEqual(status["runtime_budget"]["hard_timeout_seconds"], 1800)
+        terminal = json.loads((run_dir / "terminal.json").read_text(encoding="utf-8"))
+        self.assertEqual(terminal["timeout_seconds"], 1800)
 
     def test_decision_context_reaches_crew_kickoff_and_public_status(self):
         """The durable field must reach execution, not merely survive storage."""
@@ -471,6 +587,53 @@ class MainEndToEndTests(unittest.TestCase):
         self.assertFalse(shadow["evidence_changed"])
         crew.kickoff.assert_called_once()
 
+    def test_each_completed_node_persists_a_usage_lower_bound(self):
+        """Usage must cross the callback-to-status seam before a later kill."""
+
+        metrics = SimpleNamespace(
+            prompt_tokens=80,
+            cached_prompt_tokens=0,
+            cache_creation_tokens=0,
+            completion_tokens=20,
+            reasoning_tokens=0,
+            total_tokens=100,
+            successful_requests=1,
+        )
+        llm = SimpleNamespace(
+            model="qwen3.5-plus",
+            get_token_usage_summary=lambda: metrics,
+        )
+        crew = MagicMock()
+        crew.agents = [SimpleNamespace(role="Academic", llm=llm)]
+        intermediate: dict = {}
+
+        def kickoff(*, inputs):
+            del inputs
+            callback = agent_cls.call_args.kwargs["task_callback"]
+            callback(_task("academic complete"))
+            status_path = (
+                self.output_root
+                / "20260101T000000Z-abcdef01"
+                / "status.json"
+            )
+            intermediate.update(json.loads(status_path.read_text(encoding="utf-8")))
+            return self._crew_result()
+
+        crew.kickoff.side_effect = kickoff
+        with patch("academic_agent.crew.AcademicAgent") as agent_cls:
+            agent_cls.return_value.crew.return_value = crew
+            run_dir = self._run()
+
+        self.assertEqual(intermediate["usage"]["total_tokens"], 100)
+        self.assertEqual(intermediate["usage"]["total_requests"], 1)
+        self.assertEqual(intermediate["usage_accounting"]["state"], "lower_bound")
+        self.assertFalse(intermediate["usage_accounting"]["run_complete"])
+        final = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+        self.assertEqual(final["usage_accounting"]["state"], "complete")
+        terminal = json.loads((run_dir / "terminal.json").read_text(encoding="utf-8"))
+        self.assertEqual(terminal["usage"]["total_tokens"], 100)
+        self.assertEqual(terminal["usage_accounting"]["state"], "complete")
+
     def test_source_collection_failure_writes_error_not_a_crash(self):
         with patch("academic_agent.source_pipeline.collect_source_collection",
                    side_effect=RuntimeError("no API key")):
@@ -486,6 +649,12 @@ class MainEndToEndTests(unittest.TestCase):
         self.assertEqual(status["stage"], "Error")
         self.assertIn("no API key", status["error"])
         self.assertTrue((run_dir / "error.log").exists())
+        terminal = json.loads((run_dir / "terminal.json").read_text(encoding="utf-8"))
+        self.assertEqual(terminal["state"], "failed")
+        self.assertEqual(terminal["usage_accounting"]["state"], "unavailable")
+        self.assertFalse(
+            terminal["usage_accounting"]["in_flight_request_may_have_spent"]
+        )
 
     def test_retrieval_failure_writes_machine_readable_diagnostics(self):
         """A failed collection used to discard its in-memory audit exactly

--- a/tests/test_run_terminal.py
+++ b/tests/test_run_terminal.py
@@ -1,0 +1,123 @@
+"""Tests for the immutable process-outcome record.
+
+``status.json`` is a mutable progress projection. A parent-enforced timeout
+stops the only process that normally rewrites it, so its mtime and last stage
+cannot establish the actual end time or whether usage is complete. The
+terminal record is the write-once join between worker and API ownership.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from academic_agent.run_terminal import (
+    TerminalRecord,
+    TerminalRecordUnreadable,
+    UsageAccounting,
+    commit_terminal_record,
+    load_terminal_record,
+)
+
+
+_START = datetime(2026, 9, 4, 1, 0, tzinfo=UTC)
+
+
+def _record(*, state: str = "completed", reason: str = "worker_completed") -> TerminalRecord:
+    usage = {"total_tokens": 12, "total_requests": 1, "cost_usd": 0.001}
+    return TerminalRecord(
+        state=state,
+        reason_code=reason,
+        termination_method="worker_exit" if state in {"completed", "failed"} else "terminate",
+        started_at=_START,
+        ended_at=_START + timedelta(seconds=17),
+        elapsed_seconds=17,
+        last_stage="Done" if state == "completed" else "Reviewer",
+        timeout_seconds=1_800,
+        usage=usage,
+        usage_accounting=UsageAccounting(
+            state="complete" if state == "completed" else "lower_bound",
+            snapshot_at=_START + timedelta(seconds=17),
+            through_stage="Done" if state == "completed" else "Reviewer",
+            run_complete=state == "completed",
+            in_flight_request_may_have_spent=state != "completed",
+        ),
+        checkpointing={"state": "complete", "committed_nodes": ["retrieval"]},
+        recovery={"state": "not_requested"},
+    )
+
+
+def test_commit_is_atomic_loadable_and_idempotent(tmp_path: Path) -> None:
+    record = _record()
+
+    first = commit_terminal_record(tmp_path, record)
+    second = commit_terminal_record(tmp_path, record)
+
+    assert first == second
+    assert load_terminal_record(tmp_path) == record
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_conflicting_second_outcome_cannot_rewrite_history(tmp_path: Path) -> None:
+    original = _record()
+    commit_terminal_record(tmp_path, original)
+
+    with pytest.raises(FileExistsError, match="conflicting"):
+        commit_terminal_record(
+            tmp_path,
+            _record(state="failed", reason="worker_exception"),
+        )
+
+    assert load_terminal_record(tmp_path) == original
+
+
+def test_invalid_existing_record_is_unreadable_not_absent(tmp_path: Path) -> None:
+    (tmp_path / "terminal.json").write_text("{broken", encoding="utf-8")
+
+    with pytest.raises(TerminalRecordUnreadable):
+        load_terminal_record(tmp_path)
+
+
+def test_public_projection_does_not_duplicate_mutable_payloads() -> None:
+    projection = _record().public_projection()
+
+    assert projection["record_state"] == "committed"
+    assert projection["elapsed_seconds"] == 17
+    assert "usage" not in projection
+    assert "checkpointing" not in projection
+
+
+def test_complete_accounting_requires_a_completed_run() -> None:
+    with pytest.raises(ValueError, match="completed run"):
+        UsageAccounting(
+            state="complete",
+            snapshot_at=_START,
+            through_stage="Reviewer",
+            run_complete=False,
+            in_flight_request_may_have_spent=False,
+        )
+
+
+def test_complete_accounting_requires_an_explicit_usage_snapshot() -> None:
+    accounting = UsageAccounting(
+        state="complete",
+        snapshot_at=_START,
+        through_stage="Done",
+        run_complete=True,
+        in_flight_request_may_have_spent=False,
+    )
+
+    with pytest.raises(ValueError, match="usage snapshot"):
+        TerminalRecord(
+            state="completed",
+            reason_code="worker_completed",
+            termination_method="worker_exit",
+            started_at=_START,
+            ended_at=_START,
+            elapsed_seconds=0,
+            last_stage="Done",
+            usage=None,
+            usage_accounting=accounting,
+        )

--- a/tests/test_runtime_budget.py
+++ b/tests/test_runtime_budget.py
@@ -1,0 +1,71 @@
+"""Tests for the API watchdog to worker/provider deadline contract.
+
+The production failure behind this module reached Reviewer and was then killed
+by the 30-minute parent watchdog. A transport timeout equal to that watchdog is
+not a bound: it leaves no time for the existing validated-draft fallback,
+independent Scorer, usage snapshot, or terminal persistence. These tests pin
+the reserves at the monotonic conversion seam without sleeping or networking.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from academic_agent.runtime_budget import RuntimeBudget
+
+
+def test_wall_deadline_is_converted_once_to_monotonic_time() -> None:
+    budget = RuntimeBudget.from_wall_deadline(
+        1_900.0,
+        1_800,
+        wall_now=100.0,
+        monotonic_now=500.0,
+    )
+
+    assert budget.hard_deadline_monotonic == 2_300.0
+    assert budget.reviewer_deadline == 2_060.0
+    assert budget.paid_work_deadline == 2_240.0
+
+
+def test_reviewer_has_a_larger_finalization_reserve_than_other_nodes() -> None:
+    budget = RuntimeBudget.from_wall_deadline(
+        1_900.0,
+        1_800,
+        wall_now=100.0,
+        monotonic_now=500.0,
+    )
+
+    assert budget.deadline_for_agent(4) == budget.reviewer_deadline
+    for index in (0, 1, 2, 3, 5):
+        assert budget.deadline_for_agent(index) == budget.paid_work_deadline
+    assert budget.reviewer_deadline < budget.paid_work_deadline
+
+
+def test_public_snapshot_exposes_policy_without_process_local_clock() -> None:
+    budget = RuntimeBudget.from_wall_deadline(
+        1_900.0,
+        1_800,
+        wall_now=100.0,
+        monotonic_now=500.0,
+    )
+
+    snapshot = budget.public_snapshot()
+
+    assert snapshot["state"] == "active"
+    assert snapshot["hard_timeout_seconds"] == 1_800
+    assert snapshot["hard_deadline_at"].endswith("+00:00")
+    assert "monotonic" not in " ".join(snapshot)
+
+
+def test_direct_cli_run_remains_explicitly_unbounded() -> None:
+    budget = RuntimeBudget.from_wall_deadline(None, None)
+
+    assert not budget.active
+    assert budget.deadline_for_agent(4) is None
+    assert budget.public_snapshot()["state"] == "unbounded_cli"
+
+
+@pytest.mark.parametrize("deadline", [0.0, -1.0])
+def test_invalid_wall_deadline_is_rejected(deadline: float) -> None:
+    with pytest.raises(ValueError, match="deadline"):
+        RuntimeBudget.from_wall_deadline(deadline, 1_800)

--- a/tests/test_web_usage_summary.py
+++ b/tests/test_web_usage_summary.py
@@ -24,6 +24,7 @@ from tempfile import TemporaryDirectory
 _REPO = Path(__file__).resolve().parent.parent
 _RUN_JS = _REPO / "web" / "static" / "js" / "run.js"
 _I18N_JS = _REPO / "web" / "static" / "js" / "i18n.js"
+_APP_JS = _REPO / "web" / "static" / "js" / "app.js"
 
 
 def _node() -> str | None:
@@ -54,10 +55,12 @@ class UsageSummaryTests(unittest.TestCase):
         (work / "harness.mjs").write_text(textwrap.dedent("""
             globalThis.localStorage = { getItem: () => null, setItem: () => {} };
             const { usageSummary, usageTitle } = await import("./run.mjs");
-            const usage = JSON.parse(process.argv[2]);
+            const payload = JSON.parse(process.argv[2]);
+            const usage = payload?.usage ?? null;
+            const accounting = payload?.accounting ?? null;
             console.log(JSON.stringify({
-                summary: usageSummary(usage),
-                title: usageTitle(usage),
+                summary: usageSummary(usage, accounting),
+                title: usageTitle(usage, accounting),
             }));
         """), encoding="utf-8")
         cls._work = work
@@ -75,9 +78,10 @@ class UsageSummaryTests(unittest.TestCase):
     def tearDownClass(cls):
         cls._tmp.cleanup()
 
-    def _render(self, usage) -> dict:
+    def _render(self, usage, accounting=None) -> dict:
+        payload = {"usage": usage, "accounting": accounting}
         result = subprocess.run(
-            [_node(), str(self._work / "harness.mjs"), json.dumps(usage)],
+            [_node(), str(self._work / "harness.mjs"), json.dumps(payload)],
             capture_output=True, text=True, encoding="utf-8", timeout=120, cwd=self._work,
         )
         if result.returncode != 0:
@@ -144,6 +148,47 @@ class UsageSummaryTests(unittest.TestCase):
         for usage in (None, {}, {"total_tokens": 0}):
             with self.subTest(usage=usage):
                 self.assertEqual(self._render(usage)["summary"], "")
+
+    def test_timeout_marks_durable_usage_as_a_lower_bound(self):
+        accounting = {
+            "state": "lower_bound",
+            "in_flight_request_may_have_spent": True,
+        }
+        out = self._render({
+            "total_tokens": 5000,
+            "cost_usd": 0.01,
+            "cost_complete": True,
+            "agents": [],
+        }, accounting)
+        self.assertIn("partial usage", out["summary"])
+        self.assertIn("lower bound", out["title"])
+    def test_zero_observed_tokens_still_exposes_lower_bound_accounting(self):
+        """A durable zero is not an exact bill while a request may be in flight."""
+        accounting = {
+            "state": "lower_bound",
+            "in_flight_request_may_have_spent": True,
+        }
+        out = self._render({"total_tokens": 0, "agents": []}, accounting)
+
+        self.assertEqual(out["summary"], "partial usage")
+        self.assertIn("lower bound", out["title"])
+
+
+    def test_unavailable_accounting_never_looks_like_zero_spend(self):
+        accounting = {
+            "state": "unavailable",
+            "in_flight_request_may_have_spent": True,
+        }
+        out = self._render(None, accounting)
+        self.assertEqual(out["summary"], "usage unavailable")
+        self.assertIn("does not mean zero", out["title"])
+
+    def test_app_passes_accounting_to_both_usage_formatters(self):
+        """Formatting correctly is insufficient if app.js drops the new field."""
+
+        source = _APP_JS.read_text(encoding="utf-8")
+        self.assertIn("usageSummary(usage, usage_accounting)", source)
+        self.assertIn("usageTitle(usage, usage_accounting)", source)
 
 
 @unittest.skipUnless(_node(), "node not installed")

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -92,7 +92,8 @@ function startClock(fromSeconds) {
 }
 
 function paintHeader({
-  topic, state, elapsed_seconds, source_counts, usage, checkpointing, recovery,
+  topic, state, elapsed_seconds, source_counts, usage, usage_accounting,
+  checkpointing, recovery,
 }) {
   if (topic) $("#run-title").textContent = topic;
 
@@ -113,10 +114,10 @@ function paintHeader({
 
   // Shown for failed runs too: a run that died halfway still spent whatever
   // it spent, and that is the bill nobody can otherwise estimate.
-  const spend = runView.usageSummary(usage);
+  const spend = runView.usageSummary(usage, usage_accounting);
   const spendEl = $("#run-usage");
   spendEl.textContent = spend ? `· ${spend}` : "";
-  spendEl.title = spend ? runView.usageTitle(usage) : "";
+  spendEl.title = spend ? runView.usageTitle(usage, usage_accounting) : "";
 
   const recoveryEl = $("#run-recovery");
   const reused = recovery?.reused_nodes?.length ?? 0;

--- a/web/static/js/i18n.js
+++ b/web/static/js/i18n.js
@@ -25,6 +25,10 @@ const STRINGS = {
     tokens_suffix: "tokens",
     price_basis: "Price basis",
     cost_partial: "Partial estimate — no price known for: {models}",
+    usage_partial: "partial usage",
+    usage_unavailable: "usage unavailable",
+    usage_partial_detail: "Durable lower bound; an in-flight provider request may be absent.",
+    usage_unavailable_detail: "Usage accounting was unavailable; this does not mean zero spend.",
 
     // Composer
     compose_title: "What should we assess?",
@@ -252,6 +256,10 @@ const STRINGS = {
     tokens_suffix: "tokens",
     price_basis: "计价依据",
     cost_partial: "部分估算 —— 以下模型无已知价格：{models}",
+    usage_partial: "用量下限",
+    usage_unavailable: "用量不可用",
+    usage_partial_detail: "这是已持久化的用量下限；可能未包含正在执行的服务商请求。",
+    usage_unavailable_detail: "未能取得用量记录；这不代表 Token 或费用为零。",
 
     compose_title: "要评估什么技术？",
     compose_sub: "六个智能体收集学术、专利与市场证据，评估商业化就绪度。每条结论都附带可核查的引用。",

--- a/web/static/js/run.js
+++ b/web/static/js/run.js
@@ -139,8 +139,14 @@ export function sourceSummary(counts) {
  * price shows its tokens and no dollar figure at all — which is the honest
  * output, and the reason this is not simply `cost ?? 0`.
  */
-export function usageSummary(usage) {
-  if (!usage || !usage.total_tokens) return "";
+export function usageSummary(usage, accounting = null) {
+  if (!usage || !usage.total_tokens) {
+    if (accounting?.state === "unavailable") return t("usage_unavailable");
+    // Zero observed counters can still be a lower bound when a provider
+    // accepted an in-flight request but never returned its usage payload.
+    if (accounting?.state === "lower_bound") return t("usage_partial");
+    return "";
+  }
   const tokens = usage.total_tokens >= 1000
     ? `${(usage.total_tokens / 1000).toFixed(1)}k`
     : String(usage.total_tokens);
@@ -149,13 +155,19 @@ export function usageSummary(usage) {
     const approx = usage.cost_complete ? "" : "~";
     parts.push(`${approx}$${usage.cost_usd.toFixed(4)}`);
   }
+  if (accounting?.state === "lower_bound") parts.push(t("usage_partial"));
   return parts.join(" · ");
 }
 
 /** Tooltip spelling out where the cost figure came from, if anywhere. */
-export function usageTitle(usage) {
-  if (!usage) return "";
+export function usageTitle(usage, accounting = null) {
   const lines = [];
+  if (accounting?.state === "lower_bound") {
+    lines.push(t("usage_partial_detail"));
+  } else if (accounting?.state === "unavailable") {
+    lines.push(t("usage_unavailable_detail"));
+  }
+  if (!usage) return lines.join("\n");
   if (usage.price_basis) lines.push(`${t("price_basis")}: ${usage.price_basis}`);
   if (usage.cost_complete === false && usage.unpriced_models?.length) {
     lines.push(t("cost_partial").replace("{models}", usage.unpriced_models.join(", ")));


### PR DESCRIPTION
## Why

A production Qwen canary reached a validated Writer checkpoint but was killed in Reviewer by the unchanged 30-minute API watchdog. The mutable status file then exposed a stale 1,404-second duration and no partial usage. Merely raising the timeout would leave both audit gaps and the unbounded closeout path intact.

## What changed

- Add a write-once terminal record for worker exits and API-owned cancellation or timeout after process termination.
- Persist monotonic per-node usage snapshots and distinguish complete, lower-bound, and unavailable temporal accounting from price completeness.
- Pass one hard-deadline identity to API workers, bound provider attempts at 150 seconds, disable SDK-hidden retries, reserve Reviewer fallback time, and retain the existing independently guarded Scorer.
- Carry runtime, terminal, and accounting fields through both API schemas and the browser, including zero-observed-token lower bounds.
- Document the contract, evidence, limits, and need for a separately authorized post-deployment canary.

## Validation

- 2,043 tests passed plus 674 subtests, zero network
- Latest Ruff passed
- CI-matching narrow Pylint passed
- Loopback Chromium smoke passed with zero external and paid-provider requests
- Three original defects were independently re-injected and made their seam tests fail before restoration

## Deliberate non-changes

No scoring formula, retrieval, guardrail, six-node topology, Tool Calling production state, or hard watchdog duration changed. No paid call was made by this work.