### PR TITLE
Preregister production runtime terminal integrity canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 2043 tests (674 subtests), CI green on Linux + Windows × Python
+Current state: 2049 tests (674 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -178,7 +178,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  120 test modules plus conftest, organised by subject
+tests/                  121 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -1125,10 +1125,17 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   accounting state is explicitly `lower_bound` or `unavailable`. Both public
   endpoints and the browser expose the distinction. Three defect reinjections
   proved the provider-call, callback-to-disk and disk-to-client seams. This does
-  not establish production success or exact interrupted-request billing; a new
-  separately authorized canary is still required. See
+  not establish production success or exact interrupted-request billing.
+  A new one-root production canary is now separately pre-registered against a
+  previously unused handheld-ultrasound topic. It freezes the deployed runtime
+  policy, one orientation request, USD 0.10 soft stop, zero operator retries,
+  resumes, cancellations, Planner calls or supplementary searches, and
+  outcome-specific semantics that cannot promote a timeout or unavailable seam
+  to a pass. The protocol itself authorizes zero provider calls; execution still
+  requires a fresh user authorization naming the merged deployed revision. See
   `docs/runtime-terminal-integrity.md` and
-  `docs/results-2026-09-04-runtime-terminal-integrity-implementation.md`.
+  `docs/results-2026-09-04-runtime-terminal-integrity-implementation.md`, plus
+  `docs/prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md`.
 
   See
   `docs/prereg-2026-08-26-decision-context-report-contract.md`,

--- a/README.md
+++ b/README.md
@@ -803,11 +803,18 @@ falls back to a stale status-file timestamp. This is not yet a production
 validation result: one separately authorized post-deployment canary is still
 required. See the [runtime contract](docs/runtime-terminal-integrity.md) and
 [implementation result](docs/results-2026-09-04-runtime-terminal-integrity-implementation.md).
+That canary now has a frozen, previously unused handheld-ultrasound request,
+exact runtime-policy and manifest identities, one-root/zero-retry bounds, a USD
+0.10 soft stop, and outcome lanes that keep ordinary completion, Reviewer
+fallback, timeout and unavailable observations distinct. The pre-registration
+authorizes zero provider calls; a fresh authorization naming the merged and
+deployed revision is still required before execution. See the
+[pre-registration](docs/prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md).
 
-The canary observed live transport and accounting for one run, not general
-report quality or benchmark equivalence. It exposed two internal-x10 score
-phrases that reached report prose; the deterministic score payload remained
-correct, and the narrow narrative seam is now covered by regression tests.
+The earlier completed Qwen provider canary observed live transport and
+accounting for one run, not general report quality or benchmark equivalence.
+It exposed two internal-x10 score phrases that reached report prose; the
+deterministic score payload remained correct, and the narrative seam is tested.
 A separate invented-threshold/citation-entailment finding remains open. See
 the [implementation record](docs/results-2026-08-30-qwen35-plus-provider-adapter-implementation.md)
 and [paid canary record](docs/results-2026-08-30-qwen35-plus-first-paid-canary.md).

--- a/docs/prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md
+++ b/docs/prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md
@@ -1,0 +1,208 @@
+# Pre-registration: runtime terminal integrity post-deployment paid canary
+
+- **Frozen:** 2026-09-04, before any provider-backed run in this study
+- **Implementation baseline:** `cca509ea7e1c122a044eb3d4d90debd46568d05b`
+- **Execution revision:** the first `main` merge commit containing this protocol
+  and its manifest; record the full deployed SHA before submission
+- **Manifest:**
+  `tests/fixtures/runtime_terminal_integrity_paid_canary_manifest.json`
+- **Manifest SHA-256:** `4aaa13f6f2fba30ffd479a086b0f192c86bfb5c2ce87c49d77f4728671a5a2b5`
+- **Provider calls authorized by this document:** none
+- **Future paid scope requiring fresh authorization:** one operator-funded root
+  run, with no operator resubmission, recovery child, cancellation, Planner call,
+  or supplementary search
+- **Future soft cost stop requiring fresh authorization:** USD 0.10; the single
+  already admitted root may finish slightly above the boundary
+
+## Question
+
+Does the deployed runtime-integrity implementation preserve one real Qwen
+run's deadline policy, cumulative usage state, immutable terminal outcome and
+elapsed time through disk, both public read endpoints, and the browser?
+
+This is a production delivery-seam canary. It is not a report-quality
+benchmark, a provider-latency SLO, an evaluation of clinical evidence, or a
+test of production Tool Calling.
+
+## Why this case was frozen
+
+The exact topic is:
+
+> AI-assisted handheld ultrasound for heart-failure screening in rural clinics
+> commercialization
+
+Repository history contains no earlier canary or benchmark with this exact
+topic. It was selected before the first provider call because it is a
+source-rich biomedical commercialization question that should exercise all
+three deterministic retrieval domains, authority coverage, six LLM stages,
+usage accounting and terminal publication. It is not designed to trigger a
+failure, and being previously unused does not make one run an independent
+generalization study.
+
+The request intentionally contains only the topic. It must therefore remain
+an `orientation` assessment with no GO/NO_GO permission and no established
+decision threshold. Decision Context behavior is not the variable under test.
+
+## Frozen production policy
+
+The manifest binds the canary to the following code-owned values:
+
+| Boundary | Frozen value |
+|---|---:|
+| API hard watchdog | 1,800 seconds |
+| One provider attempt | 150 seconds |
+| Reviewer reserve | 240 seconds |
+| Other-node finalization reserve | 60 seconds |
+| Terminal schema | 1 |
+| Poll interval | 10 seconds |
+| Maximum observation window | 1,900 seconds |
+
+The deployed wrapper remains the visible retry owner. "No operator retry"
+means this study will not submit another root, resume a child, or repair a
+failed result. It does not pretend that code-owned retries disappeared; SDK-
+hidden retries must remain disabled and every visible provider attempt must be
+represented by the run's normal accounting.
+
+## Admission preflight
+
+The paid root is inadmissible until all of the following are recorded:
+
+1. this protocol, manifest, and manifest tests are merged to `main`;
+2. the committed manifest bytes reproduce the SHA-256 above;
+3. Railway serves the exact merge revision and `/health/ready` returns HTTP
+   200 with `llm`, `search`, `outputs`, and `paid_accounting` all `ok`;
+4. the deployed OpenAPI schemas expose `pipeline_revision`, `runtime_budget`,
+   `usage`, `usage_accounting`, and `terminal` on both `RunStatus` and
+   `RunProgress`;
+5. the deployed browser bundle contains the complete/lower-bound/unavailable
+   accounting branches and terminal-reason rendering;
+6. one operator access code passes the read-only admission check without the
+   code entering the manifest, URL, inspected log projection, or artifact;
+7. pre-run history, readiness, revision and active paid-operation count are
+   recorded before submission; and
+8. the user gives fresh authorization naming the exact deployed revision,
+   chosen access code, one root run, USD 0.10 soft stop, the bans above, and
+   the possible small overrun of the already admitted root.
+
+Failure of any item means zero paid submissions. Readiness and access checks
+are not permission to start the run.
+
+## Frozen execution protocol
+
+1. Recompute the manifest digest from the committed bytes and validate `RTI01`
+   through the deployed request schema.
+2. Submit the root exactly once and persist its run ID before the first poll.
+3. Poll both status and progress at no less than ten-second intervals. Preserve
+   every observed stage, elapsed value, cumulative usage snapshot, accounting
+   state, runtime budget, terminal projection, checkpoint state and quality-
+   review state in a non-secret observation artifact.
+4. Do not cancel, replace, retry or resume the run. The API hard watchdog may
+   stop it under the deployed policy; that is an observed `timeout`, not an
+   operator cancellation.
+5. Stop polling after a terminal state or 1,900 seconds. If neither endpoint
+   exposes an inspectable terminal state by then, classify the result as
+   `not_inspectable`; do not launch another run.
+6. After terminal observation, fetch status, progress, the full `terminal`
+   artifact, top-level usage fields, checkpoint index, report if present,
+   evidence-gap shadow,
+   run history and browser run page. Do not call a supplementary evidence
+   adapter or open external source pages.
+7. Compare the full terminal record with its bounded projection on both read
+   endpoints. Compare the final durable usage snapshot with top-level usage
+   and accounting on both endpoints.
+8. Verify that every *observed* cumulative token/request/cost counter is
+   monotonic. Polling need not see every node; an unseen intermediate snapshot
+   is `not_observed`, not a failure or a fabricated measurement.
+9. Classify the run into exactly one frozen outcome lane and report both the
+   primary canary result and any narrower terminal/accounting observation.
+10. Publish the result even if it fails, times out, exceeds the soft stop, or
+    cannot be inspected.
+
+## Primary acceptance criteria
+
+The post-deployment canary passes only if every item below passes:
+
+1. Exactly one root exists, no child is created, and its
+   `pipeline_revision` exactly equals the separately authorized deployed SHA.
+2. The root reaches `completed`. Its immutable record has schema 1,
+   `state=completed`, `reason_code=worker_completed`,
+   `termination_method=worker_exit`, and a timezone-aware start and end.
+3. `runtime_budget.state=active` and all four frozen timeout/reserve values are
+   identical on status and progress. Missing metadata is not a historical-run
+   exemption because this canary is created after deployment.
+4. The downloadable `terminal` artifact and both public projections agree on
+   state, reason, method, timestamps, elapsed time, last stage and timeout.
+   Public elapsed time must equal the monotonic terminal value, not a status-
+   file modification-time estimate.
+5. External submission-to-terminal duration and terminal elapsed time differ
+   by no more than 30 seconds. This tolerance covers polling and network delay;
+   it is not a latency target.
+6. `usage_accounting.state=complete`, `run_complete=true`, and
+   `in_flight_request_may_have_spent=false`. Usage is a non-null snapshot on
+   disk and is identical on status and progress. `unavailable` or a missing
+   snapshot fails this completed-run criterion rather than meaning zero spend.
+7. Every cumulative counter actually observed during polling is nondecreasing,
+   and the final snapshot is no smaller than any earlier snapshot. Absence of
+   an intermediate poll sample is reported separately.
+8. The final estimated cost is inspectable and no greater than USD 0.10. A
+   permitted overrun is preserved as evidence but fails this numerical gate.
+9. Every recorded LLM role identity is exactly `qwen3.5-plus`; provider,
+   request, token and cost-completeness fields remain inspectable.
+10. The evidence-gap artifact records zero Planner/tool calls, zero
+    supplementary-search cost and no supplementary mutation of the validated
+    source set.
+11. Status, progress and the browser agree that the run is terminal and expose
+    the same accounting meaning. The browser must not display an exact or zero
+    bill when the API says lower-bound or unavailable.
+12. The orientation gate remains bounded and contains no supplied owner,
+    threshold or GO/NO_GO authority.
+
+## Outcome lanes fixed before execution
+
+The primary gate above deliberately requires completion. Other outcomes may
+still provide narrower evidence, but cannot be promoted to a pass:
+
+- `completed_reviewed`: the primary gate is evaluated; only the ordinary
+  completion path was observed.
+- `completed_reviewer_fallback`: the primary gate is evaluated, and
+  `quality_review.status=fallback` plus the validated Writer and independent
+  Scorer artifacts are additionally required. This is the only lane that can
+  support a live Reviewer-deadline fallback claim.
+- `failed`: the worker's failed terminal record and accounting semantics are
+  evaluated, while the primary canary fails.
+- `timeout`: the API's `hard_timeout` record must use `terminate`, `kill`, or
+  `already_exited`; elapsed time must be at least 1,800 seconds, and accounting
+  must be `lower_bound` when a snapshot exists or `unavailable` when it does
+  not. Any in-flight uncertainty must remain explicit. The primary canary
+  fails even when this narrower timeout contract is correct.
+- `cancelled`: this violates the no-cancellation protocol and fails.
+- `not_inspectable`: a required seam or artifact could not be read; silence is
+  not a pass.
+
+If Reviewer fallback or hard timeout does not occur, that path remains
+`not_observed`. A successful ordinary completion cannot validate it by analogy.
+
+## Measurement limits fixed in advance
+
+This study cannot establish:
+
+- report accuracy, source truth, citation entailment or clinical validity;
+- whether the topic is commercially viable or useful to a real decision maker;
+- stable latency, cost, availability, timeout rate or any production SLO;
+- behavior on another topic, model, language, deployment or host failure;
+- exactly-once provider billing after an interrupted request;
+- Reviewer fallback unless that lane actually occurs;
+- hard-timeout lower-bound behavior unless that lane actually occurs; or
+- value, precision, recall or readiness of production Tool Calling.
+
+One run is one boundary observation, not a rate. All failed, partial,
+unavailable, over-budget, `not_inspectable`, and `not_observed` states must be
+retained.
+
+## Explicit exclusions
+
+This protocol changes no scoring formula, evidence-confidence floor, maturity-
+language check, uncited-claim blocking policy, prompt cache, source-summary
+retrieval, CrewAI version, model adapter, retrieval rule, timeout value,
+guardrail, or production Tool Calling connection. It authorizes no provider
+request by itself.

--- a/docs/runtime-terminal-integrity.md
+++ b/docs/runtime-terminal-integrity.md
@@ -103,10 +103,15 @@ fails the run.
 ## Remaining boundary
 
 This implementation has zero-network test evidence only. A fresh, separately
-pre-registered paid canary is required after deployment to observe whether a
-slow production Reviewer exits early enough for fallback and Scorer, and
-whether partial usage survives a real external timeout. The consumed
-2026-09-04 canary must not be rerun or reclassified.
+authorized paid canary is required after deployment to observe whether the
+runtime contract survives real provider execution. That canary is now frozen
+in [its pre-registration](prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md)
+with a new topic, one root, zero operator retry/resume/cancellation, a USD 0.10
+soft stop, and explicit outcome lanes. The protocol authorizes zero provider
+calls by itself. A normal completion cannot be used to claim that Reviewer
+fallback or external-timeout accounting was observed; either path remains
+`not_observed` unless it actually occurs. The consumed earlier 2026-09-04
+Decision Context canary must not be rerun or reclassified.
 
 An operating-system or host loss that bypasses both worker cleanup and the API
 watchdog can still leave no terminal record. Checkpoints remain the recovery

--- a/tests/fixtures/runtime_terminal_integrity_paid_canary_manifest.json
+++ b/tests/fixtures/runtime_terminal_integrity_paid_canary_manifest.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "experiment_id": "runtime-terminal-integrity-post-deployment-paid-canary-2026-09-04",
+  "implementation_baseline": "cca509ea7e1c122a044eb3d4d90debd46568d05b",
+  "topic_selection": {
+    "topic": "AI-assisted handheld ultrasound for heart-failure screening in rural clinics commercialization",
+    "selection_basis": "This previously unused, source-rich biomedical topic exercises academic, patent, market, authority-coverage, report, review, scoring, accounting, and terminal seams without deliberately inducing malformed input or a provider failure. It is a runtime canary, not an independent report-quality benchmark."
+  },
+  "cases": [
+    {
+      "case_id": "RTI01",
+      "expected_assessment_mode": "orientation",
+      "request": {
+        "topic": "AI-assisted handheld ultrasound for heart-failure screening in rural clinics commercialization"
+      },
+      "expected_gate": {
+        "status": "checked",
+        "mode": "orientation",
+        "provided_fields": [],
+        "missing_core_fields": [
+          "asset_description",
+          "target_application",
+          "decision_owner",
+          "decision_type"
+        ],
+        "go_no_go_allowed": false,
+        "threshold_provenance": {
+          "status": "not_established",
+          "criteria_supplied": false,
+          "owner_approval_declared": false
+        }
+      }
+    }
+  ],
+  "runtime_contract": {
+    "hard_timeout_seconds": 1800,
+    "request_timeout_seconds": 150,
+    "reviewer_reserve_seconds": 240,
+    "finalization_reserve_seconds": 60,
+    "terminal_schema_version": 1,
+    "terminal_states": [
+      "completed",
+      "failed",
+      "cancelled",
+      "timeout"
+    ],
+    "termination_methods": [
+      "worker_exit",
+      "terminate",
+      "kill",
+      "already_exited"
+    ],
+    "usage_accounting_states": [
+      "complete",
+      "lower_bound",
+      "unavailable"
+    ]
+  },
+  "primary_acceptance": {
+    "required_terminal_state": "completed",
+    "required_reason_code": "worker_completed",
+    "required_termination_method": "worker_exit",
+    "required_usage_accounting_state": "complete",
+    "required_runtime_budget_state": "active",
+    "required_artifacts": [
+      "terminal"
+    ],
+    "required_public_seams": [
+      "status",
+      "progress",
+      "browser"
+    ],
+    "nonpassing_terminal_states": [
+      "failed",
+      "cancelled",
+      "timeout"
+    ]
+  },
+  "outcome_lanes": {
+    "completed_reviewed": "The run completed with a non-fallback quality-review state; only the ordinary completion path was observed.",
+    "completed_reviewer_fallback": "The run completed with quality_review.status=fallback; the early Reviewer deadline and validated-Writer fallback path were observed.",
+    "failed": "The worker committed a failed terminal record; terminal observability may be assessed, but the paid canary does not pass.",
+    "timeout": "The API committed a hard-timeout terminal record; lower-bound or unavailable usage semantics may be assessed, but the paid canary does not pass.",
+    "cancelled": "The run was externally cancelled; this is protocol interruption and the paid canary does not pass.",
+    "not_inspectable": "A required artifact, response seam, revision identity, or accounting state could not be inspected; silence is not a pass."
+  },
+  "execution_bounds": {
+    "maximum_root_runs": 1,
+    "maximum_runs_per_case": 1,
+    "maximum_operator_retries": 0,
+    "maximum_resumes": 0,
+    "maximum_operator_cancellations": 0,
+    "maximum_planner_calls": 0,
+    "maximum_supplementary_search_calls": 0,
+    "soft_stop_usd_total": 0.1,
+    "allow_one_in_flight_overrun": true,
+    "poll_interval_seconds": 10,
+    "maximum_observation_seconds": 1900
+  }
+}

