### PR TITLE
Preserve fractional scores, paid identity and truthful progress connectivity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,12 @@ Score/grounding/consistency detail faults must not become zero or agreement.
 Denied storage is page-local fallback, not authentication bypass; failed logout
 must not reload stale credentials. See the [delivery boundary and limits](docs/results-2026-09-08-client-delivery-seams.md).
 
+Normalized score dimensions include fractions in 1..maximum. Malformed BYOK
+must not select operator billing; logout waits for paid acknowledgements and
+clears old attachment/context. Progress read loss is not worker failure, and
+its bounded GET must never become a paid-POST timeout. See the
+[combined boundary regression](docs/results-2026-09-08-client-boundary-combinations.md).
+
 ## Tool Calling: do not turn experimental code into production by accident
 
 - Production is phase-1 **zero-call shadow mode**. Phase-2 execution, provider

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -88,6 +88,13 @@ page-local identity with explicit persistence/logout limits. These are
 offline HTTP/Chromium contracts, not production incident rates or semantic
 report validation. See the [delivery seam audit](results-2026-09-08-client-delivery-seams.md).
 
+The follow-up corrects integer-only score display against 109 stored score
+files (64 contain fractions). Malformed BYOK no longer chooses operator billing;
+pending acknowledgements retain their identity, and stale progress reads have a
+separate visible state. These are bounded offline request/browser regressions,
+not measured production charge errors or an uptime SLO. See the
+[combined client-boundary audit](results-2026-09-08-client-boundary-combinations.md).
+
 | Question | Observed evidence | Boundary / decision |
 |---|---|---|
 | Can the frozen baseline complete with consistent mechanics? | 30/30 completed; 26/30 TRL-range hits; 30/30 correct formula and structure; zero uncited numeric lines; 7/10 topics hit their range in every repetition | Expected ranges were revised after early observations. Not independent accuracy or full hallucination measurement. [CSV](../outputs/benchmark/benchmark_summary.csv), [stability](../outputs/benchmark/benchmark_stability.csv) |

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -24,6 +24,7 @@ to reuse consumed cohorts.
 ## Recent offline maintenance
 
 - [2026-09-08 client delivery seams](results-2026-09-08-client-delivery-seams.md) — optional log isolation/cursors, truthful details and browser-storage fallback, zero provider calls.
