### PR TITLE
Record RTI02 runtime terminal integrity canary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ src/academic_agent/     pipeline: crew, agents/tasks config, source retrieval,
 api/                    FastAPI: runs registry, papers, access gate, models
 web/                    vanilla JS client, no build step, strict CSP
 ui/                     shared i18n, run-reader, and PDF-export utilities
-tests/                  121 test modules plus conftest, organised by subject
+tests/                  122 test modules plus conftest, organised by subject
 e2e/browser_smoke.py    real Chromium access/input/report seam; blocks external
                         and mutating requests, so it cannot start paid work
 benchmark.py            paid batch runs; --fixtures replays frozen evidence
@@ -1135,19 +1135,34 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   commits schema-1 terminal bytes and asserts disk-to-API-to-DOM delivery; a
   dropped DOM assignment was re-injected and made that journey fail.
 
-  Because no RTI01 run existed, the same topic remains unconsumed. A new RTI02
-  protocol freezes one root, USD 0.10 soft stop, zero operator retries,
-  resumes, cancellations, Planner calls or supplementary searches, and
-  outcome-specific semantics that cannot promote timeout, unavailable, or
-  API-only presence to a pass. It authorizes zero provider calls and requires
-  fresh authorization naming the new merged deployment; the old authorization
-  cannot carry across changed code. This still does not establish production
-  success or exact interrupted-request billing. See
+  A separately authorized RTI02 root then completed on exact deployed revision
+  `522094a4330133c33aba2c3059bfd646be80b792`. Status, progress, the immutable
+  terminal record and real Chromium agreed on `completed`,
+  `worker_completed`, `worker_exit`, timestamps, 885 seconds and the
+  1,800-second timeout. Six exact `qwen3.5-plus` requests used 69,932 tokens
+  with a complete USD 0.067922 estimate; all seven checkpoints committed,
+  Reviewer passed, every observed cumulative usage counter was nondecreasing,
+  and the orientation gate remained non-binding. No retry, resume,
+  cancellation, Planner call or supplementary search occurred. The primary
+  gate passed 12/12.
+
+  Two of 88 read-only polling intervals were 9.984 seconds, 16 milliseconds
+  earlier than the frozen cadence. That observer-only deviation did not change
+  provider work, cost or any primary assertion, but the result retains the
+  qualifier rather than claiming perfect protocol conformance. RTI02 is
+  consumed and must not be rerun to erase it. This ordinary completion does
+  not validate Reviewer fallback, hard-timeout behavior, interrupted-request
+  billing, report accuracy or a latency SLO. It also exposed three separate
+  measurement candidates: stale absolute time promises, likely false-positive
+  proposed-threshold audit warnings, and clinical authority applicability.
+  Measure those on existing artifacts before changing code. See
   `docs/runtime-terminal-integrity.md`,
   `docs/results-2026-09-04-runtime-terminal-integrity-implementation.md`,
   `docs/results-2026-09-04-runtime-terminal-integrity-paid-canary-preflight.md`,
   and
-  `docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md`.
+  `docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md`,
+  plus
+  `docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md`.
 
   See
   `docs/prereg-2026-08-26-decision-context-report-contract.md`,

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Running on Railway — nothing to install. The gate offers two ways in:
 - **Access code** — runs on the deployment's own keys. Codes are handed out
   privately; without one, use the BYOK option above.
 
