### PR TITLE
Narrow decision-threshold warnings to actionable report gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 2062 tests (678 subtests), CI green on Linux + Windows × Python
+Current state: 2066 tests (678 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -1098,6 +1098,24 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   reinjection caught both a dropped applicability block and a swallowed source-
   scope mismatch. This remains advisory and does not change scoring, block a
   report, or connect production Tool Calling.
+
+  RTI02 later exposed a precision defect in the threshold half of that audit:
+  six labelled gates were warned even though the same Markdown section had
+  explicitly declared every following threshold to be an analyst proposal
+  requiring owner confirmation. A zero-network replay measured the shipped
+  rule on 110 preserved reports before changing it: eight candidate lines
+  produced seven warnings, and internal context coding classified all seven as
+  false positives. The frozen 30-report benchmark contributed no candidate, so
+  there is no precision denominator and no 100% claim. Candidate detection now
+  requires either label punctuation or the explicit `threshold(s) must be met`
+  sentence form, while a forward proposal declaration applies only within its
+  current Markdown section. The same corpus now retains six qualified RTI02
+  candidates and emits zero warnings; the known unqualified fixture remains
+  detectable. Both the broad noun-phrase matcher and a missing heading reset
+  were re-injected and made their seam tests fail. This remains a diagnostic
+  removal of known false positives, not evidence of unseen precision or recall.
+  See `docs/prereg-2026-09-04-decision-threshold-warning-precision.md` and
+  `docs/results-2026-09-04-decision-threshold-warning-precision.md`.
 
   A separately pre-registered one-root post-fix paid canary froze the earlier
   sulfide-electrolyte topic with a complete synthetic Decision Context and

--- a/README.md
+++ b/README.md
@@ -828,6 +828,20 @@ or hard-timeout accounting. See the
 [pre-registration](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)
 and [paid result](docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md).
 
+RTI02 also exposed six false-positive threshold-provenance warnings: the audit
+matched each labelled gate but did not understand the same section's explicit
+statement that all following thresholds were analyst proposals requiring owner
+confirmation. Before changing code, the shipped rule was replayed over 110
+preserved reports: eight candidate lines produced seven warnings, all seven
+were internally coded as false positives, and the 30-report benchmark had no
+candidate denominator. The precision-first fix now requires label punctuation
+or the explicit `threshold(s) must be met` form and bounds a forward proposal
+declaration to its Markdown section. The same corpus retains six qualified
+RTI02 candidates and emits zero warnings; this removes the observed false
+positives but is not reported as a measured precision or recall rate. See the
+[pre-registration](docs/prereg-2026-09-04-decision-threshold-warning-precision.md)
+and [zero-network result](docs/results-2026-09-04-decision-threshold-warning-precision.md).
+
 The earlier completed Qwen provider canary observed live transport and
 accounting for one run, not general report quality or benchmark equivalence.
 It exposed two internal-x10 score phrases that reached report prose; the
@@ -1126,7 +1140,7 @@ disconnected. See the
 the [boundary result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md),
 and the [final human-review result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md).
 
-Local verification now passes **2,062 tests plus 678 subtests**, latest Ruff,
+Local verification now passes **2,066 tests plus 678 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2352,6 +2366,16 @@ P0 修复会在每个节点后持久化单调用量，预留 Reviewer/finalizati
 [修复后预注册](docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)与
 [付费结果](docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md)。
 
+RTI02 还暴露出 6 条决策阈值来源告警误报：审计能识别各条门槛标签，却没有理解
+同一 Markdown 章节已明确声明后续全部阈值均为分析者提案，仍需决策所有者确认。
+改代码前先对磁盘上 110 份保留报告回放原规则：8 条候选产生 7 条告警，内部逐条
+上下文编码认为 7 条均为误报；30 份冻结基准没有候选，因此不存在可发布的精度
+分母。精度优先修复现在只接受带标签冒号或明确 `threshold(s) must be met` 句式的
+候选，并把前向提案声明严格限制在当前 Markdown 章节。相同语料仍保留 RTI02 的
+6 条合格候选且不再告警。这证明已知误报被消除，不代表已测得未知样本上的精度或
+召回率。详见[预注册](docs/prereg-2026-09-04-decision-threshold-warning-precision.md)
+和[零网络结果](docs/results-2026-09-04-decision-threshold-warning-precision.md)。
+
 此外，生产隔离的 v5 Evidence Judge 已实现严格的 Qwen 单请求原始 HTTP
 Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 W01 第一遍，
 逆序第二遍超过冻结的 60 秒超时后无重试停止。聚合成本仍不可检查，0 个案例和
@@ -2560,7 +2584,7 @@ cohort，在保留输出目录或构造网络适配器前锁定原始 fixture、
 [人评预注册](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md)与
 [边界实现结果](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md)。
 
-本地验证现通过 **2,062 项测试与 678 个 subtests**、最新版 Ruff、CI 同款窄范围
+本地验证现通过 **2,066 项测试与 678 个 subtests**、最新版 Ruff、CI 同款窄范围
 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/prereg-2026-09-04-decision-threshold-warning-precision.md
+++ b/docs/prereg-2026-09-04-decision-threshold-warning-precision.md
@@ -1,0 +1,91 @@
+# Pre-registration: decision-threshold warning precision
+
+Date: 2026-09-04
+
+## Question
+
+Can the advisory report audit stop treating source facts and explicitly scoped
+analyst proposals as unqualified decision thresholds without weakening the
+known unqualified-threshold detection?
+
+This is a zero-network precision study over artifacts already on disk. It does
+not authorize a provider request, a search request, a production run, or a
+change to report scoring or blocking behavior.
+
+## Frozen pre-change measurement
+
+The exact narrow vocabulary currently shipped was applied before any code
+change to 110 report files:
+
+- 30 frozen benchmark reports;
+- 79 timestamped historical reports at the local output root; and
+- the separately preserved RTI02 production report.
+
+The 30-report benchmark contained zero candidate lines, so it supplies no
+precision denominator. Across all 110 reports, eight candidate lines appeared
+in two reports. One candidate was already qualified and seven produced
+warnings.
+
+Manual report-context inspection classified all seven warnings as false
+positives:
+
+1. One historical comparison table described the USMLE pass threshold as a
+   source fact. The phrase was not a decision-gate label and was followed by a
+   semicolon rather than a label colon.
+2. RTI02 contained six labelled pass/stop criteria. The same Markdown section
+   explicitly stated before the list that all thresholds below were analyst
+   proposals requiring confirmation by the eventual decision owner. Each gate
+   also repeated analyst provenance after its criteria.
+
+This coding was performed internally by an AI assistant and was not an
+independent human or expert review. The corpus was not held out: RTI02 motivated
+the measurement. The observed 0/7 warning precision is therefore a diagnostic,
+not a production-rate estimate.
+
+## Narrow implementation hypothesis
+
+Two restrictions should remove the observed false positives while preserving
+the known defect:
+
+1. A bare `pass threshold`, `evidence threshold`, `decision threshold`, `kill
+   criteria`, or `stop criteria` phrase is a candidate only when it is rendered
+   as a Markdown/plain-text label followed by a colon. The already explicit
+   sentence form `threshold(s) must be met` remains a candidate without a
+   colon.
+2. A forward-scoped declaration may qualify later candidates only when one line
+   explicitly says that all thresholds below or in the section are proposals,
+   require confirmation, or carry another existing authority qualifier. The
+   declaration expires at the next Markdown heading. A generic disclaimer or a
+   qualifier in an earlier section cannot qualify later text.
+
+The second rule deliberately does not use a fixed line window. A list may be
+long, while Markdown section boundaries provide a stricter semantic boundary
+than arbitrary distance. It also does not treat the machine-readable decision
+gate alone as proof that model prose is safe.
+
+## Falsification and acceptance criteria
+
+The change is rejected or narrowed further if any of the following occurs:
+
+- any frozen benchmark report gains a warning;
+- any of the seven observed false-positive warnings remains;
+- the known unqualified Qwen `Pass Threshold:` line stops producing a warning;
+- a scoped declaration qualifies a candidate after a new Markdown heading;
+- an ordinary source-fact phrase without a label colon remains a candidate;
+- unavailable/non-English states become clean passes;
+- the audit becomes blocking or changes report text, scoring, evidence, Tool
+  Calling, or provider behavior.
+
+The post-change result must report the zero candidate denominator in the
+30-report baseline separately from the broader 110-report diagnostic. Zero
+warnings must not be described as measured perfect precision.
+
+## Verification plan
+
+- Add focused tests for source-fact exclusion, scoped qualification, heading
+  expiry, and preservation of the known unqualified warning.
+- Re-inject both defects: remove label-shape filtering and allow scoped state to
+  cross a heading. The new tests must fail before the correct implementation is
+  restored.
+- Replay the 110 on-disk reports with zero network access.
+- Run the complete zero-network suite, latest Ruff, and narrow Pylint `E0701`.

--- a/docs/results-2026-09-04-decision-threshold-warning-precision.md
+++ b/docs/results-2026-09-04-decision-threshold-warning-precision.md
@@ -1,0 +1,103 @@
+# Result: decision-threshold warning precision
+
+Date: 2026-09-04
+
+## Outcome
+
+The precision-first narrowing is implemented and passes its pre-registered
+zero-network acceptance criteria. It removes the seven observed false-positive
+warnings while preserving the known unqualified Qwen threshold finding and the
+explicit `threshold(s) must be met` sentence form.
+
+This is an advisory detector improvement. It does not change report prose,
+guardrail blocking, scoring, evidence, provider calls, Tool Calling, or run
+admission.
+
+## Pre-change measurement
+
+The exact shipped rule was replayed against 110 report files already on disk:
+
+| Corpus | Reports | Candidate lines | Warnings |
+|---|---:|---:|---:|
+| Frozen benchmark | 30 | 0 | 0 |
+| Timestamped historical output root | 79 | 1 | 1 |
+| RTI02 preserved production report | 1 | 7 | 6 |
+| **Total** | **110** | **8** | **7** |
+
+The benchmark has no candidate and therefore no precision denominator. Manual
+context inspection classified all seven warnings as false positives. The one
+historical warning described an external USMLE pass threshold in a comparison
+table, not a commercialization gate. RTI02's six warnings were pass/stop labels
+inside a section that had already declared all following thresholds to be
+analyst proposals requiring owner confirmation.
+
+The eighth candidate was RTI02's code-derived narrative statement that any
+additional decision threshold is an analyst proposal. The old rule already
+treated that line as qualified, so it did not warn.
+
+The coding was performed internally by an AI assistant. It was not an
+independent human/expert review, and RTI02 was not held out because it motivated
+the study. The pre-change `0/7` is a diagnostic on this corpus, not a production
+precision estimate.
+
+## Implemented boundary
+
+The detector now separates two actionable shapes from source-fact noun phrases:
+
+- `pass threshold`, `evidence threshold`, `decision threshold`, `kill criteria`,
+  and `stop criteria` require label punctuation, accepting both common Markdown
+  emphasis placements around the colon;
+- `threshold(s) must be met` remains actionable without a colon and is checked
+  before the shorter regex alternatives can consume it.
+
+A forward declaration qualifies later candidates only when it explicitly
+scopes all thresholds below or in the section and contains an existing authority
+qualifier. The state resets at every Markdown heading. A generic disclaimer,
+machine-readable gate state, or declaration in another section cannot suppress
+a warning.
+
+## Post-change replay
+
+The same 110 files produced:
+
+| Corpus | Reports | Candidate lines | Warnings |
+|---|---:|---:|---:|
+| Frozen benchmark | 30 | 0 | 0 |
+| Timestamped historical output root | 79 | 0 | 0 |
+| RTI02 preserved production report | 1 | 6 | 0 |
+| **Total** | **110** | **6** | **0** |
+
+The USMLE source fact and RTI02's code-derived narrative line are no longer
+candidates. RTI02's six labelled criteria remain candidates but are correctly
+qualified by their same-section declaration. Zero warnings is not reported as
+perfect precision because the post-change corpus contains no positive warning
+denominator.
+
+## Defect reinjection
+
+Both protocol-required defects were reintroduced independently:
+
+1. Replacing label-shape detection with the old broad noun-phrase search made
+   `test_source_fact_pass_threshold_without_label_colon_is_not_a_candidate`
+   fail: the USMLE source fact changed from `not_applicable` to `completed`.
+2. Removing the Markdown-heading reset made
+   `test_section_scope_expires_before_a_later_markdown_heading` fail: an
+   unqualified investment threshold in a later section was incorrectly cleared.
+
+The correct implementation was restored, and all 11 focused report-audit tests
+passed. The complete zero-network suite then passed 2,066 tests plus 678
+subtests in 62.94 seconds. Latest Ruff reported `All checks passed!`, and the
+CI-matching narrow Pylint gate for exception ordering, unreachable code,
+used-before-assignment and undefined variables completed cleanly. No browser,
+provider, search or model call was required because no API or DOM seam changed.
+
+## Interpretation limits
+
+This result establishes that two observed false-positive classes no longer
+warn on the measured files and that the known synthetic/production-derived
+defect fixture remains detectable. It does not establish precision, recall,
+source truth, report accuracy, user value, or behavior on unseen model prose.
+
+A future natural positive warning should be reviewed rather than assumed
+correct. A new held-out corpus with eligible independent labels is required
+before publishing a precision rate or making this advisory check blocking.

--- a/src/academic_agent/report_audit.py
+++ b/src/academic_agent/report_audit.py
@@ -32,15 +32,31 @@ _DECISION_THRESHOLD = re.compile(
     r"|\b(?:kill|stop)\s+criteria\b",
     re.IGNORECASE,
 )
+# A decision-gate noun phrase is ambiguous without label punctuation: for
+# example, a comparison table can describe an examination's "pass threshold"
+# as a source fact.  The explicit "must be met" sentence remains actionable on
+# its own; every shorter noun phrase must be shaped like a report label.  Both
+# common Markdown placements of the closing emphasis marker are accepted.
+_THRESHOLD_LABEL_SUFFIX = re.compile(r"^(?:[*_]{1,2})?\s*:\s*(?:[*_]{1,2})?")
+_EXPLICIT_THRESHOLD_REQUIREMENT = re.compile(
+    r"\bthresholds?\s+must\s+be\s+met\b",
+    re.IGNORECASE,
+)
 _THRESHOLD_QUALIFIER = re.compile(
     r"\b(?:owner[- ]approved|approved by (?:the )?(?:owner|user)|"
     r"user[- ]supplied|supplied (?:success )?criteri(?:on|a)|"
-    r"analyst (?:proposal|proposed|inference)|proposed by (?:the )?analyst|"
-    r"illustrative|requires? (?:owner )?confirmation|to be confirmed|"
+    r"analyst (?:proposals?|proposed|inference)|proposed by (?:the )?analyst|"
+    r"illustrative|requir(?:es?|ing) (?:owner )?confirmation|to be confirmed|"
     r"pending (?:owner )?approval|external benchmark|source benchmark|"
     r"evidence benchmark|not established)\b",
     re.IGNORECASE,
 )
+_SCOPED_THRESHOLD_DECLARATION = re.compile(
+    r"\ball\s+(?:the\s+)?(?:(?:pass|evidence|decision)\s+)?"
+    r"thresholds?\s+(?:listed\s+)?(?:below|in\s+(?:this|the)\s+section)\b",
+    re.IGNORECASE,
+)
+_MARKDOWN_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+")
 
 # These are intentionally electrolyte-specific rather than a generic material
 # ontology.  Generic "oxide" and "polymer" comparisons cross too many domains
@@ -91,6 +107,17 @@ def _source_registry(collection: "SourceCollection") -> dict[str, EvidenceSource
     return {source.source_id: source for source in sources}
 
 
+def _is_decision_threshold_candidate(line: str) -> bool:
+    """Require actionable grammar instead of a source-fact noun phrase."""
+
+    if _EXPLICIT_THRESHOLD_REQUIREMENT.search(line):
+        return True
+    for match in _DECISION_THRESHOLD.finditer(line):
+        if _THRESHOLD_LABEL_SUFFIX.match(line[match.end():]):
+            return True
+    return False
+
+
 def _audit_thresholds(
     report: str,
     *,
@@ -110,15 +137,30 @@ def _audit_thresholds(
     candidates = 0
     findings: list[dict[str, Any]] = []
     lines = report.splitlines()
+    section_declares_proposal_scope = False
     for index, line in enumerate(lines):
-        if not _DECISION_THRESHOLD.search(line):
+        # A forward declaration is allowed to cover a long gate list, but only
+        # when it explicitly scopes *all* thresholds below.  Resetting at every
+        # heading prevents a generic caveat from laundering later sections.
+        if _MARKDOWN_HEADING.match(line):
+            section_declares_proposal_scope = False
+        if (
+            _SCOPED_THRESHOLD_DECLARATION.search(line)
+            and _THRESHOLD_QUALIFIER.search(line)
+        ):
+            section_declares_proposal_scope = True
+
+        if not _is_decision_threshold_candidate(line):
             continue
         candidates += 1
         # A label may be immediately preceded by a qualifier heading. Looking
         # farther away would let an unrelated disclaimer qualify the whole
         # report, recreating the ambiguity this check is intended to expose.
         local_context = " ".join(lines[max(0, index - 1): index + 1])
-        if _THRESHOLD_QUALIFIER.search(local_context):
+        if (
+            section_declares_proposal_scope
+            or _THRESHOLD_QUALIFIER.search(local_context)
+        ):
             continue
         cited_ids, _errors = parse_citation_ids(line)
         findings.append(

--- a/tests/test_report_audit.py
+++ b/tests/test_report_audit.py
@@ -112,6 +112,90 @@ def test_broad_minimum_language_is_not_reclassified_as_a_decision_threshold() ->
     assert result["decision_thresholds"]["unqualified"] == 0
 
 
+def test_source_fact_pass_threshold_without_label_colon_is_not_a_candidate() -> None:
+    """A factual USMLE comparison exposed the old noun-phrase false positive."""
+
+    result = audit_report(
+        "# Report\n\n"
+        "| Provider | Evidence |\n"
+        "| OpenAI | USMLE pass threshold; broad clinical knowledge [A1] |",
+        collection=_collection(_source("A1", "oxide")),
+        decision_gate=_gate(),
+        output_language="English",
+    )
+
+    thresholds = result["decision_thresholds"]
+    assert thresholds["status"] == "not_applicable"
+    assert thresholds["candidate_lines"] == 0
+    assert thresholds["unqualified"] == 0
+
+
+def test_markdown_label_and_explicit_requirement_remain_candidates() -> None:
+    """Precision narrowing must preserve both actionable threshold forms."""
+
+    result = audit_report(
+        "# Report\n\n"
+        "**Pass Threshold**: reproduce the result independently.\n"
+        "The evidence thresholds must be met before proceeding.",
+        collection=_collection(),
+        decision_gate=_gate(),
+        output_language="English",
+    )
+
+    thresholds = result["decision_thresholds"]
+    assert thresholds["status"] == "completed"
+    assert thresholds["candidate_lines"] == 2
+    assert thresholds["unqualified"] == 2
+
+
+def test_explicit_section_scope_qualifies_all_following_gate_labels() -> None:
+    """RTI02's bounded declaration must reach every gate in its section."""
+
+    result = audit_report(
+        "# Report\n\n"
+        "## Commercialization plan\n"
+        "All thresholds listed below are analyst proposals requiring confirmation "
+        "by the eventual decision owner.\n\n"
+        "1. **Gate one**\n"
+        "   * **Proposed Pass Threshold:** complete two field pilots.\n"
+        "   * **Stop/Kill Criteria:** stop when both pilots fail.\n\n"
+        "2. **Gate two**\n"
+        "   * **Proposed Pass Threshold:** secure one payer agreement.\n"
+        "   * **Stop/Kill Criteria:** stop when reimbursement is unavailable.",
+        collection=_collection(),
+        decision_gate=_gate(),
+        output_language="English",
+    )
+
+    thresholds = result["decision_thresholds"]
+    assert thresholds["status"] == "completed"
+    assert thresholds["candidate_lines"] == 4
+    assert thresholds["unqualified"] == 0
+
+
+def test_section_scope_expires_before_a_later_markdown_heading() -> None:
+    """A proposal note must never qualify a decision label in another section."""
+
+    result = audit_report(
+        "# Report\n\n"
+        "## Proposed experiments\n"
+        "All thresholds below are analyst proposals requiring confirmation.\n"
+        "**Pass Threshold:** reproduce the result.\n\n"
+        "## Investment decision\n"
+        "**Pass Threshold:** approve the investment.",
+        collection=_collection(),
+        decision_gate=_gate(),
+        output_language="English",
+    )
+
+    thresholds = result["decision_thresholds"]
+    assert thresholds["candidate_lines"] == 2
+    assert thresholds["unqualified"] == 1
+    assert thresholds["findings"][0]["excerpt"] == (
+        "**Pass Threshold:** approve the investment."
+    )
+
+
 def test_one_matching_citation_prevents_a_mixed_source_false_positive() -> None:
     result = audit_report(
         "# Report\n\nThe sulfide electrolyte layer remains the target [A1, A2].",


### PR DESCRIPTION
## Summary

- pre-register and replay the shipped decision-threshold audit over 110 preserved reports before implementation
- require actionable label punctuation or the explicit threshold-must-be-met sentence form
- honor an explicit analyst-proposal declaration only within its current Markdown section
- document that the seven observed warnings were internally coded false positives while the frozen benchmark has no precision denominator

## Evidence

- pre-change: 110 reports, 8 candidate lines, 7 warnings
- post-change: 110 reports, 6 qualified candidate lines, 0 warnings
- focused report-audit tests: 11 passed
- complete zero-network suite: 2,066 passed plus 678 subtests
- latest Ruff: passed
- CI-matching narrow Pylint gate: passed
- broad-matcher and missing-heading-reset defects were independently re-injected and each made its seam test fail

## Boundaries

This removes two observed false-positive classes. It is not a measured precision or recall result because the post-change corpus has no positive warning denominator and the coding was not an independent expert review. The audit remains non-blocking. No report prose, scoring, evidence, provider, Tool Calling, API, browser, or paid-run behavior changes.