--- a/tests/test_runtime_terminal_integrity_paid_canary.py
+++ b/tests/test_runtime_terminal_integrity_paid_canary.py
@@ -1,0 +1,150 @@
+"""Frozen-input checks for the runtime-terminal-integrity paid canary.
+
+The suite must never execute this canary. A production root run spends owner
+funds and requires later authorization naming the merged and deployed revision.
+These checks bind the request, runtime policy, outcome semantics, privacy, and
+budget before that authorization can be used.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import get_args
+
+from api.models import RunRequest
+from api.runs import TIMEOUT_SECONDS, artifact_names
+from academic_agent.run_spec import DecisionContext
+from academic_agent.run_terminal import (
+    TerminalState,
+    TerminationMethod,
+    UsageAccountingState,
+)
+from academic_agent.runtime_budget import (
+    FINALIZATION_RESERVE_SECONDS,
+    REQUEST_TIMEOUT_SECONDS,
+    REVIEWER_RESERVE_SECONDS,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = (
+    ROOT / "tests/fixtures/runtime_terminal_integrity_paid_canary_manifest.json"
+)
+PREREG_PATH = (
+    ROOT / "docs/prereg-2026-09-04-runtime-terminal-integrity-paid-canary.md"
+)
+CONSUMED_CANARY_PATH = (
+    ROOT / "tests/fixtures/report_decision_seams_paid_canary_manifest.json"
+)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_freezes_one_new_orientation_root_request() -> None:
+    manifest = _manifest()
+    cases = manifest["cases"]
+    consumed = json.loads(CONSUMED_CANARY_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["schema_version"] == 1
+    assert [case["case_id"] for case in cases] == ["RTI01"]
+    assert cases[0]["request"]["topic"] == manifest["topic_selection"]["topic"]
+    # The failed RDS01 run is historical evidence, not a reusable paid fixture.
+    assert cases[0]["request"]["topic"] != consumed["topic_selection"]["topic"]
+
+
+def test_frozen_payload_reaches_the_real_request_and_gate_seams() -> None:
+    case = _manifest()["cases"][0]
+
+    # RunRequest is the paid POST boundary. Constructing only a topic string
+    # would miss an accidental BYOK field or an invalid future API payload.
+    request = RunRequest.model_validate(case["request"])
+    assert request.assessment_mode == case["expected_assessment_mode"]
+    assert request.decision_context is None
+    assert request.byok is False
+    assert request.model_dump(exclude_none=True) == case["request"]
+    assert DecisionContext().gate_snapshot() == case["expected_gate"]
+
+
+def test_frozen_runtime_contract_matches_the_production_policy() -> None:
+    contract = _manifest()["runtime_contract"]
+
+    assert contract["hard_timeout_seconds"] == TIMEOUT_SECONDS == 1800
+    assert contract["request_timeout_seconds"] == REQUEST_TIMEOUT_SECONDS == 150
+    assert contract["reviewer_reserve_seconds"] == REVIEWER_RESERVE_SECONDS == 240
+    assert (
+        contract["finalization_reserve_seconds"]
+        == FINALIZATION_RESERVE_SECONDS
+        == 60
+    )
+    assert contract["terminal_schema_version"] == 1
+    assert set(contract["terminal_states"]) == set(get_args(TerminalState))
+    assert set(contract["termination_methods"]) == set(get_args(TerminationMethod))
+    assert set(contract["usage_accounting_states"]) == set(
+        get_args(UsageAccountingState)
+    )
+
+
+def test_primary_gate_cannot_turn_a_partial_terminal_path_into_a_pass() -> None:
+    manifest = _manifest()
+    gate = manifest["primary_acceptance"]
+    lanes = manifest["outcome_lanes"]
+
+    assert gate["required_terminal_state"] == "completed"
+    assert gate["required_reason_code"] == "worker_completed"
+    assert gate["required_termination_method"] == "worker_exit"
+    assert gate["required_usage_accounting_state"] == "complete"
+    assert gate["required_runtime_budget_state"] == "active"
+    # Usage is a status/terminal field, not a separately registered download.
+    # Checking the real registry prevents a plausible-looking protocol from
+    # requesting an artifact that the production route can never deliver.
+    assert gate["required_artifacts"] == ["terminal"]
+    assert set(gate["required_artifacts"]) <= set(artifact_names())
+    assert set(gate["nonpassing_terminal_states"]) == {
+        "failed",
+        "cancelled",
+        "timeout",
+    }
+    assert set(lanes) == {
+        "completed_reviewed",
+        "completed_reviewer_fallback",
+        "failed",
+        "timeout",
+        "cancelled",
+        "not_inspectable",
+    }
+
+
+def test_manifest_contains_no_credentials_or_open_ended_paid_authority() -> None:
+    manifest = _manifest()
+    serialized = json.dumps(manifest, sort_keys=True).lower()
+    bounds = manifest["execution_bounds"]
+
+    for secret_field in (
+        "access_code",
+        "api_key",
+        "llm_api_key",
+        "serper_api_key",
+        "authorization",
+    ):
+        assert secret_field not in serialized
+    assert bounds["maximum_root_runs"] == len(manifest["cases"]) == 1
+    assert bounds["maximum_runs_per_case"] == 1
+    assert bounds["maximum_operator_retries"] == 0
+    assert bounds["maximum_resumes"] == 0
+    assert bounds["maximum_operator_cancellations"] == 0
+    assert bounds["maximum_planner_calls"] == 0
+    assert bounds["maximum_supplementary_search_calls"] == 0
+    assert 0 < bounds["soft_stop_usd_total"] <= 0.10
+    assert bounds["poll_interval_seconds"] >= 10
+    assert bounds["maximum_observation_seconds"] > TIMEOUT_SECONDS
+
+
+def test_preregistration_names_the_exact_committed_manifest_bytes() -> None:
+    digest = sha256(MANIFEST_PATH.read_bytes()).hexdigest()
+    preregistration = PREREG_PATH.read_text(encoding="utf-8")
+
+    assert f"**Manifest SHA-256:** `{digest}`" in preregistration


### PR DESCRIPTION
## Why

The runtime P0 is deployed and zero-network validated, but no fresh production run has yet shown that the deadline, cumulative usage, and immutable terminal contract survive the real Qwen path. This PR freezes that next observation before any paid request so the outcome cannot move the topic, budget, or pass criteria.

## What

- freeze one previously unused orientation topic and exact manifest digest
- bind the study to current timeout/reserve constants, terminal/accounting enums, and the real artifact registry
- cap execution at one root and USD 0.10 with no operator retry, recovery, cancellation, Planner call, or supplementary search
- separate ordinary completion, Reviewer fallback, timeout, failure, cancellation, and not-inspectable lanes
- sync README, AGENTS, and the runtime contract without authorizing any provider call

## Validation

- 2,049 tests and 674 subtests passed with zero network
- latest Ruff passed
- CI-matching narrow Pylint passed
- focused preregistration suite: 6 passed
- re-injected 1,800 -> 1,801 second drift made the runtime-policy seam fail before restoration

No paid provider request is authorized or executed by this PR.