### PR TITLE
Expose maintenance observation age without changing readiness policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,9 @@ See the [stop-ownership seam](docs/results-2026-09-06-run-stop-ownership.md).
 Synchronous maintenance stays off the ASGI loop but remains serial and owned.
 Cancellation must drain the current stage before worker shutdown; cancelling
 an await does not stop its thread. See the [scheduling/drain boundary](docs/results-2026-09-06-maintenance-event-loop.md).
+Health/readiness timestamps distinguish current dispatch from last completion;
+elapsed facts use monotonic clocks and do not change readiness policy. See the
+[observation-age contract](docs/results-2026-09-07-maintenance-observation-age.md).
 
 Composer submission/extraction locks are tab-local, not server idempotency.
 Readiness checks the effective selected credential without contacting providers;

--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,8 @@ import os
 import threading
 import time
 from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
@@ -45,6 +47,7 @@ from api.models import (  # noqa: E402
     BYOK_PROVIDERS,
     HealthStatus,
     MaintenanceStatus,
+    MaintenanceTiming,
     PaperExtraction,
     ReadinessStatus,
     ResumeRunRequest,
@@ -60,30 +63,90 @@ _LOGGER = logging.getLogger(__name__)
 _REAP_INTERVAL_SECONDS = 30
 _maintenance_task: asyncio.Task | None = None
 _maintenance_checks: dict[str, str] = {}
+_maintenance_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _MaintenanceTimes:
+    """Process-local clock pairs; monotonic anchors never cross the HTTP seam."""
+
+    current_started_at: datetime | None = None
+    current_started_mono: float | None = None
+    last_started_at: datetime | None = None
+    last_finished_at: datetime | None = None
+    last_duration_seconds: float | None = None
+    last_finished_mono: float | None = None
+
+
+_maintenance_timings: dict[str, _MaintenanceTimes] = {}
+
+
+def _maintenance_clock() -> tuple[datetime, float]:
+    """Keep elapsed facts independent of NTP/manual changes to UTC labels."""
+    return datetime.now(UTC), time.monotonic()
+
+
+def _maintenance_finished(name: str, result: Literal["ok", "failed"]) -> None:
+    # Sync HTTP handlers read on other threads. Publish the result and its
+    # matching clock pair together, never new 'ok' next to an old completion.
+    # This lock covers only snapshots, not I/O or the stage's blocking work.
+    with _maintenance_lock:
+        wall, mono = _maintenance_clock()
+        previous = _maintenance_timings[name]
+        _maintenance_timings[name] = _MaintenanceTimes(
+            last_started_at=previous.current_started_at,
+            last_finished_at=wall,
+            last_duration_seconds=max(0.0, mono - previous.current_started_mono),
+            last_finished_mono=mono,
+        )
+        _maintenance_checks[name] = result
 
 
 def _maintenance_status() -> MaintenanceStatus:
     """Expose task death even when it bypassed the per-stage fault boundary."""
-    task = _maintenance_task
+    with _maintenance_lock:
+        task = _maintenance_task
+        checks = dict(_maintenance_checks)
+        records = dict(_maintenance_timings)
+        wall, mono = _maintenance_clock()
     if task is None:
         state = "not_started"
     elif task.done():
         state = "stopped" if task.cancelled() else "failed"
     else:
-        state = "degraded" if "failed" in _maintenance_checks.values() else "running"
-    return MaintenanceStatus(state=state, checks=dict(_maintenance_checks))
+        state = "degraded" if "failed" in checks.values() else "running"
+    timings = {}
+    for name in checks:
+        record = records.get(name, _MaintenanceTimes())
+        timings[name] = MaintenanceTiming(
+            current_started_at=record.current_started_at,
+            current_elapsed_seconds=(None if record.current_started_mono is None
+                                     else max(0.0, mono - record.current_started_mono)),
+            last_started_at=record.last_started_at,
+            last_finished_at=record.last_finished_at,
+            last_duration_seconds=record.last_duration_seconds,
+            last_finished_age_seconds=(None if record.last_finished_mono is None
+                                       else max(0.0, mono - record.last_finished_mono)),
+        )
+    return MaintenanceStatus(state=state, checks=checks, observed_at=wall, timings=timings)
 
 
 async def _maintenance_stage(name: str, operation: Callable[[], object]) -> None:
     """Offload blocking work without abandoning it when the owner is cancelled."""
     async def execute() -> None:
+        # Starting another attempt does not refresh its last completed result.
+        # Preserve that observation while the new attempt queues/runs/drains.
+        with _maintenance_lock:
+            wall, mono = _maintenance_clock()
+            previous = _maintenance_timings.get(name, _MaintenanceTimes())
+            _maintenance_timings[name] = replace(previous, current_started_at=wall, current_started_mono=mono)
         try:
             changed = await asyncio.to_thread(operation)
         except Exception:  # noqa: BLE001 - supervise one stage and preserve its completed fault observation
-            _maintenance_checks[name] = "failed"
+            _maintenance_finished(name, "failed")
             _LOGGER.exception("Background maintenance stage failed: %s", name)
         else:
-            _maintenance_checks[name] = "ok"
+            _maintenance_finished(name, "ok")
             if changed:
                 _LOGGER.info("Background maintenance %s: %s", name, changed)
 
@@ -131,8 +194,10 @@ async def _reaper() -> None:
 
 @contextlib.asynccontextmanager
 async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
-    global _maintenance_task, _maintenance_checks
-    _maintenance_checks = dict.fromkeys(("timeouts", "papers", "retention"), "not_checked")
+    global _maintenance_task, _maintenance_checks, _maintenance_timings
+    with _maintenance_lock:
+        _maintenance_checks = dict.fromkeys(("timeouts", "papers", "retention"), "not_checked")
+        _maintenance_timings = {}
     task = asyncio.create_task(_reaper())
     _maintenance_task = task
     try:
@@ -549,8 +614,9 @@ def health_ready(response: Response) -> ReadinessStatus:
     # an actually managed task is a readiness precondition here. Liveness
     # always exposes not_started/stopped explicitly. Retention failures are
     # advisory: restarting paid workers cannot repair a cleanup permission.
-    if _maintenance_task is not None:
-        maintenance = _maintenance_status()
+    maintenance = _maintenance_status()
+    status.maintenance = maintenance
+    if maintenance.state != "not_started":
         watchdog_ok = (
             maintenance.state in {"running", "degraded"}
             and maintenance.checks.get("timeouts") != "failed"

--- a/api/models.py
+++ b/api/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, field_validator, model_validator
 
 from academic_agent.run_spec import AssessmentMode, DecisionContext
 
@@ -465,11 +465,38 @@ class RunList(BaseModel):
     total: int
 
 
+class MaintenanceTiming(BaseModel):
+    """Dispatch/completion observations; null is unknown, not a zero duration."""
+
+    current_started_at: AwareDatetime | None = Field(
+        default=None, description="UTC dispatch time of the attempt without a completed observation. "
+                                  "May include executor queueing; consult supervisor state too.",
+    )
+    current_elapsed_seconds: float | None = Field(default=None, ge=0, allow_inf_nan=False)
+    last_started_at: AwareDatetime | None = None
+    last_finished_at: AwareDatetime | None = None
+    last_duration_seconds: float | None = Field(
+        default=None, ge=0, allow_inf_nan=False,
+        description="Monotonic dispatch-to-observed-completion duration of the last completed attempt.",
+    )
+    last_finished_age_seconds: float | None = Field(
+        default=None, ge=0, allow_inf_nan=False,
+        description="Monotonic age of the last completed result, including failures. "
+                    "Not a freshness verdict or SLO.",
+    )
+
+
 class MaintenanceStatus(BaseModel):
     """Observed watchdog state, not proof that every retained artifact is healthy."""
 
     state: Literal["not_started", "running", "degraded", "failed", "stopped"]
-    checks: dict[str, Literal["not_checked", "ok", "failed"]] = Field(default_factory=dict)
+    checks: dict[str, Literal["not_checked", "ok", "failed"]] = Field(
+        default_factory=dict, description="Last completed result per stage, not proof of current freshness.",
+    )
+    observed_at: AwareDatetime | None = Field(
+        default=None, description="UTC snapshot time, not the time the stages last completed.",
+    )
+    timings: dict[str, MaintenanceTiming] = Field(default_factory=dict)
 
 
 class HealthStatus(BaseModel):
@@ -517,3 +544,7 @@ class ReadinessStatus(BaseModel):
     )
     llm_provider: str | None = None
     search_provider: str | None = None
+    maintenance: MaintenanceStatus | None = Field(
+        default=None, description="HTTP supervisor snapshot shared with health. "
+                                  "Absent from the standalone configuration-only readiness check.",
+    )

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -69,6 +69,12 @@ are offline-tested; this is not a probe-latency SLO, freshness guarantee or proo
 that a stuck filesystem can be interrupted. See the
 [event-loop/drain contract](results-2026-09-06-maintenance-event-loop.md).
 
+Both health endpoints additionally expose UTC dispatch/completion times and
+monotonic duration/age facts. A current attempt preserves the previous result;
+polling does not refresh it. This is observation metadata, not a new stale
+threshold or readiness eviction rule. See the
+[time-qualified snapshot contract](results-2026-09-07-maintenance-observation-age.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,7 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-07 maintenance observation age](results-2026-09-07-maintenance-observation-age.md) — time-qualified health/readiness snapshots without a new SLO or provider call.
 - [2026-09-06 maintenance event-loop ownership](results-2026-09-06-maintenance-event-loop.md) — held-stage HTTP probes and shutdown drain, zero provider calls.
 - [2026-09-06 run stop ownership](results-2026-09-06-run-stop-ownership.md) — cancellation/timeout capacity and artifact boundaries, no provider calls.
 - [2026-09-06 readiness, PDF query and audit-detail maintenance](results-2026-09-06-maintenance-readiness-query-audit.md) — offline boundary verification, not a paid experiment.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -118,6 +118,18 @@ after that cancellation. A stuck filesystem can still delay this drain and
 the next watchdog cycle: neither shutdown duration nor check freshness has an
 SLO. See the [offline scheduling verification](results-2026-09-06-maintenance-event-loop.md).
 
+Both HTTP health endpoints expose `maintenance.observed_at` (snapshot UTC time)
+and per-stage `timings`. `current_started_at`/`current_elapsed_seconds` describe
+an unfinished dispatch, including queueing/drain; `last_started_at`,
+`last_finished_at`, `last_duration_seconds` and `last_finished_age_seconds`
+describe its last completed attempt. `checks` keeps that completed result
+while a new attempt is in flight. Unknown facts are null, not zero; UTC labels
+can shift with clock corrections, while durations/ages use monotonic time.
+Use task state and observation age together: a past `ok` is not proof of current
+freshness. There is no new stale cutoff or automatic readiness failure based
+on age. Standalone configuration-only `readiness()` leaves maintenance null.
+See the [exact field meanings and verification](results-2026-09-07-maintenance-observation-age.md).
+
 Concurrent PDF uploads share a process-wide PDFium parsing/closure mutex;
 their subsequent LLM calls remain under normal paid admission, not that mutex.
 PDF export uses a bounded per-run striped lock and sibling-file atomic publication.

--- a/docs/results-2026-09-07-maintenance-observation-age.md
+++ b/docs/results-2026-09-07-maintenance-observation-age.md
@@ -1,0 +1,94 @@
+# Time-qualified maintenance observations at both health endpoints
+
+Date: 2026-09-07. Base: `19719798ae35d8505e007980fa9e20933febdc2f`.
+Zero-provider maintenance, not a new freshness policy or production SLO.
+
+## Starting evidence
+
+The unmodified suite passed 2,381 tests and 1,176 subtests. The retained cohort
+still contains 109 direct timestamped run directories and 30 benchmark reports.
+Those files do not contain the process-local maintenance observation clock;
+they cannot establish the age of a live watchdog's last result or how often
+an operator has misread it. No benchmark, provider call or retained run changed.
+
+The health payload exposed only the last `ok`/`failed`/`not_checked` result, and
+the readiness payload omitted the maintenance snapshot entirely. Three new
+HTTP regressions first failed at that missing readiness projection. A frozen
+clock then makes the important distinction testable without waiting an hour:
+polling an hour after completion must retain its result and timestamp, but
+report an age of 3,600 seconds rather than manufacturing another fresh check.
+
+## Contract
+
+`/health.maintenance` and `/health/ready.maintenance` share the same typed
+projection. Separate requests have separate snapshot times; equality tests
+freeze the clock deliberately, not because real responses must be identical.
+Existing state, checks and HTTP status rules remain compatible.
+
+| Field | Meaning |
+|---|---|
+| `observed_at` | UTC time this snapshot was taken, not when maintenance completed |
+| `checks[name]` | Last completed result for that stage, not a current freshness verdict |
+| `timings[name].current_started_at` | UTC dispatch time of an attempt without a completed observation; null when none is retained |
+| `current_elapsed_seconds` | Monotonic dispatch-to-snapshot interval, including queueing and drain; null without an unfinished attempt |
+| `last_started_at`, `last_finished_at` | UTC start/completion labels of the last completed attempt |
+| `last_duration_seconds` | Monotonic dispatch-to-observed-completion duration |
+| `last_finished_age_seconds` | Monotonic age of that last completed result, whether success or failure |
+
+Unknown completion facts are null, never a zero duration or a passing check.
+A zero age is valid only immediately after a completed observation. Starting
+another attempt preserves the previous result and its clock pair; cancellation
+drain does not refresh those completed facts. On success or ordinary failure,
+completion is published with its matching clocks and the current attempt clears.
+Failure in one stage neither refreshes nor clears another stage's observations.
+Supervisor death stays a failed/stopped supervisor even beside a past `ok`.
+
+Short process-local locking pairs results and immutable clock records for
+threaded HTTP readers. It does not enclose provider work, filesystem operations
+or process waits. UTC labels support inspection; monotonic anchors measure
+durations and ages and never leave the process. A wall-clock adjustment can
+make UTC labels appear reordered without creating negative durations or
+artificial freshness. A new managed lifespan discards the old clock anchors.
+
+The standalone configuration-only `readiness()` does not acquire an ASGI
+supervisor requirement and leaves `maintenance` null. The HTTP wrapper adds
+the explicit managed or `not_started` snapshot. A failed timeout stage or
+dead supervisor still returns 503; an old success alone does not introduce
+a new failure threshold. A cleanup-only failure remains advisory.
+
+## Verification
+
+Twenty-four new cases cover ageing completed results, preservation of both old
+success and old failure while a subsequent success/failure is draining, first
+in-flight attempts, UTC jumps in either direction, lifecycle reset, supervisor
+death and the public schema. Assertions cross actual health/readiness HTTP
+responses and OpenAPI, not only an in-memory field. Clocks are locally frozen;
+the real asyncio scheduler is not patched. Existing cancellation-drain,
+stop-ownership and readiness tests remain active without relaxed assertions.
+
+Five defect re-injections target a lost readiness snapshot, wall-clock-derived
+age, polling that resets age, dispatch that discards previous completion, and
+a new lifespan that keeps old clock anchors. Each must fail its intended seam
+and restore the exact production-file SHA-256 before further verification.
+
+All five re-injections failed at their intended seams and restored the exact
+file hash. The final local Windows/Python 3.12 suite passed 2,405 tests and
+1,181 subtests, with fresh coverage of 88.76% above the unchanged 85% floor.
+Latest Ruff, narrow Pylint and both real Chromium journeys passed. The read-only
+journey recorded zero external requests, mutations and page/console errors;
+the composer intercepted ten simulated POSTs with zero API requests reaching
+its static server, unexpected requests or paid-provider calls. No warning
+filter was relaxed and no existing test was skipped.
+
+## Limits and rejected shortcuts
+
+There is no measured safe freshness cutoff, so this adds observation facts,
+not an invented stale threshold, automatic cancellation, restart or readiness
+eviction. Operators can inspect age alongside current elapsed time and task
+state; this is not a browser dashboard or an alerting/SLO implementation.
+The nominal reaper sleep interval is not a maximum interval between checks:
+stages remain serial, and stuck cleanup may delay the next cycle and graceful
+shutdown. Forced process loss may leave no final observation. Nothing here
+establishes provider connectivity, source truth, report accuracy, distributed
+ownership or lower billing. Scoring and frozen experiments are unchanged;
+production supplementary Tool Calling remains zero-call shadow mode.

--- a/tests/test_maintenance_event_loop.py
+++ b/tests/test_maintenance_event_loop.py
@@ -34,6 +34,7 @@ def maintenance_fixture(tmp_path, monkeypatch):
     monkeypatch.setattr(runs, "_inline_paid_operations", {})
     monkeypatch.setattr(main, "_maintenance_task", None)
     monkeypatch.setattr(main, "_maintenance_checks", {})
+    monkeypatch.setattr(main, "_maintenance_timings", {})
     monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(main, "readiness", lambda: ReadinessStatus(ready=True, checks={}))
     operations = dict.fromkeys(STAGES)

--- a/tests/test_maintenance_supervision.py
+++ b/tests/test_maintenance_supervision.py
@@ -14,6 +14,7 @@ from api.models import ReadinessStatus
 def isolated_supervisor(monkeypatch):
     monkeypatch.setattr(main, "_maintenance_task", None)
     monkeypatch.setattr(main, "_maintenance_checks", {})
+    monkeypatch.setattr(main, "_maintenance_timings", {})
 
 
 def test_cleanup_fault_keeps_later_stage_and_next_timeout_cycle_alive():
@@ -63,9 +64,11 @@ def test_health_delivers_cleanup_failure_but_only_dead_watchdog_blocks_readiness
 
 
 def test_unstarted_is_not_a_passing_audit():
-    assert TestClient(main.app).get("/health").json()["maintenance"] == {
-        "state": "not_started", "checks": {},
+    snapshot = TestClient(main.app).get("/health").json()["maintenance"]
+    assert snapshot == {
+        "state": "not_started", "checks": {}, "timings": {}, "observed_at": snapshot["observed_at"],
     }
+    assert snapshot["observed_at"].endswith("Z")
 
 
 def test_stage_recovers_only_after_its_next_success():

--- a/tests/test_maintenance_timing.py
+++ b/tests/test_maintenance_timing.py
@@ -1,0 +1,240 @@
+"""Time-qualified maintenance observations must survive both HTTP schemas."""
+
+import asyncio
+import contextlib
+from datetime import UTC, datetime, timedelta
+from threading import Event
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from api import main, runs
+from api.models import ReadinessStatus
+
+
+STAGES = ("timeouts", "papers", "retention")
+TIMING_FIELDS = {
+    "current_started_at", "current_elapsed_seconds", "last_started_at",
+    "last_finished_at", "last_duration_seconds", "last_finished_age_seconds",
+}
+
+
+class Clock:
+    """Do not patch time.monotonic globally: asyncio needs its real scheduler."""
+
+    def __init__(self):
+        self.wall = datetime(2026, 9, 7, tzinfo=UTC)
+        self.mono = 100.0
+
+    def __call__(self):
+        return self.wall, self.mono
+
+    def advance(self, seconds, wall_seconds=None):
+        self.mono += seconds
+        self.wall += timedelta(seconds=seconds if wall_seconds is None else wall_seconds)
+
+
+@pytest.fixture
+def clock(monkeypatch, tmp_path):
+    clock = Clock()
+    monkeypatch.setattr(main, "_maintenance_clock", clock)
+    monkeypatch.setattr(main, "_maintenance_timings", {})
+    monkeypatch.setattr(main, "_maintenance_checks", dict.fromkeys(STAGES, "not_checked"))
+    monkeypatch.setattr(main, "_maintenance_task", Mock(done=lambda: False))
+    monkeypatch.setattr(main, "readiness", lambda: ReadinessStatus(ready=True, checks={}))
+    monkeypatch.setattr(runs, "_registry", {})
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(runs, "_stop_claims", {})
+    monkeypatch.setattr(runs, "_inline_paid_operations", {})
+    monkeypatch.setattr(runs, "shutdown_all", Mock())
+    monkeypatch.setattr(runs.subprocess, "Popen", Mock(side_effect=AssertionError("worker launch leaked")))
+    return clock
+
+
+def read_both():
+    client = TestClient(main.app)
+    responses = [client.get(path) for path in ("/health", "/health/ready")]
+    snapshots = [response.json()["maintenance"] for response in responses]
+    assert snapshots[0] == snapshots[1], "HTTP endpoints lost or changed observation fields"
+    return snapshots[0], responses
+
+
+def timestamp(value):
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    assert parsed.utcoffset() == timedelta(0)
+    return parsed
+
+
+@pytest.mark.parametrize("stage", STAGES)
+def test_old_success_ages_without_becoming_a_new_check(clock, stage):
+    """A one-hour-old ok formerly looked identical to a just-completed ok."""
+    operation = Mock(side_effect=lambda: clock.advance(3))
+    asyncio.run(main._maintenance_stage(stage, operation))
+    first, _ = read_both()
+    clock.advance(3600)
+    later, responses = read_both()
+    timing = later["timings"][stage]
+    assert set(timing) == TIMING_FIELDS
+    assert later["checks"][stage] == first["checks"][stage] == "ok"
+    assert timing["last_finished_at"] == first["timings"][stage]["last_finished_at"]
+    assert timing["last_finished_age_seconds"] == 3600
+    assert first["timings"][stage]["last_finished_age_seconds"] == 0
+    assert timing["last_duration_seconds"] == 3
+    assert timing["current_started_at"] is None
+    assert timing["current_elapsed_seconds"] is None
+    assert timestamp(timing["last_started_at"]) == datetime(2026, 9, 7, tzinfo=UTC)
+    assert timestamp(later["observed_at"]) == clock.wall
+    assert all(response.status_code == 200 for response in responses)
+    operation.assert_called_once_with()
+
+
+@pytest.mark.parametrize("stage", STAGES)
+@pytest.mark.parametrize("failure", [False, True])
+@pytest.mark.parametrize("previous_failure", [False, True])
+def test_running_attempt_preserves_previous_result_and_completion_time(clock, stage, failure, previous_failure):
+    """Dispatch is not completion, including while graceful cancellation drains."""
+    def first():
+        clock.advance(2)
+        if previous_failure:
+            raise PermissionError("previous failure")
+
+    asyncio.run(main._maintenance_stage(stage, first))
+    before, _ = read_both()
+    clock.advance(10)
+    started = clock.wall
+    entered, release = Event(), Event()
+
+    def slow():
+        entered.set()
+        assert release.wait(15), "test did not release maintenance"
+        if failure:
+            raise PermissionError("private fixture path")
+        return []
+
+    async def exercise():
+        task = asyncio.create_task(main._maintenance_stage(stage, slow))
+        try:
+            assert await asyncio.to_thread(entered.wait, 10)
+            clock.advance(45)
+            for _ in range(2):
+                task.cancel()
+                await asyncio.sleep(0)
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                for route in ("/health", "/health/ready"):
+                    response = await client.get(route)
+                    assert response.status_code == (503 if route.endswith("ready") and previous_failure and stage == "timeouts" else 200)
+                    snapshot = response.json()["maintenance"]
+                    timing = snapshot["timings"][stage]
+                    assert snapshot["checks"][stage] == ("failed" if previous_failure else "ok")
+                    assert timestamp(timing["current_started_at"]) == started
+                    assert timing["current_elapsed_seconds"] == 45
+                    assert timing["last_finished_at"] == before["timings"][stage]["last_finished_at"]
+                    assert timing["last_duration_seconds"] == 2
+                    assert timing["last_finished_age_seconds"] == 55
+        finally:
+            release.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, 10)
+
+    asyncio.run(exercise())
+    after, responses = read_both()
+    timing = after["timings"][stage]
+    assert after["checks"][stage] == ("failed" if failure else "ok")
+    assert timestamp(timing["last_started_at"]) == started
+    assert timestamp(timing["last_finished_at"]) == clock.wall
+    assert timing["last_duration_seconds"] == 45
+    assert timing["last_finished_age_seconds"] == 0
+    assert timing["current_started_at"] is None
+    assert timing["current_elapsed_seconds"] is None
+    assert responses[1].status_code == (503 if failure and stage == "timeouts" else 200)
+    assert "private fixture path" not in responses[1].text
+    for other in set(STAGES) - {stage}:
+        assert after["checks"][other] == "not_checked"
+        assert all(value is None for value in after["timings"][other].values())
+
+
+@pytest.mark.parametrize("wall_shift", [-86400, 86400])
+def test_clock_adjustments_do_not_rewrite_duration_or_age(clock, wall_shift):
+    """NTP changes may reorder UTC labels, never the monotonic elapsed facts."""
+    asyncio.run(main._maintenance_stage("timeouts", lambda: clock.advance(4, wall_shift)))
+    clock.advance(7, wall_shift)
+    snapshot, _ = read_both()
+    assert snapshot["timings"]["timeouts"]["last_duration_seconds"] == 4
+    assert snapshot["timings"]["timeouts"]["last_finished_age_seconds"] == 7
+    assert timestamp(snapshot["observed_at"]) == clock.wall
+
+
+@pytest.mark.parametrize("stage", STAGES)
+def test_first_inflight_attempt_has_no_fabricated_completion(clock, stage):
+    """A current dispatch time must not mint a completed result or zero age."""
+    entered, release = Event(), Event()
+
+    def first():
+        entered.set()
+        assert release.wait(15)
+
+    async def exercise():
+        task = asyncio.create_task(main._maintenance_stage(stage, first))
+        try:
+            assert await asyncio.to_thread(entered.wait, 10)
+            clock.advance(8)
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                for route in ("/health", "/health/ready"):
+                    snapshot = (await client.get(route)).json()["maintenance"]
+                    timing = snapshot["timings"][stage]
+                    assert snapshot["checks"][stage] == "not_checked"
+                    assert timing["current_elapsed_seconds"] == 8
+                    assert timestamp(timing["current_started_at"]) == datetime(2026, 9, 7, tzinfo=UTC)
+                    assert all(value is None for key, value in timing.items() if key.startswith("last_"))
+        finally:
+            release.set()
+            await asyncio.wait_for(task, 10)
+
+    asyncio.run(exercise())
+
+
+def test_lifespan_resets_prior_process_observations(clock, monkeypatch):
+    """A new managed lifespan cannot inherit the previous watchdog's ok."""
+    asyncio.run(main._maintenance_stage("timeouts", lambda: clock.advance(4)))
+    monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 3600)
+
+    async def exercise():
+        async with main._lifespan(main.app):
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                for route in ("/health", "/health/ready"):
+                    snapshot = (await client.get(route)).json()["maintenance"]
+                    assert snapshot["state"] == "running"
+                    assert snapshot["checks"] == dict.fromkeys(STAGES, "not_checked")
+                    assert set(snapshot["timings"]) == set(STAGES)
+                    assert all(value is None for timing in snapshot["timings"].values() for value in timing.values())
+        runs.shutdown_all.assert_called_once_with()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("cancelled", [False, True])
+def test_dead_supervisor_preserves_old_observation_without_passing_readiness(clock, monkeypatch, cancelled):
+    """A timestamp is evidence of a past result, not proof the supervisor lives."""
+    asyncio.run(main._maintenance_stage("timeouts", lambda: clock.advance(1)))
+    clock.advance(300)
+    monkeypatch.setattr(main, "_maintenance_task", Mock(done=lambda: True, cancelled=lambda: cancelled))
+    snapshot, responses = read_both()
+    assert snapshot["state"] == ("stopped" if cancelled else "failed")
+    assert snapshot["checks"]["timeouts"] == "ok"
+    assert snapshot["timings"]["timeouts"]["last_finished_age_seconds"] == 300
+    assert responses[1].status_code == 503
+
+
+def test_unmanaged_readiness_is_explicit_and_timing_schema_is_public(clock, monkeypatch):
+    """Readiness previously dropped maintenance entirely at the response seam."""
+    monkeypatch.setattr(main, "_maintenance_task", None)
+    snapshot, responses = read_both()
+    assert snapshot["state"] == "not_started"
+    assert "watchdog" not in responses[1].json()["checks"]
+    assert all(value is None for timing in snapshot["timings"].values() for value in timing.values())
+    schema = TestClient(main.app).get("/openapi.json").json()["components"]["schemas"]
+    assert set(schema["MaintenanceTiming"]["properties"]) == TIMING_FIELDS
+    assert "timings" in schema["MaintenanceStatus"]["properties"]
+    assert "maintenance" in schema["ReadinessStatus"]["properties"]


### PR DESCRIPTION
## Why
An old maintenance `ok` was indistinguishable from a new one, and readiness did not expose the supervisor snapshot. A query or another attempt must not refresh the prior result.

## Scope
- Add typed UTC observation/dispatch/completion labels and monotonic elapsed/age values to both health responses.
- Keep current attempt separate from previous completion, including failure and repeated cancellation/drain.
- Pair status and timing under a short snapshot lock; reset anchors on a new lifespan.
- Preserve readiness policy; no invented stale cutoff, alerting, restart or paid invocation.
- Link the dated result and operating contract; keep frozen experiments and production zero-call shadow unchanged.

## Verification
- Baseline: 2381 tests / 1176 subtests.
- Final: 2405 tests / 1181 subtests; 88.76% fresh local coverage, unchanged 85% gate.
- Latest Ruff, narrow Pylint, both zero-provider Chromium journeys passed.
- 24 new seam cases, 5 targeted defect re-injections, exact source hash restoration.
- Final docs/timing check: 30 tests / 489 subtests.

## Limits
No production freshness incident or SLO is inferred from historical artifacts. Maintenance remains serial; blocked cleanup can delay subsequent cycles and graceful shutdown. This adds HTTP metadata, not a new dashboard or production Tool Calling.