### PR TITLE
Preserve PDF identity, signed-unit uncertainty and thread-owned failure receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,11 @@ the [identity/logging regression and accounting limits](docs/results-2026-09-10-
 
 ## Keeping this index short without erasing decisions
 
+PDF candidates never become A1 citation identity, including legacy conversion.
+Numeric sign/unit uncertainty must not become support; known PDF thread failures
+must finalize receipts even without a waiter, while journal write failure stays
+unresolved. See the [boundary repair and coverage tradeoff](docs/results-2026-09-11-pdf-numeric-receipt-seams.md).
+
 Crew-node accounting now publishes scope separately from temporal/price
 completeness. Legacy benchmark inspection is not paid reuse authorization:
 new batches bind source/model/config/fixture identity and refuse occupied

--- a/api/main.py
+++ b/api/main.py
@@ -1287,6 +1287,26 @@ async def _process_uploaded_paper(paper_id: str, pdf_path: str, **credentials) -
                 # the normal paper TTL; raw input was removed by save_extraction.
                 ticket.finish({"paper_id": paper_id}, 200)
             return contribution
+        except (receipts.ReceiptError, _PaperAbandoned):
+            # A failed commit is unavailable acknowledgement, not extraction
+            # failure. Queued abandonment already has its own final receipt.
+            raise
+        except Exception as exc:  # noqa: BLE001 - SDK/parser failures vary; actual thread owns finality
+            if ticket is not None:
+                if isinstance(exc, (runs.ConcurrencyLimitReached, runs.DailyCapReached)):
+                    status = 429
+                    code = ("concurrency_limit" if isinstance(exc, runs.ConcurrencyLimitReached)
+                            else "daily_quota_exceeded")
+                else:
+                    status = (503 if isinstance(exc, runs.PaidLedgerUnavailable) else
+                              500 if isinstance(exc, _PaperStorageError) else 422)
+                    code = None
+                # A cancelled waiter cannot run its HTTP exception mapping.
+                # Record known execution failure here, including local 5xx.
+                # No exception text, refund claim or inferred zero usage.
+                ticket.finish({"detail": "The original request failed and was not retried. This does not establish zero cost.",
+                               "error_code": code}, status, failed=True)
+            raise
         finally:
             if not stored or (abandoned.is_set() and ticket is None):
                 papers.discard(paper_id)

--- a/api/models.py
+++ b/api/models.py
@@ -132,6 +132,8 @@ class PaperExtraction(BaseModel):
     authors: str = ""
     doi: str | None = None
     url: str | None = None
+    candidate_doi: str | None = None
+    candidate_url: str | None = None
     core_contribution: str
     application_domain: str
     key_metrics: list[str] = Field(default_factory=list)

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -47,6 +47,13 @@ production incident rates or improved report accuracy. See the
 
 ## Main evaluation ledger
 
+PDF candidate locators are now separate from A1 citation identity, including
+legacy extraction conversion. Signed quantities and milli/mega symbols remain
+distinct; unsupported unit notation abstains. The actual PDF thread publishes
+known failure receipts after HTTP cancellation. Read-only 90-artifact replay
+moves 18 previously checked findings to unverifiable; it is not an accuracy
+gain. See the [repair and explicit limits](results-2026-09-11-pdf-numeric-receipt-seams.md).
+
 Run/PDF/resume acceptance now supports opt-in durable idempotency and read-only
 receipt lookup. Fresh-document Chromium recovery for all three first-party
 operations uses intercepted POSTs, not paid-provider calls; unknown and corrupt

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -25,6 +25,8 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-11 PDF/numeric/receipt seams](results-2026-09-11-pdf-numeric-receipt-seams.md) — separate candidate identity, signed/case-sensitive quantities and thread-owned failure receipts; zero provider calls.
+
 - [2026-09-10 evidence/PDF/terminal boundaries](results-2026-09-10-evidence-pdf-terminal-boundaries.md) — precision-aware numeric matching, production-only citation admission, actual PDF input coverage, candidate identity limits and terminal-authoritative operational outcomes; zero provider calls.
 
 - [2026-09-08 upload/history/cancellation boundaries](results-2026-09-08-upload-history-cancellation-boundaries.md) — pre-parser byte/time/capacity limits, generation-bound history and thread-owned PDF cleanup; zero provider calls.

--- a/docs/operating-guide.md
+++ b/docs/operating-guide.md
@@ -7,6 +7,13 @@ experiment. Frozen experiments have separate identities and authorization gates.
 
 ## Local setup and provider selection
 
+Uploaded PDF `candidate_doi` / `candidate_url` fields are unverified locators,
+not the document's public identity. A1 uses a synthetic upload identifier until
+independent manuscript verification exists. Known extraction failures are
+queryable through the receipt even after disconnection; receipt storage failure
+still means unresolved, never permission for automatic resend. See the
+[PDF/quantity/receipt contract](results-2026-09-11-pdf-numeric-receipt-seams.md).
+
 Use `uv sync` with Python 3.11/3.12 to reproduce the CI-tested environment.
 Copy [the public template](../.env.example) to `.env`; only real execution
 requires keys. On PowerShell:

