### PR TITLE
Audit market metric comparability without changing calibrated scores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,11 @@ the [identity/logging regression and accounting limits](docs/results-2026-09-10-
 
 ## Keeping this index short without erasing decisions
 
+Market-metric v1 is an offline diagnostic, not a replacement scoring cap. Its
+30 local units are 29 live + 1 fixture and cannot establish original CSV
+identity; zero complete comparable pairs is not agreement. See the
+[snapshot-qualified audit](docs/results-2026-09-11-market-metric-comparability.md).
+
 PDF candidates never become A1 citation identity, including legacy conversion.
 Numeric sign/unit uncertainty must not become support; known PDF thread failures
 must finalize receipts even without a waiter, while journal write failure stays

--- a/docs/artifacts/2026-09-11-market-metric-audit/summary.json
+++ b/docs/artifacts/2026-09-11-market-metric-audit/summary.json
@@ -1,0 +1,323 @@
+{
+  "version": "market-metric-audit-v1",
+  "execution": "offline_only",
+  "production_effect": "none",
+  "implementation_sha256": "0b770c228236cf81edf0bbd360f228b049e923af6a01b1ac0edba804555da375",
+  "summary": {
+    "units": 30,
+    "available": 30,
+    "unavailable": 0,
+    "legacy_above_five": 30,
+    "verdicts": {
+      "not_assessed": 30
+    },
+    "meta_modes": {
+      "live": 29,
+      "fixture": 1
+    },
+    "score_states": {
+      "available": 30
+    },
+    "metric_occurrences": {
+      "acquisition": 3,
+      "funding": 19,
+      "market_size": 336,
+      "non_monetary": 17,
+      "revenue": 21,
+      "unknown": 462
+    },
+    "exclusion_reasons": {
+      "bound_not_point_estimate": 25,
+      "context_only_not_independent_estimate": 636,
+      "currency_unknown_or_conflicting": 168,
+      "geography_unknown_or_multiple": 593,
+      "market_scope_unknown_or_multiple": 531,
+      "metric_not_market_size": 60,
+      "metric_unknown_or_mixed": 462,
+      "multiple_amounts_unattributed": 808,
+      "nonpositive_or_range_or_signed_amount": 3,
+      "period_unknown_or_multiple": 835,
+      "single_registered_source_required": 105
+    }
+  },
+  "archived_csv_sha256": "d4f8bb9ec1e6883b13eff57a13b670a6a8b929568f42c37a3fc6378134d1d673",
+  "archived_csv_modes": {
+    "live": 30
+  },
+  "archived_csv_mode_mismatches": [
+    "03-solid-state-batteries-for-electric-vehicles"
+  ],
+  "historical_identity": "not_established_by_matching_csv_labels",
+  "inputs": [
+    {
+      "unit": "01-car-t-cell-therapy-for-blood-cancers",
+      "sha256": {
+        "market_evidence.json": "858fc9f85c834b9196a20c082933f825fcc6891d040b35c12cdf0b48be8b822e",
+        "meta.json": "9521c96eaba514469ec06d8324ccca04e8550ea9b741804d414f3d1308964da3",
+        "commercialization_scores.json": "c30ceadc9bce1b13485ea1dfaf2741dfb047a7b265f6d60926361f878404f16a"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "01-car-t-cell-therapy-for-blood-cancers__r2",
+      "sha256": {
+        "market_evidence.json": "f1e3f44832fcda9012aab809d31cfda5cc4c4f608ec605835875697e4e39260b",
+        "meta.json": "7c1b48cba8bf5ea2d543883fdc6e773b177e9d21e3b2671d5411972db5540da1",
+        "commercialization_scores.json": "77792120952dfa6af48258c8e41a7a143ab27196734cb03a13ea2725725a3fd0"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "01-car-t-cell-therapy-for-blood-cancers__r3",
+      "sha256": {
+        "market_evidence.json": "ebc0791e261f2dd2573e0cba7963d72f59a7170d769e621312fc7190b6d117e2",
+        "meta.json": "f5e5d61b6643ca5234605075c28ef1caa4cf13ed75d3b4518da3e5824c0d2a0e",
+        "commercialization_scores.json": "b84da34460b2c21da11826976a913de6b65c274d72e25925cd0d254c45c8eb2a"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "02-mrna-vaccines-for-cancer-immunotherapy",
+      "sha256": {
+        "market_evidence.json": "974122cf2f796c9bd5babf0d2a23572439579636b84cefca80463aaca6cd7bdd",
+        "meta.json": "79caa917c780af71d277b8000cc76a0ddee43976381f6f2127054fc2bb99fefc",
+        "commercialization_scores.json": "e1cbd5a0f6ee1797738a334490748cc9b737e858fb201fcdb984ce6aa0a95e1d"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "02-mrna-vaccines-for-cancer-immunotherapy__r2",
+      "sha256": {
+        "market_evidence.json": "6dcf3e06ba9e067ab37e06d1b20853f6cc8213b0390c42290fdc79437e294c65",
+        "meta.json": "6f21cb17ecb8b736ed44f7ccae5f1813c7308c5019d5849e2eec8223d6e46a6a",
+        "commercialization_scores.json": "467ee1760e34f46cc23973d0efe9bcd2a2b54267bb9002213a9f5b36e1a204a3"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "02-mrna-vaccines-for-cancer-immunotherapy__r3",
+      "sha256": {
+        "market_evidence.json": "e2413e01657ebecfed6fbc6216c26232b905005cfcd410cadd67d055d2a547e4",
+        "meta.json": "6b5ebdd2ba7b391d5e2ee33115eec3c8d14001fb443a18438fabb0a9aa709c63",
+        "commercialization_scores.json": "33060358b42d421484249032ac94ec4028ea8f4c6f39572c4638bd0dde5ee9dc"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "03-solid-state-batteries-for-electric-vehicles",
+      "sha256": {
+        "market_evidence.json": "5bbabd5f7cfa23542597774bcf1989cc1f7d8a1cd947e79f5e19429bde52bf04",
+        "meta.json": "5428961e2b390603e0f173456bd07b86c7c01a1b400102435368b8c0f95bb9e1",
+        "commercialization_scores.json": "0fb78e6a97e817b61118780121bd81552b4faaa4fcf90130f9e7541e57756520"
+      },
+      "mode": "fixture"
+    },
+    {
+      "unit": "03-solid-state-batteries-for-electric-vehicles__r2",
+      "sha256": {
+        "market_evidence.json": "f1db5b2a1f480499d3d8cb6ac3cfc78b41ab82840a0af1ff5af71289e8aa73e7",
+        "meta.json": "3e758bb3b918eeceb766a3387ff388096777a74fce8c50bc0bd012df40fd3f29",
+        "commercialization_scores.json": "508540e7773e5b5bb9043e9b8d8baa472e93366fed31da46327077b128963b77"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "03-solid-state-batteries-for-electric-vehicles__r3",
+      "sha256": {
+        "market_evidence.json": "5ed7501b22dad7fa8c3f5132b06114770f9b09959053dd497a094066e87fe31e",
+        "meta.json": "920e2a884b4d9bd3e9348463b717bfccd9a9dedfea8dd27a4afed8d594c14ce5",
+        "commercialization_scores.json": "8edbe4c7d8cb669cf9101dd0b846ffac0c0be27a9dd60d33f96c686dbcf66c9b"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "04-perovskite-solar-cells-for-utility-scale-powe",
+      "sha256": {
+        "market_evidence.json": "3608ae93314755416c798c66723c56674ff16746abfa4b73339885d9cc36bc94",
+        "meta.json": "cba72c45c7090e7c852bea47788c65f3b277ecba9673475cd6d668ea71b28807",
+        "commercialization_scores.json": "aa39f97cd42b6c4549864e348fa858735a01410f04fbee2ddc13bc29e8965cf9"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "04-perovskite-solar-cells-for-utility-scale-powe__r2",
+      "sha256": {
+        "market_evidence.json": "140e6e286df64f63e8c3b713087f24bd25a535468cb2cdaca5925dda14823dab",
+        "meta.json": "2e65f8f2fc1d13a642b016ef3a9feb0272aeab3f93b9fd0338781a63bc29ba52",
+        "commercialization_scores.json": "1f035bba77ebda67c436c385f7a827f72fd111eee26c9aabb9a8b84e6dc9a661"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "04-perovskite-solar-cells-for-utility-scale-powe__r3",
+      "sha256": {
+        "market_evidence.json": "35d1a1f6d8c0db168702156e85c54f915a8e517873aba61cc3d4110d2e497657",
+        "meta.json": "fcf240c539f4dc0628e7c5cb5eee57eb7b0704dfd0a57f72b15072508aef9468",
+        "commercialization_scores.json": "cfabd6bf8cfd923a0b844a1b55cd42d1810410c9e5e270e51fa96c5f7a7fa334"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "05-crispr-gene-editing-for-genetic-diseases",
+      "sha256": {
+        "market_evidence.json": "33f1eb5f10418153f6df54a6089c3c9ff2c425b301bfd1c943a17c40eded1907",
+        "meta.json": "13d88a36edcbeaa75a45af072ad2a8d9c6c3252f3132193260b2a6c0fb1b249d",
+        "commercialization_scores.json": "4dc9dab0a97467a13ed90598dba0b264656e65fee4fa82357ebc27ea246facfe"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "05-crispr-gene-editing-for-genetic-diseases__r2",
+      "sha256": {
+        "market_evidence.json": "d21390f9f052f3f052e1434fc05a7cffa252eb59c189d2a6cd19ce5b2094e897",
+        "meta.json": "3eb64633c3f38681ca9a6342b84df098858c011c1373657098caa2e24e7bcbd0",
+        "commercialization_scores.json": "18b7eba247250e653be9f5298833f3a5a2e13e961ecddfd9c0982e2a34540fa0"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "05-crispr-gene-editing-for-genetic-diseases__r3",
+      "sha256": {
+        "market_evidence.json": "583a74840313154830d467f5dc8be04b64ea83b69a0e8eb9c168e70a88d2148d",
+        "meta.json": "89c2d84c37a253db025aecd985bd095ae93baef807294fb7ae56cc84b544b55f",
+        "commercialization_scores.json": "350c11be46ff9ab06dac42a1368a7bf0fd361faabc53ec4f919a4f66935bfb52"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "06-carbon-capture-and-storage-for-industrial-emi",
+      "sha256": {
+        "market_evidence.json": "619647b8bf43f028c8ee89988e17c6ef1d75c4cc39eca92bd5f51f1b970f60b2",
+        "meta.json": "fcdb773ce2374c4e990f1c0a47022833daa195b5d1c9bd1bb1ea739dd9600f96",
+        "commercialization_scores.json": "82393595c532926b69e3a859961a98726fa46f8d9a0ed299f21dbac7a0444a3b"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "06-carbon-capture-and-storage-for-industrial-emi__r2",
+      "sha256": {
+        "market_evidence.json": "0a364577bd8bf08242301fe9cca0d12aae558189f9f6ee214dea001250933287",
+        "meta.json": "ea056f1061e726ce914b02941b2e86299439cad4e1f8d4c198f9abee5ca52147",
+        "commercialization_scores.json": "57c7bf3f92f9c177a6b5d2c0d5dc8aabe2c7ad568c9bfb18f89a1637e8b2dc99"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "06-carbon-capture-and-storage-for-industrial-emi__r3",
+      "sha256": {
+        "market_evidence.json": "eb43f9775b8e13fd56d90e9ad4b979e2c15633a47e96cd3edb9ce4611c0b18ae",
+        "meta.json": "e4c34afdde53827a2d0caa52e6cde81118b45cc928e16ef50757034d119c2773",
+        "commercialization_scores.json": "e2ce7509385a24f27b376a5b25f16e2402e29daad376aa1d2ea6ec4a8f14dfb8"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "07-cultivated-meat-for-food-industry",
+      "sha256": {
+        "market_evidence.json": "4ca09661be214c8a189ec2f648c83b3addbd2fd42f63b93eda5bfd63b7471327",
+        "meta.json": "20e060989167a8a07a3681f1915a783a26f612fa7dafb4b1024642638ca8b51f",
+        "commercialization_scores.json": "c6fca6051a956e24db2db86e5655cbaa3898b0e1c84b06d9955f7dd2d66fea9e"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "07-cultivated-meat-for-food-industry__r2",
+      "sha256": {
+        "market_evidence.json": "8c6210f10edd4c631519a2479ddf9ba244ed969ff13a3741cca004554e8bf007",
+        "meta.json": "5fe01c8e26bd9cc4b1a506c6b2034392f72e77652f2b18fc5d956a26f23ad6a1",
+        "commercialization_scores.json": "3351014e6378c28b6df0f11d2d1d0f376cbce400c6030962fd461dfdab69a831"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "07-cultivated-meat-for-food-industry__r3",
+      "sha256": {
+        "market_evidence.json": "670e7a961f32c71d2826f5d68a5a64d4332150a45f87cdb9f60110bd1204fb1f",
+        "meta.json": "ffe3df0935434c47407b891eaaf7c96e61b621a01a9761cd85f688dd43b5270c",
+        "commercialization_scores.json": "ab5425193c991854185484da37e587fd4625e9984468249675255b5e0c850dd1"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "08-quantum-computing-for-drug-discovery",
+      "sha256": {
+        "market_evidence.json": "d1499bee87f01add380f27afeb1c4121b6ba63dab786c96b05d26c112feb772a",
+        "meta.json": "f4856b6b55ebd56d36235da92bf4eb1ea59c94a866860a83013cd8789f31a6bc",
+        "commercialization_scores.json": "c5fed40c92972a3212b690ef81ad4d510e46f81debc85c59a9522f557357f7cf"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "08-quantum-computing-for-drug-discovery__r2",
+      "sha256": {
+        "market_evidence.json": "87bd0269394120e3f3fcbadbb58617475a5847d156c0cf8e7b5c2d6559b79852",
+        "meta.json": "e36bbe5ed1f8c4f933b9ee7fab3a12dfb1344ddf8eed8236df782c854fec74ab",
+        "commercialization_scores.json": "243c957c4fa57d2a08c9f4202ba03f2c3ede089d660f0602b27fc24fdf5ff6ef"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "08-quantum-computing-for-drug-discovery__r3",
+      "sha256": {
+        "market_evidence.json": "aab8ddaed330f3574360e0b1b8c3cb83c76c70b6e5a803af96d0e5fba374115d",
+        "meta.json": "47b90737c7e7a906d39d5ea4320c5405303eb12f055ad298163b9239fc2b0070",
+        "commercialization_scores.json": "738de3b582c63c5f72731850297889246e48b2f8f99a488d49e08a4ed0bd1c7c"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "09-graphene-based-flexible-electronics",
+      "sha256": {
+        "market_evidence.json": "7bffca588f1ced768395a61c5edc94c077ba71afaf13bc13d5f41f5bb3a826ef",
+        "meta.json": "6169205412af7bb798f084a299cb3363e6c0599fde107579611649e9378e28a2",
+        "commercialization_scores.json": "9847d9da0eadc5ce66b2313d77856790622e9c007de6bbf1183d920436676284"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "09-graphene-based-flexible-electronics__r2",
+      "sha256": {
+        "market_evidence.json": "fdea60cde56dc1df66eb3b7b514d65751d8da8a92559e29eb280b510e29c04f4",
+        "meta.json": "a60491287c4bb77901f3cd2e673a31b746d5c17763286de660b17e3bc44d1d7e",
+        "commercialization_scores.json": "d920e02bf1f2c034fcd71718f1b9c17717c1ea46bff7293db0d971d4c030f100"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "09-graphene-based-flexible-electronics__r3",
+      "sha256": {
+        "market_evidence.json": "f73c5514218f93200a5075886eeb45c17c673093f364c8eb970f0b39aaf2cb8c",
+        "meta.json": "cc25f62d939cf8c22982940f1e92a89bfeb451381b59fee9f2e136b7d2cd5e1f",
+        "commercialization_scores.json": "4188cc3a68db61e675f99de3019bcb82988158fd624e70eff98275acc82d0ce4"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "10-room-temperature-ambient-pressure-superconduc",
+      "sha256": {
+        "market_evidence.json": "39bfd0de69d08c1a03633db3e1410661c5ca00ab0c7c9dcedb9ce61f132f531d",
+        "meta.json": "c43d340c7df7738b8f1019bce60ac5869d5dcbfe607bac889b4610d5d62a7513",
+        "commercialization_scores.json": "ae8e58c18627c7074ac2ff13d54ca132bfd3b2047aac62d8b806f2cd6bab4b4b"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "10-room-temperature-ambient-pressure-superconduc__r2",
+      "sha256": {
+        "market_evidence.json": "04e5cb37dd2a86a266a75ff1b2a0867fb515fe31f33013b1f659bb5e42915aab",
+        "meta.json": "1c05ca484e1e07a63b4f89491d55f46525f55141e4e044d1c98b1f7707736577",
+        "commercialization_scores.json": "6376db994ab8022d9df4a9225c8dc274b88b98e8559515912dac05f3aa3cfa83"
+      },
+      "mode": "live"
+    },
+    {
+      "unit": "10-room-temperature-ambient-pressure-superconduc__r3",
+      "sha256": {
+        "market_evidence.json": "838b4676919fd35736204769d7abe2b3a70808b2bbb628e9bc1f5e3ace8785b5",
+        "meta.json": "090a73a985566f0254e24cd34e51731f03472fe424c62c2eb2f5d26cae0ce768",
+        "commercialization_scores.json": "3704cdf2d33c0a06b36c52784d00a2b7ec5a6dbc2f0ab12c0b2e1ba9cbf04e3b"
+      },
+      "mode": "live"
+    }
+  ]
+}

--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -47,6 +47,13 @@ production incident rates or improved report accuracy. See the
 
 ## Main evaluation ledger
 
+An offline market-metric audit reproduces the untyped >5 spread in 30/30
+current local units, but their metadata is 29 live + 1 fixture, unlike the
+archived all-live CSV. Strict typed comparison finds no fully attributable
+pairs, so all 30 are `not_assessed`, not verified agreement. This does not
+change market scores or establish penalty counts. See the
+[qualified snapshot and next gate](results-2026-09-11-market-metric-comparability.md).
+
 PDF candidate locators are now separate from A1 citation identity, including
 legacy extraction conversion. Signed quantities and milli/mega symbols remain
 distinct; unsupported unit notation abstains. The actual PDF thread publishes

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -25,6 +25,8 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-11 market-metric comparability](results-2026-09-11-market-metric-comparability.md) — offline typed diagnostic, snapshot/CSV identity mismatch and explicit non-assessment; production cap unchanged.
+
 - [2026-09-11 PDF/numeric/receipt seams](results-2026-09-11-pdf-numeric-receipt-seams.md) — separate candidate identity, signed/case-sensitive quantities and thread-owned failure receipts; zero provider calls.
 
 - [2026-09-10 evidence/PDF/terminal boundaries](results-2026-09-10-evidence-pdf-terminal-boundaries.md) — precision-aware numeric matching, production-only citation admission, actual PDF input coverage, candidate identity limits and terminal-authoritative operational outcomes; zero provider calls.

--- a/docs/results-2026-09-11-market-metric-comparability.md
+++ b/docs/results-2026-09-11-market-metric-comparability.md
@@ -1,0 +1,135 @@
+# Offline market-metric comparability audit v1
+
+Date: 2026-09-11
+Status: offline_diagnostic / production_disconnected / no_paid_calls
+Inspection base: `d3beb2c19cce5ad9fbd4ef4c4eeb3bbcda1d3cd6` (PR #133).
+
+## Decision
+
+The mixed-metric defect is real, but a replacement cap is **not validated**.
+Keep the production formula, confidence floor, 3.5 market cap, frozen evidence
+module and old calibration CSVs unchanged. The new `market_metric_audit` module
+is an operator-invoked offline diagnostic, not a production guardrail, a score
+repair, a Tool Calling activation or a new market-accuracy benchmark.
+
+The minimal reproduction puts a USD 20 billion market and USD 10 million
+company financing into the legacy extractor. Its untyped ratio is 2000; the
+typed diagnostic excludes financing from market-size comparisons. Other observed
+confounds include acquisitions, revenue, tonnes of CO2, molecule counts, future
+versus current estimates and parent versus application-specific markets.
+
+## Snapshot identity matters
+
+This replay reads the **current 30 local unit directories**, not a newly frozen
+copy of the original 30 live runs. Their metadata says **29 live + 1 fixture**.
+`03-solid-state-batteries-for-electric-vehicles/meta.json` is the fixture unit;
+the separately archived `benchmark_summary.csv` describes all 30 as live.
+Matching names or the other 29 mode labels do not establish byte identity with
+the historical run that generated that CSV.
+
+This qualifies the earlier September 10/11 descriptions of local artifact
+replays as "baseline" replays. It does not rewrite their observations or the
+historical CSV, nor show that the original live experiment itself used a fixture.
+Do not claim these local diagnostic results as a new independent confirmation of
+26/30 TRL calibration or as a clean, current-model live evaluation.
+
+The export binds each market, metadata and saved-score file by SHA-256, plus
+the implementation and archived CSV. A separate read-only check compared 183
+local JSON/CSV files before/after the audit: all were unchanged. Its manifest
+digest was `5a8c3650511019e404c4f28b49184afe55645723bb246f8cfd70bfd0acf7f0d4`.
+The [public aggregate and input hashes](artifacts/2026-09-11-market-metric-audit/summary.json)
+contain no raw reports, reviewer labels, credentials or private run URLs.
+
+## Measurements, not an accuracy claim
+
+| Observation | Result |
+|---|---|
+| Readable market artifacts | 30/30 |
+| Exact historical extraction and float-ratio parity | 30/30 |
+| Positive amount occurrences, including duplicates/context | 858 |
+| Legacy ratio above five | 30/30 |
+| Lexical funding occurrences / containing units | 19 / 9 |
+| Lexical acquisition occurrences / containing units | 3 / 3 |
+| Explicit non-monetary occurrences / containing units | 17 / 6 |
+| Revenue occurrences / containing units | 21 / 3 |
+| Market-labelled / unknown-or-mixed occurrences | 336 / 462 |
+| Units with a complete comparable pair under v1 | 0/30 |
+| Typed comparison outcome | 30 `not_assessed`, not 30 passes |
+| Saved market scores below / at the 3.5 ceiling | 17 / 13 |
+
+These are lexical occurrence counts, **not distinct sources, independent
+judgments or confirmed factual errors**. Limitations and summaries contribute
+636 context occurrences to the old extractor. Exclusion reasons overlap: for
+example, a multi-year paragraph may also lack explicit geography and currency.
+The archived normalized score does not retain its pre-cap input. Thirteen
+scores equal to 3.5 do not establish thirteen deductions; this audit deliberately
+does not publish reconstructed penalty amounts or a counterfactual total score.
+
+## Narrow implementation contract
+
+- Preserve the legacy `bn`/`billion`/`mn`/`million` grammar and historical float
+  division for its replay. The real corpus exposed `78.6 / 1000` becoming
+  `0.07859999999999999`; Decimal normalization is kept separate rather than
+  incorrectly described as bit-exact old behavior.
+- Store field paths, character offsets, raw numeric tokens and source IDs.
+  Do not classify every number from a finding's model-authored category label.
+- Typed comparisons require one point amount, one registered M source, a clear
+  market metric, explicit currency, a single calendar year, explicit geography
+  and an exact lexical market scope. Bare `$`, bounds, multiple amounts/years,
+  mixed metrics and missing dimensions abstain. A shared topic is not scope.
+- Compare only matching dimensions across distinct registered source IDs.
+  Deduplicate equivalent numeric quotations from one source. Source summaries
+  and limitations explain legacy extrema but are not independent estimates.
+- `not_assessed`, `spread_candidate` and `no_spread_in_checked_pairs` are
+  distinct. The latter is limited to the checked pairs, never all evidence.
+- Broken or missing market artifacts remain in the denominator as unavailable;
+  absent metadata/scores have separate states. Empty audits return nonzero.
+  The CLI refuses existing output directories and output inside its input tree.
+
+Exact lexical scope is intentionally low-recall. Distinct source IDs do not
+prove independent publishers; matching scopes do not prove equal market
+definitions, time bases or methodologies. This is not Chinese amount parsing,
+currency conversion, general semantic entailment, independent annotation or
+an acceptance test for changing scores. **Zero comparable pairs is a failure
+to establish coverage**, not evidence that all market estimates agree.
+
+## Reproduce without provider calls
+
+Use the local snapshot if it is available; the public repo does not distribute
+these complete ignored run directories. Do not substitute another snapshot and
+reuse these measured counts. For example, with a new output directory:
+
+```bash
+uv run --offline --no-sync python -m academic_agent.market_metric_audit --input outputs/benchmark --output outputs/market-metric-audit-new
+uv run --offline --no-sync pytest -q tests/test_market_metric_audit.py
+```
+
+The CLI writes `audit.json` and prints the same summary delivered in that JSON.
+It uses only standard-library file/text operations, not providers, model repair
+or retrieval. Regression fixtures cover the actual subprocess-to-JSON seam,
+corrupt/missing/oversized inputs, manifest identity, unchanged input bytes and
+non-overwrite behavior. A production scoring call is also exercised while the
+offline diagnostic is made unusable; the returned score matches the legacy
+guardrail exactly.
+
+Nine deliberate defect variants fail their assertions: accepting funding as
+market size; losing currency, year, geography or scope comparisons; accepting
+the same source twice; calling no comparison agreement; accepting a bound as a
+point; and double-counting equivalent numeric representations. The funding
+mutation was also tested alone at the comparison verdict, not merely its label.
+Each mutated implementation was restored and SHA-256 checked before the final
+suite. Baseline was 2922 tests + 1242 subtests; final local verification was
+2995 tests + 1242 subtests with 88.98% coverage. Latest Ruff, narrow Pylint and
+both Chromium journeys passed with zero provider requests. Composer's 26 paid
+POST fixtures were intercepted, not sent to the API. Exact CI/deployment
+observations belong to the release PR.
+
+## Next gate
+
+Before changing the cap, construct a small versioned set of **explicitly
+attributed, same-definition market estimates** with the original source span,
+metric, time basis, currency, geography and covered segment. Evaluate extraction
+and comparison separately, retaining unknowns and rejected pairs. Existing
+snapshot text can support initial engineering cases; it cannot supply expert
+truth by inference or retroactively become a held-out test. Any scoring-policy
+change needs a separate baseline-impact decision. No paid experiment is implied.

--- a/src/academic_agent/market_metric_audit.py
+++ b/src/academic_agent/market_metric_audit.py
@@ -1,0 +1,319 @@
+"""Offline-only diagnostic for the legacy, untyped market variance cap.
+
+This module is deliberately not imported by the Crew or delivery path. A regex
+can expose obviously mixed quantities, but cannot establish that two commercial
+estimates use the same methodology. Unknown dimensions abstain, and absence of
+comparable pairs is not agreement. Changing the calibrated cap needs a separate
+decision; this audit neither repairs scores nor authorizes paid reruns.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import csv
+from decimal import Decimal
+import hashlib
+from itertools import combinations
+import json
+import math
+from pathlib import Path
+import re
+
+
+VERSION = "market-metric-audit-v1"
+# Match the historical grammar, including its lack of currency/unit checking.
+# Keeping every occurrence lets a replay explain why the old cap fired. This
+# is not a new Chinese/compact-amount parser or a currency conversion service.
+_AMOUNT = re.compile(r"(\d[\d,]*(?:\.\d+)?)\s*(bn|billion|mn|million)", re.I)
+_YEAR = re.compile(r"\b(?:19|20)\d{2}\b")
+_CURRENCY = r"USD|US\s*\$|EUR|€|GBP|£|CNY|RMB|JPY|CAD|C\$|AUD|A\$|\$|¥"
+_PREFIX = re.compile(rf"(?<![\w$])({_CURRENCY})\s*$", re.I)
+_SUFFIX = re.compile(rf"^\s*({_CURRENCY})(?!\w)", re.I)
+_CURRENCIES = {
+    "USD": "USD", "US$": "USD", "EUR": "EUR", "€": "EUR",
+    "GBP": "GBP", "£": "GBP", "CNY": "CNY", "RMB": "CNY",
+    "JPY": "JPY", "CAD": "CAD", "C$": "CAD", "AUD": "AUD", "A$": "AUD",
+}
+_PHYSICAL = re.compile(
+    r"^\s+(?:metric\s+)?(?:tonnes?|tons?|molecules?|cells?|users?|units?|vehicles?|people)\b", re.I,
+)
+_SIGNALS = {
+    "funding": re.compile(r"\b(?:funding|funded|raised|investments?|invested|capital|financing)\b", re.I),
+    "acquisition": re.compile(r"\b(?:acquisitions?|acquired|buyout)\b", re.I),
+    "revenue": re.compile(r"\brevenues?\b", re.I),
+    "cost": re.compile(r"\b(?:costs?|prices?|capex|expenditure)\b", re.I),
+    "valuation": re.compile(r"\bvaluation\b", re.I),
+    "market_size": re.compile(r"\bmarket\b", re.I),
+}
+_GEO = r"global|worldwide|U\.S\.|United States|North America|Asia Pacific|Europe|China"
+_GEO_ALIASES = {"worldwide": "global", "u.s.": "united states"}
+_GEOGRAPHY = re.compile(rf"(?<!\w)({_GEO})(?!\w)", re.I)
+# Exact lexical scope, never the report topic: the latter would merge a niche
+# into its parent market. Multiple phrases, mixed metrics or multi-year prose
+# abstain instead of guessing which qualifier belongs to the nearest number.
+_SCOPE = re.compile(rf"(?<!\w)(?:{_GEO})\s+([\w()/-]+(?:\s+[\w()/-]+){{0,15}}?)\s+market\b", re.I)
+_SUBYEAR = re.compile(
+    r"\bQ[1-4]\b|\bFY\b|\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\b"
+    r"|\b(?:19|20)\d{2}\s*[-–/]\s*\d{2}\b", re.I,
+)
+_BOUND = re.compile(rf"\b(?:over|under|at least|at most|up to|more than|less than)\s*(?:{_CURRENCY})?\s*$", re.I)
+_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _currency(text: str, match: re.Match) -> str | None:
+    labels = []
+    for found in (_PREFIX.search(text[:match.start()]), _SUFFIX.search(text[match.end():])):
+        if found:
+            labels.append(_CURRENCIES.get(re.sub(r"\s", "", found[1]).upper()))
+    # A bare $ or yen symbol is intentionally ambiguous, even in a US report.
+    return labels[0] if labels and labels[0] and len(set(labels)) == 1 else None
+
+
+def _legacy_value(row: dict) -> float:
+    # Replay the historical float division too: 78.6 million became
+    # 0.07859999999999999 billion there, not Decimal('0.0786'). Typed comparisons
+    # use Decimal separately; calling the decimal result a bit-exact legacy
+    # replay would misdescribe a real difference at threshold boundaries.
+    match = _AMOUNT.fullmatch(row["raw"])
+    value = float(match[1].replace(",", ""))
+    if match[2].lower() in {"mn", "million"}:
+        value /= 1000
+    if not math.isfinite(value):
+        raise ValueError("non-finite legacy quantity")
+    return value
+
+
+def _observations(text: str, path: str, source_ids: list[str], known: set[str], *, finding: bool) -> list[dict]:
+    matches = list(_AMOUNT.finditer(text))
+    years = set(_YEAR.findall(text))
+    year = next(iter(years)) if len(years) == 1 and not _SUBYEAR.search(text) else None
+    geos = {_GEO_ALIASES.get(m[0].lower(), m[0].lower()) for m in _GEOGRAPHY.finditer(text)}
+    geo = next(iter(geos)) if len(geos) == 1 else None
+    scopes = {" ".join(m[1].lower().split()) for m in _SCOPE.finditer(text)}
+    scope = next(iter(scopes)) if len(scopes) == 1 else None
+    signals = [name for name, pattern in _SIGNALS.items() if pattern.search(text)]
+    rows = []
+    for match in matches:
+        amount = Decimal(match[1].replace(",", ""))
+        if match[2].lower() in {"mn", "million"}:
+            amount /= 1000
+        physical = bool(_PHYSICAL.match(text[match.end():]))
+        metric = "non_monetary" if physical else signals[0] if len(signals) == 1 else "unknown"
+        currency = _currency(text, match)
+        reasons = []
+        # Multiple amounts may be a range or different subjects even within a
+        # single year. Do not invent attribution, or compare bounds as points.
+        if len(matches) != 1:
+            reasons.append("multiple_amounts_unattributed")
+        if _BOUND.search(text[:match.start()]):
+            reasons.append("bound_not_point_estimate")
+        if not finding:
+            reasons.append("context_only_not_independent_estimate")
+        if metric != "market_size":
+            reasons.append("metric_not_market_size" if metric != "unknown" else "metric_unknown_or_mixed")
+        if currency is None:
+            reasons.append("currency_unknown_or_conflicting")
+        if year is None:
+            reasons.append("period_unknown_or_multiple")
+        if geo is None:
+            reasons.append("geography_unknown_or_multiple")
+        if scope is None:
+            reasons.append("market_scope_unknown_or_multiple")
+        if len(source_ids) != 1 or source_ids[0] not in known:
+            reasons.append("single_registered_source_required")
+        # The legacy grammar drops signs. Preserve its magnitude for parity,
+        # but do not turn a negative amount/range endpoint into an estimate.
+        if amount <= 0 or re.search(r"[-−–+]\s*$", text[:match.start()]):
+            reasons.append("nonpositive_or_range_or_signed_amount")
+        rows.append({
+            "path": path, "start": match.start(), "end": match.end(), "raw": match[0],
+            "amount_billions": str(amount), "metric": metric, "currency": currency,
+            "year": year, "geography": geo, "market_scope": scope,
+            "source_ids": source_ids, "eligible": not reasons, "reasons": reasons,
+        })
+    return rows
+
+
+def analyze_report(report: dict) -> dict:
+    """Return a typed diagnostic, not an alternative score or a semantic label.
+
+    Findings are the comparison surface; limitations/summaries still explain
+    legacy extrema but cannot count as additional, independent estimates.
+    A finding citing multiple sources cannot identify which supplied a number.
+    """
+    if not isinstance(report, dict) or not isinstance(report.get("topic"), str):
+        raise ValueError("invalid report")
+    findings, sources = report.get("findings"), report.get("sources")
+    if not isinstance(findings, list) or not isinstance(sources, list) or len(findings) + len(sources) > 500:
+        raise ValueError("invalid report collections")
+    known = set()
+    for source in sources:
+        if not isinstance(source, dict) or not isinstance(source.get("source_id"), str):
+            raise ValueError("invalid source")
+        sid = source["source_id"]
+        if not re.fullmatch(r"M[1-9]\d*", sid) or sid in known:
+            raise ValueError("invalid or duplicate market source")
+        known.add(sid)
+    rows = []
+    for index, item in enumerate(findings):
+        if not isinstance(item, dict):
+            raise ValueError("invalid finding")
+        ids = item.get("source_ids")
+        if not isinstance(ids, list) or not all(isinstance(sid, str) for sid in ids):
+            raise ValueError("invalid finding sources")
+        for field in ("claim", "limitations"):
+            text = item.get(field)
+            if field == "limitations" and text is None:
+                continue
+            if not isinstance(text, str):
+                raise ValueError("invalid finding text")
+            rows.extend(_observations(text, f"findings[{index}].{field}", ids, known, finding=field == "claim"))
+    for index, item in enumerate(sources):
+        if not isinstance(item.get("evidence_summary"), str):
+            raise ValueError("invalid source summary")
+        rows.extend(_observations(item["evidence_summary"], f"sources[{index}].evidence_summary",
+                                  [item["source_id"]], known, finding=False))
+    if len(rows) > 1000:
+        raise ValueError("too many amount observations")
+    for index, row in enumerate(rows):
+        row["id"] = index
+    values = [value for row in rows if (value := _legacy_value(row)) > 0]
+    legacy_ratio = max(values) / min(values) if len(values) >= 2 else None
+    # Repeated quotations from one registered source are not independent votes.
+    # Group by the complete observation identity, then require different IDs;
+    # distinct IDs still do not prove independent publishers/methodologies.
+    unique = {}
+    for row in rows:
+        if row["eligible"]:
+            key = (*[row[k] for k in ("currency", "year", "geography", "market_scope")], Decimal(row["amount_billions"]))
+            unique.setdefault((*key, row["source_ids"][0]), row)
+    pairs, skipped = [], Counter()
+    for left, right in combinations(unique.values(), 2):
+        reasons = [key for key in ("currency", "year", "geography", "market_scope") if left[key] != right[key]]
+        if left["source_ids"] == right["source_ids"]:
+            reasons.append("same_source")
+        if reasons:
+            skipped.update(reasons)
+            continue
+        a, b = Decimal(left["amount_billions"]), Decimal(right["amount_billions"])
+        ratio = max(a, b) / min(a, b)
+        pairs.append({"left": left["id"], "right": right["id"], "ratio": str(ratio), "above_five": ratio > 5})
+    verdict = "not_assessed" if not pairs else "spread_candidate" if any(p["above_five"] for p in pairs) else "no_spread_in_checked_pairs"
+    return {
+        "version": VERSION, "status": "available", "production_effect": "none",
+        "legacy_untyped": {"positive_occurrences": len(values), "ratio": str(legacy_ratio) if legacy_ratio is not None else None,
+                           "above_five": legacy_ratio is not None and legacy_ratio > 5},
+        "metric_counts": dict(sorted(Counter(row["metric"] for row in rows).items())),
+        "comparison": {"verdict": verdict, "eligible_occurrences": sum(row["eligible"] for row in rows),
+                       "excluded_occurrences": sum(not row["eligible"] for row in rows),
+                       "pairs": pairs, "skipped_pair_reasons": dict(sorted(skipped.items()))},
+        "observations": rows,
+    }
+
+
+def _read(path: Path, inputs: dict) -> dict:
+    with path.open("rb") as handle:
+        data = handle.read(_MAX_BYTES + 1)
+    if len(data) > _MAX_BYTES:
+        raise ValueError("input too large")
+    inputs[path.name] = hashlib.sha256(data).hexdigest()
+    value = json.loads(data)
+    if not isinstance(value, dict):
+        raise ValueError("invalid input object")
+    return value
+
+
+def audit_directory(root: Path) -> dict:
+    """Read each unit, including incomplete/corrupt units, without rewriting it."""
+    if not root.is_dir():
+        raise ValueError("input directory unavailable")
+    units = []
+    for directory in sorted(p for p in root.iterdir() if p.is_dir()):
+        row = {"unit": directory.name, "input_sha256": {}}
+        try:
+            report = _read(directory / "market_evidence.json", row["input_sha256"])
+            row["audit"] = analyze_report(report)
+        except (OSError, UnicodeError, ValueError, ArithmeticError) as exc:
+            # A broken artifact stays in the denominator. Do not expose file
+            # contents through JSON decoder errors or replace it with []/pass.
+            row["audit"] = {"status": "unavailable", "error_type": type(exc).__name__}
+        for filename, field in (("meta.json", "meta"), ("commercialization_scores.json", "score")):
+            try:
+                data = _read(directory / filename, row["input_sha256"])
+                if field == "meta":
+                    mode = data.get("evidence_mode")
+                    num, rep = data.get("num"), data.get("rep")
+                    row[field] = {
+                        "status": "available", "evidence_mode": mode if mode in {"live", "fixture"} else "unknown",
+                        "case_num": num if isinstance(num, str) and re.fullmatch(r"\d{2}", num) else None,
+                        "rep": rep if type(rep) is int and rep > 0 else None,
+                    }
+                else:
+                    saved = data.get("market_accessibility")
+                    valid = type(saved) in {float, int} and 1 <= saved <= 5
+                    row[field] = {"status": "available" if valid else "unavailable",
+                                  "market_accessibility": saved if valid else None,
+                                  "cap_effect": "not_reconstructable_without_pre_cap_score"}
+            except (OSError, UnicodeError, ValueError) as exc:
+                row[field] = {"status": "unavailable", "error_type": type(exc).__name__}
+        units.append(row)
+    available = [row for row in units if row["audit"]["status"] == "available"]
+    observations = [item for row in available for item in row["audit"]["observations"]]
+    result = {
+        "version": VERSION, "execution": "offline_only", "production_effect": "none",
+        "implementation_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "summary": {
+            "units": len(units), "available": len(available), "unavailable": len(units) - len(available),
+            "legacy_above_five": sum(row["audit"]["legacy_untyped"]["above_five"] for row in available),
+            "verdicts": dict(Counter(row["audit"]["comparison"]["verdict"] for row in available)),
+            "meta_modes": dict(Counter(row["meta"].get("evidence_mode", "unavailable") for row in units)),
+            "score_states": dict(Counter(row["score"]["status"] for row in units)),
+            "metric_occurrences": dict(sorted(Counter(item["metric"] for item in observations).items())),
+            "exclusion_reasons": dict(sorted(Counter(reason for item in observations for reason in item["reasons"]).items())),
+        },
+        "units": units,
+    }
+    csv_path = root / "benchmark_summary.csv"
+    if csv_path.is_file():
+        # The CSV is a separate historical artifact, not proof that the local
+        # unit files are still its original inputs. Bind both, never overwrite.
+        data = csv_path.read_bytes()
+        result["archived_csv_sha256"] = hashlib.sha256(data).hexdigest()
+        rows = list(csv.DictReader(data.decode("utf-8-sig").splitlines()))
+        result["archived_csv_modes"] = dict(Counter(row.get("evidence_mode", "unknown") for row in rows))
+        mismatches = []
+        for unit in units:
+            meta = unit["meta"]
+            matches = [row for row in rows if meta.get("case_num") is not None
+                       and row.get("case_num") == meta["case_num"] and row.get("rep") == str(meta.get("rep"))]
+            if len(matches) == 1 and matches[0].get("evidence_mode") != meta.get("evidence_mode"):
+                mismatches.append(unit["unit"])
+        result["archived_csv_mode_mismatches"] = mismatches
+        result["historical_identity"] = "not_established_by_matching_csv_labels"
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True, help="New directory; existing paths are refused")
+    args = parser.parse_args(argv)
+    try:
+        root, output = args.input.resolve(), args.output.resolve()
+        if output == root or output.is_relative_to(root):
+            raise ValueError("output cannot be inside input")
+        result = audit_directory(root)
+        output.mkdir(parents=True, exist_ok=False)
+        with (output / "audit.json").open("x", encoding="utf-8") as handle:
+            json.dump(result, handle, ensure_ascii=False, indent=2, allow_nan=False)
+            handle.write("\n")
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"status": "unavailable", "error_type": type(exc).__name__}))
+        return 2
+    print(json.dumps(result["summary"], sort_keys=True))
+    return 0 if result["summary"]["units"] and not result["summary"]["unavailable"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_market_metric_audit.py
+++ b/tests/test_market_metric_audit.py
@@ -1,0 +1,308 @@
+"""Typed offline comparisons must never masquerade as a scoring repair."""
+
+from copy import deepcopy
+import hashlib
+import json
+import subprocess
+import sys
+
+import pytest
+
+from academic_agent import market_metric_audit as audit
+
+
+def report(*claims):
+    return {
+        "topic": "batteries",
+        "findings": [{"claim": text, "source_ids": [f"M{i}"]} for i, text in enumerate(claims, 1)],
+        "sources": [{"source_id": f"M{i}", "evidence_summary": "Public source abstract."}
+                    for i in range(1, len(claims) + 1)],
+    }
+
+
+LOW = "The global battery market is valued at USD 2 billion in 2025."
+HIGH = "The global battery market is valued at USD 20 billion in 2025."
+
+
+def test_market_and_funding_reproducer_never_becomes_a_comparable_spread():
+    """The old 2000x signal is real; calling its two metrics inconsistent is not."""
+    value = audit.analyze_report(report(HIGH, "The company raised USD 10 million in 2025."))
+    assert value["legacy_untyped"] == {"positive_occurrences": 2, "ratio": "2000.0", "above_five": True}
+    assert value["metric_counts"] == {"funding": 1, "market_size": 1}
+    assert value["comparison"]["verdict"] == "not_assessed"
+    assert value["comparison"]["pairs"] == []
+    assert value["production_effect"] == "none"
+
+
+@pytest.mark.parametrize("other,reason", [
+    (HIGH.replace("USD", "EUR"), "currency"),
+    (HIGH.replace("2025", "2035"), "year"),
+    (HIGH.replace("global", "China"), "geography"),
+    (HIGH.replace("battery", "EV battery"), "market_scope"),
+])
+def test_known_different_denominators_are_not_compared(other, reason):
+    value = audit.analyze_report(report(LOW, other))
+    assert value["comparison"]["eligible_occurrences"] == 2
+    assert value["comparison"]["verdict"] == "not_assessed"
+    assert value["comparison"]["skipped_pair_reasons"][reason] == 1
+
+
+@pytest.mark.parametrize("low,high,reason", [
+    (LOW.replace("USD", "$"), HIGH.replace("USD", "$"), "currency_unknown_or_conflicting"),
+    (LOW.replace("global ", ""), HIGH.replace("global ", ""), "geography_unknown_or_multiple"),
+    (LOW.replace(" in 2025", ""), HIGH.replace(" in 2025", ""), "period_unknown_or_multiple"),
+    (LOW + " Forecast grows in 2035.", HIGH, "period_unknown_or_multiple"),
+    (LOW.replace("2025", "Q1 2025"), HIGH, "period_unknown_or_multiple"),
+    (LOW.replace("2025", "January 2025"), HIGH, "period_unknown_or_multiple"),
+    (LOW.replace("2025", "2025-26"), HIGH, "period_unknown_or_multiple"),
+    (LOW + " North America leads.", HIGH, "geography_unknown_or_multiple"),
+    (LOW + " The company raised USD 10 million.", HIGH, "metric_unknown_or_mixed"),
+    (LOW.replace("valued at", "funded with"), HIGH, "metric_unknown_or_mixed"),
+    (LOW.replace("USD 2 billion", "USD 2 billion EUR"), HIGH, "currency_unknown_or_conflicting"),
+])
+def test_unknown_or_mixed_dimensions_cannot_match_each_other(low, high, reason):
+    """None==None and shared report topics must not become evidence of sameness."""
+    value = audit.analyze_report(report(low, high))
+    assert value["comparison"]["verdict"] == "not_assessed"
+    assert reason in value["observations"][0]["reasons"]
+
+
+@pytest.mark.parametrize("text,metric", [
+    ("The firm received US$145 million funding.", "funding"),
+    ("The firm invested EUR 3 billion.", "funding"),
+    ("Acquisition of a company for USD 74 billion.", "acquisition"),
+    ("Company revenue was USD 5 billion.", "revenue"),
+    ("Factory costs were USD 40 million.", "cost"),
+    ("Its valuation was USD 40 billion.", "valuation"),
+    ("Captured 2 million metric tons of CO2.", "non_monetary"),
+    ("Screened 100 million molecules.", "non_monetary"),
+    ("The market includes 2 million vehicles.", "non_monetary"),
+    ("It reached 40 million.", "unknown"),
+])
+def test_named_non_market_quantities_are_excluded_but_keep_provenance(text, metric):
+    value = audit.analyze_report(report(text))
+    row = value["observations"][0]
+    assert row["metric"] == metric
+    assert not row["eligible"]
+    assert text[row["start"]:row["end"]] == row["raw"]
+    assert row["path"] == "findings[0].claim"
+    assert value["comparison"]["verdict"] == "not_assessed"
+
+
+@pytest.mark.parametrize("currency,expected", [("USD", "USD"), ("US $", "USD"), ("EUR", "EUR"),
+                                              ("GBP", "GBP"), ("C$", "CAD"), ("AUD", "AUD"),
+                                              ("RMB", "CNY"), ("JPY", "JPY")])
+def test_explicit_currency_survives_the_actual_pair_result(currency, expected):
+    value = audit.analyze_report(report(LOW.replace("USD", currency), HIGH.replace("USD", currency)))
+    assert value["observations"][0]["currency"] == expected
+    assert value["comparison"]["pairs"] == [{"left": 0, "right": 1, "ratio": "10", "above_five": True}]
+    assert value["comparison"]["verdict"] == "spread_candidate"
+
+
+@pytest.mark.parametrize("amount,above", [("10 billion", False), ("10.01 billion", True), ("2,000 million", False)])
+def test_exact_decimal_threshold_and_scale_only_apply_to_comparable_pairs(amount, above):
+    value = audit.analyze_report(report(LOW, HIGH.replace("20 billion", amount)))
+    assert value["comparison"]["pairs"][0]["above_five"] == above
+    assert value["comparison"]["verdict"] == ("spread_candidate" if above else "no_spread_in_checked_pairs")
+
+
+@pytest.mark.parametrize("amount", ["0 billion", "-2 billion", "−2 billion", "+2 billion"])
+def test_legacy_unsigned_grammar_does_not_make_signed_amounts_eligible(amount):
+    value = audit.analyze_report(report(LOW.replace("2 billion", amount), HIGH))
+    assert "nonpositive_or_range_or_signed_amount" in value["observations"][0]["reasons"]
+    assert value["comparison"]["verdict"] == "not_assessed"
+
+
+def test_source_summary_and_limitations_are_not_independent_estimates():
+    data = report(LOW)
+    data["findings"][0]["limitations"] = HIGH
+    data["sources"][0]["evidence_summary"] = HIGH
+    value = audit.analyze_report(data)
+    assert value["legacy_untyped"]["above_five"]
+    assert value["comparison"]["eligible_occurrences"] == 1
+    assert value["comparison"]["pairs"] == []
+    assert value["comparison"]["excluded_occurrences"] == 2
+
+
+@pytest.mark.parametrize("text,reason", [
+    (LOW.replace("USD 2", "over USD 2"), "bound_not_point_estimate"),
+    (LOW.replace("USD 2", "up to USD 2"), "bound_not_point_estimate"),
+    (LOW.replace("2 billion", "2 billion to USD 4 billion"), "multiple_amounts_unattributed"),
+])
+def test_bounds_and_unattributed_multiple_amounts_are_not_point_estimates(text, reason):
+    value = audit.analyze_report(report(text, HIGH))
+    assert value["comparison"]["verdict"] == "not_assessed"
+    assert reason in value["observations"][0]["reasons"]
+
+
+@pytest.mark.parametrize("ids", [["M1"], ["M999"], ["M1", "M2"], []])
+def test_same_unregistered_or_multi_source_claim_cannot_supply_a_second_vote(ids):
+    data = report(LOW, HIGH)
+    data["findings"][1]["source_ids"] = ids
+    assert audit.analyze_report(data)["comparison"]["verdict"] == "not_assessed"
+
+
+def test_duplicate_quotations_do_not_inflate_pair_count():
+    data = report(LOW, HIGH)
+    data["findings"].append(deepcopy(data["findings"][0]))
+    data["findings"][-1]["claim"] = LOW.replace("2 billion", "2.00 billion")
+    value = audit.analyze_report(data)
+    assert value["legacy_untyped"]["positive_occurrences"] == 3
+    assert len(value["comparison"]["pairs"]) == 1
+
+
+def test_unrecognised_language_and_amount_format_is_unassessed_not_agreement():
+    value = audit.analyze_report(report("市场规模是200亿美元，公司融资1000万美元。"))
+    assert value["legacy_untyped"]["positive_occurrences"] == 0
+    assert value["comparison"]["verdict"] == "not_assessed"
+
+
+def test_legacy_extraction_replay_is_exact_without_loading_a_provider():
+    """Test the old/new extraction seam, not two copies of the same regex."""
+    from academic_agent.evidence import _extract_market_size_billions
+    from tests.test_scoring_guardrail import _market_task
+
+    task = _market_task(HIGH, "Funding of USD 10 million. Captured 100 million tonnes.",
+                        "Values span 2 bn to 5 billion with 3 mn, 78.6 million and 0 million.")
+    original = task.output.pydantic.model_dump()
+    value = audit.analyze_report(original)
+    expected = _extract_market_size_billions(task)
+    actual = [audit._legacy_value(row) for row in value["observations"] if audit._legacy_value(row) > 0]
+    assert sorted(actual) == sorted(expected)
+    assert value["legacy_untyped"]["ratio"] == str(max(expected) / min(expected))
+    assert original == task.output.pydantic.model_dump()
+
+
+def test_diagnostic_cannot_change_production_guardrail_or_frozen_scores(monkeypatch):
+    """Observe the production scoring call while the diagnostic is unusable."""
+    from academic_agent.evidence import make_scoring_guardrail as legacy
+    from academic_agent.scoring_contract import make_scoring_guardrail as current
+    from tests.test_scoring_guardrail import _market_task, _run
+
+    task = _market_task(HIGH, "The company raised USD 10 million in 2025.")
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("offline diagnostic reached production")
+
+    monkeypatch.setattr(audit, "analyze_report", forbidden)
+    before = _run(legacy(market_task=task), market_accessibility=50)
+    after = _run(current(market_task=task), market_accessibility=50)
+    assert before == after
+    assert after[0] and after[1]["market_accessibility"] == 3.5
+
+
+def write_unit(root, name="unit", *, mode="live", score=3.5):
+    unit = root / name
+    unit.mkdir(parents=True)
+    (unit / "market_evidence.json").write_text(json.dumps(report(LOW, HIGH)), encoding="utf-8")
+    (unit / "meta.json").write_text(json.dumps({"evidence_mode": mode, "num": "01", "rep": 1}), encoding="utf-8")
+    (unit / "commercialization_scores.json").write_text(json.dumps({"market_accessibility": score}), encoding="utf-8")
+    return unit
+
+
+def run_cli(root, output):
+    return subprocess.run([sys.executable, "-m", "academic_agent.market_metric_audit", "--input", str(root),
+                           "--output", str(output)], capture_output=True, text=True, timeout=20, check=False)
+
+
+def test_cli_delivers_manifest_counts_and_unknown_cap_effect_without_rewriting_inputs(tmp_path):
+    """A computed diagnostic must reach its exported JSON, not just stdout."""
+    root, output = tmp_path / "inputs", tmp_path / "result"
+    write_unit(root)
+    write_unit(root, "second", mode="fixture")
+    (root / "benchmark_summary.csv").write_text("case_num,rep,evidence_mode\n01,1,live\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
+    process = run_cli(root, output)
+    assert process.returncode == 0, process.stderr
+    result = json.loads((output / "audit.json").read_text(encoding="utf-8"))
+    assert json.loads(process.stdout) == result["summary"]
+    assert result["summary"]["meta_modes"] == {"fixture": 1, "live": 1}
+    assert result["archived_csv_modes"] == {"live": 1}
+    assert result["archived_csv_mode_mismatches"] == ["second"]
+    assert result["historical_identity"] == "not_established_by_matching_csv_labels"
+    assert result["summary"]["verdicts"] == {"spread_candidate": 2}
+    assert result["execution"] == "offline_only" and result["production_effect"] == "none"
+    for row in result["units"]:
+        for name, digest in row["input_sha256"].items():
+            assert digest == hashlib.sha256(before[root / row["unit"] / name]).hexdigest()
+        assert row["score"]["cap_effect"] == "not_reconstructable_without_pre_cap_score"
+        assert row["audit"]["comparison"]["pairs"][0]["above_five"]
+    assert result["archived_csv_sha256"] == hashlib.sha256(before[root / "benchmark_summary.csv"]).hexdigest()
+    assert before == {p: p.read_bytes() for p in root.rglob("*") if p.is_file()}
+    assert str(tmp_path) not in (output / "audit.json").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("defect", ["missing", "corrupt", "shape", "bad_source", "text", "too_large"])
+def test_incomplete_unit_stays_in_cli_denominator_and_returns_nonzero(tmp_path, defect):
+    root, output = tmp_path / "inputs", tmp_path / "result"
+    unit = write_unit(root)
+    path = unit / "market_evidence.json"
+    if defect == "missing":
+        path.unlink()
+    elif defect == "corrupt":
+        path.write_text("PRIVATE-BROKEN-CONTENT", encoding="utf-8")
+    elif defect == "shape":
+        path.write_text("[]", encoding="utf-8")
+    elif defect in {"bad_source", "text"}:
+        data = report(LOW)
+        if defect == "bad_source":
+            data["sources"].append(deepcopy(data["sources"][0]))
+        else:
+            data["findings"][0]["claim"] = None
+        path.write_text(json.dumps(data), encoding="utf-8")
+    else:
+        path.write_bytes(b"x" * (audit._MAX_BYTES + 1))
+    process = run_cli(root, output)
+    assert process.returncode == 2
+    text = (output / "audit.json").read_text(encoding="utf-8")
+    value = json.loads(text)
+    assert value["summary"]["units"] == value["summary"]["unavailable"] == 1
+    assert value["summary"]["verdicts"] == {}
+    assert "PRIVATE-BROKEN-CONTENT" not in text + process.stdout + process.stderr
+
+
+def test_empty_input_is_not_a_successful_audit(tmp_path):
+    root = tmp_path / "empty"
+    root.mkdir()
+    result = run_cli(root, tmp_path / "result")
+    assert result.returncode == 2
+    assert json.loads(result.stdout)["units"] == 0
+
+
+@pytest.mark.parametrize("target", ["existing", "inside_input", "same_input", "missing_input"])
+def test_cli_refuses_overwrite_and_input_mutation(tmp_path, target):
+    root, output = tmp_path / "inputs", tmp_path / "result"
+    write_unit(root)
+    if target == "existing":
+        output.mkdir()
+        (output / "audit.json").write_text("keep", encoding="utf-8")
+    elif target == "inside_input":
+        output = root / "new"
+    elif target == "same_input":
+        output = root
+    else:
+        root = tmp_path / "absent"
+    before = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    process = run_cli(root, output)
+    assert process.returncode == 2
+    assert json.loads(process.stdout)["status"] == "unavailable"
+    assert before == {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+
+
+@pytest.mark.parametrize("saved", [None, "3.5", True, float("nan"), float("inf"), 0, 50])
+def test_malformed_saved_score_does_not_become_a_zero_or_an_estimated_penalty(tmp_path, saved):
+    root = tmp_path / "inputs"
+    write_unit(root, score=saved)
+    value = audit.audit_directory(root)
+    assert value["summary"]["score_states"] == {"unavailable": 1}
+    assert value["units"][0]["score"]["market_accessibility"] is None
+
+
+def test_missing_metadata_and_scores_are_separate_from_successful_text_inspection(tmp_path):
+    unit = write_unit(tmp_path / "inputs")
+    (unit / "meta.json").unlink()
+    (unit / "commercialization_scores.json").unlink()
+    value = audit.audit_directory(unit.parent)
+    assert value["summary"]["available"] == 1
+    assert value["summary"]["meta_modes"] == {"unavailable": 1}
+    assert value["summary"]["score_states"] == {"unavailable": 1}


### PR DESCRIPTION
## Decision and scope

Add an offline-only typed market-metric audit, not a replacement production cap.
Market/funding mixing is reproducible, but the current local 30-unit snapshot
has no fully attributable comparable pair under conservative v1. It is also
29 live + 1 fixture, whereas the archived CSV says 30 live; matching labels do
not restore historical byte identity. Both facts remain explicit.

The protected scoring formula, confidence floor, 3.5 cap, frozen source bytes,
benchmark CSVs, production report path and zero-call shadow mode are unchanged.
Only anonymous aggregate counts and hashes are published; no raw run reports,
reviewer labels, credentials or private run URLs.

## Verification

- Baseline: 2922 passed + 1242 subtests.
- Final local: 2995 passed + 1242 subtests, 88.98% coverage.
- Focused diagnostic/docs: 79 passed + 552 subtests.
- Exact legacy float/extraction parity on all 30 local artifacts; 183 input
  JSON/CSV files unchanged before/after read-only replay.
- Nine defect variants killed and SHA-256 restored, including a separate
  funding-as-market comparison-verdict check rather than only a label check.
- Latest Ruff and narrow Pylint pass.
- Chromium read-only and composer journeys pass, 26 intercepted paid POST
  fixtures, zero provider requests or unexpected requests.

CI must be green and the merged tree must match the tested head before release.
No paid canary, provider search, manual restart or Tool Calling activation.