### PR TITLE
Retain stop ownership across process exit, terminal writes and paid admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,11 @@ under a per-run striped cache lock. Accepted run navigation must survive optiona
 browser-history failures; pending resume state belongs to the parent, not the
 button. See the [maintenance regression and limits](docs/results-2026-09-06-maintenance-runtime-paid-delivery.md).
 
+An external stop retains its run slot through physical exit and terminal
+publication. Competing mutations return conflict; a failed stop retains the
+worker instead of freeing capacity. Do not pop handles to claim cancellation.
+See the [stop-ownership seam](docs/results-2026-09-06-run-stop-ownership.md).
+
 Composer submission/extraction locks are tab-local, not server idempotency.
 Readiness checks the effective selected credential without contacting providers;
 429 reasons remain distinct. See the [HTTP/browser contract and limits](docs/results-2026-09-06-composer-paid-operation-integrity.md).

--- a/api/main.py
+++ b/api/main.py
@@ -774,6 +774,7 @@ def get_run(run_id: str) -> RunStatus:
     responses={
         404: {"description": "Unknown run_id"},
         409: {"description": "Run state conflicts with the requested mutation intent"},
+        503: {"description": "Worker stop could not be confirmed; refresh status before retrying"},
     },
 )
 def delete_run(
@@ -806,6 +807,16 @@ def delete_run(
         try:
             runs.cancel_run(run_id)
             return {"run_id": run_id, "action": "cancelled"}
+        except runs.RunStillActive as exc:
+            # A second stop (including legacy DELETE) cannot fall through to
+            # deletion while the first owns process exit or terminal writes.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except runs.RunStopFailed as exc:
+            _LOGGER.exception("Failed to stop run %s", run_id)
+            raise HTTPException(
+                status_code=503,
+                detail="The run could not be stopped. Refresh its status before trying again.",
+            ) from exc
         except runs.RunNotFound:
             if intent == "cancel":
                 # A preflight GET in the browser cannot close this race: the

--- a/api/models.py
+++ b/api/models.py
@@ -475,7 +475,7 @@ class MaintenanceStatus(BaseModel):
 class HealthStatus(BaseModel):
     status: Literal["ok"]
     active_runs: int = Field(
-        description="Worker subprocesses currently running. Kept separately "
+        description="Occupied run slots, including launch and stop finalization. Kept separately "
                     "from active_paid_operations for API compatibility and "
                     "run-specific operational diagnostics.",
     )

--- a/api/runs.py
+++ b/api/runs.py
@@ -323,7 +323,11 @@ class RunNotFound(Exception):
 
 
 class RunStillActive(Exception):
-    """Raised when delete_run is asked to remove a run that has not stopped."""
+    """A mutation conflicts with live, launching or already-stopping work."""
+
+
+class RunStopFailed(Exception):
+    """Process termination could not be confirmed; ownership is retained."""
 
 
 class RunNotResumable(Exception):
@@ -331,6 +335,13 @@ class RunNotResumable(Exception):
 
 
 _registry: dict[str, _Handle] = {}
+
+# A stop claim is not a released admission slot. Keep the handle registered
+# through wait/kill AND terminal publication, so health cannot reap it between
+# those steps and a second mutation cannot remove its files. Identity checks
+# make claim release apply only to the original registration. This is local
+# ownership, not distributed locking or provider-level cancellation.
+_stop_claims: dict[str, _Handle] = {}
 
 # Inline paid operations live in the API process rather than a subprocess, so
 # they cannot be represented by _Handle without making cancellation, polling
@@ -355,9 +366,9 @@ _registry_lock = threading.RLock()
 
 
 def active_count() -> int:
-    """Number of runs still executing. Reaps finished handles as a side effect."""
+    """Occupied run slots, including stop finalization; reap unowned exits."""
     with _registry_lock:
-        for run_id in [rid for rid, h in _registry.items() if not h.alive()]:
+        for run_id in [rid for rid, h in _registry.items() if not _occupies_slot(rid, h)]:
             h = _registry.pop(run_id, None)
             if h and h.log_file is not None:
                 try:
@@ -367,9 +378,13 @@ def active_count() -> int:
         return len(_registry)
 
 
+def _occupies_slot(run_id: str, handle: _Handle) -> bool:
+    """Caller holds the registry lock; a terminal write still owns its slot."""
+    return _stop_claims.get(run_id) is handle or handle.alive()
+
+
 def active_byok_count() -> int:
-    """Live runs billed to a visitor's own key. Reaps first, via active_count,
-    so a finished run cannot keep holding a slot it no longer occupies."""
+    """BYOK run slots, including launch/stop finalization; reap settled exits."""
     active_count()
     with _registry_lock:
         return sum(1 for h in _registry.values() if h.byok)
@@ -886,38 +901,65 @@ def resume_run(
     )
 
 
-def cancel_run(run_id: str) -> None:
-    """Terminate a live run and mark it cancelled."""
-    # Removed under the lock so two concurrent cancels cannot both decide the
-    # run is theirs to terminate.
+@contextmanager
+def _stop_worker(run_id: str) -> Iterator[tuple[_Handle, str]]:
+    """Own a stop until the caller has finished publishing its outcome.
+
+    Do not hold the global lock during wait/kill or filesystem writes: doing
+    so would stall health, polling and unrelated admissions for up to ten
+    seconds. Claim under the lock, then retain that claim across slow work.
+    Launch reservations are not processes; rejecting them is safer than
+    acknowledging a no-op stop followed by Popen installing a live worker.
+    """
     with _registry_lock:
         handle = _registry.get(run_id)
-        if handle is None or not handle.alive():
+        if handle is None:
             raise RunNotFound(f"No live run with id {run_id}")
-        _registry.pop(run_id, None)
-    method = handle.terminate()
+        if _stop_claims.get(run_id) is handle or isinstance(handle.proc, _PendingProcess):
+            raise RunStillActive("Run is starting or already stopping. Refresh its status.")
+        _stop_claims[run_id] = handle
+    stopped = False
     try:
-        (run_dir_for(run_id) / _CANCEL_MARKER).write_text(
-            datetime.now(UTC).isoformat(), encoding="utf-8"
-        )
-    except OSError:
-        # The directory can vanish here if a concurrent delete_run() call for
-        # the same id already popped this handle's twin registration and won
-        # the race to remove it — see delete_run's docstring. Nothing left to
-        # mark at that point is a fine outcome, not a failure to report.
-        pass
-    try:
-        _commit_external_terminal(
-            handle,
-            state="cancelled",
-            reason_code="user_cancelled",
-            termination_method=method,
-            timeout_seconds=TIMEOUT_SECONDS,
-        )
-    except (OSError, ValueError) as exc:
-        # The legacy marker still preserves cancellation if the stronger
-        # audit record cannot be committed; never turn cancel into HTTP 500.
-        print(f"[api] terminal record failed for {run_id}: {exc}", file=sys.stderr)
+        try:
+            method = handle.terminate()
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RunStopFailed("Worker stop could not be confirmed.") from exc
+        stopped = True
+        yield handle, method
+    finally:
+        with _registry_lock:
+            if stopped and _registry.get(run_id) is handle:
+                _registry.pop(run_id)
+            if _stop_claims.get(run_id) is handle:
+                _stop_claims.pop(run_id)
+
+
+def cancel_run(run_id: str) -> None:
+    """Stop a live process without reporting a natural exit as cancellation."""
+    with _stop_worker(run_id) as (handle, method):
+        if method == "already_exited":
+            raise RunNotFound(f"No live run with id {run_id}")
+        try:
+            (run_dir_for(run_id) / _CANCEL_MARKER).write_text(
+                datetime.now(UTC).isoformat(), encoding="utf-8"
+            )
+        except OSError:
+            # A storage fault may lose the legacy marker; the independent
+            # immutable publication below is still attempted. API deletion
+            # and retention cannot remove the directory while we own it.
+            pass
+        try:
+            _commit_external_terminal(
+                handle,
+                state="cancelled",
+                reason_code="user_cancelled",
+                termination_method=method,
+                timeout_seconds=TIMEOUT_SECONDS,
+            )
+        except (OSError, ValueError) as exc:
+            # Keep the historical best-effort audit boundary separate from
+            # failure to stop a process. The worker has physically stopped.
+            print(f"[api] terminal record failed for {run_id}: {exc}", file=sys.stderr)
 
 
 
@@ -939,7 +981,7 @@ def delete_run(run_id: str) -> None:
 
     with _registry_lock:
         handle = _registry.get(run_id)
-        if handle is not None and handle.alive():
+        if handle is not None and _occupies_slot(run_id, handle):
             raise RunStillActive(f"Run {run_id} is still active — cancel it first")
         _registry.pop(run_id, None)
 
@@ -949,56 +991,55 @@ def delete_run(run_id: str) -> None:
 def reap_timeouts() -> list[str]:
     """Kill runs past the deadline. Returns the run_ids that were killed."""
     killed: list[str] = []
-    # Claim each expired run under the lock before terminating it, so a
-    # concurrent cancel_run cannot terminate the same handle twice.
+    # Snapshot candidates only. Each is claimed just before its stop, allowing
+    # concurrent cancellation to win without releasing capacity prematurely.
     with _registry_lock:
         expired = [
-            (rid, h) for rid, h in _registry.items()
-            if h.alive() and h.elapsed > TIMEOUT_SECONDS
+            rid for rid, h in _registry.items()
+            # A launch thread can replace an old reservation with a fresh
+            # process before claim. Never carry the reservation's age into
+            # the new worker's deadline merely because their run id matches.
+            if not isinstance(h.proc, _PendingProcess) and h.alive() and h.elapsed > TIMEOUT_SECONDS
         ]
-        for run_id, _handle in expired:
-            _registry.pop(run_id, None)
 
     failures = []
-    for run_id, handle in expired:
+    for run_id in expired:
         try:
-            method = handle.terminate()
-        except (OSError, subprocess.SubprocessError) as exc:
-            # A denied stop is not a stopped worker. Restore its ownership so
-            # admission still counts it and a later watchdog cycle can retry.
-            # Continue the batch before surfacing the failed supervision stage.
-            with _registry_lock:
-                _registry.setdefault(run_id, handle)
+            with _stop_worker(run_id) as (handle, method):
+                if method == "already_exited":
+                    # It won the race with the watchdog; do not relabel it.
+                    continue
+                try:
+                    (run_dir_for(run_id) / "error.log").write_text(
+                        f"Analysis timed out after {TIMEOUT_SECONDS // 60} minutes.",
+                        encoding="utf-8",
+                    )
+                except OSError:
+                    # The immutable record below is authoritative; this text
+                    # file is retained only for historical readers.
+                    pass
+                try:
+                    _commit_external_terminal(
+                        handle,
+                        state="timeout",
+                        reason_code="hard_timeout",
+                        termination_method=method,
+                        timeout_seconds=TIMEOUT_SECONDS,
+                    )
+                except (OSError, ValueError) as exc:
+                    print(f"[api] terminal record failed for {run_id}: {exc}", file=sys.stderr)
+                killed.append(run_id)
+        except (RunNotFound, RunStillActive):
+            # A pending launch has no process deadline yet; a concurrent
+            # stopper owns its exit. Neither is a second watchdog stop.
+            continue
+        except RunStopFailed as exc:
+            # The failed claim was released, but the handle never left the
+            # registry. Later admission still counts it and reaping can retry.
             failures.append(run_id)
-            print(f"[api] timeout termination failed for {run_id}: {exc}", file=sys.stderr)
-            continue
-        if method == "already_exited":
-            # It won the race with the watchdog; do not relabel it timeout.
-            continue
-        try:
-            (run_dir_for(run_id) / "error.log").write_text(
-                f"Analysis timed out after {TIMEOUT_SECONDS // 60} minutes.",
-                encoding="utf-8",
-            )
-        except OSError:
-            # The immutable record below is authoritative; this text file is
-            # retained only for compatibility with historical readers.
-            pass
-        try:
-            _commit_external_terminal(
-                handle,
-                state="timeout",
-                reason_code="hard_timeout",
-                termination_method=method,
-                timeout_seconds=TIMEOUT_SECONDS,
-            )
-        except (OSError, ValueError) as exc:
-            # One damaged run directory must not stop the global reaper.
-            print(
-                f"[api] terminal record failed for {run_id}: {exc}",
-                file=sys.stderr,
-            )
-        killed.append(run_id)
+            # Preserve the actual OS/wait diagnostic in operator logs only;
+            # the HTTP cancellation path emits a stable, non-secret message.
+            print(f"[api] timeout termination failed for {run_id}: {exc.__cause__ or exc}", file=sys.stderr)
     if failures:
         raise RuntimeError(f"Timeout termination failed for {len(failures)} run(s)")
     return killed
@@ -1007,15 +1048,19 @@ def reap_timeouts() -> list[str]:
 def shutdown_all() -> None:
     """Terminate every live run. Called on application shutdown."""
     with _registry_lock:
-        handles = list(_registry.values())
-        _registry.clear()
+        run_ids = list(_registry)
     failures = []
-    for handle in handles:
+    for run_id in run_ids:
         try:
-            handle.terminate()
-        except (OSError, subprocess.SubprocessError) as exc:
+            with _stop_worker(run_id):
+                pass
+        except RunNotFound:
+            continue
+        except (RunStopFailed, RunStillActive) as exc:
             # One inaccessible process must not prevent stopping the rest.
-            # Aggregate after all attempts; do not report shutdown as clean.
+            # ASGI normally drains requests before shutdown; if a launch or
+            # stop is still outstanding, retain it and report incomplete
+            # shutdown rather than clearing ownership or stopping it twice.
             failures.append(exc)
     if failures:
         raise RuntimeError(f"Shutdown could not stop {len(failures)} worker(s)") from failures[0]
@@ -1326,6 +1371,13 @@ def get_state(run_id: str) -> dict:
     if not run_dir.is_dir():
         raise RunNotFound(f"No run with id {run_id}")
 
+    # Snapshot ownership before disk reads. Releasing a stop after these reads
+    # cannot turn an earlier, incomplete terminal snapshot into a failed run.
+    # Returning Running for a request begun during finalization is conservative
+    # and keeps recovery/deletion unavailable until a later settled read.
+    with _registry_lock:
+        handle = _registry.get(run_id)
+        occupied = handle is not None and _occupies_slot(run_id, handle)
     try:
         status, status_record_state = _read_status_snapshot(run_dir)
     except StatusUnreadable:
@@ -1334,9 +1386,8 @@ def get_state(run_id: str) -> dict:
         status, status_record_state = {}, "unreadable"
     status, audit_metadata_unreadable = project_audit_metadata(status)
     terminal_record, terminal_projection = _read_terminal(run_dir)
-    handle = _registry.get(run_id)
 
-    if handle is not None and handle.alive():
+    if occupied:
         state = "running"
         error = None
         elapsed = handle.elapsed
@@ -1580,7 +1631,7 @@ def prune_expired_runs(retention_days: int | None = None) -> list[str]:
 
     cutoff = datetime.now(UTC) - timedelta(days=days)
     with _registry_lock:
-        live = {rid for rid, h in _registry.items() if h.alive()}
+        live = {rid for rid, h in _registry.items() if _occupies_slot(rid, h)}
 
     removed: list[str] = []
     for directory in DEFAULT_OUTPUT_ROOT.iterdir():

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -56,6 +56,13 @@ exports. These are fault-injected offline contracts, not measured production
 incident reductions, exact-once billing or PDF semantic validation. See the
 [runtime/paid-delivery maintenance record](results-2026-09-06-maintenance-runtime-paid-delivery.md).
 
+Stop ownership also spans process termination and terminal publication: capacity,
+status/progress, deletion and retention share that boundary. Failed termination
+retains the worker; concurrent stops cannot acknowledge two successful owners.
+Event-held HTTP tests and local child-process tests establish the bounded offline
+contract, not a production incident rate or remote-provider cancellation. See the
+[stop-ownership verification](results-2026-09-06-run-stop-ownership.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,7 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-06 run stop ownership](results-2026-09-06-run-stop-ownership.md) — cancellation/timeout capacity and artifact boundaries, no provider calls.
 - [2026-09-06 readiness, PDF query and audit-detail maintenance](results-2026-09-06-maintenance-readiness-query-audit.md) — offline boundary verification, not a paid experiment.
 
 ## Release snapshot

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -149,6 +149,16 @@ never cancels a live run: that conflict also returns 409. Invalid explicit
 values return 422; a missing run remains 404. For compatibility, omitting
 intent still uses the legacy cancel-or-delete behaviour, so older callers
 must adopt the parameter to avoid stale clicks changing the operation.
+
+Starting or already-stopping runs also return 409 to a Cancel request; refresh
+status instead of issuing a competing stop. A failed process stop returns a
+sanitized 503 and retains the run and its capacity slot. Active counts include
+launch reservations and stop finalization, not just executing subprocesses.
+While external termination/terminal publication is owned, status stays Running,
+progress stays unfinished, and Delete/retention cannot remove the artifacts.
+This is single-process ownership, not provider cancellation or guaranteed audit
+durability during a storage fault. See the
+[stop-ownership contract](results-2026-09-06-run-stop-ownership.md).
 Unknown or not-yet-read states do not expose mutation buttons in the shipped
 client; a BYOK history read error is Unknown, not a failed worker.
 See the [request and browser verification](results-2026-09-06-run-mutation-intent.md).

--- a/docs/results-2026-09-06-run-stop-ownership.md
+++ b/docs/results-2026-09-06-run-stop-ownership.md
@@ -1,0 +1,97 @@
+# Retain run ownership through stop and terminal publication
+
+Date: 2026-09-06. Base: `c9d92d22efe1c4bfa6107ae2985fac93c7824365`.
+Zero-provider maintenance, not a paid experiment or observed production incident.
+
+## Evidence before changing production code
+
+The unmodified baseline passed 2,341 tests and 1,166 subtests. A read-only census
+found 109 direct timestamped run directories and no `terminal.json` in that
+cohort. These retained historical artifacts cannot measure a transient ownership
+gap, its production frequency or financial impact. No benchmark was rerun.
+
+Twelve new deterministic regressions failed against the original implementation:
+four capacity checks read `(0, 0)` while a stop was held; four deletion checks
+returned 200 instead of conflict and removed the fixture directory; two failed
+termination paths escaped HTTP handling; pending launch cancellation and a natural
+completion race each returned 200 instead of conflict. No paid worker was launched.
+
+Cancellation, timeout and shutdown removed registrations before waiting for the
+process. Restoring a timeout handle only after an exception did not close this
+transient gap, and cancellation did not restore it at all. Keeping the handle
+only until `wait()` returned would still leave a gap during terminal publication.
+
+## Change and rejected alternatives
+
+- A local, identity-bound stop claim retains the existing registry entry through
+  terminate/wait/kill and the caller's outcome publication. Slot counters, both
+  HTTP readers, Delete and retention honor that same claim.
+- Claims are acquired/released under the registry lock, while waiting and disk
+  writes remain outside it. Holding that global lock for a potentially ten-second
+  stop was rejected because it would block unrelated health and admission calls.
+- Competing mutations return 409, including legacy DELETE: an already-owned stop
+  is not an absent handle and cannot fall through to deletion. No new public run
+  state or second server-side ownership identity is introduced.
+- A pending launch is rejected as a stop conflict, not acknowledged through its
+  no-op placeholder. The watchdog skips it until an actual process is registered;
+  shutdown reports unresolved launch/stop overlap instead of silently clearing it.
+- Failed physical termination returns safe HTTP 503 and retains ownership in the
+  registry for later attempts. The watchdog still attempts other expired workers.
+  A natural exit before termination keeps its own outcome.
+- Readers snapshot ownership before reading disk, so release during a stale
+  terminal read cannot produce a prematurely settled projection. Progress is
+  `done=false` during the observed ownership interval.
+
+No scoring, model/provider, CrewAI, checkpoint identity, retrieval, frozen fixture
+or experimental selector was changed. Supplementary retrieval remains zero-call
+shadow mode. No fee authorization or Railway restart was used.
+
+## Tests and fault injection
+
+Twenty-one new tests include eight event-held cancel/timeout × process/terminal
+checks, denied and timed-out stop failures, launch and shutdown conflicts,
+natural completion, read/release and pending-launch deadline races. The last
+regression also failed during self-review: selecting an old placeholder and
+claiming a newly installed process killed a fresh worker as overdue. Candidate
+selection now excludes placeholders before their registration can be replaced.
+Four cases use real local Python
+children blocked on stdin to verify OS terminate and kill/wait paths; those
+children do not import the pipeline or call a provider. Escalation's first wait
+timeout is injected, not a measurement of the real five-second grace period.
+
+Assertions cross HTTP health/status/progress, both inline funding modes, root
+admission, explicit/legacy mutations, retained report bytes and terminal files.
+The original four-caller concurrency assertion is retained and strengthened to
+require all four threads to settle with exactly one successful stop. Its fixture
+now isolates wallet cache/date from operator configuration; charging stays enabled.
+A mkdir injection is scoped after reservation so it tests both slot cleanup and
+refund instead of failing prematurely at the durable ledger's own mkdir.
+
+Nine defect re-injections are checked independently: early registry removal,
+physical-exit-only reaping, release after denied stop, no-op launch cancellation,
+natural-exit relabelling, late ownership observation, retention ignoring the
+writer, Delete ignoring the writer and reservation age killing a fresh worker.
+Each must fail its intended assertion;
+each production file is restored to its exact SHA-256 before further checks.
+
+All nine triggered their intended assertions and were restored. Final local
+verification passed 2,362 tests and 1,171 subtests, latest Ruff, narrow Pylint and
+both real Chromium journeys. Fresh Windows/Python 3.12 coverage was 88.69%, above
+the unchanged 85% floor. The read-only browser journey recorded zero external
+requests, mutations, page/console errors or provider requests; the separate
+composer journey used ten intercepted POSTs, with zero API requests reaching its
+static-only server, zero unexpected requests and zero provider calls. These
+are revision-specific offline observations, not a production reliability rate.
+
+## Limits
+
+This closes a reproduced single-process stop/finalization seam, not distributed
+ownership, queued cancellation of a blocked launch, forced recovery, arbitrary
+filesystem integrity, remote-provider interruption/refund, exactly-once billing,
+or a production SLO. Terminal persistence remains best effort after a confirmed
+physical stop; a broken volume can still lose the audit record. Shutdown assumes
+normal ASGI request draining and explicitly reports unexpected outstanding work.
+
+An unchanged historical report count is not evidence of zero past incidents.
+Deployment verification should be read-only health/readiness and version checks;
+this deterministic ownership fix does not require a paid canary.

--- a/docs/runtime-terminal-integrity.md
+++ b/docs/runtime-terminal-integrity.md
@@ -80,6 +80,30 @@ tooltip. A missing or unreadable immutable record after a terminal state is
 explicitly labelled rather than looking like an ordinary clean finish. The
 downloadable `terminal` artifact contains the full non-secret record.
 
+## External-stop ownership
+
+The parent keeps a local stop claim and registered handle while waiting for
+terminate/kill and publishing the external terminal record. The global registry
+lock is held only for ownership transitions, never for those slow operations.
+Health counts include launch reservations and stop finalization; both run readers
+continue to report Running with progress `done=false` for a read begun while the
+slot is owned. A later read observes the settled outcome. Deletion and retention
+cannot remove a claimed directory, even after its process has physically exited.
+
+A competing Cancel or legacy DELETE returns 409, not successful cancellation or
+fallthrough deletion. A launch placeholder also returns 409 because it is not a
+process that can be stopped. If termination fails, cancellation returns a safe
+503 and retains the registration; the watchdog continues its peers and reports
+failure before retrying on a later cycle. Natural exit before termination is not
+relabelled Cancelled or Timeout. Shutdown uses the same claim; unexpected overlap
+with an unfinished launch/stop is reported as incomplete, not silently cleared.
+
+Terminal writes retain their existing best-effort storage-failure boundary:
+physical stop can succeed without a durable audit record. This does not make
+the record durable on a failed volume, implement queued cancellation of pending
+launches, or confirm cancellation/refund of a remote provider request. See the
+[offline stop regression](results-2026-09-06-run-stop-ownership.md).
+
 ## Usage states
 
 The HTTP read projection also isolates malformed selected runtime summaries

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -54,6 +54,15 @@ class _ConcurrencyTestBase(unittest.TestCase):
         patcher = patch.object(runs, "DEFAULT_OUTPUT_ROOT", Path(self._tmp.name))
         patcher.start()
         self.addCleanup(patcher.stop)
+        # Concurrency tests must not depend on the operator's .env daily cap
+        # or another test's cached ledger date. Keep real charging enabled,
+        # but give this isolated wallet enough room for all eight contenders;
+        # only the concurrency policy under test should reject them.
+        for name, value in (
+            ("DAILY_CAP", 100), ("_daily_counts", {}), ("_daily_date", None),
+            ("_inline_paid_operations", {}), ("_stop_claims", {}),
+        ):
+            self.enterContext(patch.object(runs, name, value))
 
     def _close_open_logs(self):
         for handle in list(runs._registry.values()):
@@ -131,11 +140,24 @@ class ConcurrencyCapTests(_ConcurrencyTestBase):
         volume, in production) leaked one slot per failed attempt with no
         way to clear it short of restarting the process.
         """
-        with patch("api.runs.Path.mkdir", side_effect=PermissionError("no access")):
+        original_mkdir = Path.mkdir
+
+        def deny_run_directory(path, *args, **kwargs):
+            # Admission now persists its wallet first. Failing every mkdir
+            # stops at that earlier boundary and never exercises the reserved
+            # run's cleanup. Inject only after a slot has actually been taken.
+            if path == runs.DEFAULT_OUTPUT_ROOT:
+                return original_mkdir(path, *args, **kwargs)
+            self.assertEqual(runs.active_count(), 1)
+            raise PermissionError("no access")
+
+        with patch("api.runs.Path.mkdir", autospec=True, side_effect=deny_run_directory), \
+             patch("api.runs.subprocess.Popen", _FakeProc):
             with self.assertRaises(PermissionError):
                 runs.start_run("topic")
 
         self.assertEqual(runs.active_count(), 0)
+        self.assertEqual(sum(runs._daily_counts.values()), 0)
         with patch("api.runs.subprocess.Popen", _FakeProc):
             runs.start_run("topic")          # must not raise
         self.assertEqual(runs.active_count(), 1)
@@ -170,6 +192,10 @@ class ConcurrencyCapTests(_ConcurrencyTestBase):
                 outcomes.append("cancelled")
             except runs.RunNotFound:
                 outcomes.append("not_found")
+            except runs.RunStillActive:
+                # Losing during finalization is an explicit conflict, not a
+                # missing run. Keep every thread outcome in the denominator.
+                outcomes.append("stopping")
 
         workers = [threading.Thread(target=cancel) for _ in range(4)]
         for w in workers:
@@ -178,6 +204,9 @@ class ConcurrencyCapTests(_ConcurrencyTestBase):
             w.join(timeout=30)
 
         self.assertEqual(outcomes.count("cancelled"), 1, outcomes)
+        self.assertTrue(all(not worker.is_alive() for worker in workers))
+        self.assertEqual(len(outcomes), 4, outcomes)
+        self.assertEqual(outcomes.count("not_found") + outcomes.count("stopping"), 3, outcomes)
 
     def test_delete_run_refuses_a_live_run(self):
         with patch("api.runs.subprocess.Popen", _FakeProc):

--- a/tests/test_run_stop_ownership.py
+++ b/tests/test_run_stop_ownership.py
@@ -1,0 +1,299 @@
+"""Stop ownership must survive physical exit and terminal publication.
+
+Events hold exact seams, not probabilistic sleeps. The processes are fakes;
+the real HTTP readers, mutations, admission and terminal writer still run.
+"""
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from threading import Event
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import access, main, runs
+
+
+_REAL_POPEN = subprocess.Popen
+
+
+class Process:
+    def __init__(self):
+        self.exited = False
+        self.terminate = Mock()
+        self.kill = Mock()
+
+    def poll(self):
+        return 0 if self.exited else None
+
+    def wait(self, timeout=None):
+        self.exited = True
+        return 0
+
+
+@pytest.fixture
+def stopped_fixture(tmp_path, monkeypatch):
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(runs, "_registry", {})
+    monkeypatch.setattr(runs, "_stop_claims", {})
+    monkeypatch.setattr(runs, "_inline_paid_operations", {})
+    monkeypatch.setattr(runs, "DAILY_CAP", 0)
+    monkeypatch.setattr(runs, "MAX_CONCURRENT", 1)
+    monkeypatch.setattr(access, "ACCESS_CODE", None)
+    monkeypatch.setattr(access, "ACCESS_CODES", None)
+    # If admission leaks, fail before anything can launch or cost money.
+    monkeypatch.setattr(runs.subprocess, "Popen", Mock(side_effect=AssertionError("worker launch leaked")))
+    rid = "20200101T000000Z-abcdef0123"
+    directory = tmp_path / rid
+    directory.mkdir()
+    (directory / "status.json").write_text(json.dumps({"done": False, "stage": "Writer"}))
+    (directory / "commercialization_report.md").write_text("Retained partial report")
+    proc = Process()
+    handle = runs._Handle(rid, "fixture", proc, byok=True)
+    handle.started -= runs.TIMEOUT_SECONDS + 1
+    runs._registry[rid] = handle
+    return TestClient(main.app), rid, directory, proc
+
+
+@contextmanager
+def held_stop(monkeypatch, fixture, method, phase):
+    client, rid, _, proc = fixture
+    reached, release = Event(), Event()
+    original = proc.wait if phase == "process" else runs._commit_external_terminal
+
+    def hold(*args, **kwargs):
+        reached.set()
+        assert release.wait(15), "test did not release stop seam"
+        return original(*args, **kwargs)
+
+    if phase == "process":
+        monkeypatch.setattr(proc, "wait", hold)
+    else:
+        monkeypatch.setattr(runs, "_commit_external_terminal", hold)
+    operation = (lambda: client.delete(f"/api/runs/{rid}?intent=cancel")) if method == "cancel" else runs.reap_timeouts
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(operation)
+        try:
+            assert reached.wait(15), "stop never reached held seam"
+            yield
+        finally:
+            release.set()
+        result = future.result(timeout=15)
+        if method == "cancel":
+            assert result.status_code == 200
+        else:
+            assert result == [rid]
+
+
+@pytest.mark.parametrize("method", ["cancel", "timeout"])
+@pytest.mark.parametrize("phase", ["process", "terminal"])
+def test_stopping_keeps_capacity_and_client_state(monkeypatch, stopped_fixture, method, phase):
+    """Popping before wait admitted paid work and presented a live run as failed."""
+    client, rid, directory, proc = stopped_fixture
+    with held_stop(monkeypatch, stopped_fixture, method, phase):
+        health = client.get("/health").json()
+        assert (health["active_runs"], health["active_paid_operations"]) == (1, 1)
+        assert runs.active_byok_count() == 1
+        for suffix in ("", "/progress"):
+            response = client.get(f"/api/runs/{rid}{suffix}")
+            assert response.status_code == 200
+            assert response.json()["state"] == "running"
+            if suffix:
+                assert response.json()["done"] is False
+        # Both funding modes share the retained host slot, including PDF calls.
+        for byok in (False, True):
+            with pytest.raises(runs.ConcurrencyLimitReached):
+                with runs.reserve_inline_paid_operation(owner=None, byok=byok):
+                    pytest.fail("inline paid admission leaked")
+        assert client.post("/api/runs", json={"topic": "isolated admission fixture"}).status_code == 429
+        runs.subprocess.Popen.assert_not_called()
+    expected = "cancelled" if method == "cancel" else "timeout"
+    assert proc.exited
+    assert client.get(f"/api/runs/{rid}").json()["state"] == expected
+    assert json.loads((directory / "terminal.json").read_text())["state"] == expected
+    assert runs.capacity_counts() == (0, 0)
+
+
+@pytest.mark.parametrize("method", ["cancel", "timeout"])
+@pytest.mark.parametrize("phase", ["process", "terminal"])
+def test_stopping_blocks_deletion_retention_and_duplicate_stop(monkeypatch, stopped_fixture, method, phase):
+    """A second Cancel or legacy DELETE must not erase the first stop's files."""
+    client, rid, directory, proc = stopped_fixture
+    with held_stop(monkeypatch, stopped_fixture, method, phase):
+        for query in ("?intent=delete", "?intent=cancel", ""):
+            assert client.delete(f"/api/runs/{rid}{query}").status_code == 409
+        assert runs.reap_timeouts() == []
+        assert runs.prune_expired_runs(retention_days=1) == []
+        assert (directory / "commercialization_report.md").read_text() == "Retained partial report"
+        proc.terminate.assert_called_once_with()
+    assert client.delete(f"/api/runs/{rid}?intent=delete").status_code == 200
+    assert not directory.exists()
+
+
+@pytest.mark.parametrize("failure", [PermissionError("private stop path"), subprocess.TimeoutExpired("private command", 5)])
+def test_cancel_failure_retains_worker_and_returns_safe_error(monkeypatch, stopped_fixture, failure):
+    """A failed terminate used to permanently lose the worker and its paid slot."""
+    client, rid, directory, proc = stopped_fixture
+    monkeypatch.setattr(proc, "wait", Mock(side_effect=failure))
+    response = client.delete(f"/api/runs/{rid}?intent=cancel")
+    assert response.status_code == 503
+    assert "private" not in response.text
+    assert client.get(f"/api/runs/{rid}").json()["state"] == "running"
+    assert runs.capacity_counts() == (1, 1)
+    assert not (directory / "terminal.json").exists()
+    assert not (directory / "cancelled.marker").exists()
+    monkeypatch.setattr(proc, "wait", lambda timeout=None: setattr(proc, "exited", True))
+    assert client.delete(f"/api/runs/{rid}?intent=cancel").status_code == 200
+    assert runs.capacity_counts() == (0, 0)
+
+
+def test_shutdown_failure_retains_capacity_and_attempts_peer(monkeypatch, stopped_fixture):
+    """Shutdown cannot clear a paid worker before knowing whether stop succeeded."""
+    client, rid, _, proc = stopped_fixture
+    peer = Process()
+    runs._registry["peer"] = runs._Handle("peer", "peer", peer)
+    monkeypatch.setattr(proc, "wait", Mock(side_effect=PermissionError("denied")))
+    with pytest.raises(RuntimeError, match="1 worker"):
+        runs.shutdown_all()
+    peer.terminate.assert_called_once_with()
+    assert peer.exited
+    assert client.get(f"/api/runs/{rid}").json()["state"] == "running"
+    assert runs.capacity_counts() == (1, 1)
+    assert runs._stop_claims == {}
+
+
+def test_shutdown_cannot_steal_an_active_stop(monkeypatch, stopped_fixture):
+    """Normal ASGI draining should avoid this, but a collision must be explicit."""
+    _, _, _, proc = stopped_fixture
+    with held_stop(monkeypatch, stopped_fixture, "cancel", "terminal"):
+        with pytest.raises(RuntimeError, match="1 worker"):
+            runs.shutdown_all()
+        assert runs.capacity_counts() == (1, 1)
+        proc.terminate.assert_called_once_with()
+    assert runs.capacity_counts() == (0, 0)
+    assert runs._stop_claims == {}
+
+
+def test_shutdown_cannot_claim_a_pending_launch(stopped_fixture):
+    """A no-op placeholder is not successful process termination at shutdown."""
+    _, rid, _, _ = stopped_fixture
+    runs._registry[rid].proc = runs._PendingProcess()
+    with pytest.raises(RuntimeError, match="1 worker"):
+        runs.shutdown_all()
+    assert runs.capacity_counts() == (1, 1)
+
+
+@pytest.mark.parametrize("method", ["cancel", "timeout"])
+@pytest.mark.parametrize("force_kill", [False, True])
+def test_real_local_child_is_reaped_before_terminal_release(monkeypatch, stopped_fixture, method, force_kill):
+    """Exercise OS wait/kill locally without importing the paid pipeline worker."""
+    client, rid, directory, _ = stopped_fixture
+    # Read stdin until EOF, with no network, repository imports or provider key
+    # access. The parent owns cleanup even if an assertion fails on either OS.
+    with _REAL_POPEN(
+        [sys.executable, "-c", "import sys; sys.stdin.buffer.read()"],
+        stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    ) as proc:
+        runs._registry[rid].proc = proc
+        original_wait = proc.wait
+        try:
+            if force_kill:
+                # Deterministically exercise escalation without waiting five
+                # seconds or relying on platform-specific signal handlers.
+                monkeypatch.setattr(proc, "terminate", Mock())
+                waits = iter((True, False))
+
+                def wait(timeout=None):
+                    if next(waits, False):
+                        raise subprocess.TimeoutExpired("local fixture", timeout)
+                    return original_wait(timeout=timeout)
+
+                monkeypatch.setattr(proc, "wait", wait)
+            if method == "cancel":
+                assert client.delete(f"/api/runs/{rid}?intent=cancel").status_code == 200
+            else:
+                assert runs.reap_timeouts() == [rid]
+            assert proc.poll() is not None
+            assert runs.capacity_counts() == (0, 0)
+            terminal = json.loads((directory / "terminal.json").read_text())
+            assert terminal["state"] == ("cancelled" if method == "cancel" else "timeout")
+            assert terminal["termination_method"] == ("kill" if force_kill else "terminate")
+            assert terminal["usage_accounting"]["state"] == "unavailable"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            original_wait(timeout=5)
+
+
+def test_pending_launch_is_not_a_cancelled_process(stopped_fixture):
+    """Terminating a no-op placeholder must not acknowledge a cancelled worker."""
+    client, rid, directory, _ = stopped_fixture
+    runs._registry[rid].proc = runs._PendingProcess()
+    assert client.delete(f"/api/runs/{rid}?intent=cancel").status_code == 409
+    assert runs.reap_timeouts() == []
+    assert runs.capacity_counts() == (1, 1)
+    assert not (directory / "terminal.json").exists()
+
+
+def test_completion_race_does_not_invent_cancellation(stopped_fixture):
+    """A natural exit between claim and terminate keeps its completed outcome."""
+    client, rid, directory, proc = stopped_fixture
+    original = runs._registry[rid].terminate
+
+    def finish_first():
+        proc.exited = True
+        (directory / "status.json").write_text(json.dumps({"done": True}))
+        return original()
+
+    runs._registry[rid].terminate = finish_first
+    assert client.delete(f"/api/runs/{rid}?intent=cancel").status_code == 409
+    assert client.get(f"/api/runs/{rid}").json()["state"] == "completed"
+    assert not (directory / "cancelled.marker").exists()
+    assert not (directory / "terminal.json").exists()
+
+
+def test_terminal_read_racing_release_keeps_nonterminal_projection(monkeypatch, stopped_fixture):
+    """A pre-publication disk snapshot cannot certify a settled process exit."""
+    client, rid, _, _ = stopped_fixture
+    original = runs._read_terminal
+
+    def finish_after_read(directory):
+        snapshot = original(directory)
+        if rid in runs._registry:
+            runs.cancel_run(rid)
+        return snapshot
+
+    monkeypatch.setattr(runs, "_read_terminal", finish_after_read)
+    response = client.get(f"/api/runs/{rid}/progress")
+    assert response.status_code == 200
+    projection = response.json()
+    assert projection["state"] == "running"
+    assert projection["done"] is False
+    monkeypatch.setattr(runs, "_read_terminal", original)
+    settled = client.get(f"/api/runs/{rid}/progress").json()
+    assert settled["state"] == "cancelled"
+    assert settled["done"] is True
+    assert settled["terminal"]["state"] == "cancelled"
+
+
+def test_pending_deadline_cannot_kill_a_freshly_installed_worker(monkeypatch, stopped_fixture):
+    """An old reservation selected before Popen is not an expired new process."""
+    _, rid, directory, proc = stopped_fixture
+    runs._registry[rid].proc = runs._PendingProcess()
+    original = runs._stop_worker
+
+    def finish_launch_before_claim(run_id):
+        runs._registry[run_id] = runs._Handle(run_id, "new worker", proc)
+        return original(run_id)
+
+    # The old candidate selection included the overdue placeholder. Swap in
+    # a fresh worker exactly at claim, as the launch thread could do there.
+    monkeypatch.setattr(runs, "_stop_worker", finish_launch_before_claim)
+    assert runs.reap_timeouts() == []
+    proc.terminate.assert_not_called()
+    assert runs.capacity_counts() == (1, 1)
+    assert not (directory / "terminal.json").exists()


### PR DESCRIPTION
## Why
Stop claims previously removed worker ownership before wait/kill completed. That released paid capacity and allowed deletion/retention to race still-live work or the terminal writer. A second race could apply an old launch reservation deadline to a fresh worker.

## Scope
Keep identity-bound stop claims through physical stop and terminal publication. Share the rule across capacity, HTTP status/progress, deletion and retention. Return 409 for competing/pending stops and a safe 503 for unconfirmed stops; keep failed workers registered. Preserve natural exits. Exclude pending launch candidates before watchdog claim. No global lock around process waits.

## Verification
- Baseline: 2341 tests / 1166 subtests.
- Twelve initial red regressions plus a self-review launch-handoff reproducer.
- 21 new cases; four use real local Python children without pipeline/provider work.
- Nine intended defect re-injection failures with exact SHA-256 restoration.
- Final suite: 2362 passed / 1171 subtests; Windows coverage 88.69% (85% gate unchanged).
- Latest Ruff, narrow Pylint and both Chromium journeys passed, zero provider requests.
- Self-review retained and strengthened old assertions; no warning ignore or skip.

## Limits
Single process only. Pending launches are not queued for cancellation. Audit writes remain best effort after physical stop. No remote-provider cancellation/refund, production incident-rate, exactly-once or SLO claim. Frozen benchmarks, providers and zero-call supplementary-search mode are unchanged. No paid canary or manual Railway restart.

User authorized maintenance, self-review and merge only after green CI. Await all checks before release.