--- a/docs/results-2026-09-11-pdf-numeric-receipt-seams.md
+++ b/docs/results-2026-09-11-pdf-numeric-receipt-seams.md
@@ -1,0 +1,88 @@
+# PDF identity, signed quantities and thread-owned failure receipts
+
+Date: 2026-09-11. Starting main: `e02677b36c07048d0e53366c6da138def88bfe90`.
+Scope: offline repair and release verification; zero paid provider calls.
+
+## Confirmed defects and adopted boundaries
+
+1. A bibliography DOI was labelled unverified but still populated A1's DOI/URL.
+   New extraction retains `candidate_doi` / `candidate_url` separately; code owns
+   these fields, not model JSON. Neither candidate nor legacy locators enter
+   citation identity. A1 keeps its actual uploaded summary/title and synthetic
+   upload identifier, with no DOI-resolution call. This also applies to old
+   extractions at conversion, not an in-place rewrite of saved reports. The
+   synthetic identifier is not a registered DOI or manuscript verification.
+2. Numeric extraction lost signs and lowercased milli/mega symbols together.
+   ASCII +/- and Unicode minus survive comparison. mW/MW, mWh/MWh, mPa/MPa
+   and mHz/MHz remain distinct. Unknown unit/compound notation on a distinctive
+   figure yields explicit unverifiable rather than a pass or accusation.
+   Other unsupported case spellings (mM versus mm, Mw versus MW), Greek and
+   Chinese suffixes also abstain instead of becoming a unitless value.
+   Ordinary count/year exclusions and precision-aware decimal rounding remain.
+   This is a narrow advisory grammar, not dimensional conversion, full unit
+   support, claim entailment or a blocking guardrail.
+3. Only a live HTTP waiter recorded extraction failures. A disconnected waiter
+   left the already-failed background thread's receipt pending. The actual PDF
+   thread now records known provider/parser, quota/capacity, accounting-admission
+   and publication failures, including local 5xx. The same safe detail/category
+   can be observed via GET and replay; failure never means free/refunded.
+   A failed receipt commit itself remains unavailable/unresolved, not fabricated
+   failure. Successful metadata survives a lost commit; unresolved intent cannot
+   launch another extraction. Existing queued-abandonment and raw cleanup remain.
+
+Local recovery identity now includes the PDF and grounding implementations.
+Protected score computation, frozen experiment sources and zero-call production
+Tool Calling remain unchanged. Candidate fields reach both the initial HTTP
+reply and receipt recovery, not only an internal model.
+
+## Measure before and after
+
+The unchanged starting suite passed **2884 tests + 1237 subtests**. Thirty new
+offline boundary cases initially produced **26 failures and four passes**.
+No real model, search or DOI request was used to reproduce them.
+
+Read-only replay of **90 archived evidence files / 30 benchmark runs**:
+
+| Numeric-screen outcome | Before | After |
+|---|---:|---:|
+| Checked findings | 50 | 32 |
+| Ungrounded findings (subset of checked) | 1 | 0 |
+| Unverifiable findings | 161 | 179 |
+
+The 18 moved findings use unsupported unit notation such as eV, GJ/tCO2, dB
+and cm². The removed warning moved to unverifiable, not to grounded. These
+figures document reduced asserted coverage, not improved independent accuracy.
+A tentative expansion making every citation count checkable created three
+unsupported warnings on old reports; it was rejected. Small counts retain their
+old exclusion. Archived evidence, calibration CSVs and scorecards were not changed.
+
+## Verification and limits
+
+Tests use real PDF extraction with an offline model substitute, HTTP delivery,
+persisted metadata, A1 conversion, actual cancellation of a waiting coroutine
+while its thread is held, and read-only receipt lookup after thread completion.
+Positive controls retain correct sign/unit pairs and already-passing receipt
+commit-loss behavior. Local source identity is tested by changing read bytes.
+
+Eleven defect variants were deliberately injected and required the named test
+assertion to fail, then restored with matching source SHA-256: candidate DOI
+assignment, candidate A1 attachment, omitted HTTP fields, lost sign, collapsed
+milli/mega symbols, unknown suffix as unitless, missing background failure
+commit, commit uncertainty as false failure, PDF/grounding omitted from local
+revision (two variants), and unsupported symbol case folding. Unit variants
+were repeated after the final Unicode/SI refinement.
+
+Release CI, mutation evidence and deployment verification are recorded on the
+release PR. Real Chromium tests intercept paid POSTs or reject mutations.
+No paid canary or manual Railway restart is part of this maintenance.
+
+Final Windows/Python 3.12.9 regression: **2922 passed + 1242 subtests**,
+**89.18% Python coverage** (85% floor unchanged); 38 added cases. Latest Ruff,
+narrow Pylint and whitespace checks pass. Both Chromium journeys pass: 26
+intercepted composer POSTs, zero provider calls, unexpected requests or page
+errors; the read-only result journey also records zero mutation attempts.
+
+Native PDF subprocess isolation, end-to-end billing, independently verified
+manuscript identity and general citation correctness are not established here.
+Hard process death or unavailable storage can still leave unresolved receipts;
+an in-flight provider request can have spent money even when delivery fails.

--- a/src/academic_agent/checkpoint_runtime.py
+++ b/src/academic_agent/checkpoint_runtime.py
@@ -110,6 +110,8 @@ def pipeline_revision() -> str:
         package / "crew.py",
         package / "evidence.py",
         package / "scoring_contract.py",
+        package / "pdf_extractor.py",
+        package / "claim_grounding.py",
         package / "llm_config.py",
         package / "pipeline_worker.py",
         package / "run_spec.py",

