### PR TITLE
Fix handheld ultrasound authority applicability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ from one codebase: a FastAPI + vanilla-JS web client and a CLI.
 
 Live at https://academic-commercialization-agent.up.railway.app
 
-Current state: 2066 tests (678 subtests), CI green on Linux + Windows × Python
+Current state: 2071 tests (678 subtests), CI green on Linux + Windows × Python
 3.11/3.12, deployed on Railway.
 
 ## Commands
@@ -1181,6 +1181,16 @@ reuse separately. See `docs/checkpoint-recovery.md` before changing this seam.
   `docs/prereg-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md`,
   plus
   `docs/results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md`.
+
+  The clinical-authority candidate was subsequently replayed over 110 preserved
+  reports before a precision-first correction. The exact `handheld ultrasound`
+  phrase changes only RTI02 from `industrial / not_applicable` to
+  `biomedical / regulatory`; all 30 frozen benchmark reports and the other 79
+  reports remain unchanged, and a generic industrial-ultrasound negative stays
+  nonclinical. Removing either the profile marker or the regulator marker makes
+  all three classification, coverage and serialized shadow-gate seam tests
+  fail. This is an in-sample correction, not a general classifier. See
+  `docs/results-2026-09-04-handheld-ultrasound-authority-applicability.md`.
 
   See
   `docs/prereg-2026-08-26-decision-context-report-contract.md`,

--- a/README.md
+++ b/README.md
@@ -842,6 +842,17 @@ positives but is not reported as a measured precision or recall rate. See the
 [pre-registration](docs/prereg-2026-09-04-decision-threshold-warning-precision.md)
 and [zero-network result](docs/results-2026-09-04-decision-threshold-warning-precision.md).
 
+RTI02's clinical-authority applicability observation has now been measured
+against 110 preserved reports representing 73 unique normalized topics. The
+precision-first correction recognizes only the exact `handheld ultrasound`
+product phrase, requires regulator evidence without inventing a trial-registry
+duty, and changes exactly RTI02; all 30 frozen benchmark reports and the other
+79 reports remain unchanged. An industrial-ultrasound negative control remains
+nonclinical, while a missing regulator now reaches the enabled Tool Calling
+shadow gate as `eligible` with zero executed calls. This is an in-sample
+correction, not a general medical-device classifier or held-out accuracy result.
+See the [zero-network result](docs/results-2026-09-04-handheld-ultrasound-authority-applicability.md).
+
 The earlier completed Qwen provider canary observed live transport and
 accounting for one run, not general report quality or benchmark equivalence.
 It exposed two internal-x10 score phrases that reached report prose; the
@@ -1140,7 +1151,7 @@ disconnected. See the
 the [boundary result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md),
 and the [final human-review result](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md).
 
-Local verification now passes **2,066 tests plus 678 subtests**, latest Ruff,
+Local verification now passes **2,071 tests plus 678 subtests**, latest Ruff,
 the narrow CI Pylint gate, and the zero-provider-call Chromium smoke journey.
 
 ### Quick start
@@ -2376,6 +2387,14 @@ RTI02 还暴露出 6 条决策阈值来源告警误报：审计能识别各条�
 召回率。详见[预注册](docs/prereg-2026-09-04-decision-threshold-warning-precision.md)
 和[零网络结果](docs/results-2026-09-04-decision-threshold-warning-precision.md)。
 
+RTI02 暴露的临床监管适用性问题现已在 110 份保留报告、73 个唯一标准化主题上完成
+零网络测量。精度优先修复只识别完整产品短语 `handheld ultrasound`，要求监管机构
+证据但不虚构普遍的临床试验注册义务；110 份报告中只有 RTI02 改变，30 份冻结基准及
+其余 79 份报告均不变。工业超声负例仍保持非临床；缺少监管来源时，现有 Tool Calling
+Shadow Gate 会以 `eligible` 明确呈现该缺口，同时执行调用数仍为 0。这是已观察
+短语的样本内修正，不是通用医疗器械分类器或未见集准确率结论。详见
+[零网络结果](docs/results-2026-09-04-handheld-ultrasound-authority-applicability.md)。
+
 此外，生产隔离的 v5 Evidence Judge 已实现严格的 Qwen 单请求原始 HTTP
 Profile。首次获授权的 schema 3 运行在合并版本 `d9adfa4` 上完成 W01 第一遍，
 逆序第二遍超过冻结的 60 秒超时后无重试停止。聚合成本仍不可检查，0 个案例和
