### PR TITLE
Keep maintenance responsive without abandoning shutdown ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,10 @@ publication. Competing mutations return conflict; a failed stop retains the
 worker instead of freeing capacity. Do not pop handles to claim cancellation.
 See the [stop-ownership seam](docs/results-2026-09-06-run-stop-ownership.md).
 
+Synchronous maintenance stays off the ASGI loop but remains serial and owned.
+Cancellation must drain the current stage before worker shutdown; cancelling
+an await does not stop its thread. See the [scheduling/drain boundary](docs/results-2026-09-06-maintenance-event-loop.md).
+
 Composer submission/extraction locks are tab-local, not server idempotency.
 Readiness checks the effective selected credential without contacting providers;
 429 reasons remain distinct. See the [HTTP/browser contract and limits](docs/results-2026-09-06-composer-paid-operation-integrity.md).

--- a/api/main.py
+++ b/api/main.py
@@ -18,7 +18,7 @@ import logging
 import os
 import threading
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
@@ -74,6 +74,41 @@ def _maintenance_status() -> MaintenanceStatus:
     return MaintenanceStatus(state=state, checks=dict(_maintenance_checks))
 
 
+async def _maintenance_stage(name: str, operation: Callable[[], object]) -> None:
+    """Offload blocking work without abandoning it when the owner is cancelled."""
+    async def execute() -> None:
+        try:
+            changed = await asyncio.to_thread(operation)
+        except Exception:  # noqa: BLE001 - supervise one stage and preserve its completed fault observation
+            _maintenance_checks[name] = "failed"
+            _LOGGER.exception("Background maintenance stage failed: %s", name)
+        else:
+            _maintenance_checks[name] = "ok"
+            if changed:
+                _LOGGER.info("Background maintenance %s: %s", name, changed)
+
+    # Process waits and filesystem cleanup cannot run on the ASGI loop. Merely
+    # awaiting to_thread is insufficient: cancelling that await does not stop
+    # its thread. Shutdown would then race an abandoned timeout stop claim.
+    # Keep a strong task reference, shield it, and drain it before propagating
+    # cancellation. One serial stage is in flight, never a fire-and-forget batch.
+    task = asyncio.create_task(execute())
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # A second shutdown cancellation must not punch through the drain.
+        # Do not mark a still-running stage as successful or proceed to the
+        # next cleanup. Python cannot forcibly interrupt a stuck filesystem
+        # thread: draining is ownership, not a bounded shutdown-time guarantee.
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+        task.result()
+        raise
+
+
 async def _reaper() -> None:
     """Kill runs that exceed the deadline.
 
@@ -91,15 +126,7 @@ async def _reaper() -> None:
             ("papers", papers.prune_old),
             ("retention", runs.prune_expired_runs),
         ):
-            try:
-                changed = operation()
-            except Exception:  # noqa: BLE001 - supervise independent recurring tasks; retain fault state/log
-                _maintenance_checks[name] = "failed"
-                _LOGGER.exception("Background maintenance stage failed: %s", name)
-            else:
-                _maintenance_checks[name] = "ok"
-                if changed:
-                    _LOGGER.info("Background maintenance %s: %s", name, changed)
+            await _maintenance_stage(name, operation)
 
 
 @contextlib.asynccontextmanager
@@ -120,6 +147,8 @@ async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
         finally:
             # Awaiting an already-failed task raises. Worker cleanup must run
             # even in that case; otherwise shutdown leaves paid work orphaned.
+            # The cancelled supervisor drains its current off-loop operation
+            # first, so shutdown cannot compete with that operation's stop.
             try:
                 runs.shutdown_all()
             finally:

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -63,6 +63,12 @@ Event-held HTTP tests and local child-process tests establish the bounded offlin
 contract, not a production incident rate or remote-provider cancellation. See the
 [stop-ownership verification](results-2026-09-06-run-stop-ownership.md).
 
+Synchronous maintenance is also offloaded from the ASGI loop without abandoning
+an active stage on cancellation. Held-stage HTTP requests and ordered shutdown
+are offline-tested; this is not a probe-latency SLO, freshness guarantee or proof
+that a stuck filesystem can be interrupted. See the
+[event-loop/drain contract](results-2026-09-06-maintenance-event-loop.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,7 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-06 maintenance event-loop ownership](results-2026-09-06-maintenance-event-loop.md) — held-stage HTTP probes and shutdown drain, zero provider calls.
 - [2026-09-06 run stop ownership](results-2026-09-06-run-stop-ownership.md) — cancellation/timeout capacity and artifact boundaries, no provider calls.
 - [2026-09-06 readiness, PDF query and audit-detail maintenance](results-2026-09-06-maintenance-readiness-query-audit.md) — offline boundary verification, not a paid experiment.
 

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -111,6 +111,13 @@ readiness on its own. A failed managed watchdog or failed timeout stage makes
 `/health/ready` return 503. Offline `readiness()` has no ASGI task prerequisite.
 Shutdown attempts worker cleanup even if awaiting the supervisor raises.
 
+Process waits and cleanup run off the ASGI loop, one maintenance stage at a
+time. Graceful shutdown drains the current stage, including after repeated
+cancellation, before stopping remaining workers. No later stage is dispatched
+after that cancellation. A stuck filesystem can still delay this drain and
+the next watchdog cycle: neither shutdown duration nor check freshness has an
+SLO. See the [offline scheduling verification](results-2026-09-06-maintenance-event-loop.md).
+
 Concurrent PDF uploads share a process-wide PDFium parsing/closure mutex;
 their subsequent LLM calls remain under normal paid admission, not that mutex.
 PDF export uses a bounded per-run striped lock and sibling-file atomic publication.

--- a/docs/results-2026-09-06-maintenance-event-loop.md
+++ b/docs/results-2026-09-06-maintenance-event-loop.md
@@ -1,0 +1,88 @@
+# Keep synchronous maintenance off the ASGI loop without losing ownership
+
+Date: 2026-09-06. Base: `db6e27c9cea158df529ab99ceaede35507528d13`.
+Zero-provider maintenance; no paid canary or observed production outage claim.
+
+## Before changing code
+
+The unmodified suite passed 2,362 tests and 1,171 subtests. A read-only census
+found 109 direct timestamped run directories and the 30 benchmark reports.
+These artifacts do not capture event-loop scheduling or probe latency; they
+cannot establish how often a watchdog wait stalled a real production request.
+No retained report or frozen experiment was rerun or modified.
+
+The async reaper directly invoked synchronous process waits and directory
+cleanup. Releasing the registry lock around termination had fixed capacity
+ownership, but it did not release the ASGI event loop. Three new tests held
+the timeout, paper and retention callbacks in turn. Each original-code test
+failed because four HTTP requests could not finish within an independent
+observer's five-second bound. An asyncio-only timeout was rejected: that timer
+would also be unable to run while the loop was blocked.
+
+## Change and rejected alternatives
+
+Each stage runs via `asyncio.to_thread`, still serially and with a single active
+stage. Completed observations and logs are applied back on the loop; a running
+stage does not become `ok` merely because it was dispatched. A stage fault
+remains isolated and visible, and later stages/cycles still run normally.
+
+Plain offloading is not enough. Cancelling a `to_thread` await does not stop
+the native thread. Without explicit ownership, lifespan shutdown could call
+`shutdown_all` while the abandoned watchdog still owned a process stop and
+terminal write. A strongly referenced, shielded stage task drains before
+cancellation propagates. Repeated cancellation of either the supervisor or its
+lifespan waiter must not break that drain. Cancellation then stops the cycle;
+it does not dispatch the next cleanup. Ordinary exceptions that settle during
+drain retain the same failed observation/log instead of disappearing.
+
+No fire-and-forget cleanup batch, additional worker replica, process ownership
+redesign, provider call or production restart was introduced. The existing
+shutdown fallback still executes after supervisor failure. Readiness's timeout
+failure versus cleanup-only advisory distinction is unchanged.
+
+## Verification
+
+Nineteen new cases exercise:
+
+- four real ASGI GET responses before releasing each of three held stages:
+  health, readiness, retained-run status and progress;
+- twelve success/failure, stage and cancellation-target combinations, with
+  repeated cancellation, no next-stage dispatch and shutdown ordered last;
+- two real registry/stop-claim/terminal-writer paths around a simulated process,
+  including a denied first stop that shutdown must subsequently take over;
+- idle shutdown with no cleanup dispatch, and ordered cycles whose timeout
+  failures remain HTTP 503 without exposing internal diagnostics.
+
+The held-stage post-fix sample returned all four HTTP responses in 0.000–0.016
+seconds (rounded local monotonic readings). The assertion is completion before
+release, not a claimed zero latency or a production SLO. Processes in these new
+tests are fakes, but the stop ownership and terminal writer are real; earlier
+real-child stop tests continue to run unchanged.
+
+Four independent re-injections cover direct loop blocking, an unshielded stage,
+abandoned drain and premature success publication. Each must fail its intended
+assertion and restore the exact production-file SHA-256. The temporary harness
+needed a unique reverse-patch context for the drain; that was corrected before
+the complete verification was repeated. No assertions or warning policy changed.
+
+All four re-injections failed at their intended seams and were restored. The
+complete local Windows/Python 3.12 suite passed 2,381 tests and 1,176 subtests;
+fresh coverage was 88.72% against the unchanged 85% floor. Latest Ruff and
+narrow Pylint passed. Both real Chromium journeys passed: the read-only journey
+observed zero external requests, mutations or page/console errors; the composer
+intercepted ten simulated POSTs, with zero API requests reaching its static
+server and zero unexpected requests. Neither journey called a paid provider.
+
+## Limits
+
+This removes one reproduced scheduling blocker, not every possible blocking
+API handler, executor saturation, dead filesystem or CPU-bound workload. Stages
+remain serial: a stuck cleanup can still delay the next watchdog cycle. A last
+successful observation is not a measured freshness/SLO guarantee.
+
+Python cannot forcibly stop a filesystem thread. Graceful shutdown drains owned
+work and therefore has no new finite shutdown-time guarantee; forced process or
+host loss can bypass it. This is not distributed supervision, exact-once billing,
+provider cancellation/refund, improved report accuracy or live fault evidence.
+Scoring, providers, CrewAI, checkpoint identities and all frozen Tool Calling
+protocols remain unchanged; production supplementary retrieval is zero-call shadow.

--- a/docs/runtime-terminal-integrity.md
+++ b/docs/runtime-terminal-integrity.md
@@ -104,6 +104,13 @@ the record durable on a failed volume, implement queued cancellation of pending
 launches, or confirm cancellation/refund of a remote provider request. See the
 [offline stop regression](results-2026-09-06-run-stop-ownership.md).
 
+The maintenance supervisor runs its synchronous stages off the ASGI event loop.
+It retains the active stage through cancellation and drains it before lifespan
+calls `shutdown_all`, so shutdown cannot take over an unfinished watchdog stop.
+Repeated cancellation does not abandon that stage or mark it successful. This
+preserves single-process ownership, not bounded filesystem/shutdown latency;
+see the [event-loop regression and limits](results-2026-09-06-maintenance-event-loop.md).
+
 ## Usage states
 
 The HTTP read projection also isolates malformed selected runtime summaries

--- a/tests/test_maintenance_event_loop.py
+++ b/tests/test_maintenance_event_loop.py
@@ -1,0 +1,276 @@
+"""Exercise the ASGI loop while a synchronous maintenance seam is held.
+
+An independent observer releases every hold, including with the original
+blocking implementation. An asyncio-only timeout could not detect that defect:
+the loop responsible for firing its timeout was itself blocked.
+"""
+
+import asyncio
+import contextlib
+import json
+import time
+from threading import Event
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from api import main, runs
+from api.models import ReadinessStatus
+
+
+STAGES = ("timeouts", "papers", "retention")
+RID = "20200101T000000Z-abcdef0123"
+_REAP_TIMEOUTS = runs.reap_timeouts
+_SHUTDOWN_ALL = runs.shutdown_all
+
+
+@pytest.fixture
+def maintenance_fixture(tmp_path, monkeypatch):
+    """No retained user artifacts or real worker can enter this watchdog."""
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(runs, "_registry", {})
+    monkeypatch.setattr(runs, "_stop_claims", {})
+    monkeypatch.setattr(runs, "_inline_paid_operations", {})
+    monkeypatch.setattr(main, "_maintenance_task", None)
+    monkeypatch.setattr(main, "_maintenance_checks", {})
+    monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(main, "readiness", lambda: ReadinessStatus(ready=True, checks={}))
+    operations = dict.fromkeys(STAGES)
+    for name, module, attribute in (
+        ("timeouts", runs, "reap_timeouts"),
+        ("papers", main.papers, "prune_old"),
+        ("retention", runs, "prune_expired_runs"),
+    ):
+        operations[name] = Mock(return_value=[])
+        monkeypatch.setattr(module, attribute, operations[name])
+    monkeypatch.setattr(runs.subprocess, "Popen", Mock(side_effect=AssertionError("worker launch leaked")))
+    shutdown = Mock()
+    monkeypatch.setattr(runs, "shutdown_all", shutdown)
+    directory = tmp_path / RID
+    directory.mkdir()
+    (directory / "status.json").write_text(json.dumps({"done": True, "stage": "Done"}))
+    (directory / "commercialization_report.md").write_text("Offline retained report")
+    return operations, shutdown
+
+
+@pytest.mark.parametrize("stage", STAGES)
+def test_http_probes_complete_before_slow_maintenance_is_released(maintenance_fixture, stage):
+    """Direct synchronous reaping prevented even free health/status responses."""
+    operations, shutdown = maintenance_fixture
+    entered, release = Event(), Event()
+
+    def slow():
+        entered.set()
+        assert release.wait(15), "observer failed to release maintenance"
+        return []
+
+    operations[stage].side_effect = slow
+
+    async def exercise():
+        loop = asyncio.get_running_loop()
+
+        async def probe():
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                responses = await asyncio.gather(*(client.get(path) for path in (
+                    "/health", "/health/ready", f"/api/runs/{RID}", f"/api/runs/{RID}/progress",
+                )))
+            assert all(response.status_code == 200 for response in responses)
+            assert responses[0].json()["maintenance"]["checks"][stage] == "not_checked"
+            assert responses[1].json()["ready"] is True
+            assert responses[2].json()["state"] == "completed"
+            assert responses[3].json()["done"] is True
+            assert not release.is_set(), "responses arrived only after maintenance ended"
+
+        def observe():
+            future = None
+            try:
+                assert entered.wait(10), "maintenance did not start"
+                started = time.monotonic()
+                future = asyncio.run_coroutine_threadsafe(probe(), loop)
+                try:
+                    future.result(timeout=5)
+                except TimeoutError:
+                    pytest.fail(f"HTTP probes stalled behind synchronous {stage} maintenance")
+                print(f"{stage}: four held-stage HTTP probes completed in {time.monotonic() - started:.3f}s")
+            finally:
+                release.set()
+                if future is not None and not future.done():
+                    future.cancel()
+
+        async with main._lifespan(main.app):
+            await asyncio.to_thread(observe)
+        shutdown.assert_called_once_with()
+        runs.subprocess.Popen.assert_not_called()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("stage", STAGES)
+@pytest.mark.parametrize("failure", [False, True])
+@pytest.mark.parametrize("cancel_target", ["supervisor", "lifespan"])
+def test_shutdown_drains_owned_stage_despite_repeated_cancellation(maintenance_fixture, stage, failure, cancel_target):
+    """Cancelling to_thread alone orphaned the stop before shutdown_all ran."""
+    operations, shutdown = maintenance_fixture
+    entered, release, finished = Event(), Event(), Event()
+
+    def slow():
+        entered.set()
+        try:
+            assert release.wait(15), "test failed to release maintenance"
+            if failure:
+                raise PermissionError("private fixture path")
+            return []
+        finally:
+            finished.set()
+
+    operations[stage].side_effect = slow
+    def assert_finished():
+        assert finished.is_set(), "shutdown stole an in-flight maintenance operation"
+
+    shutdown.side_effect = assert_finished
+
+    async def exercise():
+        scope = main._lifespan(main.app)
+        await scope.__aenter__()
+        closing = None
+        try:
+            assert await asyncio.to_thread(entered.wait, 10)
+            closing = asyncio.create_task(scope.__aexit__(None, None, None))
+            # Yield after each cancellation so both reach the actual owner,
+            # rather than coalescing before its first suspended await.
+            for _ in range(3):
+                await asyncio.sleep(0)
+                target = main._maintenance_task if cancel_target == "supervisor" else closing
+                target.cancel()
+            await asyncio.sleep(0)
+            assert not closing.done(), "lifespan abandoned its active stage"
+            shutdown.assert_not_called()
+            assert main._maintenance_checks[stage] == "not_checked"
+            assert all(operations[name].call_count == 0 for name in STAGES[STAGES.index(stage) + 1:])
+        finally:
+            release.set()
+            if closing is None:
+                await scope.__aexit__(None, None, None)
+            else:
+                await asyncio.wait_for(closing, 10)
+        assert main._maintenance_checks[stage] == ("failed" if failure else "ok")
+        assert all(operation.call_count <= 1 for operation in operations.values())
+        shutdown.assert_called_once_with()
+        assert main._maintenance_task is None
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("failure", [False, True])
+def test_real_stop_claim_is_settled_before_shutdown(maintenance_fixture, monkeypatch, failure):
+    """Draining must reach the registry/terminal seam, not just an event flag."""
+    operations, shutdown = maintenance_fixture
+    entered, release = Event(), Event()
+    proc = Mock()
+    proc.poll.return_value = None
+
+    def wait(timeout=None):
+        if not entered.is_set():
+            entered.set()
+            assert release.wait(15)
+            if failure:
+                raise PermissionError("first stop denied")
+        proc.poll.return_value = 0
+        return 0
+
+    proc.wait.side_effect = wait
+    handle = runs._Handle(RID, "offline fixture", proc)
+    handle.started -= runs.TIMEOUT_SECONDS + 1
+    runs._registry[RID] = handle
+    monkeypatch.setattr(runs, "reap_timeouts", _REAP_TIMEOUTS)
+
+    def stop_remaining():
+        assert not runs._stop_claims, "shutdown raced a still-owned stop"
+        assert (RID in runs._registry) is failure
+        assert (runs.DEFAULT_OUTPUT_ROOT / RID / "terminal.json").exists() is not failure
+        _SHUTDOWN_ALL()
+
+    shutdown.side_effect = stop_remaining
+
+    async def exercise():
+        scope = main._lifespan(main.app)
+        await scope.__aenter__()
+        closing = None
+        try:
+            assert await asyncio.to_thread(entered.wait, 10)
+            closing = asyncio.create_task(scope.__aexit__(None, None, None))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert runs._stop_claims.get(RID) is handle
+            assert runs.active_count() == 1
+            shutdown.assert_not_called()
+        finally:
+            release.set()
+            if closing is None:
+                await scope.__aexit__(None, None, None)
+            else:
+                await asyncio.wait_for(closing, 10)
+        shutdown.assert_called_once_with()
+        assert proc.terminate.call_count == (2 if failure else 1)
+        assert runs.active_count() == 0
+        assert main._maintenance_checks["timeouts"] == ("failed" if failure else "ok")
+        operations["papers"].assert_not_called()
+        operations["retention"].assert_not_called()
+        runs.subprocess.Popen.assert_not_called()
+
+    asyncio.run(exercise())
+
+
+def test_cancellation_between_cycles_does_not_start_maintenance(maintenance_fixture, monkeypatch):
+    """Idle shutdown must not dispatch a cleanup merely to drain the scheduler."""
+    operations, shutdown = maintenance_fixture
+    monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 3600)
+
+    async def exercise():
+        async with main._lifespan(main.app):
+            await asyncio.sleep(0)
+        assert all(operation.call_count == 0 for operation in operations.values())
+        shutdown.assert_called_once_with()
+
+    asyncio.run(exercise())
+
+
+def test_cycles_remain_serial_and_faults_reach_http(maintenance_fixture):
+    """Offloading must not launch a cleanup batch or hide a completed failure."""
+    operations, _ = maintenance_fixture
+    order = []
+    complete = Event()
+    count = 0
+
+    def operation(name):
+        nonlocal count
+        order.append(name)
+        count += 1
+        if count == 6:
+            complete.set()
+        if name == "timeouts":
+            raise PermissionError("private fixture path")
+        return []
+
+    for name in STAGES:
+        operations[name].side_effect = lambda name=name: operation(name)
+
+    async def exercise():
+        task = asyncio.create_task(main._reaper())
+        main._maintenance_task = task
+        try:
+            assert await asyncio.to_thread(complete.wait, 10)
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                response = await client.get("/health/ready")
+                assert response.status_code == 503
+                assert response.json()["checks"]["watchdog"] == "timeout watchdog unavailable"
+                assert "private fixture path" not in response.text
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        assert order[:6] == list(STAGES) * 2
+        assert order == [STAGES[index % 3] for index in range(len(order))]
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Why
The async watchdog directly invoked synchronous termination and filesystem cleanup. Three held-stage regressions blocked actual ASGI health/readiness/status/progress requests. Prior mutex/slot fixes did not make those calls nonblocking.

## Change
Run one synchronous stage off-loop at a time. Retain and shield its task; drain it even through repeated cancellation before lifespan can stop remaining workers. Preserve independent fault reporting, serial stages, and shutdown after supervisor failure.

## Evidence
- Baseline: 2362 tests / 1171 subtests.
- Final: 2381 tests / 1176 subtests; coverage 88.72%, unchanged 85% gate.
- 19 new seam tests; four defect re-injections each fail and restore exact file hashes.
- Latest Ruff, narrow Pylint and two zero-provider Chromium journeys passed.
- Dated result and operating/decision guides updated; private resume material excluded.

## Limits and release
No paid requests, production fault injection, manual restart, frozen experiment changes or SLO claim. A stuck filesystem still delays serial maintenance and graceful shutdown. Merge only after exact-head CI is green under the owner's standing maintenance authorization.