--- a/src/academic_agent/claim_grounding.py
+++ b/src/academic_agent/claim_grounding.py
@@ -66,16 +66,58 @@ _UNIT_SYNONYMS = {
     "month": "months", "cycle": "cycles",
 }
 
+# Explicit SI spellings only; case folding is reserved for ordinary words.
+# mM is not mm and MK is not mK. Unsupported symbols must abstain instead of
+# silently acquiring the meaning of a differently cased recognised symbol.
+_SI_UNITS = {
+    "Wh/kg": "wh/kg", "Wh/L": "wh/l", "Wh/l": "wh/l", "mAh": "mah",
+    "kWh": "kwh", "MWh": "mwh", "GWh": "gwh",
+    "kW": "kw", "MW": "mw", "GW": "gw",
+    "MPa": "mpa", "GPa": "gpa", "kPa": "kpa", "°C": "°c", "℃": "°c", "K": "k",
+    "nm": "nm", "µm": "µm", "um": "µm", "mm": "mm", "cm": "cm", "km": "km",
+    "kg": "kg", "mg": "mg", "µg": "µg", "ug": "µg", "ml": "ml", "mL": "ml",
+    "mol": "mol", "Hz": "hz", "kHz": "khz", "MHz": "mhz", "GHz": "ghz",
+}
+
 
 def _normalize_unit(unit: str) -> str:
-    cleaned = (unit or "").strip().lower().rstrip(".,;:)")
+    raw = (unit or "").strip().rstrip(".,;:)")
+    # SI prefixes are case-sensitive. Lowercasing mW into MW's canonical key
+    # erases six orders of magnitude; these spellings must remain distinct.
+    milli = {"mW": "milliwatt", "mWh": "milliwatt-hour", "mPa": "millipascal",
+             "mHz": "millihertz"}
+    if raw in milli:
+        return milli[raw]
+    cleaned = raw.lower()
+    if cleaned in {symbol.lower() for symbol in _SI_UNITS}:
+        return _SI_UNITS.get(raw, _UNKNOWN_UNIT + raw)
     return _UNIT_SYNONYMS.get(cleaned, cleaned)
 
 
 _FIGURE_RE = re.compile(
-    r"(?<![\w.])(\d[\d,]*(?:\.\d+)?)\s*(?:" + _UNIT_PATTERN + r")?",
+    r"(?<![\w.])([+\-−]?\d[\d,]*(?:\.\d+)?)\s*(?:" + _UNIT_PATTERN + r")?",
     re.IGNORECASE,
 )
+
+# An unrecognised suffix is NOT a unitless number. Preserve uncertainty rather
+# than accepting identical digits as support. Ordinary connective words after a
+# unitless value are allowed; this short grammar is not universal unit parsing.
+_UNIT_TAIL = re.compile(r"(?:[^\W\d_]|[°℃%])[\w°℃%/^²³·*_-]*")
+_PROSE_AFTER_NUMBER = {"under", "in", "at", "for", "and", "or", "of", "to", "as",
+                       "is", "was", "were", "with", "by", "from", "than",
+                       "citation", "citations"}
+_UNKNOWN_UNIT = "?unknown:"
+
+
+def _figure_unit(match: re.Match, text: str) -> str:
+    raw = match.group(0)[len(match.group(1)):].strip()
+    tail = text[match.end():]
+    extra = _UNIT_TAIL.match(tail)
+    if raw and (tail.startswith(("/", "^", "²", "³", "·", "*")) or extra or tail[:1].isalnum()):
+        return _UNKNOWN_UNIT + raw + tail.split()[0]
+    if not raw and extra and extra.group().lower() not in _PROSE_AFTER_NUMBER:
+        return _UNKNOWN_UNIT + extra.group()
+    return _normalize_unit(raw)
 
 #: Words that turn a following round number into a bound rather than a
 #: quotation. "above 100 GPa" is the analyst's threshold, and is a correct
@@ -161,7 +203,7 @@ def _normalize_number(raw: str) -> str:
     """'1,250.0' -> '1250'. Thousands separators and trailing zeros are
     formatting, not content, and a claim that writes 26.10% against a source
     that writes 26.1% is quoting the same figure."""
-    cleaned = raw.replace(",", "").strip()
+    cleaned = raw.replace(",", "").replace("−", "-").strip().lstrip("+")
     if "." in cleaned:
         cleaned = cleaned.rstrip("0").rstrip(".")
     return cleaned or "0"
@@ -182,7 +224,7 @@ def checkable_figures(text: str) -> list[tuple[str, str]]:
     seen: set[str] = set()
     for match in _FIGURE_RE.finditer(text or ""):
         raw = match.group(1)
-        unit = _normalize_unit(match.group(0)[len(raw):])
+        unit = _figure_unit(match, text)
         number = _normalize_number(raw)
         try:
             value = float(number)
@@ -195,7 +237,7 @@ def checkable_figures(text: str) -> list[tuple[str, str]]:
         # report that ordinary, correct sentence as a fabrication. A figure
         # carrying a unit stays even if it looks like a year: "2024 GWh" is a
         # quantity, not a date.
-        if not unit and 1900 <= value <= 2100 and "." not in number:
+        if (not unit or unit.startswith(_UNKNOWN_UNIT)) and 1900 <= value <= 2100 and "." not in number:
             continue
 
         # A round number behind a comparative is a bound the analyst chose,