-A full run takes roughly 3 minutes and costs a few cents of LLM plus about 9
-search queries. The deployment therefore caps shared paid-operation concurrency
-and daily operator-funded admissions per code, including PDF extraction. See
+Run time is provider-bound rather than fixed. Two completed Qwen production
+canaries took 306 and 885 seconds; these are observations, not a latency SLO,
+while the 30-minute watchdog remains the hard availability boundary. A run
+costs a few cents of LLM usage plus about 9 search queries. The deployment
+therefore caps shared paid-operation concurrency and daily operator-funded
+admissions per code, including PDF extraction. See
 [Deploying publicly](#deploying-publicly) for the exact boundary.
 
 ---
@@ -812,13 +815,18 @@ reason plus raw reason/method inspection, and the real loopback Chromium job
 asserts the disk-to-API-to-DOM seam. See the
 [zero-request result](docs/results-2026-09-04-runtime-terminal-integrity-paid-canary-preflight.md).
 
-Because the topic was never submitted, a replacement RTI02 protocol preserves
-the same handheld-ultrasound request under a new identity. It keeps one-root,
-zero-retry/resume/cancellation/Planner/supplementary-search bounds and a USD
-0.10 soft stop. The protocol authorizes zero provider calls; execution still
-requires a fresh authorization naming the new merged and deployed revision.
-See the
-[post-browser-seam pre-registration](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md).
+A separately authorized RTI02 root then completed on exact deployed revision
+`522094a4330133c33aba2c3059bfd646be80b792`. Status, progress, the immutable
+terminal record, and real Chromium agreed on the normal completion reason and
+method. Six `qwen3.5-plus` requests used 69,932 tokens and a complete USD
+0.067922 estimate; all seven checkpoints committed and the primary gate passed
+12/12 with no retry, recovery, cancellation, Planner call, or supplementary
+search. Two of 88 read-only polling intervals were 16 milliseconds earlier than
+the frozen cadence, so the result retains that protocol qualifier and RTI02
+will not be rerun. This observes one ordinary completion, not Reviewer fallback
+or hard-timeout accounting. See the
+[pre-registration](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)
+and [paid result](docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md).
 
 The earlier completed Qwen provider canary observed live transport and
 accounting for one run, not general report quality or benchmark equivalence.
@@ -1727,7 +1735,7 @@ Each dimension records its supporting source IDs, shown on the scorecard and tra
 - **自带 API Key（BYOK）**——不需要访问口令。选择 LLM 供应商、填入自己的 LLM Key 与检索 Key 即可运行，费用记在自己账上。密钥只进入这一次运行的子进程环境变量：不落盘、不并入服务端自身环境、不会被同时运行的其他任务看到，关闭标签页即清除
 - **访问口令**——用部署方自己的 Key 运行。口令私下提供；没有口令请用上面的 BYOK 入口
 
-一次运行约 3 分钟，消耗几美分的 LLM 额度加约 9 次检索，因此部署方设有并发上限和每个口令的每日次数上限。两个入口的具体机制见下方「访问控制」。
+运行耗时取决于上游供应商，并非固定 3 分钟。两次已完成的 Qwen 生产 canary 分别耗时 306 秒和 885 秒；它们只是观测值，不是延迟 SLO，30 分钟 watchdog 才是硬性可用性边界。单次运行消耗几美分的 LLM 额度加约 9 次检索，因此部署方设有并发上限和每个口令的每日次数上限。两个入口的具体机制见下方「访问控制」。
 
 ---
 
@@ -2333,12 +2341,16 @@ P0 修复会在每个节点后持久化单调用量，预留 Reviewer/finalizati
 终止方式；真实 loopback Chromium 测试覆盖从磁盘经 FastAPI 到 DOM 的完整接缝。
 详见[零请求结果](docs/results-2026-09-04-runtime-terminal-integrity-paid-canary-preflight.md)。
 
-由于该主题从未提交，新的 RTI02 协议仍使用同一手持超声主题，但拥有新的冻结
-身份。它继续限制为一个根运行、0 次重试/恢复/取消/Planner/补充搜索与 0.10 美元
-软停止线。协议本身不授权任何调用；必须在新版本合并部署后，由用户重新授权精确
-SHA 才能执行。详见
-[运行时契约](docs/runtime-terminal-integrity.md)与
-[修复后预注册](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)。
+随后一次单独授权的 RTI02 根运行在精确部署版本
+`522094a4330133c33aba2c3059bfd646be80b792` 上完成。状态、进度、不可变终态记录与
+真实 Chromium 对正常完成原因及终止方式完全一致；6 次 `qwen3.5-plus` 请求使用
+69,932 tokens，完整成本估算为 0.067922 美元，7 个检查点全部提交，主验收门
+12/12 通过，且没有重试、恢复、取消、Planner 或补充搜索。88 个只读轮询间隔中有
+2 个比冻结节奏早 16 毫秒，因此结果保留该协议限定且不会重跑 RTI02。它只验证
+一次普通完成路径，不验证 Reviewer fallback 或硬超时计费。详见
+[运行时契约](docs/runtime-terminal-integrity.md)、
+[修复后预注册](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)与
+[付费结果](docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)。
 
 此外，生产隔离的 v5 Evidence Judge 已实现严格的 Qwen 单请求原始 HTTP
 Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 W01 第一遍，

--- a/api/main.py
+++ b/api/main.py
@@ -487,7 +487,8 @@ def health_ready(response: Response) -> ReadinessStatus:
 def submit_run(request: RunRequest, http_request: Request) -> RunAccepted:
     """Queue an assessment. Returns immediately with a run_id to poll.
 
-    A full run takes roughly 2.5–4 minutes. Authorized either by the
+    Run time is provider-bound and may take several minutes; the 30-minute
+    watchdog is the hard availability boundary. Authorized either by the
     X-Access-Code header (billed to the deployment) or by supplying
     llm_provider/llm_api_key/serper_api_key in the body (billed to the
     caller) — not gated by the middleware because that choice needs the

--- a/docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md
+++ b/docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md
@@ -1,0 +1,136 @@
+# Runtime terminal integrity post-browser-seam paid canary result
+
+Date: 2026-09-04
+
+- **Execution revision:** `522094a4330133c33aba2c3059bfd646be80b792`
+- **Railway deployment:** `6259902301`, successful before admission
+- **CI:** 8/8 required checks passed on the execution revision
+- **Frozen manifest SHA-256:**
+  `3293fe6abc95f1a2da113136e152a15ae1d27db432f0efe27ee9e776dc5fde37`
+- **Case:** `RTI02`
+- **Run ID:** `20260904T074754Z-737dc6af90498c395a3ff2ac942c1cf8`
+- **Outcome lane:** `completed_reviewed`
+- **Primary acceptance:** **PASS, 12/12**
+- **Protocol conformance:** qualified by a minor read-only observer-cadence
+  deviation described below
+
+## Admission and execution bounds
+
+The admission preflight completed before the only paid POST. The local checkout
+and Railway deployment matched the authorized revision. The committed manifest
+reproduced its frozen digest; readiness returned HTTP 200 with `llm`, `search`,
+`outputs`, and `paid_accounting` all `ok`; both OpenAPI response schemas exposed
+the five runtime fields; and the deployed HTML and JavaScript contained the
+terminal reason/method DOM seam. The selected operator code passed without its
+value entering a URL, manifest, observation artifact, or result document.
+
+Pre-run owner history contained 10 runs, zero with the frozen topic. Shared
+capacity reported zero active runs and zero active paid operations out of five.
+The POST created one root. Post-run history contained 11 runs and exactly one
+matching topic. No child, operator retry, resume, cancellation, Planner call, or
+supplementary search occurred.
+
+## Observed path
+
+The first observations of each public stage were:
+
+| Seconds after admission | State | Stage | Cumulative cost state |
+|---:|---|---|---|
+| 10 | running | status accepted | unavailable |
+| 20 | running | Source Collection & Validation | unavailable |
+| 80 | running | Evidence Collection | unavailable |
+| 310 | running | Report Writing | USD 0.016776 lower bound |
+| 530 | running | Quality Review & Citation Check | USD 0.040317 lower bound |
+| 690 | running | Commercialization Scoring | USD 0.053175 lower bound |
+| 890 | completed | Done | USD 0.067922 complete |
+
+The immutable record reports 885 seconds from worker start to finish. The
+submission-to-terminal interval was 885.581212 seconds, only 0.581212 seconds
+different from the recorded monotonic elapsed value.
+
+## Primary acceptance result
+
+| # | Frozen criterion | Result | Observed evidence |
+|---:|---|---|---|
+| 1 | One root, no child, exact revision | PASS | One new history row; no `resumed_from`; status and progress both report `git:522094a...` |
+| 2 | Normal immutable completion | PASS | Schema 1, `completed`, `worker_completed`, `worker_exit`; both timestamps are timezone-aware |
+| 3 | Runtime budget survives both APIs | PASS | `active`; 1800 / 150 / 240 / 60-second policy agrees field-for-field |
+| 4 | Artifact/status/progress terminal agreement | PASS | State, reason, method, timestamp instants, elapsed, last stage and timeout agree |
+| 5 | Wall and monotonic elapsed agree | PASS | Difference 0.581212 seconds, below the frozen 30-second maximum |
+| 6 | Complete final usage | PASS | `complete`, `run_complete=true`, no possible in-flight spend; usage agrees across all three seams |
+| 7 | Cumulative counters never decrease | PASS | 89 snapshots; 51 status and 51 progress counters checked with zero regressions |
+| 8 | Cost remains within authorization | PASS | USD 0.067922, below USD 0.10 |
+| 9 | Provider/model and pricing identity | PASS | Six requests and 69,932 tokens; all six roles are exactly `qwen3.5-plus`; pricing is complete with no unpriced model |
+| 10 | No Tool Calling mutation | PASS | `planner_state=not_run`, zero proposed/executed calls, USD 0.00 added search cost, `evidence_changed=false` |
+| 11 | Browser receives the real terminal truth | PASS | Real Chromium showed `COMPLETED · worker completed`; tooltip preserved `worker_completed` and `worker_exit` |
+| 12 | Orientation remains non-binding | PASS | No supplied fields, no owner-approved threshold, and `go_no_go_allowed=false` on status and progress |
+
+The real-browser inspection allowed only same-origin GET requests. It observed
+20 GETs, zero mutating methods, and zero blocked attempts. This is DOM evidence,
+not an inference from shipped source text.
+
+## Usage, persistence, and review
+
+The final six model requests used 69,932 tokens and a conservative USD 0.067922
+estimate. `usage.cost_complete=true`, `unpriced_models=[]`, and the price basis
+is the built-in Qwen3.5 Plus peak tier dated 2026-08-30. Intermediate accounting
+correctly remained a lower bound; only the final snapshot became complete.
+
+Checkpointing finished `complete` with retrieval, academic, patent, market,
+Writer, Reviewer, and Scorer committed and no persistence errors. Recovery was
+`not_requested`. The independent quality-review projection was `passed` with
+zero unapplied corrections. Retrieval retained 3 academic, 8 patent, and 5
+market sources with no failed domain and no incomplete evidence artifact.
+
+## Observer protocol deviation
+
+The observer intended a fixed ten-second cadence. Of 88 repeated intervals,
+86 were at least 10.000 seconds when measured at dispatch and two were 9.984
+seconds. The maximum early dispatch was therefore 16 milliseconds. This arose
+because the loop scheduled against absolute ten-second boundaries: ordinary
+timer jitter in one cycle can be followed by a slightly shorter interval in
+the next.
+
+This did not create another root, provider call, search call, mutation, or
+cost, and it cannot change any of the 12 primary terminal assertions. It is
+still a literal deviation from the frozen instruction to poll no more often
+than every ten seconds. The result is therefore reported as
+`completed_reviewed / primary PASS with minor observer-protocol deviation`, not
+as perfectly conformant. A future observer must sleep ten seconds after each
+completed status/progress pair rather than target absolute clock boundaries.
+RTI02 is consumed and must not be rerun to erase this note.
+
+## Secondary observations outside the primary question
+
+Three observations are retained without turning this terminal canary into a
+quality or latency benchmark:
+
+1. The 885-second completion is much slower than the README and API's old
+   roughly-three-minute wording. Together with the earlier 306-second Qwen
+   completion, it proves provider-bound variability but does not establish a
+   percentile or SLO. Absolute public time promises should be removed.
+2. The advisory report audit emitted six
+   `decision_threshold_has_no_local_authority_qualifier` warnings even though
+   the report labels each pass item `Proposed Pass Threshold` and immediately
+   precedes the section with a global statement that every threshold is an
+   analyst proposal requiring owner confirmation. This is a precision-study
+   candidate, not evidence for blocking or a reason to edit the heuristic
+   before measuring the existing 30 reports.
+3. Claim grounding checked one quantitative academic claim with zero
+   mismatches and marked three market claims unverifiable. Authority coverage
+   returned `not_applicable` for a clinical-screening topic. That classification
+   is a separate applicability hypothesis requiring offline measurement; this
+   run alone does not justify changing the detector.
+
+## What this establishes — and what it does not
+
+This run establishes one ordinary Qwen completion's terminal, deadline,
+accounting, checkpoint, decision-gate, API, and browser delivery seams on the
+named deployment. It also establishes that the production shadow planner made
+zero calls and did not mutate evidence for this run.
+
+It does not establish a latency SLO, report accuracy, source truth, clinical
+validity, repeated-run stability, Reviewer fallback, hard-timeout behavior,
+cancel behavior, missing/unreadable-terminal behavior, interrupted-request
+billing, or production Tool Calling value. Those unobserved branches remain
+unobserved; offline tests cannot promote them to live evidence.

--- a/docs/runtime-terminal-integrity.md
+++ b/docs/runtime-terminal-integrity.md
@@ -103,7 +103,7 @@ Scorer has completed. The unchanged Writer draft is delivered with an explicit
 own guardrail and earlier deadline. A Writer failure or Scorer failure still
 fails the run.
 
-## Remaining boundary
+## Production observation and remaining boundary
 
 The first separately authorized canary never crossed admission. Its preflight
 confirmed the deployed revision, readiness, API schemas, accounting branches,
@@ -112,20 +112,34 @@ reason or method. It stopped before the paid POST with zero roots, zero
 provider/search requests, and USD 0.00 observed cost. See the
 [zero-request preflight result](results-2026-09-04-runtime-terminal-integrity-paid-canary-preflight.md).
 
-The browser seam is now implemented and covered by both shipped-JavaScript
-tests and a real loopback Chromium journey whose on-disk fixture contains a
-valid immutable terminal record. The original topic remains unconsumed because
-no run existed. A replacement study is frozen in the
+The browser seam is covered by both shipped-JavaScript tests and a real loopback
+Chromium journey whose on-disk fixture contains a valid immutable terminal
+record. A replacement study was frozen in the
 [post-browser-seam pre-registration](prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)
-under a new RTI02 identity, one root, zero operator
-retry/resume/cancellation, a USD 0.10 soft stop, and explicit outcome lanes.
-The protocol authorizes zero provider calls by itself and the earlier
-authorization cannot carry across changed code.
+under a new RTI02 identity.
 
-Until a fresh authorization names the new merged and deployed revision,
-production behavior remains unobserved. A normal completion still cannot
-validate Reviewer fallback or external-timeout accounting; either path remains
-`not_observed` unless it actually occurs. The consumed earlier 2026-09-04
+One separately authorized root then completed on exact deployed revision
+`522094a4330133c33aba2c3059bfd646be80b792`. The schema-1 terminal record,
+status, progress, and real browser agreed on `completed`,
+`worker_completed`, `worker_exit`, timezone-aware timestamps, 885 seconds,
+and the 1,800-second timeout. Six `qwen3.5-plus` requests used 69,932 tokens
+with a complete USD 0.067922 estimate. All seven checkpoints committed,
+Reviewer passed, every observed cumulative counter was nondecreasing, and the
+orientation gate remained non-binding. The browser visibly rendered
+`worker completed` and preserved the raw reason and method in its tooltip.
+The primary gate passed 12/12. See the
+[paid result](results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md).
+
+The observer also records a minor protocol deviation rather than hiding it:
+two of 88 read-only polling intervals were 9.984 seconds, 16 milliseconds
+earlier than the frozen ten-second minimum. It did not change provider work,
+cost, or any primary assertion. RTI02 is consumed and must not be rerun to
+erase that qualifier.
+
+This normal completion still cannot validate Reviewer fallback or external-
+timeout accounting; either path remains `not_observed` unless it actually
+occurs. It establishes no latency SLO: this run took 885 seconds while an
+earlier Qwen completion took 306 seconds. The consumed earlier 2026-09-04
 Decision Context canary must not be rerun or reclassified.
 
 An operating-system or host loss that bypasses both worker cleanup and the API


### PR DESCRIPTION
## Why

RTI02 is the first separately authorized ordinary production completion after the runtime-terminal and browser-seam fixes. Its evidence should travel with the implementation, including the observer qualifier and the branches that remain unobserved.

## What

- records the exact Railway revision, manifest identity, one-root run, terminal/API/browser agreement, usage, cost, checkpoints, and 12/12 primary result
- preserves two 9.984-second read-only polling intervals as a minor protocol deviation and marks RTI02 consumed
- replaces the fixed three-minute public promise with provider-bound language after observed 306-second and 885-second Qwen completions
- updates the runtime contract and project decision index without claiming fallback, timeout, report-quality, or production Tool Calling validation

## Validation

- `uv run pytest -q --basetemp outputs/pytest-rti02-final-20260904T0900`
  - 2,062 passed
  - 678 subtests passed
- `uv run --with ruff ruff check .`
  - all checks passed

No access code is stored in the branch.