@@ -2584,7 +2603,7 @@ cohort，在保留输出目录或构造网络适配器前锁定原始 fixture、
 [人评预注册](docs/prereg-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review.md)与
 [边界实现结果](docs/results-2026-09-03-openalex-adaptive-role-gap-v8-ad-human-review-boundary.md)。
 
-本地验证现通过 **2,066 项测试与 678 个 subtests**、最新版 Ruff、CI 同款窄范围
+本地验证现通过 **2,071 项测试与 678 个 subtests**、最新版 Ruff、CI 同款窄范围
 Pylint，以及零供应商调用的 Chromium 冒烟用户旅程。
 
 ### 快速开始

--- a/docs/results-2026-09-04-handheld-ultrasound-authority-applicability.md
+++ b/docs/results-2026-09-04-handheld-ultrasound-authority-applicability.md
@@ -1,0 +1,142 @@
+# Handheld-ultrasound authority applicability
+
+- **Date:** 2026-09-04
+- **Status:** implemented and zero-network validated
+- **Production search/tool effect:** none executed by this study
+
+## Origin
+
+The separately authorized RTI02 runtime canary completed successfully, but its
+report audit classified this topic as outside the clinical-authority scope:
+
+> AI-assisted handheld ultrasound for heart-failure screening in rural clinics
+> commercialization
+
+The resulting authority-coverage state was `not_applicable`, even though the
+report treated the product as a diagnostic medical device and discussed
+FDA-cleared competitors. This was a deterministic applicability error, separate
+from RTI02's runtime-integrity question and from source truth.
+
+The corpus census and acceptance criteria below were completed before editing
+the detector in this working branch. Because the plan and implementation enter
+Git history together, this document is not an independently timestamped
+pre-registration or a held-out evaluation.
+
+## Before-change measurement
+
+The existing detector was replayed over 110 preserved completed reports:
+
+- 30 reports under `outputs/benchmark/`;
+- 79 timestamped production or development outputs; and
+- the separately named RTI02 output.
+
+Those reports represented 73 unique normalized topics. Before the change the
+weight-profile counts were:
+
+| Profile | Reports |
+|---|---:|
+| material_science | 54 |
+| biomedical | 31 |
+| industrial | 14 |
+| software_ai | 7 |
+| clean_tech | 4 |
+
+Twenty-two reports required at least one clinical-authority category. RTI02 was
+the only preserved report containing either `handheld ultrasound` or
+`ultrasound`.
+
+Broader candidate markers were rejected before implementation:
+
+- `clinical` occurred in seven reports across five unique topics and would
+  newly require authority evidence for six reports;
+- `screening` occurred in three reports across three unique topics and would
+  newly require authority evidence for one report; and
+- bare `ultrasound` is not product-specific: it also describes industrial
+  inspection, cleaning, extraction, and processing.
+
+Those phrases therefore had a higher false-positive surface than the exact
+product phrase observed in RTI02.
+
+## Narrow rule
+
+The exact phrase `handheld ultrasound` now:
+
+1. selects the biomedical scoring/search profile;
+2. requires official regulator evidence; and
+3. does **not** invent a universal clinical-trial-registry requirement.
+
+This mirrors the earlier precision-first handling of `blood pressure monitor`.
+It does not change the scoring formula, the evidence-confidence floor, or any
+blocking guardrail. Evidence-gap Tool Calling remains in zero-call shadow mode;
+the change only makes a missing regulator category visible to that existing
+gate.
+
+## Acceptance criteria and result
+
+The change had to satisfy all of these conditions:
+
+| Criterion | Result |
+|---|---|
+| RTI02 becomes biomedical | pass |
+| RTI02 requires regulator evidence only | pass |
+| RTI02 missing-regulator state reaches the shadow gate as `eligible` | pass |
+| Shadow execution remains zero calls | pass |
+| All 30 frozen benchmark reports remain unchanged | pass |
+| Every other preserved report remains unchanged | pass |
+| Generic industrial ultrasound remains nonclinical | pass |
+
+After the change the profile counts are 54 material-science, 32 biomedical, 13
+industrial, seven software/AI, and four clean-tech reports. Twenty-three reports
+require at least one authority category. Exactly one of 110 reports changed:
+
+`industrial + no requirements -> biomedical + regulatory`
+
+The negative control, `ultrasound-assisted heavy metal recovery for industrial
+wastewater`, remains `industrial` with no clinical-authority requirement.
+
+The focused source-pipeline and evidence-gap suite passed 82 tests plus 40
+subtests.
+
+The first full-suite run also exposed 11 failures in the v6 failure-diagnostic
+test module. Its synthetic fixture generated a mock run from current code and
+already rebound that run's source-file hashes and execution observations, but
+still compared its manifest against the real historical v6 implementation
+identity. Changing any shared dependency therefore broke an otherwise unrelated
+synthetic review test. The fixture now binds the exact implementation map
+persisted by its synthetic manifest, while a separate assertion keeps the real
+v6 constants unchanged. The focused diagnostic module passes 15/15. Removing
+only the fixture binding reproduces the original
+`v6 implementation identity drifted` rejection. This is test-fixture
+decoupling; the historical production-disconnected experiment identity was not
+rewritten or accepted under a second hash.
+
+## Defect re-injection
+
+Two separate defects were re-injected after the passing test:
+
+1. Removing the biomedical product marker made all three profile/query,
+   authority-coverage, and shadow-boundary tests fail. The topic reverted to
+   `industrial` and authority coverage reverted to `not_applicable`.
+2. Restoring the biomedical marker but removing only the regulator marker also
+   made all three tests fail. The profile remained `biomedical`, while the
+   serialized shadow gate changed from `eligible` to `no_gap`.
+
+This second failure matters because it proves the tests cover the delivery
+seam, not merely an internal classification field.
+
+Final local verification passed 2,071 zero-network tests plus 678 subtests,
+latest Ruff, and the CI-matching narrow Pylint gate. No provider, search, or
+model request was made.
+
+## Limits
+
+This is a correction for one observed product phrase, not a general medical
+device classifier. The 110-report replay is an in-sample safety census, not an
+independent precision or recall estimate. It does not establish regulator
+source quality, report correctness, Tool Calling value, or production search
+success. New product classes should be measured against preserved topics before
+adding another marker; broad words such as `clinical`, `screening`, or
+`ultrasound` must not be promoted from this result.
+
+The originating runtime observation remains documented in
+[the RTI02 result](results-2026-09-04-runtime-terminal-integrity-post-browser-seam-paid-canary.md).