@@ -207,7 +249,10 @@ def checkable_figures(text: str) -> list[tuple[str, str]]:
         if "." not in number and _BOUND_QUALIFIERS.search(text[: match.start()]):
             continue
 
-        distinctive = bool(unit) or "." in number or value >= _LARGE_ENOUGH
+        # A recognised base with an unsupported suffix (1 cm², 2 kg/foo) is
+        # still a quantity requiring abstention, not a disposable small count.
+        has_unit_prefix = bool(match.group(0)[len(raw):].strip())
+        distinctive = has_unit_prefix or "." in number or abs(value) >= _LARGE_ENOUGH
         key = f"{number}|{unit}"
         if distinctive and key not in seen:
             seen.add(key)
@@ -295,6 +340,8 @@ def _supported(number: str, unit: str, present: list[tuple[str, str]],
     without repeating the unit" into an accusation of fabrication.
     """
     for source_number, source_unit in present:
+        if unit.startswith(_UNKNOWN_UNIT) or source_unit.startswith(_UNKNOWN_UNIT):
+            continue
         if source_unit and unit and source_unit != unit:
             continue
         if _same_numeric_value(number, source_number):
@@ -305,6 +352,7 @@ def _supported(number: str, unit: str, present: list[tuple[str, str]],
     return not unit and any(
         _same_numeric_value(number, _normalize_number(match.group(1)))
         for match in _FIGURE_RE.finditer(haystack)
+        if not _figure_unit(match, haystack).startswith(_UNKNOWN_UNIT)
     )
 
 
@@ -378,6 +426,19 @@ def _check_report(report: Any, sources: Any = None) -> GroundingReport:
 
         haystack = " ".join(_source_text(s) for s in checkable)
         present = checkable_figures(haystack)
+        if any(unit.startswith(_UNKNOWN_UNIT) for _, unit in figures) or any(
+            source_unit.startswith(_UNKNOWN_UNIT) and _same_numeric_value(number, source_number)
+            and not _supported(number, unit, present, haystack)
+            for number, unit in figures for source_number, source_unit in present
+        ):
+            # Unknown units cannot earn a pass or a false accusation. Keep
+            # this outside the checked denominator, visible in the audit.
+            checks.append(ClaimCheck(
+                finding_id=str(getattr(finding, "finding_id", "")), claim=claim,
+                source_ids=cited_ids, unverifiable_reason="unrecognised unit notation prevents numeric comparison",
+            ))
+            unverifiable += 1
+            continue
         hit, miss = [], []
         for number, unit in figures:
             if _supported(number, unit, present, haystack):

--- a/src/academic_agent/pdf_extractor.py
+++ b/src/academic_agent/pdf_extractor.py
@@ -55,6 +55,8 @@ class PaperContribution(BaseModel):
     authors: str = ""
     doi: str | None = None
     url: str | None = None
+    candidate_doi: str | None = None
+    candidate_url: str | None = None
     core_contribution: str = Field(min_length=20)
     application_domain: str = Field(min_length=3)
     key_metrics: list[str] = Field(default_factory=list)
@@ -369,11 +371,11 @@ def extract_paper_contribution(
     # a DOI in a bibliography is not proof of this document's identity.
     model_doi = data.get("doi")
     model_url = data.get("url")
-    data["doi"] = doi_found
-    data["url"] = f"https://doi.org/{doi_found}" if doi_found else arxiv_url
+    data["candidate_doi"] = doi_found
+    data["candidate_url"] = f"https://doi.org/{doi_found}" if doi_found else arxiv_url
     conflict = bool(
         (model_doi and model_doi != doi_found)
-        or (model_url and model_url != data["url"])
+        or (model_url and model_url != data["candidate_url"])
         or len({m.group(1).rstrip(".,;") for m in _DOI_RE.finditer(text)}) > 1
     )
     data["locator_status"] = (
@@ -383,9 +385,11 @@ def extract_paper_contribution(
     # Never trust model-supplied coverage/identity fields, even if valid JSON.
     data["input_coverage"] = PDFInputCoverage.model_validate(coverage)
 
-    # Fallback placeholder DOI so EvidenceSource passes model validation
-    if not data.get("doi") and not data.get("url"):
-        data["doi"] = _placeholder_doi(str(data.get("title", "paper")))
+    # A regex hit is only a candidate, even a lone first-page DOI. Front matter
+    # can cite prior work too. A synthetic upload identity prevents that hit
+    # becoming A1's registered DOI or dedup key without manuscript verification.
+    data["doi"] = _placeholder_doi(str(data.get("title", "paper")))
+    data["url"] = None
 
     valid_fields = PaperContribution.model_fields.keys()
     return PaperContribution(**{k: v for k, v in data.items() if k in valid_fields})
@@ -395,81 +399,28 @@ def paper_to_evidence_source(
     pc: PaperContribution,
     url_checker: "UrlChecker | None" = None,  # noqa: F821
 ) -> "EvidenceSource":  # noqa: F821
-    """Convert a PaperContribution into an EvidenceSource for pipeline injection as A1.
+    """Use the upload as A1, never a bibliography locator as its identity.
 
-    Newly extracted locators are candidates found in the actual model input;
-    legacy contributions may still carry model-provided locators. A reachable
-    URL proves neither manuscript identity nor support for the model summary.
-    Keep uploads at medium credibility, even when the candidate is reachable,
-    and retain the identity limitation explicitly instead of upgrading to high.
+    Candidate and legacy locators have no independent manuscript match. The
+    optional checker remains call-compatible but is not invoked: reachability
+    cannot authorize identity or an additional network request at this seam.
     """
-    from academic_agent.evidence import EvidenceSource, check_public_url
+    from academic_agent.evidence import EvidenceSource
 
-    if url_checker is None:
-        url_checker = check_public_url
-
-    # Prefer real DOI URL; placeholder DOIs get stored in the doi field only.
-    # Always populate src_doi when available so dedup and citation-tracking work.
-    _real_doi = pc.doi if (pc.doi and not pc.doi.startswith(_PLACEHOLDER_DOI_PREFIX)) else None
-    if not _real_doi and pc.url:
-        # Extract DOI from a doi.org URL the LLM returned in the url field.
-        _m = re.match(r"https?://doi\.org/(10\.\d{4,9}/[^\s?#]+)", pc.url.strip())
-        if _m:
-            _real_doi = _m.group(1)
-
-    if _real_doi:
-        src_doi: str | None = _real_doi
-        src_url: str | None = pc.url or f"https://doi.org/{_real_doi}"
-    elif pc.url:
-        src_doi = None
-        src_url = pc.url
-    else:
-        src_doi = pc.doi  # placeholder, passes format check
-        src_url = None
-
-    if src_url is not None and not url_checker(str(src_url))[0]:
-        # A doi.org link that does not resolve condemns the DOI itself, not
-        # just the link. Any other URL failing says nothing about a DOI that
-        # was extracted separately, so that one is re-checked below instead.
-        if src_doi and str(src_url).startswith("https://doi.org/"):
-            src_doi = None
-        src_url = None
-
-    if src_url is None and _real_doi and src_doi:
-        _resolver = f"https://doi.org/{src_doi}"
-        src_url = _resolver if url_checker(_resolver)[0] else None
-        if src_url is None:
-            src_doi = None
-
-    # Nothing survived verification, but the upload itself is still real and
-    # still has to reach the crew as A1 — fall back to the same synthetic id
-    # used for a paper that never carried an identifier at all.
-    if src_url is None and src_doi is None:
-        src_doi = _placeholder_doi(pc.title or "Uploaded Paper")
-
-    # Reachability, document identity and claim support are separate tests.
-    # The first cannot promote an uploaded model summary to verified identity.
-    verifiable = src_url is not None or not src_doi.startswith(_PLACEHOLDER_DOI_PREFIX)
-
+    # Apply this to old saved contributions too. Fixing only new uploads would
+    # leave legacy model/regex locators citable after a deployment restart.
+    src_doi = (pc.doi if pc.doi and pc.doi.startswith(_PLACEHOLDER_DOI_PREFIX)
+               else _placeholder_doi(pc.title or "Uploaded Paper"))
     summary = f"{pc.core_contribution.rstrip('.')}. {pc.delta_from_prior}"
-
     return EvidenceSource(
-        source_id="A1",
-        title=pc.title or "Uploaded Paper",
-        url=src_url,  # type: ignore[arg-type]
-        doi=src_doi,
-        publisher=pc.authors or "Uploaded",
-        published_date=None,
-        accessed_date=date.today(),
-        source_type="academic_paper",
+        source_id="A1", title=pc.title or "Uploaded Paper",
+        url=None, doi=src_doi, publisher=pc.authors or "Uploaded",
+        published_date=None, accessed_date=date.today(), source_type="academic_paper",
         credibility_tier="medium",
         credibility_reason=(
-            "Uploaded paper with a reachable candidate locator; document identity "
-            f"and claim support have not been independently checked ({pc.locator_status})."
-            if verifiable else
-            "Primary source uploaded by the researcher; no independently "
-            "resolvable DOI or URL was found in the paper."
+            "Uploaded paper; document identity and claim support have not been independently checked. "
+            f"Candidate locators are excluded from citation identity ({pc.locator_status}); "
+            "the synthetic upload identifier is not a registered DOI."
         ),
-        evidence_summary=summary[:500],
-        citation_count=None,
+        evidence_summary=summary[:500], citation_count=None,
     )

--- a/tests/test_pdf_extraction.py
+++ b/tests/test_pdf_extraction.py
@@ -148,20 +148,25 @@ class ContributionAssemblyTests(unittest.TestCase):
 
     def test_a_model_doi_cannot_override_document_text(self):
         pc = self._extract(["doi:10.1000/from-text"], doi="10.1000/from-model")
-        self.assertEqual(pc.doi, "10.1000/from-text")
+        self.assertEqual(pc.candidate_doi, "10.1000/from-text")
+        self.assertTrue(pc.doi.startswith("10.0000/uploaded-"))
         self.assertEqual(pc.locator_status, "conflicting_candidates")
-        self.assertIn("from-text", pc.url)
+        self.assertIn("from-text", pc.candidate_url)
+        self.assertIsNone(pc.url)
 
     def test_a_doi_in_the_text_is_used_when_the_model_returns_none(self):
         """The regex is the check on the model: a DOI it invented would not
         appear in the paper, and one it missed still gets found."""
         pc = self._extract(["Preprint. doi:10.1000/from-text here"])
-        self.assertEqual(pc.doi, "10.1000/from-text")
+        self.assertEqual(pc.candidate_doi, "10.1000/from-text")
+        self.assertTrue(pc.doi.startswith("10.0000/uploaded-"))
+        self.assertIsNone(pc.url)
 
     def test_an_arxiv_url_is_used_when_there_is_no_doi(self):
         pc = self._extract(["Available at https://arxiv.org/abs/2501.01234"])
-        self.assertEqual(str(pc.url), "https://arxiv.org/abs/2501.01234")
-        self.assertIsNone(pc.doi)
+        self.assertEqual(pc.candidate_url, "https://arxiv.org/abs/2501.01234")
+        self.assertIsNone(pc.url)
+        self.assertTrue(pc.doi.startswith("10.0000/uploaded-"))
 
     def test_a_placeholder_doi_is_minted_when_nothing_identifies_the_paper(self):
         """Without one the paper cannot become an EvidenceSource, so the

--- a/tests/test_pdf_extractor.py
+++ b/tests/test_pdf_extractor.py
@@ -185,10 +185,10 @@ class PaperToEvidenceSourceTests(unittest.TestCase):
         self.assertEqual(src.credibility_tier, "medium")
         self.assertIn("not been independently checked", src.credibility_reason)
 
-    def test_real_doi_sets_doi_and_doi_org_url(self):
+    def test_legacy_real_doi_is_not_a_verified_upload_identity(self):
         src = paper_to_evidence_source(_make_pc(doi="10.1038/s41586-023-001"), _reachable)
-        self.assertEqual(src.doi, "10.1038/s41586-023-001")
-        self.assertIn("doi.org", str(src.url))
+        self.assertTrue(src.doi.startswith("10.0000/uploaded-"))
+        self.assertIsNone(src.url)
 
     def test_placeholder_doi_stored_but_no_url(self):
         placeholder = "10.0000/uploaded-abc123"
@@ -196,18 +196,19 @@ class PaperToEvidenceSourceTests(unittest.TestCase):
         self.assertEqual(src.doi, placeholder)
         self.assertTrue(src.url is None or not src.url.startswith("https://doi.org/10.0000"))
 
-    def test_arxiv_url_used_when_no_real_doi(self):
+    def test_legacy_arxiv_url_is_not_a_verified_upload_identity(self):
         src = paper_to_evidence_source(
             _make_pc(doi=None, url="https://arxiv.org/abs/1706.03762"), _reachable
         )
-        self.assertIn("1706.03762", str(src.url))
-        self.assertIsNone(src.doi)
+        self.assertIsNone(src.url)
+        self.assertTrue(src.doi.startswith("10.0000/uploaded-"))
 
-    def test_doi_org_url_in_url_field_extracts_real_doi(self):
+    def test_legacy_doi_url_cannot_bypass_upload_identity_boundary(self):
         src = paper_to_evidence_source(
             _make_pc(doi=None, url="https://doi.org/10.1016/j.cell.2024.01.001"), _reachable
         )
-        self.assertEqual(src.doi, "10.1016/j.cell.2024.01.001")
+        self.assertIsNone(src.url)
+        self.assertTrue(src.doi.startswith("10.0000/uploaded-"))
 
     def test_evidence_summary_combines_contribution_and_delta(self):
         pc = _make_pc(doi="10.1234/test")
@@ -228,8 +229,11 @@ class PaperToEvidenceSourceTests(unittest.TestCase):
 
 
 class PaperLocatorVerificationTests(unittest.TestCase):
-    """The DOI/URL come from an LLM reading PDF text, so they are checked
-    before this source is offered to the report as a citable reference."""
+    """Old extraction locators must not bypass the new identity boundary.
+
+    These replace the old resolver-fallback assertions deliberately: even a
+    successful HTTP check cannot justify attaching a citation to this upload.
+    """
 
     def test_unresolvable_doi_is_dropped_rather_than_cited(self):
         """The bad identifier must not survive into the report. It degrades
@@ -246,10 +250,10 @@ class PaperLocatorVerificationTests(unittest.TestCase):
         locator that claim is not the pipeline's to make."""
         src = paper_to_evidence_source(_make_pc(doi="10.1234/hallucinated"), _unreachable)
         self.assertEqual(src.credibility_tier, "medium")
-        self.assertIn("no independently resolvable", src.credibility_reason)
+        self.assertIn("not been independently checked", src.credibility_reason)
 
-    def test_unreachable_url_falls_back_to_the_doi_resolver(self):
-        """A dead publisher link does not condemn a DOI extracted separately."""
+    def test_dead_legacy_url_does_not_trigger_candidate_doi_resolution(self):
+        """Neither URL reachability nor a successful resolver grants identity."""
         checks = []
 
         def only_doi_org_resolves(url: str) -> tuple[bool, str]:
@@ -260,11 +264,11 @@ class PaperLocatorVerificationTests(unittest.TestCase):
             _make_pc(doi="10.1038/s41586-023-001", url="https://publisher.example/dead"),
             only_doi_org_resolves,
         )