+- [2026-09-08 combined client boundaries](results-2026-09-08-client-boundary-combinations.md) — fractional score regression, explicit BYOK identity and visible stale reads; zero provider calls.
 - [2026-09-07 cleanup outcomes](results-2026-09-07-cleanup-outcome-observability.md) — advisory per-attempt counters and explicit incomplete coverage at both HTTP schemas.
 - [2026-09-07 maintenance observation age](results-2026-09-07-maintenance-observation-age.md) — time-qualified health/readiness snapshots without a new SLO or provider call.
 - [2026-09-06 maintenance event-loop ownership](results-2026-09-06-maintenance-event-loop.md) — held-stage HTTP probes and shutdown drain, zero provider calls.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -204,12 +204,24 @@ held until newline publication. See the [delivery contract](results-2026-09-08-c
 Score, grounding and consistency tabs validate downloaded display fields rather
 than defaulting missing data to zero or agreement. This neither rewrites stored
 artifacts nor changes scoring/heuristics. Healthy report tabs remain usable.
+Normalized dimensions accept fractions in 1..maximum, not just rubric integers.
 
 If browser storage is denied, credentials can be held only in page memory and
 preferences use safe defaults. Bookmark accepted run links. A failed persistent
 logout returns to the gate without reloading stale credentials; clear site data
 before reopening when prompted. This does not erase inaccessible storage, revoke
 capability URLs, or stop work on the server.
+
+Malformed saved BYOK requires explicit credential selection before any paid
+request; a residual access code is not an automatic fallback payer. Logout waits
+for run, resume and PDF acknowledgements, then clears old attachment/context.
+Do not treat closing a tab or aborting a request as provider cancellation.
+
+A progress read failing or exceeding its 15-second deadline shows either no
+confirmed observation or a stale last state, separate from the worker outcome.
+Successful polling clears the warning; 404 stops polling. Other read requests
+do not acquire this deadline, and browser suspension can delay timers. See the
+[combined boundary contract](results-2026-09-08-client-boundary-combinations.md).
 
 Each run writes its own `outputs/<run_id>/` directory. Files depend on how
 far the run progressed; a missing report on an early failure is not a completed

--- a/docs/results-2026-09-08-client-boundary-combinations.md
+++ b/docs/results-2026-09-08-client-boundary-combinations.md
@@ -1,0 +1,82 @@
+# Fractional scores, paid identity and stale progress reads
+
+Date: 2026-09-08. Base: `207670addc16b59c65026f1ddcabed3d172b02a0`.
+This corrects a display regression and synthetic client-boundary failures.
+It is not a new paid experiment or a general security/accuracy certification.
+
+## Evidence before changing code
+
+The unchanged baseline passed 2,499 tests and 1,191 subtests. A bounded,
+read-only inventory of existing timestamped and benchmark outputs found 109
+readable score files, 64 with at least one fractional dimension: TRL 45, MRL
+30, patent 33, market 51 and evidence 34. These counts overlap. They identify
+stored reports affected by the display rule, not 64 observed online incidents.
+
+The preceding maintenance mistakenly required dimension integers. Actual
+normalization exports fractions (including 8.5 and 3.5), so an integer-only
+positive test missed legitimate values hidden as dashes. Zero also passed the
+old display range despite the dimension contract starting at one.
+
+Fake-fetch replays reproduced corrupt stored BYOK objects, arrays and strings
+omitting the credential fields while retaining an access-code header. With a
+valid operator code this can change the payer; without authorization the server
+still rejects it. A delayed identity-A PDF reply also attached to identity B's
+next request after same-page logout. Three failed polls after a running response
+produced no connection-loss notification. These failures were synthesized, not
+claims about observed production charges or an authorization bypass.
+
+## Contracts now enforced
+
+- Dimension values are finite numbers in **1..dimension maximum**, including
+  fractions; the overall score remains 0..100. Invalid dimensions have visible
+  local explanations and dashes without hiding valid neighbours. No formula,
+  weight, confidence floor, saved score or frozen calibration changes.
+- Only an absent BYOK storage entry means no BYOK. Invalid JSON, JSON null,
+  wrong shapes, unknown providers and missing/non-string/blank keys block run,
+  resume and PDF requests before fetch. Boot asks for an explicit credential
+  choice even when an access code remains. Setters reject malformed credentials
+  without clearing the existing payer; explicit code login can clear BYOK.
+  This is local shape validation, not verification that a supplier accepts a key.
+- Logout waits for outstanding run/resume/PDF acknowledgements. Aborting fetch
+  would not cancel a paid provider request and dropping a response could lose
+  its only run capability. Once settled, logout clears attachment, topic and
+  decision context before reload or same-page gate entry. Gate submission cannot
+  switch identity while a code check is pending or after its gate has finished.
+- The progress GET has a 15-second deadline through body consumption. A failed
+  read shows an independent connection warning and stops elapsed extrapolation;
+  it does not change the worker state or create a failed run. A successful poll
+  clears the warning and re-anchors time. No initial observation is distinct
+  from a stale prior observation; 404 stops polling with a distinct message.
+  Existing cursor and read-backoff rules remain. No paid POST gets this timeout.
+
+## Verification and limits
+
+Final local Windows / Python 3.12.9 verification: **2,619 passed + 1,196
+subtests**, fresh coverage **88.89%**. Latest Ruff, the narrow CONTRIBUTING
+Pylint command and both Chromium journeys passed. This adds 120 tests; document
+link subtests are separate. Committed-tree CI supplies platform-specific counts.
+
+The regression suite exercises stored files through HTTP into the actual score
+renderer, all three paid client entrypoints with absent/valid/corrupt credentials,
+the API/browser provider allowlist seam, delayed acknowledgements across identity
+changes, stalled headers/body reads, first-read failure, recovery, 404 and stop.
+Real Chromium additionally sees the gate rejection, all three pending-operation
+logout guards, A-to-B attachment isolation and a visible stale/healthy transition.
+Its 12 POSTs are intercepted fixtures: none reaches the static-only server or a
+provider. The independent read-only browser journey remains zero-mutation.
+
+Seven original/related defects are reinjected individually: integer-only scores,
+corrupt BYOK fallback, pending-payer clearing, old attachment retention, silent
+poll failures, a warning that never clears, and loss of the bounded read deadline.
+Each test must fail at the relevant assertion and every source hash is restored.
+The final local and CI runs determine committed-tree counts; the unchanged
+coverage floor remains 85%, and no warning filter or skip is loosened.
+
+These controls belong to one document/tab. They do not revoke capability links,
+purge inaccessible storage, coordinate other tabs, guarantee server/provider
+idempotency, or stop work when a tab closes. A paid acknowledgement that never
+settles keeps logout guarded; closing the tab risks losing that acknowledgement
+and is not cancellation. Browser timer throttling can delay the read deadline.
+Other GETs and arbitrary hostile/corrupt payloads are not comprehensively bounded.
+Production Tool Calling remains zero-call shadow mode; no new source/model calls,
+reserved cohort access, Railway restart or paid canary occurred in this audit.

--- a/e2e/composer_smoke.py
+++ b/e2e/composer_smoke.py
@@ -53,6 +53,7 @@ def main() -> None:
     unexpected: list[str] = []
     page_errors: list[str] = []
     storage_gate = False
+    progress_read_failure = False
     run_id = "20260906T000000Z-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     child_id = "20260906T000001Z-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     progress = {"run_id": run_id, "topic": "Accepted fixture assessment", "state": "completed",
@@ -86,7 +87,10 @@ def main() -> None:
             elif url.path == "/api/runs":
                 _json(route, {"runs": []})
             elif url.path == f"/api/runs/{run_id}/progress":
-                _json(route, progress)
+                if progress_read_failure:
+                    route.abort()
+                else:
+                    _json(route, progress)
             elif url.path == f"/api/runs/{child_id}/progress":
                 _json(route, {**progress, "run_id": child_id, "state": "completed", "topic": "Accepted child"})
             elif url.path == "/health":
@@ -141,9 +145,17 @@ def main() -> None:
             expect(run).to_be_enabled()
             run.click()
             _wait_requests(page, requests, 3)
+            progress["state"] = "running"
             _json(requests[2], {"run_id": run_id, "topic": progress["topic"], "state": "running"}, status=202)
             expect(page.locator("#run-title")).to_have_text(progress["topic"])
+            expect(page.locator("#run-pill")).to_have_text("running")
+            progress_read_failure = True
+            expect(page.locator("#run-connection")).to_contain_text("last confirmed state")
+            expect(page.locator("#run-pill")).to_have_text("running")
+            progress_read_failure = False
+            progress["state"] = "completed"
             expect(page.locator("#run-pill")).to_have_text("completed")
+            expect(page.locator("#run-connection")).to_have_text("")
             assert requests[2].request.post_data_json["paper_id"] == "selected-paper"
 
             # A fresh compose document covers auto-fill, extraction failure,
@@ -193,6 +205,9 @@ def main() -> None:
             topic.fill("Accepted despite browser history quota")
             run.click()
             _wait_requests(page, requests, 8)
+            page.locator("#byok-exit").click()
+            expect(page.locator("#toasts")).to_contain_text("回包后再退出")
+            expect(page.locator("#byok-badge")).to_be_visible()
             _json(requests[7], {"run_id": run_id, "topic": progress["topic"], "state": "running"}, status=202)
             expect(page).to_have_url(f"{base}/run/{run_id}")
             expect(page.locator("#run-pill")).to_have_text("failed")
@@ -200,6 +215,8 @@ def main() -> None:
             resume = page.locator(f'[data-resume-run="{run_id}"]')
             resume.click()
             _wait_requests(page, requests, 9)
+            page.locator("#byok-exit").click()
+            expect(page.locator("#byok-badge")).to_be_visible()
             expect(resume).to_be_disabled()
             page.locator("#ui-lang").select_option("English")
             expect(page.locator("#run-pill")).to_have_text("failed")
@@ -219,6 +236,23 @@ def main() -> None:
             requests[9].abort()
             expect(page.locator("#toasts")).to_contain_text("may already have started")
             assert len(requests) == 10
+            # A valid leftover code must not silently replace corrupted BYOK.
+            # Even a programmatic submit behind the gate cannot emit a POST.
+            page.evaluate("""() => {
+                sessionStorage.setItem('byok-credentials', '{}');
+                localStorage.setItem('access-code', 'storage-fixture-code');
+            }""")
+            page.goto(base)
+            expect(page.locator("#gate")).to_be_visible()
+            expect(page.locator("#gate-error")).to_contain_text("Saved BYOK credentials are invalid")
+            page.locator("#topic").evaluate("el => { el.value = 'Corrupt identity fixture'; el.dispatchEvent(new Event('input')); }")
+            page.locator("#compose-form").evaluate("form => form.requestSubmit()")
+            expect(page.locator("#toasts")).to_contain_text("no paid request was sent")
+            assert len(requests) == 10
+            page.locator("#gate-input").fill("storage-fixture-code")
+            page.locator("#gate-submit").click()
+            expect(page.locator("#gate")).to_be_hidden()
+            expect(page.locator("#code-badge")).to_be_visible()
             # Deny access to the Storage objects themselves before boot, not
             # just a particular history write after acceptance. Authentication
             # still requires the exact fixture code; only persistence degrades.
@@ -263,11 +297,36 @@ def main() -> None:
             expect(page.locator("#gate")).to_be_hidden()
             expect(page.locator("#byok-badge")).to_be_visible()
             assert fixture_credentials_match(page)
+            # A delayed extraction cannot follow a same-page logout into the
+            # next payer. Logout waits, then clears the acknowledged attachment.
+            topic.fill("Identity A paper topic")
+            page.locator("#pdf-input").set_input_files(pdf)
+            _wait_requests(page, requests, 11)
+            page.locator("#byok-exit").click()
+            expect(page.locator("#toasts")).to_contain_text("回包后再退出")
+            expect(page.locator("#gate")).to_be_hidden()
+            _json(requests[10], {"paper_id": "identity-A-paper", "title": "Identity A paper"})
+            expect(page.locator("#attachment")).to_contain_text("Identity A paper")
             page.locator("#byok-exit").click()
             expect(page.locator("#gate")).to_be_visible()
+            expect(page.locator("#attachment")).to_be_hidden()
+            expect(topic).to_have_value("")
             expect(page.locator("#byok-llm-key")).to_have_value("")
             expect(page.locator("#byok-serper-key")).to_have_value("")
-            assert len(requests) == 10  # This extra browser lane cannot submit paid work.
+            page.locator("#gate-to-byok").click()
+            page.locator("#byok-provider").select_option("qwen")
+            page.locator("#byok-llm-key").fill("fixture-B")
+            page.locator("#byok-serper-key").fill("fixture-search-B")
+            page.locator("#byok-form").evaluate("form => form.requestSubmit()")
+            expect(page.locator("#gate")).to_be_hidden()
+            topic.fill("Identity B topic")
+            run.click()
+            _wait_requests(page, requests, 12)
+            body = requests[11].request.post_data_json
+            assert body["llm_api_key"] == "fixture-B" and body["paper_id"] is None
+            _json(requests[11], {"detail": "Fixture rejection"}, status=422)
+            expect(run).to_be_enabled()
+            assert len(requests) == 12
             assert not unexpected, unexpected
             assert not reached_server, reached_server
             assert not page_errors, page_errors

--- a/tests/js/client_boundary_contract.mjs
+++ b/tests/js/client_boundary_contract.mjs
@@ -1,0 +1,119 @@
+/* Native JS client contracts with fake fetch/storage; no sockets or keys. */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const [scenario, argument] = process.argv.slice(2);
+const credentials = { provider: "qwen", llmKey: "fixture-A", serperKey: "fixture-search" };
+const requests = [];
+const store = new Map();
+globalThis.localStorage = { getItem: () => "fixture-operator", removeItem() {} };
+globalThis.sessionStorage = {
+  getItem: key => store.get(key) ?? null,
+  setItem: (key, value) => store.set(key, value), removeItem: key => store.delete(key),
+};
+globalThis.fetch = async (url, options) => {
+  requests.push({ url, options });
+  return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+};
+const api = await import("../../web/static/js/api.js");
+
+if (scenario === "credentials") {
+  const { raw, valid, operation } = JSON.parse(argument);
+  if (raw !== null) store.set('byok-credentials', raw);
+  const call = () => operation === "run" ? api.startRun({ topic: "Fixture topic" })
+    : operation === "resume" ? api.resumeRun("parent")
+    : api.uploadPaper(new File(['%PDF-fixture'], 'fixture.pdf'));
+  if (!valid) {
+    await assert.rejects(Promise.resolve().then(call), err => err.code === 'invalid_byok'
+      && !err.message.includes('fixture-secret'));
+    assert.equal(requests.length, 0, "Corrupt BYOK must not buy an operator-billed request");
+    // An explicit choice, not parsing failure, can switch to operator billing.
+    api.setByok(null);
+    await call();
+    assert.equal(requests.at(-1).options.headers['X-Access-Code'], 'fixture-operator');
+  } else {
+    await call();
+    const sent = requests[0].options.body;
+    const expected = raw === null ? null : JSON.parse(raw);
+    if (operation === 'pdf') assert.equal(sent.get('llm_api_key'), expected?.llmKey ?? null);
+    else {
+      const body = JSON.parse(sent);
+      assert.equal(body.llm_api_key, expected?.llmKey);
+      assert.equal(body.llm_provider, expected?.provider);
+      assert.equal(body.serper_api_key, expected?.serperKey);
+    }
+  }
+  assert.equal(requests.length, 1);
+} else if (scenario === "setter") {
+  api.setByok(credentials);
+  assert.throws(() => api.setByok({}), err => err.code === 'invalid_byok');
+  assert.deepEqual(api.getByok(), credentials, "Rejected changes cannot erase the current payer");
+} else if (["read_timeout", "body_timeout"].includes(scenario)) {
+  let expire, timeoutMs, cleared = false;
+  const originalSet = globalThis.setTimeout, originalClear = globalThis.clearTimeout;
+  globalThis.setTimeout = (callback, ms) => { timeoutMs = ms; expire = callback; return 41; };
+  globalThis.clearTimeout = id => { assert.equal(id, 41); cleared = true; };
+  try {
+    globalThis.fetch = (url, options) => new Promise((resolve, reject) => {
+      assert.ok(url.includes('/progress?since=7'));
+      if (scenario === 'body_timeout') resolve({ ok: true, status: 200,
+        headers: { get: () => 'application/json' }, json: () => new Promise((yes, no) => {
+          options.signal.addEventListener('abort', () => no(new Error('aborted body')));
+        }) });
+      else options.signal.addEventListener('abort', () => reject(new Error('aborted fixture')));
+    });
+    const pending = api.getProgress('fixture', 7);
+    assert.equal(timeoutMs, 15000, 'A stalled progress read must have the documented finite deadline');
+    await Promise.resolve();  // Let the response headers enter the body reader.
+    expire();
+    await assert.rejects(pending, err => scenario === 'body_timeout' ? err.message === 'aborted body' : err.status === 0);
+    assert.ok(cleared, 'Read timeout must release its timer');
+    // Only reads get a deadline, never a paid request with unknown acceptance.
+    globalThis.fetch = async (url, options) => {
+      assert.equal(options.signal, undefined);
+      return new Response('{}', { headers: { 'Content-Type': 'application/json' } });
+    };
+    await api.startRun({ topic: 'Fixture paid boundary' });
+  } finally { globalThis.setTimeout = originalSet; globalThis.clearTimeout = originalClear; }
+} else if (scenario.startsWith("poll_")) {
+  const timers = [], connections = [], updates = [], errors = [], done = [], cursors = [];
+  let response, reject;
+  const context = vm.createContext({
+    api: { getProgress: (id, cursor) => { cursors.push(cursor); return new Promise((yes, no) => { response = yes; reject = no; }); } },
+    setTimeout: fn => { timers.push(fn); return 1; }, clearTimeout: () => timers.splice(0),
+    connections, updates, errors, done, t: k => k,
+  });
+  vm.runInContext(fs.readFileSync(new URL('../../web/static/js/run.js', import.meta.url), 'utf8')
+    .replace(/^import .*;\r?\n/gm, '').replace(/export /g, ''), context);
+  const handle = vm.runInContext(`follow('fixture', {
+    onConnection: x => connections.push(x), onUpdate: x => updates.push(x),
+    onError: x => errors.push(x), onDone: x => done.push(x) })`, context);
+  const flush = () => new Promise(resolve => setImmediate(resolve));
+  const progress = { state: 'running', steps: [], steps_next_cursor: 4 };
+  if (scenario === 'poll_missing') {
+    reject({ status: 404 }); await flush();
+    assert.equal(connections.at(-1).state, 'missing');
+    assert.equal(errors.length, 1); assert.equal(timers.length, 0); assert.equal(done.length, 0);
+  } else if (scenario === 'poll_stop') {
+    handle.stop(); response(progress); await flush();
+    assert.deepEqual([connections.length, updates.length, timers.length], [0, 0, 0]);
+  } else {
+    if (scenario === 'poll_recovery') {
+      response(progress); await flush(); timers.shift()();
+    }
+    for (let i = 0; i < 3; i++) {
+      reject({ status: 0 }); await flush();
+      assert.equal(connections.at(-1).state, 'stale');
+      assert.equal(connections.at(-1).lastSuccessAt === null, scenario !== 'poll_recovery');
+      assert.equal(errors.length, 0); assert.equal(done.length, 0);
+      assert.equal(timers.length, 1); timers.shift()();
+    }
+    response({ ...progress, state: 'completed' }); await flush();
+    assert.equal(connections.at(-1).state, 'connected');
+    assert.equal(done.length, 1); assert.equal(timers.length, 0);
+    assert.ok(updates.every(p => ['running', 'completed'].includes(p.state)));
+    assert.ok(cursors.slice(1).every(c => c === (scenario === 'poll_recovery' ? 4 : 0)));
+  }
+} else throw new Error(`Unknown scenario ${scenario}`);
+console.log(`PASS ${scenario}`);

--- a/tests/js/composer_contract.mjs
+++ b/tests/js/composer_contract.mjs
@@ -28,7 +28,7 @@ function fixture() {
     set innerHTML(value) { this.children = []; }
     append(...children) { this.children.push(...children); }
     querySelectorAll() { return []; }
-    focus() {} remove() {} setAttribute() {} removeAttribute() {}
+    focus() {} remove() {} reset() {} setAttribute() {} removeAttribute() {}
   }
   const get = (selector) => {
     if (!elements.has(selector)) elements.set(selector, new Element());
@@ -43,7 +43,7 @@ function fixture() {
   };
   const context = vm.createContext({
     api, runView: { isTerminalState: (state) => ["completed", "failed", "cancelled", "timeout"].includes(state) },
-    sidebar: {}, result: {}, needsScopeWarning: () => false,
+    sidebar: { refresh: () => Promise.resolve([]) }, result: {}, needsScopeWarning: () => false,
     i18n: { t: (key) => translations[key] || key, language: () => "English", apply: () => {} },
     document: { querySelector: get, querySelectorAll: (selector) => selector === '[data-resume-run]'
       ? get("#run-actions").children.filter((el) => el.dataset?.resumeRun) : [], createElement: () => new Element(),
@@ -77,6 +77,58 @@ function paintResume(f) {
 
 const paper = { paper_id: "paper-one", title: "Fixture paper", commercialization_topic: "Suggested topic" };
 const scenarios = {
+  async gate_pending() {
+    const f = fixture(); f.run('showGate()');
+    f.get('#gate-input').value = 'candidate-code';
+    f.get('#gate-form').onsubmit({preventDefault(){}}); // Deliberately held access check.
+    assert.equal(f.get('#gate-submit').disabled, true);
+    f.get('#gate-to-byok').onclick();
+    assert.equal(f.get('#byok-form').hidden, true);
+    f.get('#byok-provider').value = 'qwen'; f.get('#byok-llm-key').value = 'fixture-B';
+    f.get('#byok-serper-key').value = 'fixture-search-B';
+    f.get('#byok-form').onsubmit({preventDefault(){}});
+    assert.equal(api.getByok(), null, 'A pending code check cannot race a new BYOK identity');
+    assert.equal(f.get('#gate').hidden, false);
+    assert.equal(f.requests.length, 0);
+  },
+  async gate_finished() {
+    const f = fixture(); const gate = f.run('showGate()');
+    f.get('#byok-provider').value = 'qwen'; f.get('#byok-llm-key').value = 'fixture-A';
+    f.get('#byok-serper-key').value = 'fixture-search';
+    f.get('#byok-form').onsubmit({preventDefault(){}}); await gate;
+    f.get('#byok-llm-key').value = 'fixture-B';
+    f.get('#byok-form').onsubmit({preventDefault(){}});
+    assert.equal(api.getByok()?.llmKey, 'fixture-A', 'A finished gate cannot accept stale input events');
+    assert.equal(f.requests.length, 0);
+  },
+  async pending_exit() {
+    const kind = process.argv[3];
+    const f = fixture(); f.topic("Identity A topic");
+    api.setByok({provider:'qwen',llmKey:'fixture-A',serperKey:'fixture-search'});
+    f.run("byokMode = true");
+    const pending = kind === 'run' ? f.submit() : kind === 'pdf' ? f.upload() : paintResume(f).listeners.click();
+    const blockedExit = f.run("exitCredentials()");
+    assert.equal(api.getByok()?.llmKey, 'fixture-A', 'A pending reply must retain the submitting payer');
+    await blockedExit;
+    assert.equal(f.get('#toasts').children.at(-1).textContent, 'logout_wait_paid');
+    f.respond(0, kind === 'pdf' ? paper : {run_id:'accepted-A',topic:'Accepted A'}, kind === 'pdf' ? 200 : 202);
+    await pending;
+    if (kind !== 'pdf') assert.deepEqual(f.opened, ['accepted-A']);
+    // Force same-page logout: old attachment/context must not reach identity B.
+    globalThis.sessionStorage.removeItem = () => { throw Error('fixture removal denied'); };
+    const exit = f.run('exitCredentials()');
+    assert.equal(api.getByok(), null);
+    assert.equal(f.run('attachedPaper'), null);
+    assert.equal(f.get('#topic').value, '');
+    f.get('#byok-provider').value = 'qwen';
+    f.get('#byok-llm-key').value = 'fixture-B'; f.get('#byok-serper-key').value = 'fixture-search-B';
+    f.get('#byok-form').onsubmit({preventDefault(){}}); await exit;
+    f.topic('Identity B topic'); const submitted = f.submit();
+    const body = JSON.parse(f.requests[1].options.body);
+    assert.equal(body.llm_api_key, 'fixture-B'); assert.equal(body.paper_id, null);
+    f.respond(1, {detail:'fixture rejected'}, 422); await submitted;
+    assert.equal(f.requests.length, 2);
+  },
   async accepted_history_success() {
     for (const kind of ["run", "resume"]) {
       const store = new Map();

--- a/tests/test_browser_storage_integrity.py
+++ b/tests/test_browser_storage_integrity.py
@@ -40,7 +40,7 @@ const load=name=>vm.runInContext(fs.readFileSync(input.root+'/web/static/js/'+na
  load('api.js');
  await vm.runInContext('health()',ctx);assert.equal(requests.length,1);
  if(input.scenario==='remove_failure'){
-  vm.runInContext("setAccessCode('stale');setByok({llmKey:'old'})",ctx);
+  vm.runInContext("setAccessCode('stale');setByok({provider:'qwen',llmKey:'old',serperKey:'old-search'})",ctx);
   denyRemove=true;
   assert.equal(vm.runInContext('setAccessCode(null)',ctx),false);
   assert.equal(vm.runInContext('setByok(null)',ctx),false);

--- a/tests/test_client_boundary_combinations.py
+++ b/tests/test_client_boundary_combinations.py
@@ -1,0 +1,47 @@
+"""Billing identity and connectivity cross actual JS request/callback seams."""
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from api.models import BYOK_PROVIDERS
+
+ROOT = Path(__file__).resolve().parents[1]
+VALID = {"provider": "qwen", "llmKey": "fixture-secret", "serperKey": "fixture-search"}
+
+
+def execute(scenario, argument=None):
+    node = shutil.which("node")
+    assert node, "Node must execute the shipped client; absence is not a pass"
+    result = subprocess.run([node, str(ROOT / "tests/js/client_boundary_contract.mjs"), scenario,
+                             json.dumps(argument)], capture_output=True, text=True, encoding="utf-8", timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"PASS {scenario}" in result.stdout
+
+
+@pytest.mark.parametrize("operation", ["run", "resume", "pdf"])
+@pytest.mark.parametrize("raw,valid", [(None, True), ("null", False), ("{}", False), ("[]", False),
+    ('"fixture-secret"', False), ("true", False), ("42", False), ("{broken", False),
+    *[(json.dumps({**VALID, field: value}), False) for field, value in [
+        ("provider", "other"), ("provider", None), ("llmKey", None), ("llmKey", " "),
+        ("llmKey", 1), ("serperKey", ""), ("serperKey", [])]],
+    *[(json.dumps({**VALID, "provider": provider}), True) for provider in BYOK_PROVIDERS]])
+def test_malformed_byok_never_selects_operator_billing(operation, raw, valid):
+    """A valid residual access code used to turn corrupt BYOK into a paid POST."""
+    execute("credentials", {"operation": operation, "raw": raw, "valid": valid})
+
+
+@pytest.mark.parametrize("scenario", ["setter", "read_timeout", "body_timeout", "poll_recovery", "poll_initial", "poll_stop", "poll_missing"])
+def test_client_observation_and_identity_boundaries(scenario):
+    execute(scenario)
+
+
+def test_provider_allowlists_match_server_and_visible_choices():
+    source = (ROOT / "web/static/js/api.js").read_text(encoding="utf-8")
+    providers = json.loads(re.search(r"BYOK_PROVIDERS = (\[.*?\]);", source)[1])
+    html = (ROOT / "web/index.html").read_text(encoding="utf-8")
+    select = re.search(r'id="byok-provider".*?</select>', html, re.S)[0]
+    assert set(providers) == set(BYOK_PROVIDERS) == set(re.findall(r'value="([^"]+)"', select))

--- a/tests/test_composer_web.py
+++ b/tests/test_composer_web.py
@@ -12,6 +12,7 @@ import pytest
     "missing_suggestion_pdf", "serialized_pdf", "stale_pdf_response", "failed_pdf",
     "upload_during_submit", "classified_errors",
     "accepted_history_failure", "resume_rerender", "lost_acknowledgement", "malformed_history",
+    "gate_pending", "gate_finished",
 ])
 def test_composer_delivers_one_intended_operation(scenario):
     """Input events and delayed extraction cannot duplicate or change paid intent."""
@@ -24,3 +25,14 @@ def test_composer_delivers_one_intended_operation(scenario):
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert f"PASS {scenario}" in result.stdout
+
+
+@pytest.mark.parametrize("operation", ["run", "pdf", "resume"])
+def test_identity_switch_waits_for_paid_ack_and_clears_attachment(operation):
+    """The previous A PDF reply attached to B's next paid request after logout."""
+    node = shutil.which("node")
+    assert node, "Node is required for the identity seam"
+    result = subprocess.run([node, str(Path(__file__).with_name("js") / "composer_contract.mjs"),
+        "pending_exit", operation], capture_output=True, text=True, encoding="utf-8", timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS pending_exit" in result.stdout

--- a/tests/test_result_detail_integrity.py
+++ b/tests/test_result_detail_integrity.py
@@ -18,6 +18,23 @@ GROUNDING = {"checked": 2, "ungrounded": 0, "unverifiable": 1, "findings": []}
 CONSISTENCY = {"checked": True, "blockers": 0, "warnings": 0, "findings": []}
 
 
+@pytest.mark.parametrize("field,maximum", [("trl_score", 9), ("mrl_score", 10),
+    ("patent_strength", 5), ("market_accessibility", 5), ("evidence_confidence", 5)])
+@pytest.mark.parametrize("value", [1, 3.5, "maximum", 0, 0.5, None, True, "3.5", -1, 11])
+def test_normalized_dimension_range_reaches_browser(tmp_path, monkeypatch, field, maximum, value):
+    """Integer-only rendering hid 64/109 stored reports with normalized fractions."""
+    value = maximum if value == "maximum" else value
+    text, rows = display({**SCORES, field: value}, "scores", tmp_path, monkeypatch)
+    valid = type(value) in (int, float) and 1 <= value <= maximum
+    if valid:
+        assert f"{value} / {maximum}" in text
+        assert "no conclusion" not in text
+    else:
+        assert any(row["text"] == "—" for row in rows)
+        assert "no conclusion" in text
+    assert "65.0" in text  # One bad dimension never erases the healthy neighbour.
+
+
 def display(payload, artifact, tmp_path, monkeypatch, language="English"):
     run_id = "20260908T010203Z-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     directory = tmp_path / run_id

--- a/web/index.html
+++ b/web/index.html
@@ -260,6 +260,7 @@
             <span id="run-status-record"></span>
             <span id="run-runtime-record"></span>
             <span id="run-step-record" role="status"></span>
+            <span id="run-connection" role="status" aria-live="polite"></span>
             <span id="run-recovery"></span>
           </div>
         </div>

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -69,16 +69,33 @@ const BYOK_KEY = "byok-credentials";
 const byokSlot = credentialSlot("sessionStorage", BYOK_KEY);
 export const storageDegraded = () => accessSlot.degraded() || byokSlot.degraded();
 
-export function getByok() {
-  try {
-    return JSON.parse(byokSlot.read());
-  } catch {
-    return null;
+// Absence selects operator billing; corruption must never mean absence.
+// Keep this allowlist aligned with API models and the visible provider select.
+export const BYOK_PROVIDERS = ["deepseek", "qwen", "openai", "anthropic"];
+function validateByok(creds) {
+  if (!creds || typeof creds !== "object" || Array.isArray(creds)
+    || !BYOK_PROVIDERS.includes(creds.provider)
+    || ![creds.llmKey, creds.serperKey].every(value => typeof value === "string" && value.trim())) {
+    throw new ApiError(0, "Saved BYOK credentials are invalid. Choose your credentials again before a paid operation.", "invalid_byok");
   }
+  return creds;
+}
+
+export function getByok() {
+  const raw = byokSlot.read();
+  if (raw === null) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // JSON syntax and schema failures share a safe error, never secret bytes.
+    return validateByok(null);
+  }
+  return validateByok(parsed);
 }
 
 export function setByok(creds) {
-  return byokSlot.write(creds ? JSON.stringify(creds) : null);
+  return byokSlot.write(creds === null ? null : JSON.stringify(validateByok(creds)));
 }
 
 /* A BYOK run gets no owner tag server-side (see api/access.py) and so never
@@ -223,8 +240,17 @@ export const resumeRun = (runId) => {
 
 export const getRun = (runId) => request(`/api/runs/${runId}`);
 
-export const getProgress = (runId, since = 0) =>
-  request(`/api/runs/${runId}/progress?since=${since}`);
+export async function getProgress(runId, since = 0) {
+  // Bound only this idempotent read, including its response body. Aborting a
+  // paid POST would not cancel provider work and must not share this timeout.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    return await request(`/api/runs/${runId}/progress?since=${since}`, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 export const cancelRun = (runId) =>
   request(`/api/runs/${runId}?intent=cancel`, { method: "DELETE" });

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -40,6 +40,7 @@ function toast(message, variant = "") {
 }
 
 function operationErrorMessage(err) {
+  if (err.code === "invalid_byok") return t("invalid_byok");
   if (err.code === "paid_ack_unknown") return t("msg_paid_ack_unknown");
   const key = {
     concurrency_limit: "msg_busy",
@@ -285,6 +286,7 @@ function paintActions(state, checkpointing = null) {
 async function openRun(runId, { known } = {}) {
   stopFollowing();
   showRun(runId);
+  $("#run-connection").textContent = "";
 
   const body = $("#run-body");
   body.innerHTML = "";
@@ -293,6 +295,14 @@ async function openRun(runId, { known } = {}) {
   history.pushState({}, "", `/run/${runId}`);
 
   follower = runView.follow(runId, {
+    onConnection({ state, lastSuccessAt }) {
+      // Connectivity is a fact about our read, not a new worker state. Stop
+      // extrapolating elapsed time until a fresh progress response anchors it.
+      $("#run-connection").textContent = state === "stale"
+        ? t(lastSuccessAt === null ? "run_connection_unconfirmed" : "run_connection_stale")
+        : state === "missing" ? t("run_connection_missing") : "";
+      if (state !== "connected") stopClock();
+    },
     onUpdate(progress) {
       paintHeader(progress);
       paintActions(progress.state, progress.checkpointing);
@@ -734,6 +744,17 @@ function showStorageNotice(key = "storage_unavailable") {
 }
 
 async function exitCredentials() {
+  // A pending paid reply may carry the only link to accepted work. Do not
+  // discard it, relabel it as the next identity, or abort a provider request
+  // merely to make logout immediate. This guard covers normal reload too.
+  if (submitting || extracting || pendingResumes.size) {
+    toast(t("logout_wait_paid"), "error");
+    return;
+  }
+  clearAttachment();
+  clearDecisionContext();
+  topic.value = "";
+  syncComposer();
   const byokCleared = api.setByok(null);
   const codeCleared = api.setAccessCode(null);
   if (byokCleared && codeCleared) { location.reload(); return; }
@@ -742,6 +763,7 @@ async function exitCredentials() {
   // Do not claim browser data was purged or cancel any server-side work.
   stopFollowing();
   stopClock();
+  activeRunId = null;
   byokMode = false;
   $("#byok-badge").hidden = true;
   $("#code-badge").hidden = true;
@@ -758,14 +780,25 @@ $("#byok-exit").addEventListener("click", exitCredentials);
 // what got the visitor past the gate, never when the gate is off entirely
 // (nothing to log out of then) and never alongside the BYOK badge.
 function applyCodeMode() {
+  api.setByok(null);
+  byokMode = false;
+  $("#byok-badge").hidden = true;
   $("#code-badge").hidden = false;
 }
 
 $("#code-exit").addEventListener("click", exitCredentials);
 
 async function ensureAccess() {
-  if (api.getByok()) {
-    applyByokMode();
+  try {
+    if (api.getByok()) {
+      applyByokMode();
+      return;
+    }
+  } catch (err) {
+    if (err.code !== "invalid_byok") throw err;
+    // Even a valid residual access code cannot choose a different payer for
+    // a corrupted BYOK session. Only an explicit gate submission can do so.
+    await showGate("invalid_byok");
     return;
   }
   try {
@@ -803,7 +836,7 @@ async function showByokRetention() {
   }
 }
 
-function showGate() {
+function showGate(errorKey = null) {
   const gate = $("#gate");
   const codeForm = $("#gate-form");
   const codeInput = $("#gate-input");
@@ -816,26 +849,31 @@ function showGate() {
   // that would validate one submission several times after repeated login.
   codeForm.reset();
   byokForm.reset();
-  codeError.hidden = true;
+  codeError.hidden = !errorKey;
+  codeError.textContent = errorKey ? t(errorKey) : "";
   gate.hidden = false;
   codeForm.hidden = false;
   byokForm.hidden = true;
   codeInput.focus();
 
   return new Promise((resolve) => {
+    let finished = false;
     const finish = () => {
+      finished = true;
       gate.hidden = true;
       if (api.storageDegraded()) showStorageNotice();
       resolve();
     };
 
     $("#gate-to-byok").onclick = () => {
+      if (codeSubmit.disabled || finished) return;
       codeForm.hidden = true;
       byokForm.hidden = false;
       $("#byok-llm-key").focus();
       showByokRetention();
     };
     $("#byok-to-gate").onclick = () => {
+      if (codeSubmit.disabled || finished) return;
       byokForm.hidden = true;
       codeForm.hidden = false;
       codeInput.focus();
@@ -844,7 +882,7 @@ function showGate() {
     codeForm.onsubmit = async (e) => {
       e.preventDefault();
       const code = codeInput.value.trim();
-      if (!code || codeSubmit.disabled) return;
+      if (!code || codeSubmit.disabled || finished) return;
 
       codeSubmit.disabled = true;
       codeError.hidden = true;
@@ -864,12 +902,18 @@ function showGate() {
 
     byokForm.onsubmit = (e) => {
       e.preventDefault();
+      if (codeSubmit.disabled || finished) return;
       const provider = $("#byok-provider").value;
       const llmKey = $("#byok-llm-key").value.trim();
       const serperKey = $("#byok-serper-key").value.trim();
       if (!llmKey || !serperKey) return;
 
-      api.setByok({ provider, llmKey, serperKey });
+      try {
+        api.setByok({ provider, llmKey, serperKey });
+      } catch (err) {
+        toast(operationErrorMessage(err), "error");
+        return;
+      }
       applyByokMode();
       finish();
     };

--- a/web/static/js/i18n.js
+++ b/web/static/js/i18n.js
@@ -11,6 +11,11 @@
 
 const STRINGS = {
   English: {
+    run_connection_missing: "The server could not find this run. Automatic polling has stopped.",
+    invalid_byok: "Saved BYOK credentials are invalid. Re-enter your keys or explicitly choose an access code; no paid request was sent.",
+    logout_wait_paid: "Wait for the paid request's reply before signing out. Switching now could lose its result; this does not cancel provider work.",
+    run_connection_stale: "Connection interrupted. Displaying the last confirmed state; retrying. This does not mean the run failed.",
+    run_connection_unconfirmed: "Cannot confirm the current run state yet; retrying. This does not mean the run failed.",
     storage_unavailable: "Browser storage is unavailable. Credentials last only on this page; settings and history may not be saved. Bookmark accepted run links.",
     storage_logout_incomplete: "Signed out on this page, but stored credentials could not be removed. Clear this site's browser data before reopening it.",
     detail_unreadable: "Detail unavailable or malformed; no conclusion can be drawn from it.",
@@ -284,6 +289,11 @@ const STRINGS = {
   },
 
   "Simplified Chinese": {
+    run_connection_missing: "服务器未找到此任务，已停止自动轮询。",
+    invalid_byok: "保存的 BYOK 凭据格式异常。请重新填写密钥，或明确选择使用口令；尚未发送付费请求。",
+    logout_wait_paid: "请等待付费请求回包后再退出，避免丢失结果。此提示不会取消供应商调用。",
+    run_connection_stale: "连接中断，当前展示最后一次确认的状态，正在重试；这不代表任务运行失败。",
+    run_connection_unconfirmed: "尚未确认任务的当前状态，正在重试；这不代表任务运行失败。",
     storage_unavailable: "浏览器存储不可用。凭据仅在当前页面临时保留，设置与历史可能无法保存；请收藏已接受任务的链接。",
     storage_logout_incomplete: "已在当前页面退出，但无法删除浏览器里保存的旧凭据。重新打开前请清除此网站的浏览器数据。",
     detail_unreadable: "详情缺失或格式异常，不能据此得出结论。",

--- a/web/static/js/result.js
+++ b/web/static/js/result.js
@@ -172,7 +172,10 @@ function renderScorecard(scores) {
   const grid = el("div", "dims");
   for (const dim of DIMENSIONS) {
     const value = scores[dim.key];
-    const valid = scoreNumber(value, dim.max) && Number.isInteger(value);
+    // The scorer normalizes tenths into fractional dimensions (e.g. TRL 8.5).
+    // Integers describe the rubric inputs, not the delivered JSON contract.
+    // Reject impossible zero dimensions without changing overall's 0..100 scale.
+    const valid = scoreNumber(value, dim.max) && value >= 1;
     const pct = valid ? (value / dim.max) * 100 : 0;
 
     const row = el("div", "dim");
@@ -185,6 +188,7 @@ function renderScorecard(scores) {
     if (!valid) row.title = t("detail_unreadable");
 
     row.append(label, bar, num);
+    if (!valid) row.append(detailUnavailable());
 
     const rationale = scores[dim.key.replace(/_score$|_strength$|_accessibility$|_confidence$/, "") + "_rationale"];
     if (valid && typeof rationale === "string" && rationale) row.title = rationale;

--- a/web/static/js/run.js
+++ b/web/static/js/run.js
@@ -78,10 +78,11 @@ function intervalFor(elapsedMs) {
  * Returns a handle with stop(); the caller must call it when leaving the
  * view, or a poll loop outlives the run it was watching.
  */
-export function follow(runId, { onUpdate, onDone, onError }) {
+export function follow(runId, { onUpdate, onDone, onError, onConnection }) {
   let stopped = false;
   let seenSteps = 0;
   let timer = null;
+  let lastSuccessAt = null;
   const startedAt = Date.now();
 
   async function tick() {
@@ -89,6 +90,9 @@ export function follow(runId, { onUpdate, onDone, onError }) {
     try {
       const progress = await api.getProgress(runId, seenSteps);
       if (stopped) return;
+
+      lastSuccessAt = Date.now();
+      onConnection?.({ state: "connected", lastSuccessAt });
 
       // A rejected physical line still advances the server cursor. Fall back
       // only for old deployments which have not introduced this field yet.
@@ -103,6 +107,9 @@ export function follow(runId, { onUpdate, onDone, onError }) {
       }
     } catch (err) {
       if (stopped) return;
+      // Retry reads, but never present silence as evidence that the worker
+      // still runs. A later successful poll clears this independent warning.
+      onConnection?.({ state: err.status === 404 ? "missing" : "stale", lastSuccessAt });
       // A transient failure should not end the run view: the worker may
       // still be fine and the next tick may well succeed. Only a 404 means
       // the run genuinely is not there.


### PR DESCRIPTION
## Why
A stored-score audit reproduced a fractional display regression in 64 of 109 local reports. Synthetic request replays also exposed malformed BYOK selecting a different payer, old extraction results surviving identity changes, and silent progress-read failures.

## Boundaries
Accept normalized dimensions without changing formulas. Validate BYOK before all paid entrypoints. Wait for acknowledgements before logout and clear old composer context. Show stale/unconfirmed/missing progress separately from worker state; bound only the progress GET.

## Verification
- 2619 tests and 1196 subtests passed locally; 88.89% coverage.
- Latest Ruff and narrow Pylint passed.
- Seven defect injections detected and source hashes restored.
- Two Chromium journeys passed; 12 intercepted fixture POSTs, zero provider calls.
- No raw reports, credentials or private notes included.

Standing maintenance authorization permits self-reviewed merge only after all CI checks pass. No paid canary or manual restart is part of this PR.