### PR TITLE
Expose advisory cleanup outcomes at both health endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,9 @@ an await does not stop its thread. See the [scheduling/drain boundary](docs/resu
 Health/readiness timestamps distinguish current dispatch from last completion;
 elapsed facts use monotonic clocks and do not change readiness policy. See the
 [observation-age contract](docs/results-2026-09-07-maintenance-observation-age.md).
+Cleanup summaries distinguish complete/partial scans from absent, disabled or
+unavailable observation; legacy normal-return checks are not proof of complete
+deletion. See [safe outcome counts](docs/results-2026-09-07-cleanup-outcome-observability.md).
 
 Composer submission/extraction locks are tab-local, not server idempotency.
 Readiness checks the effective selected credential without contacting providers;

--- a/api/cleanup.py
+++ b/api/cleanup.py
@@ -1,0 +1,63 @@
+"""Per-attempt cleanup observations, separate from legacy removal return values."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from stat import S_ISDIR
+from typing import Literal
+
+from api.models import CleanupSummary
+
+
+@dataclass
+class CleanupAudit:
+    """Owned by one offloaded call; only its final immutable snapshot is public."""
+
+    scanned: int = 0
+    deleted: int = 0
+    skipped: int = 0
+    failed: int = 0
+    skip_reasons: dict[str, int] = field(default_factory=dict)
+    failure_reasons: dict[str, int] = field(default_factory=dict)
+    started: bool = False
+    scan_complete: bool = False
+    state: Literal["complete", "partial", "disabled", "absent", "unavailable"] = "unavailable"
+
+    def entries(self, root: Path) -> Iterator[Path]:
+        # is_dir can collapse absence and a failed stat on some Python versions.
+        # Only definite absence is a no-scan result; a denied/file root remains
+        # unavailable and reaches the existing per-stage exception boundary.
+        try:
+            mode = root.stat().st_mode
+        except FileNotFoundError:
+            self.state = "absent"
+            return
+        if not S_ISDIR(mode):
+            raise NotADirectoryError("Cleanup root is not a directory")
+        self.started = True
+        for directory in root.iterdir():
+            self.scanned += 1
+            yield directory
+        self.scan_complete = True
+        self.state = "partial" if self.failed else "complete"
+
+    def skip(self, reason: Literal["fresh", "live", "unrelated"]) -> None:
+        self.skipped += 1
+        self.skip_reasons[reason] = self.skip_reasons.get(reason, 0) + 1
+
+    def fail(self, reason: Literal["metadata", "delete"]) -> None:
+        self.failed += 1
+        self.failure_reasons[reason] = self.failure_reasons.get(reason, 0) + 1
+
+    def snapshot(self, *, interrupted: bool = False) -> CleanupSummary:
+        # No scan is not an empty successful scan. A mid-iteration failure keeps
+        # the observed prefix, explicitly incomplete, rather than zeroing facts
+        # or presenting partial counts as the root's complete inventory.
+        state = "unavailable" if interrupted else self.state
+        if not self.started:
+            return CleanupSummary(state=state)
+        return CleanupSummary(
+            state=state, scan_complete=self.scan_complete and not interrupted,
+            scanned=self.scanned, deleted=self.deleted, skipped=self.skipped, failed=self.failed,
+            skip_reasons=dict(self.skip_reasons), failure_reasons=dict(self.failure_reasons),
+        )

--- a/api/main.py
+++ b/api/main.py
@@ -43,8 +43,10 @@ from academic_agent.pdf_extractor import (  # noqa: E402
     extract_paper_contribution,
 )
 from api import access, papers, runs  # noqa: E402  — must follow load_dotenv
+from api.cleanup import CleanupAudit  # noqa: E402
 from api.models import (  # noqa: E402
     BYOK_PROVIDERS,
+    CleanupSummary,
     HealthStatus,
     MaintenanceStatus,
     MaintenanceTiming,
@@ -76,6 +78,7 @@ class _MaintenanceTimes:
     last_finished_at: datetime | None = None
     last_duration_seconds: float | None = None
     last_finished_mono: float | None = None
+    cleanup: CleanupSummary | None = None
 
 
 _maintenance_timings: dict[str, _MaintenanceTimes] = {}
@@ -86,7 +89,7 @@ def _maintenance_clock() -> tuple[datetime, float]:
     return datetime.now(UTC), time.monotonic()
 
 
-def _maintenance_finished(name: str, result: Literal["ok", "failed"]) -> None:
+def _maintenance_finished(name: str, result: Literal["ok", "failed"], cleanup: CleanupSummary | None = None) -> None:
     # Sync HTTP handlers read on other threads. Publish the result and its
     # matching clock pair together, never new 'ok' next to an old completion.
     # This lock covers only snapshots, not I/O or the stage's blocking work.
@@ -98,6 +101,7 @@ def _maintenance_finished(name: str, result: Literal["ok", "failed"]) -> None:
             last_finished_at=wall,
             last_duration_seconds=max(0.0, mono - previous.current_started_mono),
             last_finished_mono=mono,
+            cleanup=cleanup,
         )
         _maintenance_checks[name] = result
 
@@ -128,12 +132,22 @@ def _maintenance_status() -> MaintenanceStatus:
             last_finished_age_seconds=(None if record.last_finished_mono is None
                                        else max(0.0, mono - record.last_finished_mono)),
         )
-    return MaintenanceStatus(state=state, checks=checks, observed_at=wall, timings=timings)
+    cleanup = {}
+    for name in ("papers", "retention"):
+        if name in checks:
+            record = records.get(name, _MaintenanceTimes())
+            cleanup[name] = record.cleanup or CleanupSummary(
+                state="not_checked" if checks[name] == "not_checked" else "unavailable",
+            )
+    return MaintenanceStatus(state=state, checks=checks, observed_at=wall, timings=timings, cleanup=cleanup)
 
 
-async def _maintenance_stage(name: str, operation: Callable[[], object]) -> None:
+async def _maintenance_stage(name: str, operation: Callable[..., object], *, collect_cleanup: bool = False) -> None:
     """Offload blocking work without abandoning it when the owner is cancelled."""
     async def execute() -> None:
+        # No global collector or shared mutable tally: even direct legacy
+        # cleanup callers cannot overwrite an in-flight reaper observation.
+        audit = CleanupAudit() if collect_cleanup else None
         # Starting another attempt does not refresh its last completed result.
         # Preserve that observation while the new attempt queues/runs/drains.
         with _maintenance_lock:
@@ -141,12 +155,16 @@ async def _maintenance_stage(name: str, operation: Callable[[], object]) -> None
             previous = _maintenance_timings.get(name, _MaintenanceTimes())
             _maintenance_timings[name] = replace(previous, current_started_at=wall, current_started_mono=mono)
         try:
-            changed = await asyncio.to_thread(operation)
+            changed = (await asyncio.to_thread(operation, cleanup=audit) if audit is not None
+                       else await asyncio.to_thread(operation))
         except Exception:  # noqa: BLE001 - supervise one stage and preserve its completed fault observation
-            _maintenance_finished(name, "failed")
+            _maintenance_finished(name, "failed", audit.snapshot(interrupted=True) if audit is not None else None)
             _LOGGER.exception("Background maintenance stage failed: %s", name)
         else:
-            _maintenance_finished(name, "ok")
+            # Keep legacy normal-return checks and readiness stable. The
+            # dedicated summary makes partial/absent/disabled outcomes explicit
+            # without evicting a host with paid work for one cleanup failure.
+            _maintenance_finished(name, "ok", audit.snapshot() if audit is not None else None)
             if changed:
                 _LOGGER.info("Background maintenance %s: %s", name, changed)
 
@@ -189,7 +207,7 @@ async def _reaper() -> None:
             ("papers", papers.prune_old),
             ("retention", runs.prune_expired_runs),
         ):
-            await _maintenance_stage(name, operation)
+            await _maintenance_stage(name, operation, collect_cleanup=name != "timeouts")
 
 
 @contextlib.asynccontextmanager

--- a/api/models.py
+++ b/api/models.py
@@ -486,6 +486,22 @@ class MaintenanceTiming(BaseModel):
     )
 
 
+class CleanupSummary(BaseModel):
+    """Last cleanup attempt, not a guarantee that every expired file is gone."""
+
+    model_config = {"frozen": True}
+    state: Literal["not_checked", "complete", "partial", "disabled", "absent", "unavailable"]
+    scan_complete: bool | None = Field(
+        default=None, description="False means observed counts cover only an incomplete scan; null means no scan.",
+    )
+    scanned: int | None = Field(default=None, ge=0, strict=True)
+    deleted: int | None = Field(default=None, ge=0, strict=True)
+    skipped: int | None = Field(default=None, ge=0, strict=True)
+    failed: int | None = Field(default=None, ge=0, strict=True)
+    skip_reasons: dict[Literal["fresh", "live", "unrelated"], int] = Field(default_factory=dict)
+    failure_reasons: dict[Literal["metadata", "delete"], int] = Field(default_factory=dict)
+
+
 class MaintenanceStatus(BaseModel):
     """Observed watchdog state, not proof that every retained artifact is healthy."""
 
@@ -497,6 +513,10 @@ class MaintenanceStatus(BaseModel):
         default=None, description="UTC snapshot time, not the time the stages last completed.",
     )
     timings: dict[str, MaintenanceTiming] = Field(default_factory=dict)
+    cleanup: dict[Literal["papers", "retention"], CleanupSummary] = Field(
+        default_factory=dict, description="Last cleanup attempt paired with that stage's completion clocks. "
+                                        "Legacy checks describe normal return, not complete deletion.",
+    )
 
 
 class HealthStatus(BaseModel):

--- a/api/papers.py
+++ b/api/papers.py
@@ -19,8 +19,10 @@ import shutil
 import time
 import uuid
 from pathlib import Path
+from stat import S_ISDIR
 
 from academic_agent.run_output import DEFAULT_OUTPUT_ROOT
+from api.cleanup import CleanupAudit
 
 # Uploads and their extractions live outside the per-run directories: a paper
 # may be uploaded and never run, and a run directory should describe a run.
@@ -210,26 +212,34 @@ def extraction_path_for_run(paper_id: str, *, owner: str | None = None) -> Path:
     return path
 
 
-def prune_old(max_age_seconds: int = _MAX_AGE_SECONDS) -> int:
+def prune_old(max_age_seconds: int = _MAX_AGE_SECONDS, *, cleanup: CleanupAudit | None = None) -> int:
     """Delete upload directories older than max_age_seconds.
 
     Best-effort: a directory that cannot be removed (open handle on Windows,
-    permissions) is skipped rather than raising, since pruning runs on a timer
-    and must not take down the caller.
+    permissions) is counted but does not abort peer cleanup. The optional
+    per-attempt observer preserves the historical integer return contract.
+    Root failures still reach the supervisor, which isolates later stages.
     """
-    if not PAPERS_ROOT.is_dir():
-        return 0
-
+    audit = cleanup if cleanup is not None else CleanupAudit()
     cutoff = time.time() - max_age_seconds
     removed = 0
-    for directory in PAPERS_ROOT.iterdir():
-        if not directory.is_dir():
+    for directory in audit.entries(PAPERS_ROOT):
+        try:
+            metadata = directory.stat()
+        except OSError:
+            audit.fail("metadata")
+            continue
+        if not S_ISDIR(metadata.st_mode):
+            audit.skip("unrelated")
+            continue
+        if metadata.st_mtime >= cutoff:
+            audit.skip("fresh")
             continue
         try:
-            if directory.stat().st_mtime >= cutoff:
-                continue
             shutil.rmtree(directory)
-            removed += 1
         except OSError:
+            audit.fail("delete")
             continue
+        removed += 1
+        audit.deleted += 1
     return removed

--- a/api/runs.py
+++ b/api/runs.py
@@ -28,6 +28,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from stat import S_ISDIR
 
 from academic_agent.checkpoints import CheckpointStore, hash_json
 from academic_agent.run_output import DEFAULT_OUTPUT_ROOT, create_run_id
@@ -44,6 +45,7 @@ from academic_agent.run_terminal import (
     load_terminal_record,
 )
 from api.audit_projection import project_audit_metadata
+from api.cleanup import CleanupAudit
 from api.runtime_projection import project_runtime_metadata
 
 # A run is killed after this long. The bound belongs to the worker contract,
@@ -1609,7 +1611,7 @@ def _format_duration(secs: int | None) -> str:
     return f"{secs}s" if secs < 60 else f"{secs // 60}m {secs % 60:02d}s"
 
 
-def prune_expired_runs(retention_days: int | None = None) -> list[str]:
+def prune_expired_runs(retention_days: int | None = None, *, cleanup: CleanupAudit | None = None) -> list[str]:
     """Delete runs older than the retention window. Returns the ids removed.
 
     Age is taken from the run id's own timestamp rather than the directory's
