### PR TITLE
Order upload deadline injection after real parser file creation

### DIFF
--- a/docs/evidence-status.md
+++ b/docs/evidence-status.md
@@ -47,6 +47,11 @@ production incident rates or improved report accuracy. See the
 
 ## Main evaluation ledger
 
+A local merged-tree upload test failed before any parser file opened, despite
+green CI. Deadline injection now follows actual file creation and separately
+asserts wait selection, cancellation, cleanup and capacity recovery. Production
+limits are unchanged. See the [ordering failure and regression](results-2026-09-11-upload-deadline-parser-order.md).
+
 Market-estimate preparation now separates 16 synthetic comparison controls
 from 20 unreviewed local source-summary candidates. Literal anchors and hashes
 are checked; unknown dimensions stay null, and no real comparisons or expert

--- a/docs/experiment-index.md
+++ b/docs/experiment-index.md
@@ -1,5 +1,7 @@
 # Experiment archive index
 
+- [2026-09-11 upload deadline parser ordering](results-2026-09-11-upload-deadline-parser-order.md) — preserve a local failure despite green CI; deterministic post-open fault injection, no production timeout change.
+
 - [2026-09-11 market estimate sample contract](results-2026-09-11-market-estimate-sample-contract.md) — synthetic controls and unreviewed snapshot preparation, not an independent market-accuracy evaluation.
 
 - [2026-09-10 durable paid receipts](results-2026-09-10-durable-paid-receipts.md) — offline HTTP/SQLite/browser acceptance recovery and defect reinjection; no paid experiment.