-        self.assertEqual(src.doi, "10.1038/s41586-023-001")
-        self.assertEqual(str(src.url), "https://doi.org/10.1038/s41586-023-001")
+        self.assertTrue(src.doi.startswith("10.0000/uploaded-"))
+        self.assertIsNone(src.url)
         self.assertEqual(src.credibility_tier, "medium")
         self.assertIn("not been independently checked", src.credibility_reason)
-        self.assertIn("https://publisher.example/dead", checks)
+        self.assertEqual(checks, [])
 
     def test_unreachable_arxiv_url_leaves_no_real_locator(self):
         src = paper_to_evidence_source(

--- a/tests/test_pdf_numeric_receipt_seams.py
+++ b/tests/test_pdf_numeric_receipt_seams.py
@@ -1,0 +1,171 @@
+"""Regression seams for candidate identity, signed units and orphaned receipts."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from pathlib import Path
+
+import pytest
+
+from academic_agent import pdf_extractor as extractor
+from academic_agent.claim_grounding import check_report
+from api import access, main, papers, receipts, runs
+from tests.test_pdf_input_identity_boundaries import _pdf, fields
+from tests.test_server_receipts import contribution, headers, paid_api  # noqa: F401
+
+
+@pytest.mark.parametrize('filename', ['pdf_extractor.py', 'claim_grounding.py'])
+def test_local_recovery_identity_binds_pdf_and_grounding_rules(monkeypatch, filename):
+    """Local resumes must notice identity/audit changes without a deployed SHA."""
+    from academic_agent import checkpoint_runtime
+    for name in checkpoint_runtime._REVISION_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    before = checkpoint_runtime.pipeline_revision()
+    read = Path.read_bytes
+    monkeypatch.setattr(Path, 'read_bytes', lambda path: read(path) + (b'changed' if path.name == filename else b''))
+    assert checkpoint_runtime.pipeline_revision() != before
+
+
+@pytest.mark.parametrize("text", [
+    "References: 10.1234/cited-paper", "Related work arXiv:2501.01234",
+    "doi:10.1234/header-candidate\nReferences: 10.1234/cited-paper",
+])
+def test_pdf_candidate_cannot_become_registry_identity_via_http_and_storage(paid_api, monkeypatch, text):
+    """A label alone did not stop the bibliography DOI reaching A1.doi/url."""
+    client, _, _ = paid_api
+    monkeypatch.setattr(extractor, "_call_llm_json", MagicMock(return_value=fields(
+        candidate_doi="10.1234/model-invention", candidate_url="https://example.com/model",
+    )))
+    auth = headers()
+    response = client.post('/api/papers', headers=auth,
+                           files={'file': ('paper.pdf', _pdf([text]).read_bytes())})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    saved = papers.load_extraction(body['paper_id'])
+    assert {k: body[k] for k in extractor.PaperContribution.model_fields} == saved
+    assert body['candidate_doi'] == extractor._find_doi(text)
+    assert body['candidate_url']
+    assert body['url'] is None and body['doi'].startswith('10.0000/uploaded-')
+    checker = MagicMock(return_value=(True, ''))
+    source = extractor.paper_to_evidence_source(extractor.PaperContribution.model_validate(saved), checker)
+    assert source.url is None and source.doi == body['doi']
+    assert source.title == body['title'] and source.evidence_summary
+    checker.assert_not_called()
+    assert client.get('/api/receipts', headers=auth).json()['response'] == body
+
+
+@pytest.mark.parametrize('claim,source,status', [
+    ('Gain +10%', 'Gain -10%', 'ungrounded'),
+    ('Gain -10%', 'Gain 10%', 'ungrounded'),
+    ('Gain −10%', 'Gain +10%', 'ungrounded'),
+    ('Gain −10%', 'Gain -10.00 percent', 'grounded'),
+    ('Gain +10%', 'Gain 10 percent', 'grounded'),
+    ('Power 100 mW', 'Power 100 MW', 'ungrounded'),
+    ('Power 100 MW', 'Power 100 mW', 'ungrounded'),
+    ('Energy 100 mWh', 'Energy 100 MWh', 'ungrounded'),
+    ('Pressure 100 mPa', 'Pressure 100 MPa', 'ungrounded'),
+    ('Frequency 100 mHz', 'Frequency 100 MHz', 'ungrounded'),
+    ('Power 100 mW', 'Power 100 mW', 'grounded'),
+    ('Figure 26.1 furlongs', 'Figure 26.1%', 'unverifiable'),
+    ('Figure 26.1%', 'Figure 26.1 furlongs', 'unverifiable'),
+    ('Figure 26.1 qubits', 'Figure 26.1 qubits', 'unverifiable'),
+    ('Figure 26.1 kg/mystery', 'Figure 26.1 kg', 'unverifiable'),
+    ('Figure 26.1', 'Figure 26.1 unknownunit', 'unverifiable'),
+    ('Resistance 26.1 Ω', 'Figure 26.1%', 'unverifiable'),
+    ('Resistance 26.1 欧姆', 'Figure 26.1%', 'unverifiable'),
+    ('Resistance 26.1 kΩ', 'Temperature 26.1 K', 'unverifiable'),
+    ('Concentration 26.1 mM', 'Length 26.1 mm', 'unverifiable'),
+    ('Power 100 Mw', 'Power 100 MW', 'unverifiable'),
+    ('Efficiency 19.7% on 1 cm²', 'Efficiency 19.7% on 1 cm', 'unverifiable'),
+])
+def test_signed_or_unknown_unit_reaches_audit_verdict(claim, source, status):
+    """A known opposite sign/scale fails; unsupported unit grammar abstains."""
+    report = SimpleNamespace(findings=[SimpleNamespace(finding_id='F1', claim=claim, source_ids=['A1'])],
+        sources=[SimpleNamespace(source_id='A1', title='', publisher='', summary_source='abstract',
+                                 evidence_summary=source + '. ' + 'Supporting prose. ' * 40)])
+    result = check_report(report)
+    assert result.error is None
+    assert len(result.checks) == 1
+    assert result.checks[0].status == status
+    assert result.checked_count == (status != 'unverifiable')
+    assert result.ungrounded_count == (status == 'ungrounded')
+    assert result.unverifiable_count == (status == 'unverifiable')
+
+
+@pytest.mark.parametrize('failure,status,code', [
+    ('provider', 422, None), ('storage', 500, None),
+    ('concurrency', 429, 'concurrency_limit'), ('quota', 429, 'daily_quota_exceeded'),
+    ('ledger', 503, None),
+])
+@pytest.mark.parametrize('cancel', [False, True])
+def test_actual_pdf_thread_publishes_failure_even_without_waiter(paid_api, monkeypatch, failure, status, code, cancel):
+    """Read a terminal failure over HTTP after the real thread, not the waiter, exits."""
+    client, _, root = paid_api
+    auth = headers()
+    ticket, _ = receipts.claim(root, auth['Idempotency-Key'], access.owner_id('offline-owner-a'), 'paper', {})
+    paper_id, path = papers.save_upload(b'%PDF-offline')
+    entered, release = threading.Event(), threading.Event()
+    failures = {'provider': ValueError, 'concurrency': runs.ConcurrencyLimitReached,
+                'quota': runs.DailyCapReached, 'ledger': runs.PaidLedgerUnavailable}
+
+    def extract(*_args, **_kwargs):
+        entered.set()
+        assert release.wait(5)
+        if failure != 'storage':
+            raise failures[failure]('SECRET_PROVIDER_EXCERPT')
+        return contribution()
+
+    monkeypatch.setattr(main, '_extract_paper_with_paid_reservation', extract)
+    if failure == 'storage':
+        monkeypatch.setattr(papers, 'save_extraction', MagicMock(side_effect=OSError('SECRET_STORAGE_PATH')))
+
+    async def exercise():
+        with receipts.activate(ticket):
+            waiter = asyncio.create_task(main._process_uploaded_paper(paper_id, str(path)))
+        try:
+            assert await asyncio.to_thread(entered.wait, 3)
+            if cancel:
+                waiter.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await waiter
+        finally:
+            release.set()
+        if not cancel:
+            with pytest.raises(main._PaperStorageError if failure == 'storage' else failures[failure]):
+                await waiter
+        for _ in range(300):
+            if not main._paper_jobs:
+                break
+            await asyncio.sleep(.01)
+        assert not main._paper_jobs
+
+    asyncio.run(exercise())
+    response = client.get('/api/receipts', headers=auth)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body['state'] == 'failed' and body['status_code'] == status
+    assert body['response']['error_code'] == code
+    assert 'SECRET' not in response.text
+    assert 'zero cost' in body['response']['detail']
+    assert not path.exists()
+    assert not (papers.paper_dir(paper_id) / 'extraction.json').exists()
+
+
+def test_pdf_receipt_commit_failure_is_not_a_false_extraction_failure(paid_api, monkeypatch):
+    """A success whose journal write fails remains unresolved and cannot re-dispatch."""
+    client, _, _ = paid_api
+    model = MagicMock(return_value=contribution())
+    monkeypatch.setattr(main, 'extract_paper_contribution', model)
+    auth = headers()
+    files = {'file': ('paper.pdf', b'%PDF-offline')}
+    with monkeypatch.context() as fault:
+        committer = MagicMock(side_effect=receipts.ReceiptError(503, 'receipt_unavailable', 'unavailable'))
+        fault.setattr(receipts.Ticket, 'finish', committer)
+        assert client.post('/api/papers', headers=auth, files=files).status_code == 503
+        assert committer.call_count == 1
+    record = client.get('/api/receipts', headers=auth).json()
+    assert record['state'] == 'pending'
+    assert papers.load_extraction(record['resource_id'])['title'] == contribution().title
+    assert client.post('/api/papers', headers=auth, files=files).status_code == 409
+    assert model.call_count == 1


### PR DESCRIPTION
## Why
The three reported boundaries were reproduced offline: bibliography DOI promotion,
lost sign/unit scale, and failure receipts left pending when a PDF waiter disconnects.

## Repair
- Keep candidate locators separate from upload citation identity, including legacy conversion.
- Preserve signs and supported SI case; unknown units explicitly abstain.
- Let the actual PDF thread commit known failure outcomes; preserve journal uncertainty.
- Bind local recovery revision to PDF/grounding implementation changes.

## Verification
- Baseline: 2884 tests + 1237 subtests.
- Final local: 2922 tests + 1242 subtests; 89.18% coverage (85% floor).
- Eleven defect variants fail the named assertions and are restored by SHA-256.
- Latest Ruff, narrow Pylint, both real Chromium journeys pass.
- 26 composer POSTs intercepted; zero provider/search/DOI calls and no paid canary.
- Frozen replay: 90 artifacts, checked 50 -> 32, ungrounded 1 -> 0,
  unverifiable 161 -> 179. All 18 changes are abstentions, not accuracy gains.

The protected scoring formula, historical artifacts and zero-call shadow mode are unchanged.
Current decision record: docs/results-2026-09-11-pdf-numeric-receipt-seams.md.
After CI succeeds, release deployment and read-only verification will be recorded here.