### PR TITLE
Isolate upload deadline fault injection from capacity recovery probe

### DIFF
--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -47,6 +47,11 @@ production incident rates or improved report accuracy. See the
 
 ## Main evaluation ledger
 
+An existing upload test leaked its injected 20ms timeout into a normal capacity
+probe and failed one main Windows CI job. Scoped fault injection retains exact
+408/401 assertions and now uses one slot to expose leakage. Runtime limits are
+unchanged. See the [CI failure and behavioral repair](results-2026-09-11-upload-timeout-test-isolation.md).
+
 An offline market-metric audit reproduces the untyped >5 spread in 30/30
 current local units, but their metadata is 29 live + 1 fixture, unlike the
 archived all-live CSV. Strict typed comparison finds no fully attributable

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -25,6 +25,8 @@ to reuse consumed cohorts.
 
 ## Recent offline maintenance
 
+- [2026-09-11 upload timeout test isolation](results-2026-09-11-upload-timeout-test-isolation.md) — retained main-CI failure, scoped 20ms fault injection and single-slot recovery assertions; production limits unchanged.
+
 - [2026-09-11 market-metric comparability](results-2026-09-11-market-metric-comparability.md) — offline typed diagnostic, snapshot/CSV identity mismatch and explicit non-assessment; production cap unchanged.
 
 - [2026-09-11 PDF/numeric/receipt seams](results-2026-09-11-pdf-numeric-receipt-seams.md) — separate candidate identity, signed/case-sensitive quantities and thread-owned failure receipts; zero provider calls.

--- a/docs/results-2026-09-11-upload-timeout-test-isolation.md
+++ b/docs/results-2026-09-11-upload-timeout-test-isolation.md
@@ -1,0 +1,35 @@
+# Upload timeout test phase isolation
+
+Date: 2026-09-11
+Base: `fc92960872eaf4efe5e238b80ed521a4a3245c7d` (market audit PR #134).
+Status: offline_test_repair / production_behavior_unchanged
+
+PR #134 passed all eight checks. Its main run
+[34563198209](https://github.com/shuxiachai/academic-commercialization-agent/actions/runs/34563198209)
+then failed only Windows/Python 3.11: the existing upload deadline test expected
+the subsequent authentication-boundary probe to return 401, but received 408.
+This is retained as a failed observation, not hidden by retrying until green.
+
+The test installed a 20ms timeout for its deliberately stalled request, then
+reused that artificial deadline for its capacity-recovery probe. A correctly
+bounded second request could time out before authentication under ordinary
+scheduler delay. Adding a 50ms inter-chunk delay reproduced the failure for
+both idle and total variants locally. The source itself correctly retained its
+normal 30s idle / 120s total limits; it was not changed.
+
+The repair scopes only the fault-injection settings with `monkeypatch.context()`.
+The first request still must return exactly 408 with `upload_timeout`, and now
+also proves its parser files are closed immediately. The second request uses
+ordinary limits and still must return exactly 401, not a list of acceptable
+statuses. A single parser slot is retained across both phases: leaking one
+slot must cause a visible 429 instead of being hidden by the ordinary second
+slot. The valid second transfer deliberately takes more than 20ms, making a
+deadline-scope regression reproducible rather than dependent on runner speed.
+
+Two defects were separately re-injected after fixing: leaking the short
+deadline and suppressing the actual parser-slot decrement. They fail at the
+HTTP seam as 408-versus-401 and 429-versus-401. Both files were SHA-256 restored
+before complete regression. No assertion was weakened, no skip or warning
+ignore was added, and no production timeout, authentication rule, provider
+call or paid admission was changed. Final local/CI/deployment facts are recorded
+on the follow-up release PR, not inferred from the successful PR #134 jobs.

--- a/tests/test_upload_ingress.py
+++ b/tests/test_upload_ingress.py
@@ -104,20 +104,37 @@ def test_valid_sized_upload_preserves_authentication(ingress):
 @pytest.mark.parametrize("kind", ["idle", "total"])
 def test_upload_deadline_closes_parser_files(ingress, monkeypatch, kind):
     """A slow body cannot retain a parser slot indefinitely before paid admission."""
-    monkeypatch.setattr(upload_boundary, "UPLOAD_IDLE_SECONDS", 0.02 if kind == "idle" else 1)
-    monkeypatch.setattr(upload_boundary, "UPLOAD_TOTAL_SECONDS", 1 if kind == "idle" else 0.02)
+    monkeypatch.setattr(upload_boundary, "MAX_UPLOAD_PARSERS", 1)
 
     async def chunks():
         yield multipart(256)[:-13]
         await asyncio.sleep(1)
         yield b"--audit--\r\n"
 
-    response = asyncio.run(post(chunks()))
-    assert response.status_code == 408
-    assert response.headers["X-Error-Code"] == "upload_timeout"
-    assert ingress
-    # A rejected request must return capacity for a later legitimate upload.
-    assert asyncio.run(post(multipart())).status_code == 401
+    # Scope the artificial fault to the rejected request. Keeping its 20ms
+    # limit for the capacity probe made Windows scheduling look like a leak:
+    # a correct next request timed out (408) before reaching authentication.
+    # Do not relax 408/auth assertions or change the production timeouts.
+    with monkeypatch.context() as deadline:
+        deadline.setattr(upload_boundary, "UPLOAD_IDLE_SECONDS", 0.02 if kind == "idle" else 1)
+        deadline.setattr(upload_boundary, "UPLOAD_TOTAL_SECONDS", 1 if kind == "idle" else 0.02)
+        response = asyncio.run(post(chunks()))
+        assert response.status_code == 408
+        assert response.headers["X-Error-Code"] == "upload_timeout"
+        assert ingress
+        assert all(file.closed for file in ingress)
+
+    # One slot makes a retained parser observable as 429 rather than allowing
+    # the next request into a second slot. A 50ms valid transfer also makes
+    # failure to restore the ordinary deadline deterministic, not host-speed
+    # dependent. The normal request must still reach auth and return 401.
+    async def legitimate_chunks():
+        body = multipart()
+        yield body[:-13]
+        await asyncio.sleep(0.05)
+        yield body[-13:]
+
+    assert asyncio.run(post(legitimate_chunks())).status_code == 401
 
 
 def test_parser_capacity_rejects_before_receive_and_recovers(ingress, monkeypatch):


### PR DESCRIPTION
Follow-up to #134. Its PR checks were green, but main Windows/3.11 exposed an
existing test that leaked a 20ms injected timeout into the normal recovery
probe. Preserve that failed run rather than repeatedly rerunning its SHA.

Both variants were reproduced, then fixed by scoping only fault-phase settings.
Exact 408/401 assertions stay; immediate file closure and single-slot recovery
are stronger. A 50ms valid probe makes configuration leakage deterministic.
Production limits and middleware code are unchanged.

Validation: 2995 local tests + 1249 subtests, 88.98% coverage; latest Ruff,
narrow Pylint and both Chromium journeys pass. Deadline and actual slot-leak
mutations fail at the HTTP boundary and were SHA-256 restored. No paid calls.