--- a/src/academic_agent/source_pipeline.py
+++ b/src/academic_agent/source_pipeline.py
@@ -44,6 +44,9 @@ _BIOMEDICAL_MARKERS: tuple[str, ...] = (
     "diagnostic", "implant", "surgical", "gene editing", "cell therapy",
     "gene therapy", "medical device", "antibody", "in vitro", "in vivo",
     "oncology", "cancer treatment", "immunotherapy", "blood pressure",
+    # Keep the full product phrase: bare "ultrasound" also describes industrial
+    # cleaning, inspection, extraction, and processing methods.
+    "handheld ultrasound",
     # Bioprocess / cellular agriculture — manufacturing maturity is the key gate
     "cultivated meat", "cultured meat", "cell-based meat", "cellular agriculture",
     "tissue engineering", "stem cell", "bioprocessing", "bioreactor scale",
@@ -60,11 +63,11 @@ _REGULATED_BIOMEDICAL_MARKERS: tuple[str, ...] = (
     "surgical", "cell therapy", "gene therapy", "medical device",
     "cancer treatment", "immunotherapy", "genetic disease",
     "drug candidate", "drug treatment", "patient treatment",
-    # The phrase is intentionally narrower than "clinical" or "monitoring".
-    # A production canary showed that a cuffless blood-pressure product reached
-    # an industrial score profile and skipped regulator retrieval, while either
-    # generic term would also catch non-product workflow and factory topics.
-    "blood pressure monitor",
+    # These phrases are intentionally narrower than "clinical", "monitoring",
+    # or "ultrasound". Production canaries showed that regulated products
+    # reached an industrial score profile and skipped regulator retrieval, while
+    # the generic terms also catch non-product workflow and factory topics.
+    "blood pressure monitor", "handheld ultrasound",
 )
 _CLINICAL_REGISTRY_MARKERS: tuple[str, ...] = (
     "therapy", "vaccine", "clinical trial", "cell therapy", "gene therapy",

--- a/tests/test_evidence_gap.py
+++ b/tests/test_evidence_gap.py
@@ -169,6 +169,35 @@ class GapGateTests(unittest.TestCase):
         )
         self.assertEqual(audit.executed_call_count, 0)
 
+    def test_handheld_ultrasound_reaches_enabled_shadow_boundary(self):
+        """The authority fix must reach the serialized Tool Calling gate context."""
+        topic = "AI-assisted handheld ultrasound for heart-failure screening"
+        profile = _detect_weight_profile(topic)
+        collection = _collection(topic=topic, profile=profile)
+        collection.authority_coverage = _measure_authority_coverage(
+            topic,
+            profile,
+            [
+                *collection.academic_sources,
+                *collection.patent_sources,
+                *collection.market_sources,
+            ],
+        )
+
+        audit = run_shadow_assessment(
+            collection,
+            configuration=parse_shadow_configuration("true"),
+        )
+
+        self.assertEqual(profile, "biomedical")
+        self.assertEqual(audit.gate_state, "eligible")
+        self.assertTrue(audit.checked)
+        self.assertEqual(
+            [(signal.code, signal.subject) for signal in audit.context.signals],
+            [("authority_category_missing", "regulatory")],
+        )
+        self.assertEqual(audit.executed_call_count, 0)
+
     def test_only_explicitly_incomplete_components_trigger(self):
         for status in ("partial", "unchecked"):
             collection = _collection(

--- a/tests/test_openalex_role_slot_failure_review.py
+++ b/tests/test_openalex_role_slot_failure_review.py
@@ -156,6 +156,7 @@ class _ModelAdapter:
 @pytest.fixture(scope="module")
 def _frozen_source(tmp_path_factory):  # noqa: ANN001, ANN202
     output = tmp_path_factory.mktemp("v6-review-source") / "result"
+    implementation_hashes = _implementation_hashes()
     provider = _ProviderAdapter()
     model = _ModelAdapter()
     execution = development.execute_development_study(
@@ -164,7 +165,7 @@ def _frozen_source(tmp_path_factory):  # noqa: ANN001, ANN202
         model_soft_stop_usd=0.021,
         acknowledge_anonymous_daily_budget=True,
         acknowledge_model_budget=True,
-        expected_implementation_sha256=_implementation_hashes(),
+        expected_implementation_sha256=implementation_hashes,
         provider_adapter_factory=lambda: provider,
         model_adapter_factory=lambda: model,
     )
@@ -182,12 +183,12 @@ def _frozen_source(tmp_path_factory):  # noqa: ANN001, ANN202
         field: getattr(execution, field)
         for field in diagnostic.EXPECTED_EXECUTION_OBSERVATIONS
     }
-    return output, source_hashes, observations
+    return output, source_hashes, observations, implementation_hashes
 
 
 @pytest.fixture
 def source(tmp_path, monkeypatch, _frozen_source):  # noqa: ANN001, ANN202
-    frozen, source_hashes, observations = _frozen_source
+    frozen, source_hashes, observations, implementation_hashes = _frozen_source
     copied = tmp_path / "source"
     shutil.copytree(frozen, copied)
     monkeypatch.setattr(
@@ -200,7 +201,24 @@ def source(tmp_path, monkeypatch, _frozen_source):  # noqa: ANN001, ANN202
         "EXPECTED_EXECUTION_OBSERVATIONS",
         observations,
     )
+    # The production diagnostic must keep the exact historical v6 hash map.
+    # This fixture instead creates a synthetic run from today's code, so its
+    # source lock must use the identity that the synthetic manifest persisted.
+    # Source hashes and observations above already follow the same boundary.
+    monkeypatch.setattr(
+        diagnostic,
+        "EXPECTED_IMPLEMENTATION_SHA256",
+        implementation_hashes,
+    )
     return copied
+
+
+def test_historical_implementation_identity_remains_frozen():
+    """Synthetic fixture adaptation must not rewrite the real v6 identity."""
+    assert (
+        diagnostic.EXPECTED_IMPLEMENTATION_SHA256
+        == development.EXPECTED_IMPLEMENTATION_SHA256
+    )
 
 
 def _lock(source: Path, tmp_path: Path) -> Path:

--- a/tests/test_source_pipeline.py
+++ b/tests/test_source_pipeline.py
@@ -1092,6 +1092,27 @@ class AuthorityQueryPlanningTests(TestCase):
         self.assertIn("site:ema.europa.eu", market[1])
         self.assertFalse(any("clinicaltrials.gov" in query for query in market))
 
+    def test_handheld_ultrasound_queries_regulators_but_not_trial_registry(self):
+        """A diagnostic device needs regulator evidence without assuming a trial."""
+        from academic_agent.source_pipeline import _queries
+
+        topic = "AI-assisted handheld ultrasound for heart-failure screening"
+        market = _queries(topic, weight_profile=_detect_weight_profile(topic))["market"]
+        self.assertIn("site:fda.gov", market[0])
+        self.assertIn("site:ema.europa.eu", market[1])
+        self.assertFalse(any("clinicaltrials.gov" in query for query in market))
+
+    def test_generic_ultrasound_processing_remains_nonclinical(self):
+        """Bare ultrasound must not pull industrial processes into medical search."""
+        from academic_agent.source_pipeline import _queries
+
+        topic = "ultrasound-assisted heavy metal recovery for industrial wastewater"
+        profile = _detect_weight_profile(topic)
+        market = _queries(topic, weight_profile=profile)["market"]
+        self.assertEqual(profile, "industrial")
+        self.assertFalse(any("fda.gov" in query for query in market))
+        self.assertFalse(any("clinicaltrials.gov" in query for query in market))
+
     def test_nonclinical_biomedical_methods_do_not_require_clinical_authorities(self):
         from academic_agent.source_pipeline import _queries
 
@@ -1231,6 +1252,20 @@ class AuthorityCoverageTests(TestCase):
         from academic_agent.source_pipeline import _measure_authority_coverage
 
         topic = "Wearable continuous blood pressure monitoring via photoplethysmography"
+        coverage = _measure_authority_coverage(
+            topic,
+            _detect_weight_profile(topic),
+            [],
+        )
+        self.assertEqual(coverage.status, "incomplete")
+        self.assertEqual(coverage.required_categories, ["regulatory"])
+        self.assertEqual(coverage.missing_categories, ["regulatory"])
+
+    def test_handheld_ultrasound_without_official_record_is_incomplete(self):
+        """The live diagnostic-device miss must not remain not-applicable."""
+        from academic_agent.source_pipeline import _measure_authority_coverage
+
+        topic = "AI-assisted handheld ultrasound for heart-failure screening"
         coverage = _measure_authority_coverage(
             topic,
             _detect_weight_profile(topic),


### PR DESCRIPTION
## Summary

- classify the exact handheld ultrasound product phrase as biomedical
- require regulator evidence without inventing a universal trial-registry duty
- cover query planning, authority coverage, and the serialized Tool Calling shadow seam
- decouple a synthetic v6 review fixture from the immutable historical experiment hash
- document the 110-report replay, rejected broad markers, reinjections, and limitations

## Why

RTI02 completed at the runtime boundary but exposed a deterministic false negative: a medical screening device was classified as industrial, authority coverage became not_applicable, and the evidence-gap gate could not see the missing regulator category. The exact phrase is intentionally narrower than clinical, screening, or ultrasound.

## Validation

- 2,071 zero-network tests passed
- 678 subtests passed
- latest Ruff passed
- CI-matching narrow Pylint passed
- 110 preserved reports replayed; only RTI02 changed and all 30 frozen benchmark reports remained unchanged
- both the profile-marker and regulator-marker defects were independently re-injected and made the seam tests fail
- removing the synthetic v6 identity binding reproduced the implementation-drift failure

No provider, search, model, or paid request was made.