### PR TITLE
Preserve evidence, PDF input and terminal truth at production boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,12 @@ the [identity/logging regression and accounting limits](docs/results-2026-09-10-
 
 ## Keeping this index short without erasing decisions
 
+Production scoring citation admission now wraps the hash-locked evidence
+factory in `scoring_contract.py`; include it in local recovery identity.
+Do not rewrite old experiment hashes to evolve production checks. PDF locator
+reachability is not manuscript identity, and ops outcomes follow terminal truth.
+See the [evidence/PDF/ops repair and remaining audit scope](docs/results-2026-09-10-evidence-pdf-terminal-boundaries.md).
+
 - Update the current ledger and link a dated result; do not append the complete
   experiment narrative to both READMEs and this file.
 - Keep historical preregistrations, results, errata, frozen bytes and long

--- a/api/models.py
+++ b/api/models.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import AwareDatetime, BaseModel, Field, field_validator, model_validator
 
 from academic_agent.run_spec import AssessmentMode, DecisionContext
+from academic_agent.pdf_extractor import PDFInputCoverage
 
 #: "unknown" means the status or terminal file could not be read, not that the run
 #: failed. It is deliberately not terminal: a client should retry rather than
@@ -138,6 +139,10 @@ class PaperExtraction(BaseModel):
     commercialization_topic: str
     search_keywords: list[str] = Field(default_factory=list)
     abstract_excerpt: str = ""
+    input_coverage: PDFInputCoverage = Field(default_factory=PDFInputCoverage)
+    locator_status: Literal[
+        "text_candidate", "conflicting_candidates", "no_public_candidate", "legacy_unverified",
+    ] = "legacy_unverified"
 
 
 class StepEvent(BaseModel):

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -47,6 +47,12 @@ production incident rates or improved report accuracy. See the
 
 ## Main evaluation ledger
 
+Decimal grounding, production score-citation admission, bounded PDF page
+coverage/candidate identity and terminal-authoritative ops outcomes have new
+offline behavioral regressions. The 30-score replay is unchanged, not new
+calibration. Remaining audit gaps are explicit in the
+[repair and scope record](results-2026-09-10-evidence-pdf-terminal-boundaries.md).
+
 Upload ingress also bounds bytes/time/preprocessing slots before multipart
 parsing; delayed history replies cannot repaint a newer view or login; actual
 extraction threads finalize raw PDF cleanup even after waiter cancellation.

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -23,6 +23,8 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-10 evidence/PDF/terminal boundaries](results-2026-09-10-evidence-pdf-terminal-boundaries.md) — precision-aware numeric matching, production-only citation admission, actual PDF input coverage, candidate identity limits and terminal-authoritative operational outcomes; zero provider calls.
+
 - [2026-09-08 upload/history/cancellation boundaries](results-2026-09-08-upload-history-cancellation-boundaries.md) — pre-parser byte/time/capacity limits, generation-bound history and thread-owned PDF cleanup; zero provider calls.
 
 - [2026-09-08 paid-request refresh warning](results-2026-09-08-paid-refresh-warning.md) — credential-free session warning, explicit acknowledgement and view-delivery settlement; zero provider calls, not server idempotency.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -68,6 +68,13 @@ topic/PDF submission, optional Decision Context, languages, scoring profiles,
 progress, history, scorecard/report/source views, reliability details and
 Markdown/PDF export.
 
+PDF extraction responses and stored metadata include `input_coverage` with the
+actual scanned/included/truncated/omitted pages and character budget. This is
+sampling visibility, not full-paper reading or section-level understanding.
+`locator_status` describes a text candidate or conflict, not a verified paper
+identity; reachable upload locators no longer imply high credibility. See the
+[input and identity contract](results-2026-09-10-evidence-pdf-terminal-boundaries.md).
+
 The composer permits one in-flight submission and one serial PDF extraction,
 never both at once. It preserves an existing topic when a paper is attached;
 only an empty topic is auto-filled. A second upload during extraction is rejected