--- a/docs/results-2026-09-11-upload-deadline-parser-order.md
+++ b/docs/results-2026-09-11-upload-deadline-parser-order.md
@@ -1,0 +1,43 @@
+# Order deadline injection after actual multipart file creation
+
+Date: 2026-09-11
+Base: `6d127eb5a41e43db73d66edbb0fb49dff419ee6f` (PR #136).
+Status: offline_test_repair / production_behavior_unchanged.
+
+PR #136 and its main CI both passed all eight jobs. A subsequent local merged-tree
+run nevertheless returned **one failed, 3044 passed, 1253 subtests**: the idle
+upload test reached `assert ingress` with no created parser files. The green CI
+does not erase that contrary observation. No paid provider request was involved.
+
+The [previous repair](results-2026-09-11-upload-timeout-test-isolation.md) scoped
+the artificial deadline away from the second authentication/capacity probe. It
+did not guarantee that the first request opened a file before the injected 20ms
+deadline. A 50ms delay before its first body chunk reproduced the empty-file
+assertion for both idle and total variants. Production correctly rejected an
+unfinished upload; the test was asserting cleanup before setup had happened.
+
+The test now keeps that 50ms delay as a regression control and orders fault
+activation after the real multipart parser opens a tracked file:
+
+- A module-local clock proxy advances beyond the unchanged total deadline only
+  after file creation. Total expiry must reject before another wait call.
+- A module-local receive-wait proxy records the actual production timeout
+  argument. The first read has a generous test watchdog; only the post-open
+  idle wait gets a short real `asyncio.wait_for` timeout. Cancellation of the
+  stalled body is explicitly observed.
+- All module-local proxies end before the normal slow upload. No global event
+  loop clock or asyncio function is replaced. Exact 408/error-code, opened and
+  closed files, expected wait sequence, idle cancellation and subsequent 401
+  assertions remain. One parser slot still exposes leakage as 429.
+
+Five separate defects were re-injected: premature first-read timeout, ignored
+total deadline, wrong idle timeout selection, leaked parser slot, and bypassed
+multipart cleanup exception type. Each failed its target, including the real
+file-closed teardown for the cleanup defect. Both source/test files were restored
+by SHA-256 before final validation. No skip, accepted-status alternatives,
+warning ignore or production timeout/auth/admission change was introduced.
+
+This is an HTTP/parser lifecycle and timeout-selection test, not a wall-clock
+load benchmark or a live 30s/120s timeout experiment. The five-second watchdog
+only bounds a broken test. Final full-suite, CI and deployment observations
+belong to the follow-up release PR; the failed local observation is retained.

--- a/tests/test_upload_ingress.py
+++ b/tests/test_upload_ingress.py
@@ -1,6 +1,7 @@
 """Assert ingress limits at HTTP/parser seams, before auth or paid admission."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
@@ -103,31 +104,61 @@ def test_valid_sized_upload_preserves_authentication(ingress):
 
 @pytest.mark.parametrize("kind", ["idle", "total"])
 def test_upload_deadline_closes_parser_files(ingress, monkeypatch, kind):
-    """A slow body cannot retain a parser slot indefinitely before paid admission."""
+    """Expire after an actual file opens, not before scheduling reaches parsing."""
     monkeypatch.setattr(upload_boundary, "MAX_UPLOAD_PARSERS", 1)
+    clock = [0.0]
+    waits, cancelled = [], []
+    original_open = formparsers.SpooledTemporaryFile
+
+    def opened(*args, **kwargs):
+        file = original_open(*args, **kwargs)
+        if kind == "total":
+            clock[0] = upload_boundary.UPLOAD_TOTAL_SECONDS + 1
+        return file
 
     async def chunks():
+        # Reproduce the old fixture failure deterministically: its 20ms limit
+        # could expire before there was any parser file to test for cleanup.
+        await asyncio.sleep(0.05)
         yield multipart(256)[:-13]
-        await asyncio.sleep(1)
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.append(True)
         yield b"--audit--\r\n"
 
-    # Scope the artificial fault to the rejected request. Keeping its 20ms
-    # limit for the capacity probe made Windows scheduling look like a leak:
-    # a correct next request timed out (408) before reaching authentication.
-    # Do not relax 408/auth assertions or change the production timeouts.
+    async def wait_receive(awaitable, timeout):
+        waits.append(timeout)
+        # Only the already-opened parser gets a deliberately expiring real
+        # asyncio timeout. The first read has a test watchdog, not a synthetic
+        # 20ms precondition. The module-local proxy leaves ASGI/httpx clocks
+        # and global asyncio scheduling untouched.
+        return await asyncio.wait_for(awaitable, 0.02 if ingress else 5)
+
+    async def exercise():
+        # Missing rejection or a bypassed wait must fail, never hang the suite.
+        return await asyncio.wait_for(post(chunks()), 5)
+
+    # Keep the production 30s/120s constants and assert their chosen wait at
+    # the seam. Total expiry jumps only this module's clock after file-open;
+    # idle expiry uses actual await cancellation on the next body receive.
+    # All injected dependencies end before the single-slot capacity probe.
     with monkeypatch.context() as deadline:
-        deadline.setattr(upload_boundary, "UPLOAD_IDLE_SECONDS", 0.02 if kind == "idle" else 1)
-        deadline.setattr(upload_boundary, "UPLOAD_TOTAL_SECONDS", 1 if kind == "idle" else 0.02)
-        response = asyncio.run(post(chunks()))
+        deadline.setattr(formparsers, "SpooledTemporaryFile", opened)
+        deadline.setattr(upload_boundary, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+        deadline.setattr(upload_boundary, "asyncio", SimpleNamespace(wait_for=wait_receive))
+        response = asyncio.run(exercise())
         assert response.status_code == 408
         assert response.headers["X-Error-Code"] == "upload_timeout"
         assert ingress
         assert all(file.closed for file in ingress)
+        expected = min(upload_boundary.UPLOAD_IDLE_SECONDS, upload_boundary.UPLOAD_TOTAL_SECONDS)
+        assert waits == [expected] * (2 if kind == "idle" else 1)
+        assert cancelled == ([True] if kind == "idle" else [])
 
     # One slot makes a retained parser observable as 429 rather than allowing
-    # the next request into a second slot. A 50ms valid transfer also makes
-    # failure to restore the ordinary deadline deterministic, not host-speed
-    # dependent. The normal request must still reach auth and return 401.
+    # the next request into a second slot. Keep the slow valid transfer as a
+    # positive control under the ordinary clock, receive and deadline limits.
     async def legitimate_chunks():
         body = multipart()
         yield body[:-13]


### PR DESCRIPTION
## Why
A local merged-tree retest after #136 failed before the upload parser opened any file, despite all eight PR and main jobs passing. The 20ms fixture deadline could precede setup. This PR preserves that contrary observation and repairs the test rather than weakening assertions or changing production limits.

## Boundary
- Open a real multipart file before injecting total or idle expiry.
- Assert production-selected timeout arguments, actual idle await cancellation, immediate file closure and single-slot recovery to exactly 401.
- Keep the delayed first chunk as the regression condition and scope proxies to this module/request only.
- No production source, scoring, provider or Tool Calling changes.

## Verification
- 3045 passed + 1256 subtests, zero providers.
- Coverage 88.77% (11682 statements / 1312 missed), existing 85% gate unchanged.
- Latest Ruff, narrow Pylint, both Chromium journeys passed; 26 intercepted paid POSTs and zero provider requests.
- Five defect reinjections killed and restored by source hash. A malformed supplementary mutation was discarded, restored, and rerun against behavioral assertions.
- No new skips, warning ignores or widened assertions.

PR #136's local failure is not erased by its successful CI/deployment. This is test timing and parser lifecycle evidence, not a new live timeout or model evaluation.