### PR TITLE
Keep optional client delivery failures separate from run truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,12 @@ Composer submission/extraction locks are tab-local, not server idempotency.
 Readiness checks the effective selected credential without contacting providers;
 429 reasons remain distinct. See the [HTTP/browser contract and limits](docs/results-2026-09-06-composer-paid-operation-integrity.md).
 
+Optional step logs cannot override run truth. Progress cursors count complete
+physical lines, not valid events; preserve partial tails and explicit read loss.
+Score/grounding/consistency detail faults must not become zero or agreement.
+Denied storage is page-local fallback, not authentication bypass; failed logout
+must not reload stale credentials. See the [delivery boundary and limits](docs/results-2026-09-08-client-delivery-seams.md).
+
 ## Tool Calling: do not turn experimental code into production by accident
 
 - Production is phase-1 **zero-call shadow mode**. Phase-2 execution, provider

--- a/api/main.py
+++ b/api/main.py
@@ -58,7 +58,6 @@ from api.models import (  # noqa: E402
     RunProgress,
     RunRequest,
     RunStatus,
-    StepEvent,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -1001,9 +1000,9 @@ def get_report(run_id: str) -> PlainTextResponse:
 def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgress:
     """Status plus new step events, for a client polling during a run.
 
-    `since` is the number of step events the client already has; only later
-    ones are returned. Without it a client would re-receive the whole log on
-    every tick, which grows to hundreds of lines over a run.
+    `since` is the physical-line cursor returned as `steps_next_cursor`, not
+    the number of valid events received. The append-only log can contain
+    rejected rows; its failure must not hide a committed run outcome.
 
     Registered before /api/runs/{run_id}/{artifact} because that route would
     otherwise match "progress" as an artifact name.
@@ -1051,7 +1050,7 @@ def get_progress(run_id: str, since: int = Query(default=0, ge=0)) -> RunProgres
         observability=state.get("observability"),
         checkpointing=state.get("checkpointing"),
         recovery=state.get("recovery"),
-        steps=[StepEvent(**s) for s in runs.read_steps(run_id, since=since)],
+        **runs.read_step_page(run_id, since=since),
         artifacts=state.get("artifacts", []),
     )
 

--- a/api/models.py
+++ b/api/models.py
@@ -291,6 +291,9 @@ class RunProgress(BaseModel):
     )
     output_language: str = "English"
     steps: list[StepEvent] = Field(default_factory=list)
+    steps_next_cursor: int = Field(default=0, ge=0)
+    steps_read_state: Literal["absent", "readable", "partial", "unavailable"] = "absent"
+    steps_rejected: int = Field(default=0, ge=0, description="Rejected complete lines observed in this log, not failed tasks.")
     artifacts: list[str] = Field(default_factory=list)
 
 

--- a/api/runs.py
+++ b/api/runs.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 import json
+import math
 import os
 import re
 import shutil
@@ -46,6 +47,7 @@ from academic_agent.run_terminal import (
 )
 from api.audit_projection import project_audit_metadata
 from api.cleanup import CleanupAudit
+from api.models import StepEvent
 from api.runtime_projection import project_runtime_metadata
 
 # A run is killed after this long. The bound belongs to the worker contract,
@@ -1192,34 +1194,48 @@ def _read_terminal(run_dir: Path) -> tuple[TerminalRecord | None, dict | None]:
 
 
 def read_steps(run_id: str, since: int = 0) -> list[dict]:
-    """Step events from steps.jsonl, skipping the first `since` entries.
+    """Compatibility wrapper; `since` counts physical lines, not valid events."""
+    return [event.model_dump() for event in read_step_page(run_id, since)["steps"]]
 
-    The worker appends to this file while running, so a partially written
-    trailing line is normal and is skipped rather than treated as corruption.
+
+def read_step_page(run_id: str, since: int = 0) -> dict:
+    """Read an append-only log without making its availability own run truth.
+
+    Count complete physical lines even when rejected. Counting returned events
+    instead duplicates later good rows forever after a bad row. Re-scan the
+    prefix for advisory loss counts, but deliver only the suffix. Never consume
+    a non-newline-terminated tail: even valid JSON may still be being appended.
+    Binary iteration isolates one invalid UTF-8 line from its healthy neighbours.
+    No raw file errors or rejected event content cross this public boundary.
     """
     if not _is_valid_run_id(run_id):
         raise RunNotFound(f"Invalid run id: {run_id!r}")
 
     path = run_dir_for(run_id) / "steps.jsonl"
-    if not path.exists():
-        return []
-
-    events: list[dict] = []
+    page = {"steps": [], "steps_next_cursor": since,
+            "steps_read_state": "readable", "steps_rejected": 0}
     try:
-        with path.open(encoding="utf-8") as handle:
+        with path.open("rb") as handle:
             for index, line in enumerate(handle):
-                if index < since:
-                    continue
-                line = line.strip()
-                if not line:
-                    continue
+                if not line.endswith(b"\n"):
+                    page["steps_read_state"] = "partial"
+                    break
+                page["steps_next_cursor"] = max(since, index + 1)
                 try:
-                    events.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue      # the writer is mid-line; it will be there next poll
+                    event = StepEvent.model_validate(json.loads(line.decode("utf-8")), strict=True)
+                    if not event.type or (event.ts is not None and not math.isfinite(event.ts)):
+                        raise ValueError("Invalid event identity or timestamp")
+                except (ValueError, RecursionError):
+                    page["steps_rejected"] += 1
+                    page["steps_read_state"] = "partial"
+                    continue
+                if index >= since:
+                    page["steps"].append(event)
+    except FileNotFoundError:
+        page["steps_read_state"] = "absent"
     except OSError:
-        return []
-    return events
+        page["steps_read_state"] = "unavailable"
+    return page
 
 
 def _failure_reason(run_dir: Path) -> str:

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -81,6 +81,13 @@ deletion from a normal return. Unknown inventory is not zero; cleanup-only
 faults remain advisory. This is not proof of a production storage failure or
 complete erasure; see the [outcome contract](results-2026-09-07-cleanup-outcome-observability.md).
 
+Optional step-log failures now stay separate from run completion and report
+delivery. Physical-line cursors prevent replay after rejected events; detail
+tabs reject fake zero/pass states, and denied browser storage degrades to
+page-local identity with explicit persistence/logout limits. These are
+offline HTTP/Chromium contracts, not production incident rates or semantic
+report validation. See the [delivery seam audit](results-2026-09-08-client-delivery-seams.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |
@@ -156,8 +163,9 @@ remain unchanged. Browse the [full experiment index](experiment-index.md).
    explicit unreadable rows; see the [nested fault verification](results-2026-09-05-nested-audit-metadata-integrity.md).
    Selected usage/accounting/checkpoint/recovery summaries now also have
    [read isolation and browser fault tests](results-2026-09-05-runtime-summary-read-integrity.md).
-   The report-audit detail renderer now also validates its displayed shapes
-   and counters locally. Other detailed artifacts and nested payloads remain
+   Report-audit, score, grounding and consistency detail renderers now validate
+   their displayed shapes/counters locally; optional step logs have separate
+   availability and cursor contracts. Other artifacts and nested payloads remain
    outside these contracts; reproduce their client failure before proposing changes.
 2. New decision-utility research should target the already observed low trust
    and actionability, use a new protocol and disclose external-source checks.

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,7 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-08 client delivery seams](results-2026-09-08-client-delivery-seams.md) — optional log isolation/cursors, truthful details and browser-storage fallback, zero provider calls.
 - [2026-09-07 cleanup outcomes](results-2026-09-07-cleanup-outcome-observability.md) — advisory per-attempt counters and explicit incomplete coverage at both HTTP schemas.
 - [2026-09-07 maintenance observation age](results-2026-09-07-maintenance-observation-age.md) — time-qualified health/readiness snapshots without a new SLO or provider call.
 - [2026-09-06 maintenance event-loop ownership](results-2026-09-06-maintenance-event-loop.md) — held-stage HTTP probes and shutdown drain, zero provider calls.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -195,6 +195,22 @@ See the [request and browser verification](results-2026-09-06-run-mutation-inten
 
 ## Artifacts and recovery
 
+Progress readers should pass `steps_next_cursor` back as `since`: it counts
+complete physical log lines, including rejected rows, not returned events.
+`steps_read_state=partial/unavailable` warns about the optional log without
+changing task completion or blocking the report. Incomplete trailing rows are
+held until newline publication. See the [delivery contract](results-2026-09-08-client-delivery-seams.md).
+
+Score, grounding and consistency tabs validate downloaded display fields rather
+than defaulting missing data to zero or agreement. This neither rewrites stored
+artifacts nor changes scoring/heuristics. Healthy report tabs remain usable.
+
+If browser storage is denied, credentials can be held only in page memory and
+preferences use safe defaults. Bookmark accepted run links. A failed persistent
+logout returns to the gate without reloading stale credentials; clear site data
+before reopening when prompted. This does not erase inaccessible storage, revoke
+capability URLs, or stop work on the server.
+
 Each run writes its own `outputs/<run_id>/` directory. Files depend on how
 far the run progressed; a missing report on an early failure is not a completed
 assessment.

--- a/docs/results-2026-09-08-client-delivery-seams.md
+++ b/docs/results-2026-09-08-client-delivery-seams.md
@@ -1,0 +1,92 @@
+# Optional logs, artifact details and browser storage delivery
+
+Date: 2026-09-08. Base: `6904b7227882e6f0991870f69440c922759909c3`.
+This is zero-provider boundary maintenance, not a new report-quality study.
+
+## Evidence before editing
+
+The unchanged baseline passed 2,428 tests and 1,186 subtests. The review's
+bounded local inventory covered 139 timestamped/benchmark directories, with
+57 step logs containing 610 lines and 109 score files. It found no invalid
+step rows or empty score objects. The fault cases below were synthetic, not
+an observed production-incident denominator. Original runs were not changed;
+private reviewer files and reserved experiment cohorts were not inspected.
+
+Actual HTTP probes reproduced status 200 beside progress 500 for malformed
+step objects, and duplicate suffix events after a rejected physical line.
+The shipped JS reproduced empty score JSON as 0.0/Nascent, empty consistency
+JSON as agreement, and localStorage denial before any HTTP request was sent.
+
+## Changed contracts
+
+### Step log reads
+
+`steps_next_cursor` is a complete physical-line offset for the existing `since`
+parameter, not the length of returned valid events. `steps_read_state` distinguishes
+absent, readable, partial and unavailable; `steps_rejected` counts observed
+rejected complete lines, not failed tasks. Prefix scanning retains loss visibility
+after a cursor advances. Binary iteration isolates malformed UTF-8 per line.
+The reader withholds every non-newline-terminated tail until the writer completes
+it, even if its current bytes parse as JSON. File errors expose no raw paths.
+
+The browser adopts that cursor, retains a fallback for older servers without
+the field, and shows degraded log state in the header without overriding the
+run outcome. Log failure does not suppress a readable saved report or trigger
+a paid rerun. Existing external clients counting valid events must adopt the
+returned cursor themselves. This assumes append-only logs, not arbitrary file
+replacement, distributed streaming or guaranteed delivery of a torn final row.
+
+### Downloaded details
+
+The artifact route still serves original bytes. Score numbers must be finite,
+in display range and correctly typed; missing values become unavailable/dashes,
+not zero or a maturity band. Valid dimensions survive a bad aggregate. Grounding
+checks validate counters and displayed row shapes, isolate malformed neighbours,
+and never paint zero coverage as a pass. Consistency requires an explicit checked
+flag, valid findings and matching counts before displaying a clear result.
+Skipped/failed checks and malformed details have distinct bilingual messages.
+
+This is display validation, not score recalibration, writer repair, general
+citation entailment or a new blocking guardrail. Historical optional detail can
+remain unavailable beside readable counters. Reports and healthy tabs survive.
+
+### Browser storage
+
+Access-code and BYOK persistence can fall back to page-local memory. A failed
+storage slot remains latched there until reload so a later read cannot resurrect
+a value whose removal failed. Language and sidebar preferences degrade without
+preventing module initialization or UI updates. Authentication, BYOK isolation,
+server ownership and paid-request retry policy are unchanged.
+
+The UI states that credentials/history may not persist. Failed persistent logout
+does not reload into stale credentials: it clears page-local identities, returns
+to the gate and asks the visitor to clear site data before reopening. This cannot
+purge inaccessible browser storage or other tabs. Closing/reloading ends memory
+fallback; it does not cancel a server run or revoke a run capability. Optional
+BYOK history still warns on failed writes rather than claiming durable history.
+Same-document gate re-entry clears old form inputs and replaces its handlers;
+repeated login must complete the current gate promise with one access check.
+
+## Verification
+
+- Final local full suite: 2,499 passed and 1,191 subtests passed on Windows / Python
+  3.12.9, with fresh coverage 88.89% against the unchanged 85% floor. All 71 added cases
+  run without network/provider requests; no assertions or warning filters weakened.
+- Latest Ruff and the narrow CONTRIBUTING Pylint command passed.
+- HTTP-file-to-JS cases cover malformed roots/counters/rows, partial UTF-8 tails,
+  permission failure, physical cursors, completion, and healthy positive controls.
+- Real Chromium read-only journey: no external requests, mutations, unexpected
+  console errors or page errors; report navigation survives bad logs/details.
+- Real Chromium composer journey: ten intercepted fixture POSTs, zero API requests
+  reaching its static-only server and zero page errors. Added storage-denial login,
+  language switch, logout and memory-only BYOK checks make no additional paid POSTs.
+- Eight defect injections were detected: event validation removal, event-count
+  cursor restoration, old detail renderers, old pre-fetch storage access,
+  language initialization storage access, sidebar initialization access, and
+  reload after failed logout, and accumulated gate handlers after re-entry.
+  Every edited file's pre-injection hash was restored.
+
+Documentation indexing can add subtests independently. The final PR CI owns
+the exact committed-tree counts across both platforms. No paid canary, Railway
+restart, scoring/model change, frozen-cohort reuse or production Tool Calling
+connection belongs to this maintenance.

--- a/e2e/browser_smoke.py
+++ b/e2e/browser_smoke.py
@@ -366,6 +366,10 @@ def _exercise_browser(
             expect(page.locator("#run-terminal")).to_have_text("· worker completed")
             expect(page.locator("article.prose")).to_contain_text(REPORT_SENTINEL)
 
+            # The fixture's optional event log is corrupt; terminal completion
+            # and report delivery must still be visible in actual Chromium.
+            expect(page.locator("#run-step-record")).to_contain_text("Step log incomplete")
+
             page.goto(f"{base_url}/run/{damaged_terminal_id}", wait_until="domcontentloaded")
             expect(page.locator("#run-pill")).to_have_text("unknown")
             expect(page.locator("#run-terminal")).to_have_text("· terminal record unreadable")
@@ -390,6 +394,10 @@ def _exercise_browser(
             expect(page.locator('.reliability__row[data-check="review"]')).to_have_attribute("data-tone", "ok")
             page.locator('button.tab[data-view="report-audit"]').click()
             expect(page.locator('.panel[data-view="report-audit"]')).to_contain_text("missing or unreadable")
+            for view in ("grounding", "consistency"):
+                page.locator(f'button.tab[data-view="{view}"]').click()
+                expect(page.locator(f'.panel[data-view="{view}"]')).to_contain_text("no conclusion can be drawn")
+                expect(page.locator(f'.panel[data-view="{view}"] .consistency__clear')).to_have_count(0)
             page.locator('button.tab[data-view="report"]').click()
             expect(page.locator("article.prose")).to_be_visible()
             expect(page.locator("article.prose")).to_contain_text(REPORT_SENTINEL)
@@ -401,6 +409,9 @@ def _exercise_browser(
             page.goto(f"{base_url}/run/{damaged_runtime_id}", wait_until="domcontentloaded")
             expect(page.locator("#run-pill")).to_have_text("completed")
             expect(page.locator("#run-terminal")).to_have_text("· worker completed")
+            expect(page.locator(".scorecard__value")).to_have_text("—")
+            expect(page.locator(".scorecard__band")).to_contain_text("no conclusion can be drawn")
+            page.locator('button.tab[data-view="report"]').click()
             expect(page.locator("article.prose")).to_contain_text(REPORT_SENTINEL)
             expect(page.locator("#run-usage")).to_contain_text("usage unavailable")
             expect(page.locator("#run-usage")).not_to_contain_text("$")
@@ -510,6 +521,8 @@ def main() -> None:
         run_id = _write_completed_run(output_root, access.owner_id(ACCESS_CODE))
         damaged_status_id = _write_completed_run(output_root, access.owner_id(ACCESS_CODE))
         (output_root / damaged_status_id / "status.json").write_bytes(b"\xff")
+        (output_root / damaged_status_id / "steps.jsonl").write_bytes(
+            b'{"type":"finish","agent_idx":0}\nnull\n{"type":"finish","agent_idx":1}\n')
         damaged_terminal_id = _write_completed_run(output_root, access.owner_id(ACCESS_CODE))
         # These are isolated mutable test fixtures, not production terminal
         # rewrites. Retain stale done=true beside a damaged immutable record.
@@ -536,12 +549,15 @@ def main() -> None:
         detail = json.loads(detail_path.read_text(encoding="utf-8"))
         detail.update(findings=[None], findings_count=1)
         detail_path.write_text(json.dumps(detail), encoding="utf-8")
+        for name in ("claim_grounding.json", "consistency.json"):
+            (output_root / damaged_audit_id / name).write_text("{}", encoding="utf-8")
         runtime_ids = tuple(_write_completed_run(output_root, access.owner_id(ACCESS_CODE)) for _ in range(3))
         for index, runtime_id in enumerate(runtime_ids):
             # Corrupt only isolated fixture bytes, never a real write-once run.
             terminal_path = output_root / runtime_id / "terminal.json"
             record = json.loads(terminal_path.read_text(encoding="utf-8"))
             if index == 0:
+                (output_root / runtime_id / "commercialization_scores.json").write_text("{}", encoding="utf-8")
                 record["usage"]["total_tokens"] = 100
                 record["usage"]["cost_usd"] = "bad-price"
                 record["checkpointing"] = {"state": "degraded", "errors": 1}

--- a/e2e/composer_smoke.py
+++ b/e2e/composer_smoke.py
@@ -52,6 +52,7 @@ def main() -> None:
     requests: list[Route] = []
     unexpected: list[str] = []
     page_errors: list[str] = []
+    storage_gate = False
     run_id = "20260906T000000Z-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     child_id = "20260906T000001Z-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     progress = {"run_id": run_id, "topic": "Accepted fixture assessment", "state": "completed",
@@ -60,6 +61,7 @@ def main() -> None:
     with _serve(app) as base, sync_playwright() as playwright:
         browser = playwright.chromium.launch(headless=True)
         context = browser.new_context()
+        code_checks = []
 
         def route_request(route: Route) -> None:
             request = route.request
@@ -75,7 +77,12 @@ def main() -> None:
                 unexpected.append(f"Unexpected method: {request.method} {url.path}")
                 route.abort()
             elif url.path == "/api/access/check":
-                _json(route, {"ok": True})
+                if storage_gate and request.headers.get("x-access-code") == "storage-fixture-code":
+                    code_checks.append(request.url)
+                if storage_gate and request.headers.get("x-access-code") != "storage-fixture-code":
+                    _json(route, {"detail": "Fixture authentication required"}, status=401)
+                else:
+                    _json(route, {"ok": True})
             elif url.path == "/api/runs":
                 _json(route, {"runs": []})
             elif url.path == f"/api/runs/{run_id}/progress":
@@ -212,6 +219,55 @@ def main() -> None:
             requests[9].abort()
             expect(page.locator("#toasts")).to_contain_text("may already have started")
             assert len(requests) == 10
+            # Deny access to the Storage objects themselves before boot, not
+            # just a particular history write after acceptance. Authentication
+            # still requires the exact fixture code; only persistence degrades.
+            storage_gate = True
+            page.add_init_script("""
+                for (const name of ['localStorage', 'sessionStorage']) {
+                    Object.defineProperty(window, name, {get() {
+                        throw new DOMException('Fixture storage denied', 'SecurityError');
+                    }});
+                }
+            """)
+            page.goto(base)
+            expect(page.locator("#gate")).to_be_visible()
+            page.locator("#gate-input").fill("storage-fixture-code")
+            page.locator("#gate-submit").click()
+            expect(page.locator("#gate")).to_be_hidden()
+            expect(page.locator("#code-badge")).to_be_visible()
+            expect(page.locator("#storage-notice")).to_contain_text("Credentials last only on this page")
+            page.locator("#ui-lang").select_option("Simplified Chinese")
+            expect(page.locator("#storage-notice")).to_contain_text("当前页面临时保留")
+            page.locator("#code-exit").click()
+            expect(page.locator("#gate")).to_be_visible()
+            expect(page.locator("#storage-notice")).to_contain_text("无法删除")
+            # Repeated same-document login must replace gate handlers. Assert
+            # the network effect; a hidden gate alone misses duplicate calls.
+            for _ in range(2):
+                expect(page.locator("#gate-input")).to_have_value("")
+                before = len(code_checks)
+                page.locator("#gate-input").fill("storage-fixture-code")
+                page.locator("#gate-submit").click()
+                expect(page.locator("#gate")).to_be_hidden()
+                expect(page.locator("#pane-compose")).to_be_visible()
+                page.wait_for_timeout(30)
+                assert len(code_checks) == before + 1
+                page.locator("#code-exit").click()
+                expect(page.locator("#gate")).to_be_visible()
+            page.locator("#gate-to-byok").click()
+            page.locator("#byok-provider").select_option("qwen")
+            page.locator("#byok-llm-key").fill("fixture-memory-key")
+            page.locator("#byok-serper-key").fill("fixture-memory-search")
+            page.locator("#byok-form").evaluate("form => form.requestSubmit()")
+            expect(page.locator("#gate")).to_be_hidden()
+            expect(page.locator("#byok-badge")).to_be_visible()
+            assert fixture_credentials_match(page)
+            page.locator("#byok-exit").click()
+            expect(page.locator("#gate")).to_be_visible()
+            expect(page.locator("#byok-llm-key")).to_have_value("")
+            expect(page.locator("#byok-serper-key")).to_have_value("")
+            assert len(requests) == 10  # This extra browser lane cannot submit paid work.
             assert not unexpected, unexpected
             assert not reached_server, reached_server
             assert not page_errors, page_errors
@@ -224,6 +280,15 @@ def main() -> None:
     print(json.dumps({"status": "passed", "browser": "chromium", "stubbed_posts": len(requests),
                       "api_requests_reaching_server": len(reached_server), "unexpected_requests": len(unexpected),
                       "paid_provider_requests": 0, "page_errors": len(page_errors)}))
+
+
+def fixture_credentials_match(page: Page) -> bool:
+    """Inspect only fake fixture identity; never log actual visitor credentials."""
+    return page.evaluate("""async () => {
+        const api = await import('/static/js/api.js');
+        return api.getAccessCode() === null && api.getByok()?.provider === 'qwen'
+            && api.getByok()?.llmKey === 'fixture-memory-key';
+    }""")
 
 
 if __name__ == "__main__":

--- a/tests/test_browser_storage_integrity.py
+++ b/tests/test_browser_storage_integrity.py
@@ -1,0 +1,69 @@
+"""Storage faults cross the real HTTP-client and language module boundaries."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("scenario", ["denied", "write_failure", "remove_failure", "normal", "language"])
+def test_storage_faults_do_not_block_requests_or_restore_cleared_keys(scenario):
+    """A successful fetch cannot repair a failed localStorage access before fetch."""
+    node = shutil.which("node")
+    assert node, "Node must execute the actual client; skipping loses the seam"
+    script = r'''
+const fs=require('node:fs'),vm=require('node:vm'),assert=require('node:assert/strict');
+const input=JSON.parse(fs.readFileSync(0,'utf8')), requests=[];
+const persisted=new Map(),session=new Map();
+let denyRead=input.scenario==='denied', denyWrite=input.scenario==='write_failure', denyRemove=false;
+function storage(map){return {
+ getItem:k=>{if(denyRead)throw Error('restricted');return map.get(k)??null;},
+ setItem:(k,v)=>{if(denyWrite)throw Error('quota');map.set(k,v);},
+ removeItem:k=>{if(denyRemove)throw Error('remove denied');map.delete(k);},
+};}
+const ctx=vm.createContext({localStorage:storage(persisted),sessionStorage:storage(session), assert, requests,
+ fetch:async(url,options)=>{requests.push({url,options});return {ok:true,status:200,headers:{get:()=> 'application/json'},json:async()=>({ok:true})};},
+ document:{querySelectorAll:()=>[],documentElement:{}}});
+const load=name=>vm.runInContext(fs.readFileSync(input.root+'/web/static/js/'+name,'utf8').replace(/^import .*;\r?\n/gm,'').replace(/export /g,''),ctx);
+(async()=>{
+ if(input.scenario==='language'){
+  denyRead=true;denyWrite=true;load('i18n.js');
+  assert.equal(vm.runInContext('language()',ctx),'English');
+  vm.runInContext("setLanguage('Simplified Chinese')",ctx);
+  assert.equal(vm.runInContext('language()',ctx),'Simplified Chinese');
+  assert.equal(ctx.document.documentElement.lang,'zh-CN');return;
+ }
+ load('api.js');
+ await vm.runInContext('health()',ctx);assert.equal(requests.length,1);
+ if(input.scenario==='remove_failure'){
+  vm.runInContext("setAccessCode('stale');setByok({llmKey:'old'})",ctx);
+  denyRemove=true;
+  assert.equal(vm.runInContext('setAccessCode(null)',ctx),false);
+  assert.equal(vm.runInContext('setByok(null)',ctx),false);
+  denyRemove=false;
+  assert.equal(persisted.get('access-code'),'stale');
+  assert.equal(vm.runInContext('getAccessCode()',ctx),null);
+  assert.equal(vm.runInContext('getByok()',ctx),null);
+  await vm.runInContext('health()',ctx);
+  assert.equal(requests.at(-1).options.headers['X-Access-Code'],undefined);
+ }else{
+  vm.runInContext("setAccessCode('page-code')",ctx);
+  await vm.runInContext('health()',ctx);
+  assert.equal(requests.at(-1).options.headers['X-Access-Code'],'page-code');
+  vm.runInContext("setByok({provider:'qwen',llmKey:'page-key',serperKey:'search-key'});setAccessCode(null)",ctx);
+  assert.equal(vm.runInContext('getByok().llmKey',ctx),'page-key');
+  await vm.runInContext('health()',ctx);
+  assert.equal(requests.at(-1).options.headers['X-Access-Code'],undefined);
+  if(input.scenario==='normal'){
+   assert.equal(persisted.has('access-code'),false);
+   assert.ok(session.has('byok-credentials'));assert.equal(vm.runInContext('storageDegraded()',ctx),false);
+  }else assert.equal(vm.runInContext('storageDegraded()',ctx),true);
+ }
+})().catch(err=>{console.error(err);process.exitCode=1;});
+'''
+    subprocess.run([node, "-e", script], input=json.dumps({"root": str(ROOT), "scenario": scenario}),
+                   text=True, encoding="utf-8", capture_output=True, timeout=30, check=True)

--- a/tests/test_result_detail_integrity.py
+++ b/tests/test_result_detail_integrity.py
@@ -1,0 +1,129 @@
+"""Actual stored artifact bytes reach shipped detail renderers without fake passes."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import runs
+from api.main import app
+
+ROOT = Path(__file__).resolve().parents[1]
+SCORES = {"overall_score": 65, "trl_score": 6, "mrl_score": 6,
+          "patent_strength": 3, "market_accessibility": 3, "evidence_confidence": 4}
+GROUNDING = {"checked": 2, "ungrounded": 0, "unverifiable": 1, "findings": []}
+CONSISTENCY = {"checked": True, "blockers": 0, "warnings": 0, "findings": []}
+
+
+def display(payload, artifact, tmp_path, monkeypatch, language="English"):
+    run_id = "20260908T010203Z-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    directory = tmp_path / run_id
+    directory.mkdir(exist_ok=True)
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    (directory / "status.json").write_text('{"done":true,"stage":"Done"}', encoding="utf-8")
+    (directory / "commercialization_report.md").write_text("# Healthy neighbour", encoding="utf-8")
+    name = {"scores": "commercialization_scores.json", "grounding": "claim_grounding.json", "consistency": "consistency.json"}[artifact]
+    (directory / name).write_text(json.dumps(payload), encoding="utf-8")
+    client = TestClient(app)
+    response = client.get(f"/api/runs/{run_id}/{artifact}")
+    assert response.status_code == 200
+    assert response.json() == payload
+    assert client.get(f"/api/runs/{run_id}/report").text == "# Healthy neighbour"
+    assert client.get(f"/api/runs/{run_id}/progress").json()["done"] is True
+    node = shutil.which("node")
+    assert node, "Node is required; this boundary cannot be silently skipped"
+    script = r'''
+const fs=require('node:fs'), vm=require('node:vm');
+const input=JSON.parse(fs.readFileSync(0,'utf8'));
+class Element {
+ constructor(tag){Object.assign(this,{tag,children:[],dataset:{},style:{},textContent:'',className:''});}
+ append(...items){this.children.push(...items);}
+ addEventListener(){}
+ set innerHTML(value){this.children=[];}
+ querySelector(selector){const id=selector.match(/data-view="([^"]+)"/)[1];return this.children.find(n=>n.dataset.view===id);}
+}
+const context=vm.createContext({localStorage:{getItem:()=>input.language},
+ document:{createElement:tag=>new Element(tag)},
+ api:{getArtifact:async()=>input.payload}, container:new Element('main'), payload:input.payload});
+for(const name of ['i18n.js','result.js']) vm.runInContext(
+ fs.readFileSync(input.root+'/web/static/js/'+name,'utf8').replace(/^import .*;\r?\n/gm,'').replace(/export /g,''),context);
+vm.runInContext(`render(container,'fixture',{artifacts:['${input.artifact}']})`,context);
+setImmediate(()=>{
+ function walk(n){return [{text:String(n.textContent||''),cls:n.className,tag:n.tag},...n.children.flatMap(walk)];}
+ const rows=walk(context.container); console.log(JSON.stringify(rows));
+});
+'''
+    result = subprocess.run([node, "-e", script], input=json.dumps({"root": str(ROOT), "artifact": artifact,
+                            "payload": response.json(), "language": language}), text=True, encoding="utf-8",
+                            capture_output=True, timeout=30, check=True)
+    rows = json.loads(result.stdout)
+    return " | ".join(row["text"] for row in rows), rows
+
+
+@pytest.mark.parametrize("artifact", ["scores", "grounding", "consistency"])
+@pytest.mark.parametrize("payload", [{}, [], None, False, "wrong root"])
+@pytest.mark.parametrize("language", ["English", "Simplified Chinese"])
+def test_invalid_root_never_becomes_zero_score_or_a_pass(tmp_path, monkeypatch, artifact, payload, language):
+    """The previous renderer printed 0.0 / Nascent or agreement for empty objects."""
+    text, rows = display(payload, artifact, tmp_path, monkeypatch, language)
+    assert ("no conclusion" if language == "English" else "不能据此得出结论") in text
+    assert "0.0" not in text
+    assert not any(row["cls"] == "consistency__clear" for row in rows)
+
+
+@pytest.mark.parametrize("value", [None, True, "65", -1, 101, {}, []])
+def test_bad_overall_does_not_hide_valid_dimensions(tmp_path, monkeypatch, value):
+    text, rows = display({**SCORES, "overall_score": value}, "scores", tmp_path, monkeypatch)
+    assert "no conclusion" in text
+    assert "6 / 9" in text
+    assert any(row["text"] == "—" for row in rows)
+    assert "Nascent" not in text
+
+
+@pytest.mark.parametrize("payload", [{**GROUNDING, "checked": None}, {**GROUNDING, "ungrounded": 3},
+    {**GROUNDING, "unverifiable": -1}, {**GROUNDING, "checked": "2"}, {**GROUNDING, "checked": True}])
+def test_invalid_coverage_counters_are_not_measurements(tmp_path, monkeypatch, payload):
+    text, rows = display(payload, "grounding", tmp_path, monkeypatch)
+    assert "no conclusion" in text
+    assert not any(row["cls"] == "grounding__stats" for row in rows)
+
+
+def test_nested_grounding_fault_preserves_healthy_counts_and_row(tmp_path, monkeypatch):
+    """A malformed neighbour must neither throw nor suppress real warnings."""
+    payload = {**GROUNDING, "ungrounded": 1, "by_domain": {"academic": [], "market": GROUNDING},
+               "findings": [None, {"finding_id": "AF1", "status": "ungrounded", "claim": "<img src=x> 26.1%",
+                                    "ungrounded_figures": ["26.1%"]}]}
+    text, rows = display(payload, "grounding", tmp_path, monkeypatch)
+    assert "26.1%" in text and "no conclusion" in text
+    assert "2/3" in text
+    assert any(row["cls"] == "grounding__stats" for row in rows)
+    assert not any(row["tag"] == "img" for row in rows)
+
+
+@pytest.mark.parametrize("payload", [{**CONSISTENCY, "checked": False}, {**CONSISTENCY, "error": "check failed"}])
+def test_skipped_or_failed_consistency_is_not_agreement(tmp_path, monkeypatch, payload):
+    text, rows = display(payload, "consistency", tmp_path, monkeypatch)
+    assert "not a pass" in text
+    assert not any(row["cls"] == "consistency__clear" for row in rows)
+
+
+@pytest.mark.parametrize("payload", [{**CONSISTENCY, "findings": {}}, {**CONSISTENCY, "warnings": 1},
+    {**CONSISTENCY, "checked": "true"}, {**CONSISTENCY, "blockers": -1}])
+def test_bad_consistency_shape_or_count_cannot_clear_report(tmp_path, monkeypatch, payload):
+    text, rows = display(payload, "consistency", tmp_path, monkeypatch)
+    assert "no conclusion" in text
+    assert not any(row["cls"] == "consistency__clear" for row in rows)
+
+
+def test_valid_results_remain_visible_and_zero_coverage_is_not_pass(tmp_path, monkeypatch):
+    """Positive controls reject an implementation which hides every detail."""
+    text, _ = display(SCORES, "scores", tmp_path, monkeypatch)
+    assert "65.0" in text and "6 / 9" in text and "no conclusion" not in text
+    text, _ = display(CONSISTENCY, "consistency", tmp_path, monkeypatch)
+    assert "recommendation matches the score" in text
+    text, rows = display({**GROUNDING, "checked": 0}, "grounding", tmp_path, monkeypatch)
+    assert "not a pass" in text
+    assert not any(row["cls"].endswith("stat--ok") for row in rows)

--- a/tests/test_step_read_integrity.py
+++ b/tests/test_step_read_integrity.py
@@ -1,0 +1,124 @@
+"""A damaged optional log must not hide a completed run or duplicate events."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import runs
+from api.main import app
+
+ROOT = Path(__file__).resolve().parents[1]
+RUN = "20260908T010203Z-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+GOOD = b'{"type":"finish","agent_idx":0}\n'
+
+
+@pytest.fixture
+def run_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path)
+    directory = tmp_path / RUN
+    directory.mkdir()
+    (directory / "status.json").write_text('{"done":true,"stage":"Done"}', encoding="utf-8")
+    (directory / "commercialization_report.md").write_text("# Preserved report", encoding="utf-8")
+    return directory / "steps.jsonl"
+
+
+def progress(client, since=0):
+    response = client.get(f"/api/runs/{RUN}/progress", params={"since": since})
+    assert response.status_code == 200
+    assert response.json()["state"] == "completed"
+    assert response.json()["done"] is True
+    assert client.get(f"/api/runs/{RUN}").status_code == 200
+    assert client.get(f"/api/runs/{RUN}/report").text == "# Preserved report"
+    return response.json()
+
+
+@pytest.mark.parametrize("bad", [b"null", b"[]", b"{}", b"false", b"", b"not-json", b"\xff",
+    b'{"type":[]}', b'{"type":"finish","agent_idx":{}}',
+    b'{"type":"finish","ts":NaN}', b'{"type":"finish","thought":null}'])
+def test_bad_step_is_local_and_cursor_skips_its_physical_line(run_log, bad):
+    """The old reader either raised HTTP 500 or replayed the healthy neighbour."""
+    raw = GOOD + bad + b"\n" + GOOD.replace(b":0", b":1")
+    run_log.write_bytes(raw)
+    client = TestClient(app)
+    body = progress(client)
+    assert [s["agent_idx"] for s in body["steps"]] == [0, 1]
+    assert body["steps_read_state"] == "partial"
+    assert body["steps_rejected"] == 1
+    assert body["steps_next_cursor"] == 3
+    later = progress(client, body["steps_next_cursor"])
+    assert later["steps"] == []
+    assert later["steps_rejected"] == 1  # Loss remains visible after the cursor passed it.
+    assert run_log.read_bytes() == raw
+
+
+@pytest.mark.parametrize("tail", [b'{"type":"fi', b'{"type":"finish"}', b'{"type":"action","thought":"\xe4'])
+def test_uncommitted_tail_is_delivered_once_after_newline(run_log, tail):
+    """Even parseable JSON without the writer's newline is not a committed row."""
+    run_log.write_bytes(GOOD + tail)
+    client = TestClient(app)
+    first = progress(client)
+    assert len(first["steps"]) == 1
+    assert first["steps_next_cursor"] == 1
+    assert first["steps_read_state"] == "partial"
+    assert first["steps_rejected"] == 0
+    run_log.write_bytes(GOOD + GOOD.replace(b":0", b":1"))
+    later = progress(client, first["steps_next_cursor"])
+    assert [s["agent_idx"] for s in later["steps"]] == [1]
+    assert later["steps_read_state"] == "readable"
+    assert progress(client, later["steps_next_cursor"])["steps"] == []
+
+
+def test_absent_empty_and_permission_denied_logs_are_distinct(run_log):
+    """A failed read cannot impersonate an empty successful observation."""
+    client = TestClient(app)
+    assert progress(client)["steps_read_state"] == "absent"
+    run_log.write_bytes(b"")
+    assert progress(client)["steps_read_state"] == "readable"
+    original = Path.open
+
+    def fail_log(path, *args, **kwargs):
+        if path == run_log:
+            raise PermissionError("private diagnostic path")
+        return original(path, *args, **kwargs)
+
+    with patch.object(Path, "open", fail_log):
+        body = progress(client, 4)
+    assert body["steps_read_state"] == "unavailable"
+    assert body["steps_next_cursor"] == 4
+    assert "private diagnostic" not in json.dumps(body)
+
+
+def test_shipped_follower_uses_server_cursor_and_still_finishes(run_log):
+    """Test real HTTP page values through the actual JS follower, not a counter helper."""
+    run_log.write_bytes(GOOD + b"null\n" + GOOD)
+    client = TestClient(app)
+    first = progress(client)
+    second = progress(client, first["steps_next_cursor"])
+    node = shutil.which("node")
+    assert node, "Node is required for client seam tests"
+    script = r'''
+const fs=require('node:fs'), vm=require('node:vm'), assert=require('node:assert/strict');
+const input=JSON.parse(fs.readFileSync(0,'utf8')), cursors=[], timers=[];
+let done=0, updates=0;
+const ctx=vm.createContext({api:{getProgress:async(id,cursor)=>{
+  cursors.push(cursor);
+  return cursors.length===1 ? {...input.first,state:'running'} : input.second;
+}}, t:k=>k, setTimeout:fn=>timers.push(fn), clearTimeout:()=>{}, done:()=>done++, update:()=>updates++});
+vm.runInContext(fs.readFileSync(input.root+'/web/static/js/run.js','utf8')
+  .replace(/^import .*;\r?\n/gm,'').replace(/export /g,''),ctx);
+vm.runInContext("follow('fixture',{onUpdate:update,onDone:done})",ctx);
+setImmediate(async()=>{
+  assert.equal(timers.length,1); await timers.shift()();
+  assert.deepEqual(cursors,[0,input.first.steps_next_cursor]);
+  assert.equal(done,1); assert.equal(updates,2); assert.equal(timers.length,0);
+  console.log('cursor and completion reached client');
+});
+'''
+    result = subprocess.run([node, "-e", script], input=json.dumps({"root": str(ROOT), "first": first, "second": second}),
+                            text=True, encoding="utf-8", capture_output=True, timeout=30, check=True)
+    assert "completion reached client" in result.stdout

--- a/web/index.html
+++ b/web/index.html
@@ -74,6 +74,7 @@
 
   <!-- ═══ Main ═════════════════════════════════════════════════════ -->
   <main class="main" id="main">
+    <p id="storage-notice" class="empty-note" role="status" hidden></p>
 
     <!-- ── Compose ─────────────────────────────────────────────── -->
     <section class="pane" id="pane-compose">
@@ -258,6 +259,7 @@
             <span id="run-terminal"></span>
             <span id="run-status-record"></span>
             <span id="run-runtime-record"></span>
+            <span id="run-step-record" role="status"></span>
             <span id="run-recovery"></span>
           </div>
         </div>

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -23,11 +23,40 @@ export class ApiError extends Error {
 
 const ACCESS_KEY = "access-code";
 
-export const getAccessCode = () => localStorage.getItem(ACCESS_KEY);
+// Storage is an optional persistence mechanism, not the authority to send a
+// request. Latch a failing slot into page-local memory: retrying a failed
+// remove on the next read could resurrect a stale credential. Nothing here
+// bypasses server authentication or retries a paid POST. A reload ends this
+// fallback; callers must not auto-reload after a failed credential removal.
+function credentialSlot(storageName, key) {
+  let memory = null, volatile = false;
+  return {
+    read() {
+      if (!volatile) {
+        try { memory = globalThis[storageName].getItem(key); }
+        catch { volatile = true; }
+      }
+      return memory;
+    },
+    write(value) {
+      memory = value;
+      if (volatile) return false;
+      try {
+        const storage = globalThis[storageName];
+        if (value === null) storage.removeItem(key);
+        else storage.setItem(key, value);
+        return true;
+      } catch { volatile = true; return false; }
+    },
+    degraded: () => volatile,
+  };
+}
+
+const accessSlot = credentialSlot("localStorage", ACCESS_KEY);
+export const getAccessCode = () => accessSlot.read();
 
 export function setAccessCode(code) {
-  if (code) localStorage.setItem(ACCESS_KEY, code);
-  else localStorage.removeItem(ACCESS_KEY);
+  return accessSlot.write(code || null);
 }
 
 /* ── Bring-your-own-key ───────────────────────────────────────────────
@@ -37,18 +66,19 @@ export function setAccessCode(code) {
  * they should not outlive the tab. */
 
 const BYOK_KEY = "byok-credentials";
+const byokSlot = credentialSlot("sessionStorage", BYOK_KEY);
+export const storageDegraded = () => accessSlot.degraded() || byokSlot.degraded();
 
 export function getByok() {
   try {
-    return JSON.parse(sessionStorage.getItem(BYOK_KEY));
+    return JSON.parse(byokSlot.read());
   } catch {
     return null;
   }
 }
 
 export function setByok(creds) {
-  if (creds) sessionStorage.setItem(BYOK_KEY, JSON.stringify(creds));
-  else sessionStorage.removeItem(BYOK_KEY);
+  return byokSlot.write(creds ? JSON.stringify(creds) : null);
 }
 
 /* A BYOK run gets no owner tag server-side (see api/access.py) and so never

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -120,7 +120,7 @@ function startClock(fromSeconds) {
 
 function paintHeader({
   topic, state, elapsed_seconds, source_counts, usage, usage_accounting,
-  terminal, status_record_state, checkpointing, recovery, runtime_metadata_unreadable,
+  terminal, status_record_state, checkpointing, recovery, runtime_metadata_unreadable, steps_read_state,
 }) {
   if (topic) $("#run-title").textContent = topic;
 
@@ -162,6 +162,8 @@ function paintHeader({
     ? `· ${t("status_record_unreadable")}` : "";
 
   const runtimeFault = runView.runtimeMetadataSummary(runtime_metadata_unreadable ?? []);
+  $("#run-step-record").textContent = ["partial", "unavailable"].includes(steps_read_state)
+    ? `· ${t("steps_" + steps_read_state)}` : "";
   $("#run-runtime-record").textContent = runtimeFault ? `· ${runtimeFault}` : "";
 
   const recoveryEl = $("#run-recovery");
@@ -649,13 +651,16 @@ $("#collapse-btn").addEventListener("click", () => {
   } else {
     const next = workbench.dataset.collapsed !== "true";
     workbench.dataset.collapsed = String(next);
-    localStorage.setItem("sidebar-collapsed", String(next));
+    try { localStorage.setItem("sidebar-collapsed", String(next)); }
+    catch { /* Sidebar persistence is optional; the current DOM already reflects the click. */ }
   }
 });
 
-if (localStorage.getItem("sidebar-collapsed") === "true" && !NARROW.matches) {
-  workbench.dataset.collapsed = "true";
-}
+try {
+  if (localStorage.getItem("sidebar-collapsed") === "true" && !NARROW.matches) {
+    workbench.dataset.collapsed = "true";
+  }
+} catch { /* A default-open sidebar must not stop access checks or routing. */ }
 
 $("#new-run-btn").addEventListener("click", showCompose);
 
@@ -721,10 +726,33 @@ function applyByokMode() {
   $("#byok-badge").hidden = false;
 }
 
-$("#byok-exit").addEventListener("click", () => {
-  api.setByok(null);
-  location.reload();
-});
+function showStorageNotice(key = "storage_unavailable") {
+  const notice = $("#storage-notice");
+  notice.dataset.i18n = key;
+  notice.textContent = t(key);
+  notice.hidden = false;
+}
+
+async function exitCredentials() {
+  const byokCleared = api.setByok(null);
+  const codeCleared = api.setAccessCode(null);
+  if (byokCleared && codeCleared) { location.reload(); return; }
+  // Failed persistent removal cannot be undone by reloading: that would read
+  // the old value again. End this page's session and ask for explicit login.
+  // Do not claim browser data was purged or cancel any server-side work.
+  stopFollowing();
+  stopClock();
+  byokMode = false;
+  $("#byok-badge").hidden = true;
+  $("#code-badge").hidden = true;
+  $("#pane-run").hidden = true;
+  $("#pane-compose").hidden = true;
+  showStorageNotice("storage_logout_incomplete");
+  await showGate();
+  showCompose();
+}
+
+$("#byok-exit").addEventListener("click", exitCredentials);
 
 // Mutually exclusive with applyByokMode(): shown only when a stored code is
 // what got the visitor past the gate, never when the gate is off entirely
@@ -733,10 +761,7 @@ function applyCodeMode() {
   $("#code-badge").hidden = false;
 }
 
-$("#code-exit").addEventListener("click", () => {
-  api.setAccessCode(null);
-  location.reload();
-});
+$("#code-exit").addEventListener("click", exitCredentials);
 
 async function ensureAccess() {
   if (api.getByok()) {
@@ -786,6 +811,12 @@ function showGate() {
   const codeSubmit = $("#gate-submit");
   const byokForm = $("#byok-form");
 
+  // Storage-denied logout reuses this document. Clear previous inputs and
+  // replace the gate-owned handlers below instead of accumulating closures
+  // that would validate one submission several times after repeated login.
+  codeForm.reset();
+  byokForm.reset();
+  codeError.hidden = true;
   gate.hidden = false;
   codeForm.hidden = false;
   byokForm.hidden = true;
@@ -794,25 +825,26 @@ function showGate() {
   return new Promise((resolve) => {
     const finish = () => {
       gate.hidden = true;
+      if (api.storageDegraded()) showStorageNotice();
       resolve();
     };
 
-    $("#gate-to-byok").addEventListener("click", () => {
+    $("#gate-to-byok").onclick = () => {
       codeForm.hidden = true;
       byokForm.hidden = false;
       $("#byok-llm-key").focus();
       showByokRetention();
-    });
-    $("#byok-to-gate").addEventListener("click", () => {
+    };
+    $("#byok-to-gate").onclick = () => {
       byokForm.hidden = true;
       codeForm.hidden = false;
       codeInput.focus();
-    });
+    };
 
-    codeForm.addEventListener("submit", async (e) => {
+    codeForm.onsubmit = async (e) => {
       e.preventDefault();
       const code = codeInput.value.trim();
-      if (!code) return;
+      if (!code || codeSubmit.disabled) return;
 
       codeSubmit.disabled = true;
       codeError.hidden = true;
@@ -828,9 +860,9 @@ function showGate() {
       } finally {
         codeSubmit.disabled = false;
       }
-    });
+    };
 
-    byokForm.addEventListener("submit", (e) => {
+    byokForm.onsubmit = (e) => {
       e.preventDefault();
       const provider = $("#byok-provider").value;
       const llmKey = $("#byok-llm-key").value.trim();
@@ -840,7 +872,7 @@ function showGate() {
       api.setByok({ provider, llmKey, serperKey });
       applyByokMode();
       finish();
-    });
+    };
   });
 }
 
@@ -913,6 +945,7 @@ document.addEventListener("visibilitychange", () => {
 });
 
 ensureAccess().then(() => {
+  if (api.storageDegraded()) showStorageNotice();
   routeFromLocation();
   refreshSidebar();
   refreshCapacity();

--- a/web/static/js/i18n.js
+++ b/web/static/js/i18n.js
@@ -11,6 +11,12 @@
 
 const STRINGS = {
   English: {
+    storage_unavailable: "Browser storage is unavailable. Credentials last only on this page; settings and history may not be saved. Bookmark accepted run links.",
+    storage_logout_incomplete: "Signed out on this page, but stored credentials could not be removed. Clear this site's browser data before reopening it.",
+    detail_unreadable: "Detail unavailable or malformed; no conclusion can be drawn from it.",
+    detail_not_checked: "This check did not establish a result; this is not a pass.",
+    steps_partial: "Step log incomplete; this does not change the run outcome.",
+    steps_unavailable: "Step log unavailable; the run outcome and report remain separate.",
     // Chrome
     brand: "Assessment",
     new_analysis: "New analysis",
@@ -278,6 +284,12 @@ const STRINGS = {
   },
 
   "Simplified Chinese": {
+    storage_unavailable: "浏览器存储不可用。凭据仅在当前页面临时保留，设置与历史可能无法保存；请收藏已接受任务的链接。",
+    storage_logout_incomplete: "已在当前页面退出，但无法删除浏览器里保存的旧凭据。重新打开前请清除此网站的浏览器数据。",
+    detail_unreadable: "详情缺失或格式异常，不能据此得出结论。",
+    detail_not_checked: "此项检查未形成有效判断，不代表通过。",
+    steps_partial: "步骤日志不完整；这不改变任务的执行结果。",
+    steps_unavailable: "无法读取步骤日志；任务结果与报告不受此状态判定。",
     brand: "商业化评估",
     new_analysis: "新建分析",
     no_runs: "暂无运行记录",
@@ -522,7 +534,9 @@ const STRINGS = {
 
 const STORAGE_KEY = "ui-language";
 
-let current = localStorage.getItem(STORAGE_KEY) ?? "English";
+let current = "English";
+try { current = localStorage.getItem(STORAGE_KEY) ?? "English"; }
+catch { /* Preferences cannot prevent module initialization in a restricted browser. */ }
 if (!STRINGS[current]) current = "English";
 
 /** Translate a key, falling back to English and then to the key itself. */
@@ -537,7 +551,8 @@ export function language() {
 export function setLanguage(next) {
   if (!STRINGS[next]) return;
   current = next;
-  localStorage.setItem(STORAGE_KEY, next);
+  try { localStorage.setItem(STORAGE_KEY, next); }
+  catch { /* Keep the selected language in memory; applying it needs no persistence. */ }
   apply();
 }
 

--- a/web/static/js/result.js
+++ b/web/static/js/result.js
@@ -139,16 +139,26 @@ export function renderMarkdown(md) {
 
 /* ── Scorecard ─────────────────────────────────────────────────────── */
 
+// Read validation only: never repair stored JSON or recompute its score.
+// A missing number is not zero, and a valid neighbour remains displayable.
+const detailRecord = value => value !== null && typeof value === "object" && !Array.isArray(value);
+const detailCount = value => Number.isSafeInteger(value) && value >= 0;
+const detailStrings = value => Array.isArray(value) && value.every(item => typeof item === "string");
+const detailUnavailable = () => el("p", "empty-note detail-unreadable", t("detail_unreadable"));
+const scoreNumber = (value, max) => typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= max;
+
 function renderScorecard(scores) {
   const wrap = el("section", "scorecard");
-  const overall = Number(scores.overall_score ?? 0);
-  const { name, tone } = band(overall);
+  if (!detailRecord(scores)) { wrap.append(detailUnavailable()); return wrap; }
+  const overall = scores.overall_score;
+  const readable = scoreNumber(overall, 100);
+  const { name, tone } = readable ? band(overall) : { name: t("detail_unreadable"), tone: "muted" };
 
   const head = el("div", "scorecard__head");
   const figure = el("div", "scorecard__figure");
   figure.dataset.tone = tone;
   figure.append(
-    el("span", "scorecard__value tabular", overall.toFixed(1)),
+    el("span", "scorecard__value tabular", readable ? overall.toFixed(1) : "—"),
     el("span", "scorecard__denom", "/ 100"),
   );
   const caption = el("div", "scorecard__caption");
@@ -161,8 +171,9 @@ function renderScorecard(scores) {
 
   const grid = el("div", "dims");
   for (const dim of DIMENSIONS) {
-    const value = Number(scores[dim.key] ?? 0);
-    const pct = Math.max(0, Math.min(100, (value / dim.max) * 100));
+    const value = scores[dim.key];
+    const valid = scoreNumber(value, dim.max) && Number.isInteger(value);
+    const pct = valid ? (value / dim.max) * 100 : 0;
 
     const row = el("div", "dim");
     const label = el("div", "dim__label", t(dim.label));
@@ -170,12 +181,13 @@ function renderScorecard(scores) {
     const fill = el("div", "dim__fill");
     fill.style.width = `${pct}%`;
     bar.append(fill);
-    const num = el("div", "dim__value tabular", `${value} / ${dim.max}`);
+    const num = el("div", "dim__value tabular", valid ? `${value} / ${dim.max}` : "—");
+    if (!valid) row.title = t("detail_unreadable");
 
     row.append(label, bar, num);
 
     const rationale = scores[dim.key.replace(/_score$|_strength$|_accessibility$|_confidence$/, "") + "_rationale"];
-    if (rationale) row.title = rationale;
+    if (valid && typeof rationale === "string" && rationale) row.title = rationale;
 
     grid.append(row);
   }
@@ -183,7 +195,9 @@ function renderScorecard(scores) {
 
   for (const [key, title] of [["key_risks", t("risks")], ["key_opportunities", t("opportunities")]]) {
     const items = scores[key];
-    if (!Array.isArray(items) || !items.length) continue;
+    if (items === undefined) continue; // Historical scorecards need not have notes.
+    if (!detailStrings(items)) { wrap.append(detailUnavailable()); continue; }
+    if (!items.length) continue;
     const block = el("div", "notes");
     block.append(el("h4", "notes__title", title));
     const ul = el("ul", "notes__list");
@@ -343,17 +357,21 @@ export async function render(container, runId, progress) {
 // relative to each other — is worth asserting on directly.
 export function renderGrounding(data) {
   const wrap = el("div", "grounding");
-
-  const checked = data.checked ?? 0;
-  const ungrounded = data.ungrounded ?? 0;
-  const unverifiable = data.unverifiable ?? 0;
+  if (!detailRecord(data) || !["checked", "ungrounded", "unverifiable"].every(key => detailCount(data[key]))
+      || data.ungrounded > data.checked) {
+    wrap.append(detailUnavailable()); return wrap;
+  }
+  const { checked, ungrounded, unverifiable } = data;
 
   wrap.append(el("p", "grounding__lede", t("grounding_lede")));
+  // Zero checked is not evidence of a successful screen, including valid
+  // all-zero historical artifacts. Do not infer full report verification.
+  if (data.error || checked === 0) wrap.append(el("p", "empty-note", t("detail_not_checked")));
 
   const stats = el("div", "grounding__stats");
   for (const [value, label, tone] of [
-    [checked, t("grounding_checked"), "ok"],
-    [ungrounded, t("grounding_ungrounded"), ungrounded ? "warn" : "ok"],
+    [checked, t("grounding_checked"), checked && !data.error ? "ok" : "muted"],
+    [ungrounded, t("grounding_ungrounded"), ungrounded ? "warn" : checked && !data.error ? "ok" : "muted"],
     [unverifiable, t("grounding_unverifiable"), "muted"],
   ]) {
     const cell = el("div", `grounding__stat grounding__stat--${tone}`);
@@ -364,7 +382,8 @@ export function renderGrounding(data) {
   wrap.append(stats);
 
   const duplicatesCollapsed = data.duplicates_collapsed ?? 0;
-  if (duplicatesCollapsed > 0) {
+  if (!detailCount(duplicatesCollapsed)) wrap.append(detailUnavailable());
+  else if (duplicatesCollapsed > 0) {
     const note = t("grounding_duplicates").replace(
       "{count}", String(duplicatesCollapsed),
     );
@@ -374,6 +393,7 @@ export function renderGrounding(data) {
   // Per domain, because one aggregate cannot say both "the check works" and
   // "market reports have no abstract to check against".
   const byDomain = data.by_domain ?? {};
+  if (data.by_domain !== undefined && !detailRecord(data.by_domain)) wrap.append(detailUnavailable());
   const domains = [
     ["academic", t("group_academic")],
     ["patent", t("group_patents")],
@@ -384,7 +404,12 @@ export function renderGrounding(data) {
     const list = el("ul", "grounding__domains");
     for (const [key, label] of domains) {
       const d = byDomain[key];
-      const total = (d.checked ?? 0) + (d.unverifiable ?? 0);
+      if (!detailRecord(d) || !["checked", "ungrounded", "unverifiable"].every(k => detailCount(d[k]))
+          || d.ungrounded > d.checked) {
+        list.append(el("li", "grounding__domain", `${label}: ${t("detail_unreadable")}`));
+        continue;
+      }
+      const total = d.checked + d.unverifiable;
       const text = total
         ? `${label}: ${d.checked}/${total} ${t("grounding_checkable")}`
         : `${label}: ${t("grounding_no_figures")}`;
@@ -393,11 +418,19 @@ export function renderGrounding(data) {
     wrap.append(list);
   }
 
-  const rows = data.findings ?? [];
+  const rows = data.findings;
+  if (!Array.isArray(rows)) { wrap.append(detailUnavailable()); return wrap; }
   if (!rows.length) return wrap;
 
   const list = el("ul", "grounding__list");
   for (const row of rows) {
+    if (!detailRecord(row) || typeof row.finding_id !== "string"
+        || !["grounded", "ungrounded", "unverifiable"].includes(row.status)
+        || (row.claim !== undefined && typeof row.claim !== "string")
+        || (row.ungrounded_figures !== undefined && !detailStrings(row.ungrounded_figures))
+        || (row.unverifiable_reason != null && typeof row.unverifiable_reason !== "string")) {
+      list.append(detailUnavailable()); continue;
+    }
     const item = el("li", `grounding__item grounding__item--${row.status}`);
     item.append(el("span", "grounding__id", `${row.finding_id}`));
     item.append(el("span", "grounding__claim", row.claim ?? ""));
@@ -646,8 +679,23 @@ export function renderReportAudit(data) {
 export function renderConsistency(data) {
   const wrap = el("div", "consistency");
   wrap.append(el("p", "grounding__lede", t("consistency_lede")));
-
-  const findings = data.findings ?? [];
+  if (!detailRecord(data) || typeof data.checked !== "boolean"
+      || !detailCount(data.blockers) || !detailCount(data.warnings) || !Array.isArray(data.findings)) {
+    wrap.append(detailUnavailable()); return wrap;
+  }
+  // Even an empty, valid findings array cannot turn a skipped/failed check
+  // into agreement. The current writer normally omits skipped artifacts;
+  // retained historical or hand-edited bytes still reach this read boundary.
+  if (!data.checked || data.error) {
+    wrap.append(el("p", "empty-note", t("detail_not_checked"))); return wrap;
+  }
+  const findings = data.findings;
+  if (data.blockers + data.warnings !== findings.length || findings.some(f =>
+    !detailRecord(f) || !["blocker", "warning"].includes(f.severity)
+    || typeof f.detail !== "string" || (f.excerpt !== undefined && typeof f.excerpt !== "string"))
+    || findings.filter(f => f.severity === "blocker").length !== data.blockers) {
+    wrap.append(detailUnavailable()); return wrap;
+  }
   if (!findings.length) {
     wrap.append(el("p", "consistency__clear", t("consistency_clear")));
     return wrap;

--- a/web/static/js/run.js
+++ b/web/static/js/run.js
@@ -90,7 +90,11 @@ export function follow(runId, { onUpdate, onDone, onError }) {
       const progress = await api.getProgress(runId, seenSteps);
       if (stopped) return;
 
-      seenSteps += progress.steps.length;
+      // A rejected physical line still advances the server cursor. Fall back
+      // only for old deployments which have not introduced this field yet.
+      seenSteps = Number.isSafeInteger(progress.steps_next_cursor)
+        && progress.steps_next_cursor >= seenSteps
+        ? progress.steps_next_cursor : seenSteps + progress.steps.length;
       onUpdate?.(progress);
 
       if (TERMINAL.has(progress.state)) {


### PR DESCRIPTION
## Why
Optional delivery failures must not invalidate an already completed assessment or turn missing observations into a pass. Synthetic probes reproduced progress HTTP 500s, duplicated suffix events after rejected log rows, empty-detail false passes and browser storage denial before fetch. The bounded existing-artifact inventory did not show these corruptions; this is preventive maintenance, not a production incident rate.

## Contracts
- Physical-line progress cursor, local malformed-row isolation, uncommitted-tail withholding and explicit read-loss state.
- Shape-aware score/grounding/consistency details without changing source bytes, formulas or blocking rules.
- Page-local access-code/BYOK fallback; failed persistent logout does not reload stale credentials or claim global erasure. Re-entry clears inputs and replaces gate handlers.
- Public maintenance/index/operating documentation updated. Private resume history stays in the separate private repository.

## Verification
- Before: 2428 tests / 1186 subtests.
- Final local: 2499 tests / 1191 subtests; Windows/Python 3.12 coverage 88.89%, unchanged 85% gate.
- Latest Ruff and narrow Pylint passed.
- Both actual Chromium journeys passed, zero provider requests; composer retains ten intercepted fixture POSTs.
- Eight targeted defect reinjections failed the expected seam checks; all source hashes restored.
- Public documentation tests passed after final evidence numbers were recorded.

No paid canary, provider/model/scoring change, production Tool Calling connection or frozen-cohort reuse.