### PR TITLE
Isolate nested audit read faults without hiding completed reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,10 @@ restart Railway, invoke a paid canary or publish private run links.
 3. Metadata reads: the core status/progress/history/browser fault seam now
    distinguishes absent and unreadable records; see the
    [fault verification](docs/results-2026-09-05-runtime-metadata-integrity.md).
-   Nested legacy audit schemas are not comprehensively validated. Unused
-   auxiliary readers still have defaults; this is not a main-pipeline outage.
+   Nine display-facing audit-summary fields have field-local isolation; see
+   the [nested contract and limits](docs/results-2026-09-05-nested-audit-metadata-integrity.md).
+   Other nested payloads, detailed audit artifacts and unused auxiliary readers
+   are not comprehensively validated; this is not a main-pipeline outage.
 4. Input distribution: language/shape admission is tested, but the 30-run
    benchmark does not validate Chinese, very short or non-technical requests.
 5. Scale and long-term operations: one replica, no distributed ownership or

--- a/api/audit_projection.py
+++ b/api/audit_projection.py
@@ -1,0 +1,117 @@
+"""Validate display-facing audit summaries without rewriting paid artifacts.
+
+The writer's current schemas are deliberately NOT the read contract: historical
+runs have count-only grounding/consistency summaries and optional newer fields.
+Validate the values the reliability panel consumes, not every experimental or
+producer-only field. This is shape validation, not citation truth validation.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+
+def _count(value: Any) -> bool:
+    # bool is an int in Python; accepting it would certify a corrupt counter.
+    return type(value) is int and value >= 0
+
+
+def _strings(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _one_of(*choices: str) -> Callable[[Any], bool]:
+    return lambda value: isinstance(value, str) and value in choices
+
+
+def _fields(value: dict, checks: dict[str, Callable[[Any], bool]], required=()) -> bool:
+    return all(key in value for key in required) and all(
+        check(value[key]) for key, check in checks.items() if key in value
+    )
+
+
+def _summary(field: str, value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    state = value.get("status")
+    if field == "source_counts":
+        return bool(value) and all(_count(count) for count in value.values())
+    if field == "consistency":
+        return _fields(value, {
+            "blockers": _count, "warnings": _count,
+            "status": _one_of("completed"),
+        }, required=("blockers",))
+    if field == "quality_review":
+        return _fields(value, {
+            "status": _one_of("passed", "partial", "fallback", "unavailable"),
+            "unapplied_corrections": _count,
+        }, required=("status", "unapplied_corrections") if state == "partial" else ("status",))
+    if field == "claim_grounding":
+        # Legacy summaries have no status but do have the three counters.
+        # A recorded failure legitimately lacks counters; do not manufacture
+        # zero measurements to make it fit a successful-screen schema.
+        required = () if state in ("failed", "unavailable", "not_applicable") else (
+            "checked", "ungrounded", "unverifiable",
+        )
+        if state == "partial":
+            required += ("unavailable_domains",)
+        return _fields(value, {
+            "status": _one_of("completed", "partial", "failed", "unavailable", "not_applicable"),
+            "checked": _count, "ungrounded": _count, "unverifiable": _count,
+            "unavailable_domains": _strings,
+        }, required=required)
+    if field == "report_audit":
+        return _fields(value, {
+            "status": _one_of("completed", "partial", "failed", "unavailable", "not_applicable"),
+            "findings": _count, "citation_scope_checked": _count,
+            "citation_scope_unverifiable": _count,
+        }, required=("status",) if state in ("failed", "unavailable", "not_applicable")
+           else ("status", "findings"))
+    if field == "authority_coverage":
+        return _fields(value, {
+            "status": _one_of("complete", "incomplete", "not_applicable"),
+            "missing_categories": _strings, "required_categories": _strings,
+        }, required=("status", "missing_categories") if state == "incomplete" else ("status",))
+    if field == "component_coverage":
+        required = ("status",)
+        if state == "incomplete":
+            required += ("missing_components",)
+        if state in ("partial", "unchecked"):
+            required += ("unchecked_components",)
+        return _fields(value, {
+            "status": _one_of("complete", "incomplete", "partial", "unchecked", "not_applicable"),
+            "missing_components": _strings, "unchecked_components": _strings,
+        }, required=required)
+    return False
+
+
+_SUMMARY_FIELDS = (
+    "consistency", "quality_review", "claim_grounding", "report_audit",
+    "authority_coverage", "component_coverage", "source_counts",
+)
+
+
+def project_audit_metadata(status: dict) -> tuple[dict, list[str]]:
+    """Return an isolated view and code-owned fault names for both HTTP readers.
+
+    None/absence retains historical semantics. A present malformed summary is
+    replaced only in this view and named explicitly: null alone would hide the
+    read fault as an old run, while rejecting the whole status would erase valid
+    neighbors and terminal/usage facts. Never expose exception text or malformed
+    values in the diagnostic, and never persist this derived view to disk.
+    """
+    projected = dict(status)
+    unreadable = []
+    for field in (*_SUMMARY_FIELDS, "failed_domains", "evidence_incomplete"):
+        value = status.get(field)
+        if value is None:
+            continue
+        if field == "failed_domains":
+            valid = _strings(value)
+        elif field == "evidence_incomplete":
+            valid = type(value) is bool
+        else:
+            valid = _summary(field, value)
+        if not valid:
+            unreadable.append(field)
+            projected[field] = {"failed_domains": [], "evidence_incomplete": False}.get(field)
+    return projected, unreadable

--- a/api/main.py
+++ b/api/main.py
@@ -805,6 +805,7 @@ def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgres
         run_id=run_id,
         state=state["state"],
         status_record_state=state.get("status_record_state"),
+        audit_metadata_unreadable=state.get("audit_metadata_unreadable", []),
         stage=state.get("stage", ""),
         topic=state.get("topic", ""),
         pipeline_revision=state.get("pipeline_revision"),

--- a/api/models.py
+++ b/api/models.py
@@ -161,6 +161,11 @@ class RunProgress(BaseModel):
     run_id: str
     state: RunState
     status_record_state: Literal["absent", "readable", "unreadable"] | None = None
+    audit_metadata_unreadable: list[str] = Field(
+        default_factory=list,
+        description="Code-owned field names whose audit summary could not be read. "
+                    "Their null/default projection is not a passing check.",
+    )
     stage: str = ""
     # Carried here so a client that opens a run from a list has a title on
     # the first response rather than a placeholder until it guesses one.
@@ -302,6 +307,11 @@ class RunStatus(BaseModel):
     # A valid immutable terminal can coexist with an unreadable live status.
     # Surface that loss even when the stronger outcome still says completed.
     status_record_state: Literal["absent", "readable", "unreadable"] | None = None
+    audit_metadata_unreadable: list[str] = Field(
+        default_factory=list,
+        description="Code-owned field names whose audit summary could not be read. "
+                    "Their null/default projection is not a passing check.",
+    )
     stage: str = ""
     topic: str = ""
     pipeline_revision: str | None = Field(

--- a/api/runs.py
+++ b/api/runs.py
@@ -43,6 +43,7 @@ from academic_agent.run_terminal import (
     commit_terminal_record,
     load_terminal_record,
 )
+from api.audit_projection import project_audit_metadata
 
 # A run is killed after this long. The bound belongs to the worker contract,
 # not to whichever client submitted or polls the run.
@@ -1309,6 +1310,7 @@ def get_state(run_id: str) -> dict:
         # Report what is known rather than guessing. "unknown" is a state a
         # client can retry; "failed" is one it reports to the user.
         status, status_record_state = {}, "unreadable"
+    status, audit_metadata_unreadable = project_audit_metadata(status)
     terminal_record, terminal_projection = _read_terminal(run_dir)
     handle = _registry.get(run_id)
 
@@ -1387,6 +1389,7 @@ def get_state(run_id: str) -> dict:
         "run_id": run_id,
         "state": state,
         "status_record_state": status_record_state,
+        "audit_metadata_unreadable": audit_metadata_unreadable,
         "stage": status.get("stage") or (terminal_record.last_stage if terminal_record else ""),
         "topic": status.get("topic") or (handle.topic if handle else ""),
         "output_language": status.get("output_language") or "English",

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -95,8 +95,10 @@ remain unchanged. Browse the [full experiment index](experiment-index.md).
 
 1. The core metadata read fault path is now hardened through both HTTP endpoints,
    history and Chromium; see the [measured scope and limits](results-2026-09-05-runtime-metadata-integrity.md).
-   Further work should reproduce a specific nested metadata failure first,
-   not rewrite unused legacy helpers or claim every schema is validated.
+   Nine reliability-summary fields now have field-local read isolation and
+   explicit unreadable rows; see the [nested fault verification](results-2026-09-05-nested-audit-metadata-integrity.md).
+   Other nested payloads and detailed audit artifacts remain outside that
+   contract. Reproduce their actual client failure before proposing changes.
 2. New decision-utility research should target the already observed low trust
    and actionability, use a new protocol and disclose external-source checks.
    Do not append new reviewers to completed panels or claim estimated

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -164,6 +164,7 @@ to reuse consumed cohorts.
 
 ## Runtime maintenance verification
 
+- [2026 09 05 nested audit metadata integrity](results-2026-09-05-nested-audit-metadata-integrity.md)
 - [2026 09 05 runtime metadata integrity](results-2026-09-05-runtime-metadata-integrity.md)
 
 ## Errata

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -135,6 +135,13 @@ unpriced, rather than showing an unknown model as free. Operators may set
 this is an estimate, not an invoice. See
 [runtime terminal integrity](runtime-terminal-integrity.md).
 
+The status/progress read projection isolates malformed reliability summaries
+through `audit_metadata_unreadable`: the affected panel row says it cannot be
+read, while a valid committed outcome and saved report remain available.
+Absent historical fields remain distinct from a corrupt summary. This does
+not rewrite artifacts or validate every nested schema; see the
+[exact read contract](results-2026-09-05-nested-audit-metadata-integrity.md).
+
 ## Deploying publicly
 
 Configure access control **before** exposing provider-funded POST routes.

--- a/docs/results-2026-09-05-nested-audit-metadata-integrity.md
+++ b/docs/results-2026-09-05-nested-audit-metadata-integrity.md
@@ -1,0 +1,73 @@
+# Nested audit metadata integrity — 2026-09-05
+
+## Scope and observation
+
+This is a zero-provider read-path repair based on `27082a7`, not a new paid
+canary or evidence of an ongoing Railway incident. The pre-change full suite
+passed with **2096 tests and 1102 subtests**.
+
+Before editing, a read-only census found 109 direct historical run directories:
+67 readable status files and 42 absent ones. The 30 benchmark directories have
+no status files. The new projection was then replayed over those 67 records:
+55 non-null fields in the selected contract, **zero rejected fields and zero
+changed records**. Most newer checks are absent from this historical sample;
+this is compatibility evidence, not comprehensive coverage or an outage rate.
+
+## Reproduced failures and repair
+
+The previous root-file repair did not validate nested summaries. A scalar
+`failed_domains` could raise before either HTTP response; scalar audit objects
+could fail response-model validation. Dictionary-shaped faults could reach
+JavaScript, where a string `unavailable_domains` broke `.join()` before the
+report loaded. An empty consistency object instead became a false clean row.
+
+`api/audit_projection.py` validates the display-facing parts of nine fields:
+consistency, reviewer quality, quantitative grounding, report audit, authority
+coverage, component coverage, source counts, failed domains and evidence-trail
+completeness. It checks literal states, required decision-making counters and
+list element types without coercing strings or booleans into measurements.
+Legacy count-only summaries remain accepted; recorded failure/unavailability
+need not pretend to contain successful-screen counters.
+
+The read projection replaces only a malformed field and carries code-owned
+names in `audit_metadata_unreadable` through **both status and progress**.
+The browser displays that row as unreadable, not passed or historically absent.
+Separate valid findings remain visible, including a known failed domain when
+source counts in the same row are damaged. A committed terminal, usage facts,
+the report and healthy history neighbors remain available. No original status
+bytes, detailed audit artifacts, reports or terminal records are rewritten.
+
+## Verification
+
+- 42 malformed-field HTTP cases, nine valid/absent compatibility cases and
+  four JavaScript tests were added. Both response models, report access and
+  unchanged on-disk bytes are asserted; the existing key-set contract also
+  guards against adding a field to only one endpoint.
+- The Chromium loopback journey now includes a fourth run with six damaged
+  audit summaries beside a valid completed terminal, report and reviewer
+  result. All six affected rows must explain the read fault while the report
+  remains visible. Browser/network guards observed zero provider requests,
+  zero mutation attempts and zero unexpected console/page errors.
+- Re-injecting the original raw passthrough made all **42 fault cases fail**.
+  Separately removing the progress field made real Chromium fail because
+  unreadable consistency was mislabelled as an English-language exclusion.
+  Both defects were restored and the browser passed again.
+- Final local verification: **2151 tests and 1118 subtests passed**, latest
+  Ruff and the project's narrow Pylint passed. Documentation link checks can
+  change subtest counts independently of runtime coverage. No assertion was
+  weakened and no skip was added. CI is verified separately on the pushed SHA.
+
+## Boundaries retained
+
+This is not a universal schema validator. Unconsumed nested fields, detailed
+audit-tab JSON, decision applicability, usage/recovery payload shapes and
+auxiliary readers need their own concrete failure reproduction before changes.
+It does not establish citation entailment, full source coverage, model quality,
+recovery success, distributed ownership or a production SLO. Missing and null
+remain historical absence; present invalid selected summaries are explicit
+read faults. The API diagnostic is a derived view, not a worker audit result.
+
+Scoring, Guardrail policy, frozen experiments and dependency versions are
+unchanged. Production Tool Calling remains zero-call shadow mode; v8's failed
+unseen result remains binding. A merge and production deployment need their
+separate authorization; no paid rerun is needed to test this read boundary.

--- a/e2e/browser_smoke.py
+++ b/e2e/browser_smoke.py
@@ -197,7 +197,7 @@ def _capture_failure(page: Page | None) -> None:
         )
 
 
-def _exercise_browser(base_url: str, run_id: str, fault_ids: tuple[str, str]) -> dict[str, int]:
+def _exercise_browser(base_url: str, run_id: str, fault_ids: tuple[str, str, str]) -> dict[str, int]:
     external_requests: list[str] = []
     mutation_attempts: list[str] = []
     console_errors: list[str] = []
@@ -298,7 +298,7 @@ def _exercise_browser(base_url: str, run_id: str, fault_ids: tuple[str, str]) ->
             # Real bytes, real endpoints and the shipped DOM must agree even
             # during storage faults. Formatter-only tests previously missed
             # the stale Done stage painting unknown outcomes entirely green.
-            damaged_status_id, damaged_terminal_id = fault_ids
+            damaged_status_id, damaged_terminal_id, damaged_audit_id = fault_ids
             page.goto(f"{base_url}/run/{damaged_status_id}", wait_until="domcontentloaded")
             expect(page.locator("#run-pill")).to_have_text("completed")
             expect(page.locator("#run-status-record")).to_contain_text("progress record unreadable")
@@ -312,6 +312,20 @@ def _exercise_browser(base_url: str, run_id: str, fault_ids: tuple[str, str]) ->
             expect(page.locator("#run-usage")).to_contain_text("partial usage")
             expect(page.locator('.stage[data-state="done"]')).to_have_count(0)
             expect(page.locator('.stage[data-state="pending"]')).to_have_count(5)
+
+            # Nested faults are weaker than completion or the report itself.
+            # Before projection isolation a scalar failed_domains caused 500;
+            # a string unavailable_domains could instead throw before the
+            # report tab loaded. An empty consistency object silently passed.
+            page.goto(f"{base_url}/run/{damaged_audit_id}", wait_until="domcontentloaded")
+            expect(page.locator("#run-pill")).to_have_text("completed")
+            expect(page.locator("#run-terminal")).to_have_text("· worker completed")
+            expect(page.locator("article.prose")).to_contain_text(REPORT_SENTINEL)
+            for check in ("consistency", "grounding", "authority", "components", "report-audit", "sources"):
+                row = page.locator(f'.reliability__row[data-check="{check}"]')
+                expect(row).to_have_attribute("data-tone", "muted")
+                expect(row).to_contain_text("Stored audit summary is unreadable")
+            expect(page.locator('.reliability__row[data-check="review"]')).to_have_attribute("data-tone", "ok")
 
             assert not external_requests, (
                 "The browser attempted non-loopback requests: "
@@ -379,8 +393,21 @@ def main() -> None:
         status["usage"] = {"total_tokens": 100, "cost_usd": 0.01, "cost_complete": True, "agents": []}
         status["usage_accounting"] = {"state": "complete"}
         status_path.write_text(json.dumps(status), encoding="utf-8")
+        damaged_audit_id = _write_completed_run(output_root, access.owner_id(ACCESS_CODE))
+        audit_path = output_root / damaged_audit_id / "status.json"
+        audit_status = json.loads(audit_path.read_text(encoding="utf-8"))
+        audit_status.update({
+            "consistency": {},
+            "claim_grounding": {"status": "partial", "checked": 1, "ungrounded": 0,
+                                "unverifiable": 0, "unavailable_domains": "market"},
+            "authority_coverage": {"status": "incomplete", "missing_categories": 1},
+            "component_coverage": {"status": "unchecked", "unchecked_components": {}},
+            "report_audit": {"status": "completed", "findings": "0"},
+            "failed_domains": 1, "quality_review": {"status": "passed"},
+        })
+        audit_path.write_text(json.dumps(audit_status), encoding="utf-8")
         with _serve(app) as base_url:
-            audit = _exercise_browser(base_url, run_id, (damaged_status_id, damaged_terminal_id))
+            audit = _exercise_browser(base_url, run_id, (damaged_status_id, damaged_terminal_id, damaged_audit_id))
 
     print(
         json.dumps(

--- a/tests/test_run_metadata_integrity.py
+++ b/tests/test_run_metadata_integrity.py
@@ -192,3 +192,85 @@ def test_permission_error_is_read_failure_not_public_diagnostic(history, monkeyp
         assert body["status_record_state"] == "unreadable"
         assert "private-storage-path" not in json.dumps(body)
     assert client.get("/api/runs").status_code == 200
+
+
+BAD_AUDIT_FIELDS = [
+    ("consistency", {}), ("consistency", {"blockers": "0"}),
+    ("consistency", {"blockers": False}), ("consistency", {"blockers": -1}),
+    ("quality_review", {"status": "invented"}), ("quality_review", {"status": []}),
+    ("quality_review", {"status": "partial", "unapplied_corrections": "1"}),
+    ("claim_grounding", {"checked": 1, "ungrounded": 0}),
+    ("claim_grounding", {"checked": 1, "ungrounded": False, "unverifiable": 0}),
+    ("claim_grounding", {"status": "partial", "checked": 1, "ungrounded": 0,
+                          "unverifiable": 0, "unavailable_domains": "market"}),
+    ("report_audit", {"status": "completed", "findings": "0"}),
+    ("report_audit", {"status": "completed", "findings": []}),
+    ("authority_coverage", {"status": "incomplete", "missing_categories": 1}),
+    ("component_coverage", {"status": "unchecked", "unchecked_components": {}}),
+    ("component_coverage", {"status": "incomplete", "missing_components": [None]}),
+    ("source_counts", {"academic": "3"}), ("source_counts", {}),
+    ("failed_domains", "market"), ("failed_domains", 1),
+    ("failed_domains", [False]), ("evidence_incomplete", "false"),
+]
+AUDIT_OBJECT_FIELDS = [
+    "consistency", "quality_review", "claim_grounding", "report_audit",
+    "authority_coverage", "component_coverage", "source_counts",
+]
+
+
+@pytest.mark.parametrize("field,value", BAD_AUDIT_FIELDS + [
+    (field, value) for field in AUDIT_OBJECT_FIELDS for value in ([], "private-bad-value", 7)
+])
+def test_nested_audit_fault_is_local_and_reaches_both_http_endpoints(history, field, value):
+    """One broken summary used to produce HTTP 500 or a false clean panel."""
+    directory, client = history
+    _commit_completed(directory)
+    path = directory / "status.json"
+    status = json.loads(path.read_text(encoding="utf-8"))
+    status.update({"consistency": {"blockers": 1, "warnings": 0}, field: value})
+    original = json.dumps(status).encode("utf-8")
+    path.write_bytes(original)
+    (directory / "commercialization_report.md").write_text("# Preserved report", encoding="utf-8")
+    for body in _responses(client):
+        assert body["state"] == "completed"
+        assert body["status_record_state"] == "readable"
+        assert body["audit_metadata_unreadable"] == [field]
+        assert body[field] == {"failed_domains": [], "evidence_incomplete": False}.get(field)
+        assert body["usage"] == USAGE
+        assert body["usage_accounting"]["state"] == "complete"
+        if field != "consistency":
+            assert body["consistency"] == {"blockers": 1, "warnings": 0}
+        assert "private-bad-value" not in json.dumps(body)
+    assert client.get("/api/runs").status_code == 200
+    assert client.get(f"/api/runs/{RID}/report").text == "# Preserved report"
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("summary", [
+    {"consistency": {"blockers": 0, "warnings": 0},
+     "claim_grounding": {"checked": 2, "ungrounded": 0, "unverifiable": 3}},
+    {"quality_review": {"status": "passed"},
+     "report_audit": {"status": "completed", "findings": 0}},
+    {"claim_grounding": {"status": "failed"}, "report_audit": {"status": "unavailable"}},
+    {"authority_coverage": {"status": "not_applicable"},
+     "component_coverage": {"status": "not_applicable"}},
+    {"component_coverage": {"status": "incomplete", "missing_components": ["edge AI"],
+                            "unchecked_components": []},
+     "authority_coverage": {"status": "incomplete", "missing_categories": ["regulatory"]}},
+    {"claim_grounding": {"status": "partial", "checked": 1, "ungrounded": 0,
+                          "unverifiable": 2, "unavailable_domains": ["market"]}},
+    {"failed_domains": [], "evidence_incomplete": False,
+     "source_counts": {"academic": 3, "patent": 0, "market": 2}},
+    {field: None for field in AUDIT_OBJECT_FIELDS}, {},
+])
+def test_valid_and_absent_audit_summaries_are_not_rewritten(history, summary):
+    """Legacy count-only summaries remain facts, not casualties of a new writer schema."""
+    directory, client = history
+    path = directory / "status.json"
+    status = json.loads(path.read_text(encoding="utf-8"))
+    status.update(summary)
+    path.write_text(json.dumps(status), encoding="utf-8")
+    for body in _responses(client):
+        assert body["audit_metadata_unreadable"] == []
+        for field, value in summary.items():
+            assert body[field] == value

--- a/tests/test_web_reliability.py
+++ b/tests/test_web_reliability.py
@@ -260,6 +260,55 @@ class ReliabilityPanelTests(unittest.TestCase):
 
     # ── Ordering ─────────────────────────────────────────────────────────
 
+    def test_corrupt_summary_is_distinct_from_absence_and_keeps_neighbor_findings(self):
+        """Safe API defaults used to become a pass or an absent-check explanation."""
+        mapping = {
+            "quality_review": "review", "claim_grounding": "grounding",
+            "report_audit": "report-audit", "authority_coverage": "authority",
+            "component_coverage": "components", "source_counts": "sources",
+            "failed_domains": "sources", "evidence_incomplete": "trail",
+        }
+        for field, row_id in mapping.items():
+            with self.subTest(field=field):
+                panel = self._panel(
+                    consistency={"blockers": 1, "warnings": 0},
+                    audit_metadata_unreadable=[field],
+                )
+                row = self._row(panel, row_id)
+                self.assertEqual(row["tone"], "muted")
+                self.assertIn("unreadable", row["detail"])
+                self.assertEqual(self._row(panel, "consistency")["tone"], "risk")
+                self.assertEqual(panel["verdict"]["tone"], "risk")
+
+    def test_corrupt_consistency_is_not_an_english_language_exclusion(self):
+        panel = self._panel(audit_metadata_unreadable=["consistency"])
+        row = self._row(panel, "consistency")
+        self.assertEqual(row["tone"], "muted")
+        self.assertIn("unreadable", row["detail"])
+        self.assertNotIn("English", row["detail"])
+
+    def test_two_source_faults_replace_the_default_pass_with_one_unknown_row(self):
+        panel = self._panel(
+            source_counts={"academic": 3, "patent": 3, "market": 3},
+            failed_domains=[],
+            audit_metadata_unreadable=["source_counts", "failed_domains"],
+        )
+        rows = [row for row in panel["rows"] if row["id"] == "sources"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["tone"], "muted")
+        self.assertIn("unreadable", rows[0]["detail"])
+
+    def test_damaged_counts_do_not_hide_a_known_retrieval_failure(self):
+        """Two metadata fields share the source row; one fault must not erase the other."""
+        panel = self._panel(
+            source_counts=None, failed_domains=["patent"],
+            audit_metadata_unreadable=["source_counts"],
+        )
+        row = self._row(panel, "sources")
+        self.assertEqual(row["tone"], "warn")
+        self.assertIn("patent", row["detail"])
+        self.assertIn("unreadable", row["detail"])
+
     def test_the_worst_finding_decides_the_verdict(self):
         """A blocker beside three passes is still a blocker. Averaging the
         rows, or taking the first, would let one good check bury a bad one."""

--- a/web/static/js/i18n.js
+++ b/web/static/js/i18n.js
@@ -147,6 +147,7 @@ const STRINGS = {
     // rather than inside a JSON file. A reader meets the flags before the
     // number they qualify.
     rel_title: "Automated checks",
+    rel_metadata_unreadable: "Stored audit summary is unreadable — no result is claimed; the report remains available",
     rel_verdict_risk: "A check disagrees with this report",
     rel_verdict_review: "Worth reading with the notes below in mind",
     rel_verdict_clear: "Nothing was flagged",
@@ -371,6 +372,7 @@ const STRINGS = {
     consistency_excerpt: "报告原文",
 
     rel_title: "自动检查",
+    rel_metadata_unreadable: "已保存的审计摘要无法读取——不对该项结果作出判断；报告仍可查看",
     tab_report_audit: "报告审计",
     report_audit_lede: "以非阻断方式检查未标明来源的决策阈值，以及电解质材料类别与引用来源明确矛盾的窄范围问题。",
     report_audit_clear: "在该窄范围审计能够判断的报告片段中未发现问题。",

--- a/web/static/js/result.js
+++ b/web/static/js/result.js
@@ -773,6 +773,36 @@ export function reliabilityRows(progress) {
                 label: t("rel_trail"), detail: t("rel_trail_incomplete") });
   }
 
+  // The API isolates malformed summaries instead of failing the paid report.
+  // Its safe null/[]/false replacements are NOT measurements. Override the
+  // affected row after ordinary rendering so defaults cannot turn a read
+  // fault into either a pass or a historically absent check. Names/labels are
+  // code-owned; never echo damaged payloads into the diagnostic.
+  const faultRows = {
+    consistency: ["consistency", "rel_consistency"],
+    quality_review: ["review", "rel_review"],
+    claim_grounding: ["grounding", "rel_grounding"],
+    report_audit: ["report-audit", "rel_report_audit"],
+    authority_coverage: ["authority", "rel_authority"],
+    component_coverage: ["components", "rel_components"],
+    source_counts: ["sources", "rel_sources"],
+    failed_domains: ["sources", "rel_sources"],
+    evidence_incomplete: ["trail", "rel_trail"],
+  };
+  for (const field of progress.audit_metadata_unreadable ?? []) {
+    if (!Object.hasOwn(faultRows, field)) continue;
+    const [id, label] = faultRows[field];
+    const row = { id, tone: "muted", label: t(label), detail: t("rel_metadata_unreadable") };
+    const index = rows.findIndex(existing => existing.id === id);
+    if (index === -1) rows.push(row);
+    else if (["warn", "risk"].includes(rows[index].tone)) {
+      // Source counts and failed_domains share a row. A damaged count must
+      // not erase a separately readable retrieval failure in that same row.
+      rows[index] = { ...rows[index], detail: rows[index].detail + " " + row.detail };
+    }
+    else rows[index] = row;
+  }
+
   return rows;
 }
 
@@ -808,6 +838,7 @@ export function renderReliability(progress) {
   for (const row of rows) {
     const item = el("li", "reliability__row");
     item.dataset.tone = row.tone;
+    item.dataset.check = row.id;
     item.append(el("span", "reliability__label", row.label));
     item.append(el("span", "reliability__detail", row.detail));
     list.append(item);


### PR DESCRIPTION
## Why
Root-file validation did not protect nested audit summaries. Scalar fields could cause HTTP 500, malformed arrays could throw before a report loaded, and an empty consistency object could appear clean.

## Scope
- Add read-only display-shape validation for nine reliability fields, preserving legacy summaries and original artifacts.
- Carry explicit field-local unreadable names through both status and progress and into the bilingual reliability panel.
- Preserve committed outcomes, usage, reports and independent findings; no writer, scoring, provider or experimental changes.
- Extend the zero-provider real Chromium journey with a fourth completed run containing six damaged audit summaries.

## Measurement and verification
- Baseline: 2096 tests / 1102 subtests.
- Historical replay: 67 readable status records, 55 populated selected fields, zero rejected fields and zero changed records. The 30 baseline directories have no status file and are not counted as new-contract passes.
- Final local suite: 2151 tests / 1118 subtests; latest Ruff and narrow Pylint passed.
- 42 malformed HTTP cases, 9 compatibility cases and 4 frontend tests added.
- Reinjection: raw passthrough makes 42 cases fail; dropping progress propagation makes Chromium catch the missing fault explanation. Restored browser run passes with zero provider/mutation/external requests and zero unexpected browser errors.

## Limits
Not an observed Railway incident or a universal schema validator. Detailed audit tabs and other nested runtime payloads remain outside this contract. Tool Calling remains zero-call shadow and v8 remains sealed. No paid experiment or production restart was performed.

Public method record: docs/results-2026-09-05-nested-audit-metadata-integrity.md
Await all public CI checks. Do not merge without separate owner authorization.