--- a/docs/results-2026-09-10-evidence-pdf-terminal-boundaries.md
+++ b/docs/results-2026-09-10-evidence-pdf-terminal-boundaries.md
@@ -1,0 +1,102 @@
+# Evidence, PDF input and terminal-consumer boundaries
+
+Date: 2026-09-10
+Status: offline_verified / no_paid_canary
+Preceding release: provider/logging repair, public PR #129.
+
+## Adopted repairs
+
+- Numeric grounding compares decimal values and explicit quotation precision,
+  not digit prefixes. Both truncation and half-up rounding at the quoted decimal
+  places remain tolerated. `26.15 -> 26.1` is not accused; `100% -> 10%` and
+  `1000 MW -> 100 MW` no longer pass. Existing unit checks and the advisory,
+  non-blocking role of this screen are unchanged. This is not unit conversion
+  or a general claim-entailment model.
+- Production scoring requires P citations for patent scores and M citations
+  for market scores. TRL/MRL lists need an A/M anchor, with patents permitted as
+  supplements. Phantom/malformed bracket citations in all rationale, risk and
+  opportunity fields are rejected when the source registry is available.
+  Scores, weights, normalization, confidence floor and market cap are unchanged.
+- PDF text budgeting reserves space across selected pages before distributing
+  remaining characters. A long introduction cannot consume the complete budget
+  of a selected result/conclusion page. The actual model input is bounded to
+  7000 characters and records scanned, selected, included, truncated and omitted
+  pages. Code-owned coverage survives the paid HTTP response and saved extraction;
+  model-provided coverage cannot override it. Blank text fails before the LLM.
+- A model-only DOI/URL cannot override document-text candidates. Conflicting or
+  absent candidates are explicit. Reachability is separate from document identity:
+  an uploaded contribution remains medium credibility even with a reachable
+  locator. Bibliography DOIs can still be candidates; this does not establish
+  manuscript identity or semantic support. Historical extraction fields default
+  to `legacy_unverified` / `not_recorded`, not a successful verification.
+- `ops_report` follows valid immutable `terminal.json` before legacy status and
+  markers. An unreadable terminal yields unknown instead of a fallback success.
+  This aligns outcome counts with the core API; it does not migrate every
+  legacy operational usage/check-summary reader.
+
+## Measure before changing
+
+The existing 90 evidence artifacts from 30 benchmark runs were read without
+provider calls. Numeric screening remained **50 checked, 1 ungrounded, 161
+unverifiable**, with identical findings before/after the repair. That is a
+regression observation, not an independent accuracy estimate.
+
+A candidate rule banning all patent references from TRL/MRL rejected 2/30
+historical scorecards. Both cited process patents alongside academic and market
+manufacturing evidence. The final anchor rule avoids those false accusations.
+All **30/30** archived scorecards pass the final wrapper; after restoring their
+input integer scale, its output is byte-identical to the unchanged legacy
+guardrail under the same source pool, market evidence and weight profile.
+
+The full suite also correctly rejected direct edits to `evidence.py`, a frozen
+dependency of previous paid experiments. Those bytes and all experiment locks
+were restored unchanged. The new `scoring_contract.py` wraps the old factory at
+the production Crew import. Local checkpoint revision hashes include this new
+module so local resumes cannot reuse scores across an admission-rule change.
+Historical runners remain bound to their original implementation, not silently
+upgraded experiments.
+
+## Verification
+
+Behavior tests cover findings-to-audit, actual Crew scoring admission, local
+recovery identity, real PDF-to-model prompt, HTTP response versus persisted
+extraction, and ops outcome versus the core API. No model output is obtained
+from a real provider. Eight deliberate defect injections fail at the intended
+assertions: numeric prefix, old Crew import, unchecked prose citations, legacy
+terminal precedence, PDF prefix truncation, model DOI override, high credibility
+from reachability, and omitted scoring code in the local revision hash. All
+mutations were restored before the final test run.
+
+Final local suite: **2784 passed + 1218 subtests**, **89.07% coverage**.
+Latest Ruff, narrow Pylint and whitespace checks pass.
+
+Both Chromium journeys pass with no provider/external requests. The composer
+intercepts 23 paid POST fixtures and three held history reads. Full-suite,
+coverage, lint, CI and exact deployment verification are recorded on the release
+PR. No paid canary, manual restart, new search call, experimental cohort access
+or production Tool Calling activation is authorized by these offline results.
+
+## Remaining audit scope
+
+The external 20-item review mixes reproducible bugs with architectural and
+research gaps. This release does not label the entire list resolved:
+
+| Review items | Disposition |
+|---|---|
+| 1 | Shared provider resolution shipped in PR #129; fake-key reproduction is not proof of historical disclosure. |
+| 2 | Named access/PDF/helper diagnostics repaired in #129; third-party and other log paths still need broader auditing. |
+| 3, 5, 6, 18 | Narrow numeric, production citation, PDF budgeting and terminal-reader contracts repaired here. |
+| 7 | Model override/high-confidence promotion repaired; full document identity and claim support remain unverified. |
+| 4 | Mixed market metrics confirmed: the existing extractor produces a spread above 5 in all 30 baseline market artifacts. This does not prove all 30 penalties wrong. Classify metric/time/currency/geography in an offline, versioned comparison before changing the calibrated cap; do not silently alter the protected formula. |
+| 8, 9, 10 | Durable paid receipts, parser subprocess isolation and explicit public-startup policy remain separate runtime designs. Existing tab warnings, PDFium mutex and readiness do not imply these capabilities. No current Railway misconfiguration was established. |
+| 11 | Crew-node usage still excludes helper/inline PDF calls. Price completeness for recorded nodes is not end-to-end bill completeness. |
+| 12, 13, 14, 15, 16 | General entailment, autonomous tool-use, isolated role benefit, cross-source selection quality and independent calibration require new evaluation; historical failures remain sealed, production remains zero-call shadow. |
+| 17 | Legacy `benchmark.py` skip/force behavior still lacks full run identity and immutable rerun batches. Preserve archived results; do not use it to claim a fresh-model evaluation by resuming old output directories. |
+| 19 | One replica remains the supported operating boundary. |
+| 20 | New regressions execute consumer boundaries and deliberate mutations; this is not a claim that every older test is end-to-end. |
+
+For uploaded PDFs, page budgeting is not section understanding, OCR, complete
+paper ingestion or a native-process memory/time fault boundary. The coverage
+fields are delivered by API and stored; they are not yet a dedicated browser
+coverage inspector. No reduction in production incident rate, spending or
+report error rate is inferred from these deterministic regressions.

--- a/ops_report.py
+++ b/ops_report.py
@@ -46,6 +46,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
+from academic_agent.run_terminal import TerminalRecordUnreadable, load_terminal_record
+
 OUTPUT_ROOT = Path(__file__).parent / "outputs"
 
 #: Run directories are <UTC timestamp>-<hex>; the benchmark writes elsewhere.