@@ -1621,12 +1623,15 @@ def prune_expired_runs(retention_days: int | None = None) -> list[str]:
     and its id is in the registry regardless of how old the id looks — which
     matters for a run that outlived the window while executing.
 
-    Best-effort, like the paper pruning it runs beside: a directory that
-    cannot be removed is skipped rather than raising, because this is called
-    from a timer whose failure would take the reaper down with it.
+    Best-effort: individual failures are counted but peer cleanup continues.
+    Keep the historical removed-ID return value; the optional observer exposes
+    only safe counts, never paths/IDs, through the maintenance HTTP snapshot.
+    Root failures still reach the supervisor's per-stage boundary.
     """
     days = RUN_RETENTION_DAYS if retention_days is None else retention_days
-    if days <= 0 or not DEFAULT_OUTPUT_ROOT.is_dir():
+    audit = cleanup if cleanup is not None else CleanupAudit()
+    if days <= 0:
+        audit.state = "disabled"
         return []
 
     cutoff = datetime.now(UTC) - timedelta(days=days)
@@ -1634,24 +1639,38 @@ def prune_expired_runs(retention_days: int | None = None) -> list[str]:
         live = {rid for rid, h in _registry.items() if _occupies_slot(rid, h)}
 
     removed: list[str] = []
-    for directory in DEFAULT_OUTPUT_ROOT.iterdir():
-        if not directory.is_dir() or not _RUN_ID_PATTERN.fullmatch(directory.name):
+    for directory in audit.entries(DEFAULT_OUTPUT_ROOT):
+        if not _RUN_ID_PATTERN.fullmatch(directory.name):
+            audit.skip("unrelated")
             continue
         if directory.name in live:
+            audit.skip("live")
+            continue
+        try:
+            metadata = directory.stat()
+        except OSError:
+            audit.fail("metadata")
+            continue
+        if not S_ISDIR(metadata.st_mode):
+            audit.skip("unrelated")
             continue
         try:
             stamp = datetime.strptime(
                 directory.name.split("-")[0], "%Y%m%dT%H%M%SZ"
             ).replace(tzinfo=UTC)
         except ValueError:
+            audit.skip("unrelated")
             continue
         if stamp >= cutoff:
+            audit.skip("fresh")
             continue
         try:
             shutil.rmtree(directory)
         except OSError:
+            audit.fail("delete")
             continue
         removed.append(directory.name)
+        audit.deleted += 1
     return removed
 
 

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -75,6 +75,12 @@ polling does not refresh it. This is observation metadata, not a new stale
 threshold or readiness eviction rule. See the
 [time-qualified snapshot contract](results-2026-09-07-maintenance-observation-age.md).
 
+Cleanup now exposes per-attempt deleted/skipped/failed counts at both health
+endpoints, with partial/unavailable scan states rather than inferring full
+deletion from a normal return. Unknown inventory is not zero; cleanup-only
+faults remain advisory. This is not proof of a production storage failure or
+complete erasure; see the [outcome contract](results-2026-09-07-cleanup-outcome-observability.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,7 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-07 cleanup outcomes](results-2026-09-07-cleanup-outcome-observability.md) — advisory per-attempt counters and explicit incomplete coverage at both HTTP schemas.
 - [2026-09-07 maintenance observation age](results-2026-09-07-maintenance-observation-age.md) — time-qualified health/readiness snapshots without a new SLO or provider call.
 - [2026-09-06 maintenance event-loop ownership](results-2026-09-06-maintenance-event-loop.md) — held-stage HTTP probes and shutdown drain, zero provider calls.
 - [2026-09-06 run stop ownership](results-2026-09-06-run-stop-ownership.md) — cancellation/timeout capacity and artifact boundaries, no provider calls.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -130,6 +130,17 @@ freshness. There is no new stale cutoff or automatic readiness failure based
 on age. Standalone configuration-only `readiness()` leaves maintenance null.
 See the [exact field meanings and verification](results-2026-09-07-maintenance-observation-age.md).
 
+Read `maintenance.cleanup.papers` and `maintenance.cleanup.retention` for
+the last attempt's scanned/deleted/skipped/failed counts and fixed reason
+categories. Legacy `checks=ok` means the operation returned normally, not
+that every directory was deleted. Detail states distinguish complete, partial,
+disabled, absent, not_checked and unavailable. No scan has null counts;
+an empty completed scan has zero counts. Interrupted enumeration retains
+observed lower-bound counts with `scan_complete=false`; a root failure is not
+counted as an invented failed entry. Results remain paired with the last
+completion clock while another attempt is running. Per-entry failures do not
+abort peers or evict paid workers. See [cleanup counts and limits](results-2026-09-07-cleanup-outcome-observability.md).
+
 Concurrent PDF uploads share a process-wide PDFium parsing/closure mutex;
 their subsequent LLM calls remain under normal paid admission, not that mutex.
 PDF export uses a bounded per-run striped lock and sibling-file atomic publication.

--- a/docs/results-2026-09-07-cleanup-outcome-observability.md
+++ b/docs/results-2026-09-07-cleanup-outcome-observability.md
@@ -1,0 +1,108 @@
+# Best-effort cleanup outcomes at the HTTP boundary
+
+Date: 2026-09-07. Base: `89afc3670d0f6687aa16079170968540f5d733ec`.
+Zero-provider maintenance; not a retention-policy or readiness-eviction change.
+
+## Evidence before the change
+
+The unmodified suite passed 2,405 tests and 1,181 subtests. A preceding bounded
+same-revision observation sampled twenty health/readiness GETs over about
+5 minutes 17 seconds. All returned 200 and all sampled cleanup checks were ok;
+ten capacity samples showed zero active paid operations. That short observation
+does not establish busy-load reliability, deletion completeness or a safe
+freshness threshold. Raw operational samples stay in the private notes archive.
+
+Code inspection identified a different gap: cleanup deliberately catches
+per-directory OSError, continues with peers and returns a removal count/list.
+The supervisor therefore observes normal return, even when some deletions fail.
+Two new regressions first failed on missing HTTP cleanup detail after actually
+retaining one denied fixture directory and removing its peer. This reproduces
+an observation gap offline, not a confirmed Railway deletion incident.
+
+## Contract and implementation
+
+Both `/health` and `/health/ready` include `maintenance.cleanup.papers` and
+`maintenance.cleanup.retention`. These are the last observed attempts, paired
+with the same stage's last-completion clocks. Legacy `checks` still means
+normal return versus an escaped stage failure; clients must inspect cleanup
+detail to distinguish best-effort partial results. Existing readiness policy
+is unchanged, including advisory cleanup faults and blocking watchdog faults.
+
+| State | Meaning |
+|---|---|
+| not_checked | No completed stage observation in this lifespan |
+| complete | Root enumeration completed with no recorded entry-operation failure |
+| partial | Enumeration completed but one or more entry operations failed |
+| disabled | Run retention was explicitly disabled, with no root scan |
+| absent | Root stat established absence, with no root scan |
+| unavailable | Root/iteration/stage failure, or no collector observation |
+
+Each summary exposes `scan_complete`, `scanned`, `deleted`, `skipped`,
+`failed`, `skip_reasons` and `failure_reasons`. No scan has null counts,
+not a fabricated zero-count success. An empty completed scan has zero counts.
+An interrupted enumeration retains observed prefix counts with
+`scan_complete=false`; those are not a complete inventory. A root/iterator
+failure is not an invented failed directory, so `failed` may be zero while
+the state is unavailable.
+
+Completed scans partition enumerated entries into deleted, deliberately skipped
+or failed operations. Skip reasons are fresh/live/unrelated; failure reasons
+are metadata/delete. No paths, IDs, raw exception text or unbounded per-entry
+lists enter the public summary. A deletion race can produce an operation error;
+the count alone does not prove that the target remains on disk.
+
+A per-call collector preserves the historical integer/list return values and
+default calling forms. It is not a process-global mutable tally. Only a
+completed immutable projection is published with the stage clock/result under
+the existing short snapshot lock. A new in-flight attempt, including repeated
+cancellation/drain, retains its previous completed observation. New lifespans
+clear the records. Calls without a collector cannot fabricate observation facts.
+
+Use explicit root stat so absence and unreadability are not conflated by
+platform-dependent is_dir behavior. A file where a directory is required is
+unavailable. Root failures still reach the per-stage supervisor; individual
+metadata/delete errors are counted while peer processing continues. Preserve
+age selection, exclusions for occupied/stop-owned runs and serial offloading.
+No new abort-on-first-error cleanup, readiness failure for an individual
+deletion error, retry, forced restart or distributed ownership is introduced.
+
+## Verification
+
+Twenty-three new cases cover denied deletion with successful peers and a later
+recovery cycle; empty/absent/file/denied roots; disabled retention; mid-listing
+failure before and after a deletion; entry metadata errors; fresh/unrelated
+skips; stop-owned retention exclusions; cancellation-held publication; lifespan
+reset and complete OpenAPI fields. Counters, partition/reason sums and no-path
+disclosure are asserted at both actual HTTP response schemas.
+
+Existing maintenance fake callables now accept the optional collector keyword.
+Their original blocking, ownership, cancellation, timing and HTTP assertions
+remain unchanged. The unstarted exact schema assertion includes the additive
+cleanup field; no warning filter was relaxed and no test was skipped.
+
+Six defect re-injections target missing HTTP projection, hidden paper deletion
+failure, hidden run deletion failure, false empty-success, premature loss of a
+prior observation and false completed coverage after an iterator fault.
+An initial temporary harness reverse patch matched a repeated line; its source
+hash guard stopped the run. Restore with contextual patches and use a uniquely
+marked mutant before repeating the full six-case audit. The final audit caught
+all six intended failures and restored each exact pre-mutation file hash.
+
+The restored-source Windows/Python 3.12 full suite passed 2,428 tests and
+1,186 subtests, with fresh coverage 88.86% above the unchanged 85% floor.
+Latest Ruff, narrow Pylint and both real Chromium journeys passed. The read-only
+journey had no external requests, mutations, page errors or console errors;
+the composer intercepted ten simulated POSTs with zero API requests reaching
+its static server, unexpected requests or paid-provider calls.
+
+## Limits
+
+This reports per-attempt operations, not directory-size inventory, recovered
+storage bytes or proof that all expired artifacts are gone. Enumeration is not
+an atomic filesystem snapshot. Best-effort cleanup remains serial, can block
+on filesystem work and cannot forcibly interrupt a native/thread operation.
+Unknown totals stay unknown. The observation is not a long-term SLO, compliance
+erasure guarantee or evidence of a production storage fault.
+
+No provider, scoring rule, frozen experiment or production supplementary
+Tool Calling change was made. Tool Calling remains zero-call shadow mode.

--- a/tests/test_cleanup_observations.py
+++ b/tests/test_cleanup_observations.py
@@ -1,0 +1,301 @@
+"""Best-effort cleanup must not hide individual failures at either HTTP seam."""
+
+import asyncio
+import contextlib
+import os
+import shutil
+import time
+from pathlib import Path
+from threading import Event
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import httpx
+from fastapi.testclient import TestClient
+
+from api import main, papers, runs
+from api.models import ReadinessStatus
+
+
+@pytest.fixture
+def cleanup_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(papers, "PAPERS_ROOT", tmp_path / "papers")
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path / "runs")
+    monkeypatch.setattr(runs, "RUN_RETENTION_DAYS", 30)
+    monkeypatch.setattr(runs, "_registry", {})
+    monkeypatch.setattr(runs, "_stop_claims", {})
+    monkeypatch.setattr(runs, "_inline_paid_operations", {})
+    monkeypatch.setattr(main, "_maintenance_task", Mock(done=lambda: False))
+    monkeypatch.setattr(main, "_maintenance_checks", dict.fromkeys(("timeouts", "papers", "retention"), "not_checked"))
+    monkeypatch.setattr(main, "_maintenance_timings", {})
+    monkeypatch.setattr(main, "readiness", lambda: ReadinessStatus(ready=True, checks={}))
+    monkeypatch.setattr(runs.subprocess, "Popen", Mock(side_effect=AssertionError("worker launch leaked")))
+    return tmp_path
+
+
+def old_directory(stage, suffix="a"):
+    root = papers.PAPERS_ROOT if stage == "papers" else runs.DEFAULT_OUTPUT_ROOT
+    name = f"paper-private-{suffix}" if stage == "papers" else f"20200101T000000Z-{suffix * 10}"
+    directory = root / name
+    directory.mkdir(parents=True)
+    os.utime(directory, (time.time() - 172800,) * 2)
+    return directory
+
+
+def cycle():
+    """One real serial maintenance cycle, with no live worker or timed waits."""
+    async def exercise():
+        with patch.object(main.asyncio, "sleep", AsyncMock(side_effect=[None, asyncio.CancelledError()])):
+            with pytest.raises(asyncio.CancelledError):
+                await main._reaper()
+    asyncio.run(exercise())
+
+
+def read_cleanup(stage):
+    snapshots = []
+    for route in ("/health", "/health/ready"):
+        response = TestClient(main.app).get(route)
+        assert response.status_code == 200, "cleanup-only observations must not evict paid workers"
+        if route.endswith("ready"):
+            assert response.json()["ready"] is True
+        snapshots.append(response.json()["maintenance"]["cleanup"][stage])
+    assert snapshots[0] == snapshots[1], "cleanup observation lost at the HTTP schema"
+    if snapshots[0]["scan_complete"]:
+        outcome = snapshots[0]
+        assert outcome["scanned"] == outcome["deleted"] + outcome["skipped"] + outcome["failed"]
+        assert outcome["skipped"] == sum(outcome["skip_reasons"].values())
+        assert outcome["failed"] == sum(outcome["failure_reasons"].values())
+    return snapshots[0]
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+def test_failed_delete_is_visible_while_peer_cleanup_and_next_cycle_continue(cleanup_env, monkeypatch, stage):
+    """An undeletable entry returned normally and only exposed a generic ok."""
+    blocked = old_directory(stage, "a")
+    removed = old_directory(stage, "b")
+    original = shutil.rmtree
+
+    def remove(path, *args, **kwargs):
+        if path == blocked:
+            raise PermissionError("private directory and capability must not reach health")
+        return original(path, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(shutil, "rmtree", remove)
+        cycle()
+    assert blocked.exists() and not removed.exists()
+    outcome = read_cleanup(stage)
+    assert outcome == {
+        "state": "partial", "scan_complete": True,
+        "scanned": 2, "deleted": 1, "skipped": 0, "failed": 1,
+        "skip_reasons": {}, "failure_reasons": {"delete": 1},
+    }
+    assert main._maintenance_checks["timeouts"] == "ok"
+    assert main._maintenance_checks[stage] == "ok", "legacy normal-return status is not deletion completeness"
+    assert "private" not in str(outcome) and blocked.name not in str(outcome)
+    cycle()
+    assert not blocked.exists()
+    outcome = read_cleanup(stage)
+    assert outcome["state"] == "complete"
+    assert outcome["scanned"] == outcome["deleted"] == 1
+    assert outcome["failed"] == 0 and outcome["failure_reasons"] == {}
+
+
+def stage_root(stage):
+    return papers.PAPERS_ROOT if stage == "papers" else runs.DEFAULT_OUTPUT_ROOT
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+@pytest.mark.parametrize("root_kind", ["absent", "empty", "file", "denied"])
+def test_no_scan_is_not_an_empty_success(cleanup_env, monkeypatch, stage, root_kind):
+    """Missing/denied/file roots used to be indistinguishable from zero removals."""
+    root = stage_root(stage)
+    original = Path.stat
+    if root_kind in {"empty", "denied"}:
+        root.mkdir()
+    if root_kind == "file":
+        root.write_text("not a directory")
+
+    def stat(path, *args, **kwargs):
+        if root_kind == "denied" and path == root:
+            raise PermissionError("private root")
+        return original(path, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "stat", stat)
+        cycle()
+    outcome = read_cleanup(stage)
+    if root_kind == "empty":
+        assert outcome == {
+            "state": "complete", "scan_complete": True,
+            "scanned": 0, "deleted": 0, "skipped": 0, "failed": 0,
+            "skip_reasons": {}, "failure_reasons": {},
+        }
+    else:
+        assert outcome["state"] == ("absent" if root_kind == "absent" else "unavailable")
+        assert all(outcome[key] is None for key in ("scan_complete", "scanned", "deleted", "skipped", "failed"))
+    assert main._maintenance_checks["timeouts"] == "ok"
+    assert main._maintenance_checks[stage] == ("failed" if root_kind in {"denied", "file"} else "ok")
+
+
+def test_disabled_retention_does_not_inspect_root(cleanup_env, monkeypatch):
+    """A deliberate no-scan policy must not masquerade as empty successful cleanup."""
+    monkeypatch.setattr(runs, "RUN_RETENTION_DAYS", 0)
+    root = runs.DEFAULT_OUTPUT_ROOT
+    original = Path.stat
+
+    def stat(path, *args, **kwargs):
+        assert path != root, "disabled retention accessed its root"
+        return original(path, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "stat", stat)
+        cycle()
+    outcome = read_cleanup("retention")
+    assert outcome["state"] == "disabled" and outcome["scan_complete"] is None
+    assert outcome["scanned"] is outcome["deleted"] is outcome["skipped"] is outcome["failed"] is None
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+@pytest.mark.parametrize("after_entry", [False, True])
+def test_interrupted_listing_preserves_explicit_lower_bound_counts(cleanup_env, monkeypatch, stage, after_entry):
+    """An iterator may fail after a deletion; zeroing or completing that scan lies."""
+    directory = old_directory(stage)
+    root = stage_root(stage)
+    original = Path.iterdir
+
+    def listing(path):
+        if path == root:
+            if after_entry:
+                yield directory
+            raise PermissionError("private listing")
+        yield from original(path)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "iterdir", listing)
+        cycle()
+    outcome = read_cleanup(stage)
+    assert outcome == {
+        "state": "unavailable", "scan_complete": False,
+        "scanned": int(after_entry), "deleted": int(after_entry), "skipped": 0, "failed": 0,
+        "skip_reasons": {}, "failure_reasons": {},
+    }
+    # failed counts entries with a known failed operation, not an invented
+    # directory for a root/iterator fault. Incomplete coverage names that fault.
+    assert main._maintenance_checks[stage] == "failed"
+    assert directory.exists() is not after_entry
+    assert main._maintenance_checks["timeouts"] == "ok"
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+def test_metadata_failure_is_counted_and_other_entries_are_processed(cleanup_env, monkeypatch, stage):
+    """A stat error must not abort peers or become an unrelated skipped entry."""
+    denied = old_directory(stage, "a")
+    peer = old_directory(stage, "b")
+    original = Path.stat
+
+    def stat(path, *args, **kwargs):
+        if path == denied:
+            raise PermissionError("private metadata")
+        return original(path, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "stat", stat)
+        cycle()
+    outcome = read_cleanup(stage)
+    assert outcome["state"] == "partial" and outcome["scan_complete"] is True
+    assert (outcome["scanned"], outcome["deleted"], outcome["skipped"], outcome["failed"]) == (2, 1, 0, 1)
+    assert outcome["failure_reasons"] == {"metadata": 1}
+    assert denied.exists() and not peer.exists()
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+def test_skips_are_not_reported_as_failed_deletions(cleanup_env, stage):
+    """Fresh and unrelated entries are intentional retention, not storage faults."""
+    old = old_directory(stage)
+    root = stage_root(stage)
+    fresh = root / ("paper-fresh" if stage == "papers" else "20990101T000000Z-bbbbbbbbbb")
+    fresh.mkdir()
+    (root / "unrelated.txt").write_text("keep")
+    cycle()
+    outcome = read_cleanup(stage)
+    assert outcome == {
+        "state": "complete", "scan_complete": True,
+        "scanned": 3, "deleted": 1, "skipped": 2, "failed": 0,
+        "skip_reasons": {"fresh": 1, "unrelated": 1}, "failure_reasons": {},
+    }
+    assert not old.exists() and fresh.exists() and (root / "unrelated.txt").exists()
+
+
+def test_retention_keeps_a_stop_owned_run_and_names_the_skip(cleanup_env, monkeypatch):
+    """Finished-but-owned terminal publication is still a live retention exclusion."""
+    directory = old_directory("retention")
+    handle = Mock()
+    handle.proc.poll.return_value = 0
+    monkeypatch.setattr(runs, "_registry", {directory.name: handle})
+    monkeypatch.setattr(runs, "_stop_claims", {directory.name: handle})
+    with patch.object(runs, "reap_timeouts", return_value=[]):
+        cycle()
+    outcome = read_cleanup("retention")
+    assert outcome["skipped"] == 1 and outcome["skip_reasons"] == {"live": 1}
+    assert outcome["failed"] == outcome["deleted"] == 0 and directory.exists()
+
+
+@pytest.mark.parametrize("stage", ["papers", "retention"])
+def test_running_and_cancel_draining_attempt_does_not_publish_tally_early(cleanup_env, monkeypatch, stage):
+    """An in-flight mutable tally must not replace the prior completed observation."""
+    directory = old_directory(stage)
+    with patch.object(shutil, "rmtree", side_effect=PermissionError("denied")):
+        cycle()
+    before = read_cleanup(stage)
+    assert before["failed"] == 1
+    entered, release = Event(), Event()
+    original = papers.prune_old if stage == "papers" else runs.prune_expired_runs
+
+    def held(*, cleanup):
+        result = original(cleanup=cleanup)
+        entered.set()
+        assert release.wait(15)
+        return result
+
+    async def exercise():
+        task = asyncio.create_task(main._maintenance_stage(stage, held, collect_cleanup=True))
+        try:
+            assert await asyncio.to_thread(entered.wait, 10)
+            for _ in range(2):
+                task.cancel()
+                await asyncio.sleep(0)
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app), base_url="http://test") as client:
+                for route in ("/health", "/health/ready"):
+                    response = await client.get(route)
+                    assert response.status_code == 200
+                    snapshot = response.json()["maintenance"]
+                    assert snapshot["cleanup"][stage] == before
+                    assert snapshot["timings"][stage]["current_started_at"] is not None
+        finally:
+            release.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(task, 10)
+    asyncio.run(exercise())
+    after = read_cleanup(stage)
+    assert after["state"] == "complete" and after["deleted"] == 1 and after["failed"] == 0
+    assert not directory.exists()
+
+
+def test_lifespan_resets_cleanup_and_http_schema_exposes_every_field(cleanup_env, monkeypatch):
+    """New lifespans cannot inherit a previous successful/partial cleanup."""
+    old_directory("papers")
+    cycle()
+    assert read_cleanup("papers")["deleted"] == 1
+    monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 3600)
+    monkeypatch.setattr(runs, "shutdown_all", Mock())
+    with TestClient(main.app) as client:
+        for route in ("/health", "/health/ready"):
+            snapshot = client.get(route).json()["maintenance"]
+            assert set(snapshot["cleanup"]) == {"papers", "retention"}
+            for outcome in snapshot["cleanup"].values():
+                assert outcome["state"] == "not_checked"
+                assert all(outcome[key] is None for key in ("scan_complete", "scanned", "deleted", "skipped", "failed"))
+        schemas = client.get("/openapi.json").json()["components"]["schemas"]
+    assert set(schemas["CleanupSummary"]["properties"]) == set(read_cleanup("papers"))
+    assert "cleanup" in schemas["MaintenanceStatus"]["properties"]

--- a/tests/test_maintenance_event_loop.py
+++ b/tests/test_maintenance_event_loop.py
@@ -38,6 +38,9 @@ def maintenance_fixture(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "_REAP_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(main, "readiness", lambda: ReadinessStatus(ready=True, checks={}))
     operations = dict.fromkeys(STAGES)
+    # Cleanup now accepts a per-attempt observer keyword, while the watchdog
+    # still has no argument. Fakes accept it without changing the held-work,
+    # timing, cancellation or HTTP assertions these tests were written for.
     for name, module, attribute in (
         ("timeouts", runs, "reap_timeouts"),
         ("papers", main.papers, "prune_old"),
@@ -61,7 +64,7 @@ def test_http_probes_complete_before_slow_maintenance_is_released(maintenance_fi
     operations, shutdown = maintenance_fixture
     entered, release = Event(), Event()
 
-    def slow():
+    def slow(**_kwargs):
         entered.set()
         assert release.wait(15), "observer failed to release maintenance"
         return []
@@ -115,7 +118,7 @@ def test_shutdown_drains_owned_stage_despite_repeated_cancellation(maintenance_f
     operations, shutdown = maintenance_fixture
     entered, release, finished = Event(), Event(), Event()
 
-    def slow():
+    def slow(**_kwargs):
         entered.set()
         try:
             assert release.wait(15), "test failed to release maintenance"
@@ -255,7 +258,7 @@ def test_cycles_remain_serial_and_faults_reach_http(maintenance_fixture):
         return []
 
     for name in STAGES:
-        operations[name].side_effect = lambda name=name: operation(name)
+        operations[name].side_effect = lambda name=name, **_kwargs: operation(name)
 
     async def exercise():
         task = asyncio.create_task(main._reaper())

--- a/tests/test_maintenance_supervision.py
+++ b/tests/test_maintenance_supervision.py
@@ -66,7 +66,7 @@ def test_health_delivers_cleanup_failure_but_only_dead_watchdog_blocks_readiness
 def test_unstarted_is_not_a_passing_audit():
     snapshot = TestClient(main.app).get("/health").json()["maintenance"]
     assert snapshot == {
-        "state": "not_started", "checks": {}, "timings": {}, "observed_at": snapshot["observed_at"],
+        "state": "not_started", "checks": {}, "timings": {}, "cleanup": {}, "observed_at": snapshot["observed_at"],
     }
     assert snapshot["observed_at"].endswith("Z")
 


### PR DESCRIPTION
## Why
Per-directory cleanup failures deliberately continue with peers, but normal return used to erase their outcomes before the HTTP boundary. Fresh `ok` is not proof that every expired directory was removed.

## Scope
- Per-attempt collector, preserving legacy removal return values and readiness policy.
- Typed summaries at both health schemas: complete/partial/disabled/absent/not_checked/unavailable; null unobserved counts and explicit incomplete prefixes.
- Fixed safe counters/reasons; no paths, capability IDs or raw exceptions.
- Completed snapshots remain paired with stage clocks through subsequent dispatch, repeated cancellation and lifespan reset.
- Preserve best-effort cleanup, age rules, stop ownership and serial off-loop scheduling.

## Verification
- Baseline 2405 tests / 1181 subtests; two new boundary regressions first failed on the original implementation.
- Final 2428 tests / 1186 subtests; 88.86% fresh coverage, unchanged 85% floor.
- 23 new regressions; six detected defect re-injections with exact restoration after fixing an initially ambiguous temporary reverse patch.
- Latest Ruff, narrow Pylint and both zero-provider Chromium journeys passed.
- Final docs/cleanup check: 29 tests / 494 subtests.

## Limits
Operation counts are not an atomic inventory, deletion-completeness guarantee or storage-bytes metric. Cleanup remains serial and can block on filesystem work. No observed production deletion fault, SLO, provider call, model change or experimental Tool Calling activation is claimed. No first-error abort or freshness-based eviction is introduced.