@@ -92,11 +94,20 @@ def _outcome(
     the history toward newer releases. The inverse is not safe: a directory
     with neither artifact is not a success merely because no error was found.
 
-    A present but unreadable status stays ``unknown`` even if a report exists.
+    A valid immutable terminal record precedes every legacy status/marker.
+    A present but unreadable terminal stays unknown, never a fallback pass.
+    Without a terminal, unreadable status stays unknown even if a report exists.
     The API makes the same conservative choice because a corrupt source-of-
     truth file can reflect a partial write or disk fault. Silence is therefore
     never converted into a pass.
     """
+    try:
+        terminal = load_terminal_record(directory)
+    except TerminalRecordUnreadable:
+        return "unknown", "unreadable terminal.json", ""
+    if terminal is not None:
+        failure = terminal.reason_code if terminal.state in {"failed", "timeout"} else ""
+        return terminal.state, "terminal.json", failure
     if (directory / "cancelled.marker").exists():
         return "cancelled", "cancelled.marker", ""
     if status_present and not status_readable:
@@ -191,6 +202,9 @@ def collect(root: Path) -> list[dict]:
                 if status_present else {}
             )
         except (OSError, ValueError):
+            status = {}
+            status_readable = False
+        if not isinstance(status, dict):
             status = {}
             status_readable = False
         stamp = _RUN_DIR.match(directory.name).group(1)

--- a/src/academic_agent/checkpoint_runtime.py
+++ b/src/academic_agent/checkpoint_runtime.py
@@ -109,6 +109,7 @@ def pipeline_revision() -> str:
         package / "checkpoints.py",
         package / "crew.py",
         package / "evidence.py",
+        package / "scoring_contract.py",
         package / "llm_config.py",
         package / "pipeline_worker.py",
         package / "run_spec.py",

--- a/src/academic_agent/claim_grounding.py
+++ b/src/academic_agent/claim_grounding.py
@@ -255,6 +255,32 @@ def _render(number: str, unit: str) -> str:
     return f"{number}{unit}" if unit in {"%", ""} else f"{number} {unit}"
 
 
+def _same_numeric_value(claim: str, source: str) -> bool:
+    """Accept exact values or explicit decimal precision, never digit prefixes.
+
+    Truncation and ordinary half-up rounding are both tolerated because this
+    advisory screen prioritizes avoiding accusations over stylistic rounding.
+    A 26.15 -> 26.1 quotation survives; 100 -> 10 does not. No arbitrary
+    relative tolerance or implicit unit conversion can hide an order of magnitude.
+    """
+    from decimal import Decimal, InvalidOperation, ROUND_DOWN, ROUND_HALF_UP, localcontext
+
+    try:
+        with localcontext() as context:
+            context.prec = max(28, len(claim) + len(source) + 2)
+            quoted, observed = Decimal(claim), Decimal(source)
+            if not quoted.is_finite() or not observed.is_finite():
+                return False
+            if quoted == observed:
+                return True
+            places = len(claim.partition(".")[2])
+            quantum = Decimal(1).scaleb(-places)
+            return any(observed.quantize(quantum, rounding=rule) == quoted
+                       for rule in (ROUND_DOWN, ROUND_HALF_UP))
+    except InvalidOperation:
+        return False
+
+
 def _supported(number: str, unit: str, present: list[tuple[str, str]],
                haystack: str) -> bool:
     """Whether a cited source states this figure.
@@ -271,14 +297,15 @@ def _supported(number: str, unit: str, present: list[tuple[str, str]],
     for source_number, source_unit in present:
         if source_unit and unit and source_unit != unit:
             continue
-        # Prefix, not equality: a claim rounding a source's 26.15 to 26.1 is
-        # quoting it.
-        if source_number == number or source_number.startswith(number):
+        if _same_numeric_value(number, source_number):
             return True
     # Last resort for a figure the extractor did not pick up as distinctive on
     # the source side — but only for unitless claims, since a bare substring
     # hit carries no unit to compare.
-    return not unit and number in haystack.replace(",", "")
+    return not unit and any(
+        _same_numeric_value(number, _normalize_number(match.group(1)))
+        for match in _FIGURE_RE.finditer(haystack)
+    )
 
 
 def check_report(report: Any, sources: Any = None) -> GroundingReport:

--- a/src/academic_agent/crew.py
+++ b/src/academic_agent/crew.py
@@ -32,8 +32,8 @@ from academic_agent.evidence import (
     make_evidence_guardrail,
     make_final_report_guardrail,
     make_reviewer_guardrail,
-    make_scoring_guardrail,
 )
+from academic_agent.scoring_contract import make_scoring_guardrail
 from academic_agent.llm_config import create_llm
 from academic_agent.source_pipeline import SourceCollection
 

--- a/src/academic_agent/pdf_extractor.py
+++ b/src/academic_agent/pdf_extractor.py
@@ -9,7 +9,7 @@ import threading
 from contextlib import closing
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -34,6 +34,20 @@ def _placeholder_doi(title: str) -> str:
     return f"{_PLACEHOLDER_DOI_PREFIX}{hashlib.md5(title.encode()).hexdigest()[:10]}"
 
 
+class PDFInputCoverage(BaseModel):
+    """Code-owned facts about text sent to the model, not semantic coverage."""
+
+    state: Literal["recorded", "not_recorded"] = "not_recorded"
+    total_pages: int | None = None
+    scanned_pages: list[int] = Field(default_factory=list)
+    selected_pages: list[int] = Field(default_factory=list)
+    included_pages: list[int] = Field(default_factory=list)
+    truncated_pages: list[int] = Field(default_factory=list)
+    omitted_pages: list[int] = Field(default_factory=list)
+    input_characters: int | None = None
+    character_budget: int | None = None
+
+
 class PaperContribution(BaseModel):
     """Structured contribution extracted from an academic paper."""
 
@@ -48,6 +62,10 @@ class PaperContribution(BaseModel):
     commercialization_topic: str = Field(min_length=10)
     search_keywords: list[str] = Field(min_length=3)
     abstract_excerpt: str = ""
+    input_coverage: PDFInputCoverage = Field(default_factory=PDFInputCoverage)
+    locator_status: Literal[
+        "text_candidate", "conflicting_candidates", "no_public_candidate", "legacy_unverified",
+    ] = "legacy_unverified"
 
 
 #: How many pages may be read from one document, however long it is.
@@ -88,7 +106,9 @@ def _pages_to_scan(n: int) -> list[int]:
     return sorted(set(head + middle + tail))
 
 
-def extract_pdf_text(pdf_path: str | Path, max_chars: int = 7000) -> str:
+def extract_pdf_text(
+    pdf_path: str | Path, max_chars: int = 7000, *, coverage: dict | None = None,
+) -> str:
     """Extract text from the highest-signal pages of a PDF.
 
     Strategy: first 3 pages (title/abstract/intro) + up to 2 middle pages
@@ -98,6 +118,8 @@ def extract_pdf_text(pdf_path: str | Path, max_chars: int = 7000) -> str:
 
     At most _MAX_PAGES_SCANNED pages are read; see there for why.
     """
+    if max_chars < 1:
+        raise ValueError("PDF character budget must be positive")
     try:
         import pypdfium2 as pdfium
     except ImportError as exc:
@@ -130,14 +152,37 @@ def extract_pdf_text(pdf_path: str | Path, max_chars: int = 7000) -> str:
 
         key_pages = sorted(fixed_idx | mid_idx)
 
-        parts: list[str] = []
-        for i in key_pages:
-            text = page_texts[i]
-            if text:
-                parts.append(f"[Page {i + 1}]\n{text}")
-
-    combined = "\n\n".join(parts)
-    return combined[:max_chars]
+    selected = [i for i in key_pages if page_texts[i]]
+    # Reserve every selected page's label and at least one content character
+    # before allocating the rest. A final prefix slice silently erased results
+    # and conclusions after a long introduction, despite selecting those pages.
+    included: list[int] = []
+    budget = max_chars
+    for i in selected:
+        overhead = len(f"[Page {i + 1}]\n") + (2 if included else 0)
+        if budget >= overhead + 1:
+            included.append(i)
+            budget -= overhead + 1
+    lengths = dict.fromkeys(included, 1)
+    # Water filling gives short pages their whole text and redistributes spare
+    # room; dense pages cannot consume another page's entire allocation.
+    ordered = sorted(included, key=lambda i: len(page_texts[i]))
+    for position, i in enumerate(ordered):
+        extra = min(len(page_texts[i]) - 1, budget // (len(ordered) - position))
+        lengths[i] += extra
+        budget -= extra
+    combined = "\n\n".join(f"[Page {i + 1}]\n{page_texts[i][:lengths[i]]}" for i in included)
+    if coverage is not None:
+        coverage.update(
+            state="recorded", total_pages=n,
+            scanned_pages=[i + 1 for i in sorted(page_texts)],
+            selected_pages=[i + 1 for i in selected],
+            included_pages=[i + 1 for i in included],
+            truncated_pages=[i + 1 for i in included if lengths[i] < len(page_texts[i])],
+            omitted_pages=[i + 1 for i in selected if i not in included],
+            input_characters=len(combined), character_budget=max_chars,
+        )
+    return combined
 
 
 def _find_doi(text: str) -> str | None:
@@ -301,7 +346,10 @@ def extract_paper_contribution(
     llm_provider/llm_api_key bill the extraction to a visitor bringing their
     own key. Omitted, it runs on the deployment's own credentials as before.
     """
-    text = extract_pdf_text(pdf_path)
+    coverage: dict = {}
+    text = extract_pdf_text(pdf_path, coverage=coverage)
+    if not text.strip():
+        raise ValueError("PDF contains no extractable text")
     doi_found   = _find_doi(text)
     arxiv_url   = _find_arxiv_url(text)
 
@@ -316,11 +364,24 @@ def extract_paper_contribution(
         api_key=llm_api_key,
     )
 
-    # Priority: LLM-found DOI > regex DOI > arXiv URL > placeholder DOI
-    if doi_found and not data.get("doi"):
-        data["doi"] = doi_found
-    if arxiv_url and not data.get("doi") and not data.get("url"):
-        data["url"] = arxiv_url
+    # A model locator may name a different real paper. Only retain locators
+    # observed in the bounded document text, and label them as candidates:
+    # a DOI in a bibliography is not proof of this document's identity.
+    model_doi = data.get("doi")
+    model_url = data.get("url")
+    data["doi"] = doi_found
+    data["url"] = f"https://doi.org/{doi_found}" if doi_found else arxiv_url
+    conflict = bool(
+        (model_doi and model_doi != doi_found)
+        or (model_url and model_url != data["url"])
+        or len({m.group(1).rstrip(".,;") for m in _DOI_RE.finditer(text)}) > 1
+    )
+    data["locator_status"] = (
+        "conflicting_candidates" if conflict else
+        "text_candidate" if doi_found or arxiv_url else "no_public_candidate"
+    )
+    # Never trust model-supplied coverage/identity fields, even if valid JSON.
+    data["input_coverage"] = PDFInputCoverage.model_validate(coverage)
 
     # Fallback placeholder DOI so EvidenceSource passes model validation
     if not data.get("doi") and not data.get("url"):
@@ -336,15 +397,11 @@ def paper_to_evidence_source(
 ) -> "EvidenceSource":  # noqa: F821
     """Convert a PaperContribution into an EvidenceSource for pipeline injection as A1.
 
-    The DOI and URL carried by `pc` were read out of the PDF's text by an LLM,
-    not resolved through a search index the way every other source in the
-    pipeline is (source_pipeline._web_source runs the same check before
-    admitting anything). A misread digit or an outright hallucinated
-    identifier is well within what PDF text extraction produces, so the
-    locators are verified here before this source is presented as a citable
-    reference — an unresolvable DOI cited at "high" credibility is worse than
-    citing none at all, since a reader who follows it finds nothing while the
-    scorer counts it as verified evidence either way.
+    Newly extracted locators are candidates found in the actual model input;
+    legacy contributions may still carry model-provided locators. A reachable
+    URL proves neither manuscript identity nor support for the model summary.
+    Keep uploads at medium credibility, even when the candidate is reachable,
+    and retain the identity limitation explicitly instead of upgrading to high.
     """
     from academic_agent.evidence import EvidenceSource, check_public_url
 
@@ -390,9 +447,8 @@ def paper_to_evidence_source(
     if src_url is None and src_doi is None:
         src_doi = _placeholder_doi(pc.title or "Uploaded Paper")
 
-    # An uploaded paper is a primary source whether or not its identifiers
-    # check out, but "high" asserts a reader can go and verify it. With no
-    # locator that resolves, that is not a claim this pipeline can make.
+    # Reachability, document identity and claim support are separate tests.
+    # The first cannot promote an uploaded model summary to verified identity.
     verifiable = src_url is not None or not src_doi.startswith(_PLACEHOLDER_DOI_PREFIX)
 
     summary = f"{pc.core_contribution.rstrip('.')}. {pc.delta_from_prior}"
@@ -406,9 +462,10 @@ def paper_to_evidence_source(
         published_date=None,
         accessed_date=date.today(),
         source_type="academic_paper",
-        credibility_tier="high" if verifiable else "medium",
+        credibility_tier="medium",
         credibility_reason=(
-            "Primary source uploaded directly by the researcher."
+            "Uploaded paper with a reachable candidate locator; document identity "
+            f"and claim support have not been independently checked ({pc.locator_status})."
             if verifiable else
             "Primary source uploaded by the researcher; no independently "
             "resolvable DOI or URL was found in the paper."

--- a/src/academic_agent/scoring_contract.py
+++ b/src/academic_agent/scoring_contract.py
@@ -1,0 +1,66 @@
+"""Current scoring citation admission, separate from frozen experiment bytes.
+
+The historical evidence module is a hash-locked dependency of paid experiments.
+Do not re-lock those protocols merely to evolve production validation. The Crew
+uses this wrapper; historical runners retain their original implementation.
+This checks citation identity/category, not semantic support or calibration.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from crewai import TaskOutput
+from pydantic import ValidationError
+
+from academic_agent.evidence import (
+    CommercializationScore, make_scoring_guardrail as legacy_scoring_guardrail,
+    parse_citation_ids,
+)
+
+
+def make_scoring_guardrail(
+    weight_profile: str = "industrial", *,
+    known_source_ids: frozenset[str] | None = None,
+    market_task: Any = None, all_sources: list[Any] | None = None,
+) -> Callable[[TaskOutput], tuple[bool, Any]]:
+    """Reject mechanical citation defects before unchanged normalization/formula."""
+    legacy = legacy_scoring_guardrail(
+        weight_profile, known_source_ids=known_source_ids,
+        market_task=market_task, all_sources=all_sources,
+    )
+
+    def validate_score(output: TaskOutput) -> tuple[bool, Any]:
+        try:
+            score = CommercializationScore.model_validate_json(output.raw)
+        except (ValidationError, ValueError):
+            # Preserve the existing schema-error contract, not a second repair.
+            return legacy(output)
+        errors: list[str] = []
+        for field, prefix in (("patent_source_ids", "P"), ("market_source_ids", "M")):
+            wrong = [sid for sid in getattr(score, field) if not sid.startswith(prefix)]
+            if wrong:
+                errors.append(f"{field} has wrong domain: {wrong}; use {prefix} sources.")
+        for field in ("trl_source_ids", "mrl_source_ids"):
+            ids = getattr(score, field)
+            # A strict P prohibition rejected 2/30 baseline scorecards: process
+            # patents supplemented academic/market manufacturing evidence. Require
+            # an A/M anchor, but do not falsely accuse those mixed references.
+            if ids and not any(sid.startswith(("A", "M")) for sid in ids):
+                errors.append(f"{field} has wrong domain: include an A/M anchor.")
+        if known_source_ids is not None:
+            prose = " ".join([
+                score.trl_rationale, score.mrl_rationale, score.patent_rationale,
+                score.market_rationale, score.evidence_rationale, score.scoring_rationale,
+                *score.key_risks, *score.key_opportunities,
+            ])
+            cited, malformed = parse_citation_ids(prose)
+            phantom = sorted(set(cited) - known_source_ids)
+            if phantom:
+                errors.append(f"Score prose references IDs absent from context: {phantom}.")
+            if malformed:
+                errors.append(f"Score prose contains malformed citations: {malformed}.")
+        if errors:
+            return False, " ".join(errors)
+        return legacy(output)
+
+    return validate_score

--- a/tests/test_evidence_terminal_boundaries.py
+++ b/tests/test_evidence_terminal_boundaries.py
@@ -1,0 +1,153 @@
+"""Mechanical evidence checks and operational terminal truth at their consumers."""
+
+from datetime import UTC, datetime
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import ops_report
+from academic_agent.claim_grounding import _supported, check_report
+from academic_agent.run_terminal import TerminalRecord, UsageAccounting, commit_terminal_record
+from academic_agent.scoring_contract import make_scoring_guardrail
+from api import runs
+from tests.test_scoring_guardrail import _run, _KNOWN
+from tests.test_crew_wiring import _make_collection
+
+
+@pytest.mark.parametrize("claim,source", [
+    ("10%", "100%"), ("100 MW", "1000 MW"), ("26.1%", "26.19 MW"),
+    ("1000", "10000"), ("10.1%", "10.19 million"),
+])
+def test_order_and_unit_errors_survive_the_findings_to_audit_seam(claim, source):
+    report = SimpleNamespace(
+        findings=[SimpleNamespace(finding_id="F1", claim=f"Measured {claim}.", source_ids=["A1"])],
+        sources=[SimpleNamespace(source_id="A1", evidence_summary=source + " Supporting prose." * 40,
+                                 summary_source="abstract")],
+    )
+    audit = check_report(report).as_dict()
+    assert audit["checked"] == 1
+    assert audit["ungrounded"] == 1
+    assert audit["findings"][0]["finding_id"] == "F1"
+    assert "error" not in audit
+
+
+@pytest.mark.parametrize("claim,source", [
+    ("26.1", "26.15"), ("26.2", "26.15"), ("100", "100.0"), ("0.12", "0.123"),
+])
+def test_decimal_quotation_precision_is_not_a_false_accusation(claim, source):
+    assert _supported(claim, "%", [(source, "%")], source + "%")
+
+
+def test_unitless_fallback_does_not_match_inside_a_longer_number():
+    assert not _supported("1000", "", [], "reported 10000 citations")
+    assert _supported("1000", "", [], "reported 1,000 citations")
+
+
+@pytest.mark.parametrize("field,ids", [
+    ("patent_source_ids", ["A1"]), ("market_source_ids", ["P1"]),
+    ("trl_source_ids", ["P1"]), ("mrl_source_ids", ["P1"]),
+])
+def test_existing_but_wrong_domain_cannot_reach_saved_scorecard(field, ids):
+    ok, error = _run(make_scoring_guardrail(known_source_ids=_KNOWN), **{field: ids})
+    assert not ok
+    assert field in error and "wrong domain" in error
+
+
+@pytest.mark.parametrize("field", [
+    "trl_rationale", "mrl_rationale", "patent_rationale", "market_rationale",
+    "evidence_rationale", "scoring_rationale", "key_risks", "key_opportunities",
+])
+def test_phantom_citations_in_each_prose_surface_are_rejected(field):
+    value = "A decision statement citing a nonexistent source [M999]."
+    if field.startswith("key_"):
+        value = [value]
+    ok, error = _run(make_scoring_guardrail(known_source_ids=_KNOWN), **{field: value})
+    assert not ok
+    assert "M999" in error
+
+
+def test_valid_domain_and_prose_refs_keep_the_existing_formula():
+    plain_ok, plain = _run(make_scoring_guardrail(known_source_ids=_KNOWN))
+    cited_ok, cited = _run(make_scoring_guardrail(known_source_ids=_KNOWN),
+                          market_rationale="Observed market adoption [M1].")
+    assert plain_ok and cited_ok
+    assert cited["overall_score"] == plain["overall_score"]
+    assert cited["score_formula"] == plain["score_formula"]
+
+
+@pytest.mark.parametrize("field", ["trl_source_ids", "mrl_source_ids"])
+def test_process_patents_can_supplement_but_not_replace_maturity_anchors(field):
+    ok, result = _run(make_scoring_guardrail(known_source_ids=_KNOWN),
+                      **{field: ["A1", "P1", "M1"]})
+    assert ok
+    assert result[field] == ["A1", "P1", "M1"]
+
+
+def test_production_crew_scoring_task_enforces_the_new_contract(monkeypatch):
+    """A correct standalone wrapper is useless if Crew still imports legacy."""
+    from academic_agent.crew import AcademicAgent
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "offline-placeholder")
+    guardrail = AcademicAgent(_make_collection()).crew().tasks[5].guardrail
+    ok, error = _run(guardrail, patent_source_ids=["A1"])
+    assert not ok and "wrong domain" in error
+    ok, error = _run(guardrail, market_rationale="Unknown source [M999].")
+    assert not ok and "M999" in error
+    ok, result = _run(guardrail, mrl_source_ids=["A1", "P1"])
+    assert ok and result["mrl_source_ids"] == ["A1", "P1"]
+
+
+def test_local_recovery_identity_changes_with_production_citation_contract(monkeypatch):
+    """A local resume must not reuse scores admitted under obsolete rules."""
+    from pathlib import Path
+    from academic_agent import checkpoint_runtime
+
+    for name in checkpoint_runtime._REVISION_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    before = checkpoint_runtime.pipeline_revision()
+    read = Path.read_bytes
+
+    def changed(path):
+        value = read(path)
+        return value + b"\n# changed admission\n" if path.name == "scoring_contract.py" else value
+
+    monkeypatch.setattr(Path, "read_bytes", changed)
+    assert checkpoint_runtime.pipeline_revision() != before
+
+
+@pytest.mark.parametrize("state", ["completed", "failed", "cancelled", "timeout"])
+@pytest.mark.parametrize("legacy", [{"done": True}, {"error": "stale error"}, ["malformed"], None])
+def test_ops_outcome_matches_core_api_despite_conflicting_legacy_artifacts(tmp_path, state, legacy):
+    """A committed terminal must beat status errors, missing status and markers."""
+    run_id = "20260910T000000Z-abcdef123456"
+    directory = tmp_path / run_id
+    directory.mkdir()
+    if legacy is not None:
+        (directory / "status.json").write_text(json.dumps(legacy), encoding="utf-8")
+    (directory / "cancelled.marker").write_text("stale", encoding="utf-8")
+    now = datetime.now(UTC)
+    record = TerminalRecord(
+        state=state, reason_code="fixture_outcome", termination_method="worker_exit",
+        started_at=now, ended_at=now, elapsed_seconds=0,
+        usage_accounting=UsageAccounting(state="unavailable", snapshot_at=now,
+                                        run_complete=state == "completed",
+                                        in_flight_request_may_have_spent=False),
+    )
+    commit_terminal_record(directory, record)
+    with patch.object(runs, "DEFAULT_OUTPUT_ROOT", tmp_path):
+        api_state = runs.get_state(run_id)
+    collected = ops_report.collect(tmp_path)
+    assert collected[0]["outcome"] == state == api_state["state"]
+    assert collected[0]["outcome_basis"] == "terminal.json"
+
+
+def test_unreadable_terminal_cannot_be_counted_as_completed(tmp_path):
+    directory = tmp_path / "20260910T000000Z-abcdef123456"
+    directory.mkdir()
+    (directory / "status.json").write_text('{"done": true}', encoding="utf-8")
+    (directory / "terminal.json").write_text('{"state":"timeout"}', encoding="utf-8")
+    record = ops_report.collect(tmp_path)[0]
+    assert record["outcome"] == "unknown"
+    assert record["outcome_basis"] == "unreadable terminal.json"

--- a/tests/test_pdf_extraction.py
+++ b/tests/test_pdf_extraction.py
@@ -146,9 +146,11 @@ class ContributionAssemblyTests(unittest.TestCase):
         with patch("academic_agent.pdf_extractor._call_llm_json", return_value=data):
             return extract_paper_contribution(_pdf(pages))
 
-    def test_a_doi_the_model_returns_wins(self):
+    def test_a_model_doi_cannot_override_document_text(self):
         pc = self._extract(["doi:10.1000/from-text"], doi="10.1000/from-model")
-        self.assertEqual(pc.doi, "10.1000/from-model")
+        self.assertEqual(pc.doi, "10.1000/from-text")
+        self.assertEqual(pc.locator_status, "conflicting_candidates")
+        self.assertIn("from-text", pc.url)
 
     def test_a_doi_in_the_text_is_used_when_the_model_returns_none(self):
         """The regex is the check on the model: a DOI it invented would not

--- a/tests/test_pdf_extractor.py
+++ b/tests/test_pdf_extractor.py
@@ -180,9 +180,10 @@ class PaperToEvidenceSourceTests(unittest.TestCase):
         src = paper_to_evidence_source(_make_pc(doi="10.1234/test"), _reachable)
         self.assertEqual(src.source_type, "academic_paper")
 
-    def test_credibility_tier_is_high(self):
+    def test_reachability_does_not_verify_uploaded_document_identity(self):
         src = paper_to_evidence_source(_make_pc(doi="10.1234/test"), _reachable)
-        self.assertEqual(src.credibility_tier, "high")
+        self.assertEqual(src.credibility_tier, "medium")
+        self.assertIn("not been independently checked", src.credibility_reason)
 
     def test_real_doi_sets_doi_and_doi_org_url(self):
         src = paper_to_evidence_source(_make_pc(doi="10.1038/s41586-023-001"), _reachable)
@@ -261,7 +262,8 @@ class PaperLocatorVerificationTests(unittest.TestCase):
         )
         self.assertEqual(src.doi, "10.1038/s41586-023-001")
         self.assertEqual(str(src.url), "https://doi.org/10.1038/s41586-023-001")
-        self.assertEqual(src.credibility_tier, "high")
+        self.assertEqual(src.credibility_tier, "medium")
+        self.assertIn("not been independently checked", src.credibility_reason)
         self.assertIn("https://publisher.example/dead", checks)
 
     def test_unreachable_arxiv_url_leaves_no_real_locator(self):

--- a/tests/test_pdf_input_identity_boundaries.py
+++ b/tests/test_pdf_input_identity_boundaries.py
@@ -1,0 +1,101 @@
+"""Real PDF to model-prompt to HTTP/persisted coverage and locator boundaries."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from academic_agent import pdf_extractor as extractor
+from api import main, papers, runs
+from tests import test_pdf_extraction as pdf_fixture
+
+_pdf = pdf_fixture._pdf
+
+
+def long_paper():
+    # Each of the first three pages contains enough real text that concatenating
+    # and taking 7000 characters used to remove both later result pages.
+    intro = "\n".join(f"Introduction line {i}: " + "background " * 7 for i in range(40))
+    return _pdf([intro, intro, intro, "RESULTS_SENTINEL measured outcomes.",
+                 "LIMITATIONS_SENTINEL and CONCLUSIONS_SENTINEL."])
+
+
+def fields(**extra):
+    return dict(pdf_fixture.ContributionAssemblyTests._LLM_FIELDS, **extra)
+
+
+def test_actual_model_input_contains_selected_tail_and_truthful_budget():
+    with patch.object(extractor, "_call_llm_json", return_value=fields(
+        input_coverage={"state": "recorded", "included_pages": [999]},
+        locator_status="text_candidate",
+    )) as model:
+        contribution = extractor.extract_paper_contribution(long_paper())
+    prompt = model.call_args.args[0]
+    payload = json.loads(prompt.split("paper payload:\n", 1)[1])
+    text = payload["paper_text"]
+    assert "RESULTS_SENTINEL" in text
+    assert "CONCLUSIONS_SENTINEL" in text
+    assert len(text) <= 7000
+    coverage = contribution.input_coverage
+    assert coverage.state == "recorded"
+    assert coverage.included_pages == [1, 2, 3, 4, 5]
+    assert coverage.truncated_pages == [1, 2, 3]
+    assert coverage.omitted_pages == []
+    assert coverage.input_characters == len(text)
+    assert coverage.character_budget == 7000
+    assert contribution.locator_status == "no_public_candidate"
+
+
+def test_paid_http_response_and_persisted_extraction_keep_every_contribution_field(tmp_path, monkeypatch):
+    """An internal coverage field is useless if response_model silently drops it."""
+    monkeypatch.setattr(papers, "PAPERS_ROOT", tmp_path / "papers")
+    monkeypatch.setattr(runs, "DEFAULT_OUTPUT_ROOT", tmp_path / "runs")
+    with patch.object(extractor, "_call_llm_json", return_value=fields()), TestClient(main.app) as client:
+        response = client.post("/api/papers", files={"file": ("paper.pdf", long_paper().read_bytes())})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(extractor.PaperContribution.model_fields) <= set(body)
+    saved = papers.load_extraction(body["paper_id"])
+    assert body["input_coverage"] == saved["input_coverage"]
+    assert body["locator_status"] == saved["locator_status"] == "no_public_candidate"
+    assert body["input_coverage"]["included_pages"] == [1, 2, 3, 4, 5]
+
+
+def test_tiny_budget_records_omitted_pages_instead_of_claiming_complete_input():
+    coverage = {}
+    text = extractor.extract_pdf_text(_pdf(["one", "two", "three"]), max_chars=12, coverage=coverage)
+    assert len(text) <= 12
+    assert coverage["omitted_pages"]
+    assert len(coverage["included_pages"]) < len(coverage["selected_pages"])
+
+
+def test_blank_scanned_paper_does_not_reach_a_paid_llm():
+    with patch.object(extractor, "_call_llm_json") as model:
+        with pytest.raises(ValueError, match="no extractable text"):
+            extractor.extract_paper_contribution(_pdf([""]))
+    model.assert_not_called()
+
+
+def test_model_only_locator_is_not_promoted_into_a_citable_identity():
+    with patch.object(extractor, "_call_llm_json", return_value=fields(
+        doi="10.1234/another-paper", url="https://doi.org/10.1234/another-paper",
+    )):
+        pc = extractor.extract_paper_contribution(_pdf(["No document identifier."]))
+    assert pc.url is None
+    assert pc.doi.startswith(extractor._PLACEHOLDER_DOI_PREFIX)
+    assert pc.locator_status == "conflicting_candidates"
+    checked = []
+    source = extractor.paper_to_evidence_source(pc, lambda url: (checked.append(url) or True, ""))
+    assert checked == []
+    assert source.credibility_tier == "medium"
+
+
+def test_a_reachable_bibliography_doi_is_still_only_a_candidate():
+    with patch.object(extractor, "_call_llm_json", return_value=fields()):
+        pc = extractor.extract_paper_contribution(_pdf(["References: 10.1234/cited-paper"]))
+    source = extractor.paper_to_evidence_source(pc, lambda url: (True, ""))
+    assert pc.locator_status == "text_candidate"
+    assert source.credibility_tier == "medium"
+    assert "document identity" in source.credibility_reason
+    assert "not been independently checked" in source.credibility_reason


### PR DESCRIPTION
## Why
Offline review reproduced numeric-prefix false support, wrong score citation domains, phantom prose citations, selected PDF tail loss, locator-overconfidence and stale ops terminal outcomes.

## Scope and evidence
- Keep frozen evidence.py and experiment locks unchanged; production-only score wrapper enters actual Crew and local checkpoint identity.
- Decimal precision instead of digit prefixes; 90-artifact replay findings unchanged.
- 30/30 archived scorecards retain identical normalized outputs. A candidate rule causing two false rejections was rejected before release.
- Code-owned PDF budget/locator state survives actual HTTP response and saved extraction; reachability is not document identity.
- Immutable terminal outcomes take precedence in ops_report.
- 2784 tests + 1218 subtests, 89.07% coverage; latest Ruff, narrow Pylint, both Chromium smoke journeys passed.
- Eight original-defect injections fail their intended behavioral assertions; restored before final tests.

## Limits
No provider calls, paid canary, manual Railway restart, new experiment access or Tool Calling activation. Formula/floor unchanged. Dated result explicitly lists unresolved review items, including full paper identity, receipt idempotency, native-process isolation and end-to-end accounting.

Automerge only after all CI checks and self-review, under the user's authorization for this maintenance release.